### PR TITLE
Phase B: HarmonografSink + goldfive ingest

### DIFF
--- a/client/harmonograf_client/__init__.py
+++ b/client/harmonograf_client/__init__.py
@@ -24,6 +24,7 @@ from .planner import (
     make_default_adk_call_llm,
 )
 from .runner import HarmonografRunner, make_harmonograf_runner
+from .sink import HarmonografSink
 from .transport import ControlAckSpec
 
 __all__ = [
@@ -33,6 +34,7 @@ __all__ = [
     "ControlAckSpec",
     "HarmonografAgent",
     "HarmonografRunner",
+    "HarmonografSink",
     "LLMPlanner",
     "PassthroughPlanner",
     "Plan",

--- a/client/harmonograf_client/sink.py
+++ b/client/harmonograf_client/sink.py
@@ -1,0 +1,66 @@
+"""HarmonografSink — goldfive.EventSink that forwards events to harmonograf.
+
+Each goldfive :class:`goldfive.v1.Event` received via ``emit`` is pushed onto
+the client's existing buffer/transport pipeline, where the send loop wraps it
+in a ``TelemetryUp(goldfive_event=...)`` frame. The sink reuses the span
+transport's backpressure, reconnect, and heartbeat semantics — nothing new on
+the wire except the ``goldfive_event`` variant introduced in the Phase A proto
+migration (issue #2).
+
+Module identity: harmonograf's generated ``telemetry_pb2`` imports
+``goldfive.v1.events_pb2`` via the same module grafted onto ``goldfive.pb``,
+so ``TelemetryUp.goldfive_event`` shares its class with whatever goldfive's
+runner produces. No serialize/parse round-trip is required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .client import Client
+
+
+class HarmonografSink:
+    """``goldfive.EventSink`` adapter that ships events to a harmonograf server.
+
+    Usage::
+
+        from goldfive import Runner
+        from harmonograf_client import Client, HarmonografSink
+
+        client = Client(name="research", server_addr="localhost:50431")
+        sink = HarmonografSink(client)
+        runner = Runner(..., sinks=[sink])
+        await runner.run(user_request)
+        await sink.close()
+        client.shutdown()
+    """
+
+    def __init__(self, client: Client) -> None:
+        self._client = client
+        self._closed = False
+
+    @property
+    def client(self) -> Client:
+        return self._client
+
+    async def emit(self, event_pb: Any) -> None:
+        """Push ``event_pb`` onto the client's transport buffer.
+
+        ``emit`` is declared async to satisfy ``goldfive.EventSink`` but does
+        no IO itself — the push is a constant-time, thread-safe buffer append
+        that the transport's send loop drains.
+        """
+        if self._closed:
+            return
+        self._client.emit_goldfive_event(event_pb)
+
+    async def close(self) -> None:
+        """Mark the sink as closed. Does *not* shut down the underlying client.
+
+        The caller owns the :class:`Client` lifecycle; call ``client.shutdown()``
+        separately to flush and join the transport. Subsequent ``emit`` calls
+        after ``close`` are silently dropped so late events from a tearing-down
+        runner do not raise.
+        """
+        self._closed = True

--- a/client/tests/test_harmonograf_sink.py
+++ b/client/tests/test_harmonograf_sink.py
@@ -1,0 +1,225 @@
+"""Tests for :class:`harmonograf_client.sink.HarmonografSink`.
+
+The sink is the goldfive -> harmonograf seam introduced in Phase B of
+the goldfive migration (issue #3). Each ``goldfive.v1.Event`` ``emit``-ed
+through the sink must end up on the underlying ``Client``'s ring buffer
+as a ``GOLDFIVE_EVENT`` envelope, with the transport notified. The payload
+must round-trip through a ``TelemetryUp(goldfive_event=...)`` wrapper
+identically to how the transport serializer would see it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from goldfive.pb.goldfive.v1 import events_pb2 as ge
+from goldfive.pb.goldfive.v1 import types_pb2 as gt
+
+from harmonograf_client.buffer import EnvelopeKind
+from harmonograf_client.client import Client
+from harmonograf_client.sink import HarmonografSink
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="test-agent",
+        agent_id="agent-sink",
+        session_id="sess-sink",
+        framework="CUSTOM",
+        buffer_size=32,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def sink(client: Client) -> HarmonografSink:
+    return HarmonografSink(client)
+
+
+def _drain(client: Client) -> list:
+    return list(client._events.drain())
+
+
+def _make_run_started(run_id: str = "run-1", sequence: int = 0) -> ge.Event:
+    evt = ge.Event()
+    evt.event_id = "e-run-started"
+    evt.run_id = run_id
+    evt.sequence = sequence
+    evt.run_started.run_id = run_id
+    evt.run_started.goal_summary = "summarize Q3"
+    return evt
+
+
+def _make_plan_submitted(run_id: str = "run-1", sequence: int = 1) -> ge.Event:
+    evt = ge.Event()
+    evt.event_id = "e-plan"
+    evt.run_id = run_id
+    evt.sequence = sequence
+    plan = evt.plan_submitted.plan
+    plan.id = "plan-1"
+    plan.run_id = run_id
+    plan.summary = "two-step"
+    t1 = plan.tasks.add()
+    t1.id = "t1"
+    t1.title = "step one"
+    t1.status = gt.TASK_STATUS_PENDING
+    t2 = plan.tasks.add()
+    t2.id = "t2"
+    t2.title = "step two"
+    t2.status = gt.TASK_STATUS_PENDING
+    edge = plan.edges.add()
+    edge.from_task_id = "t1"
+    edge.to_task_id = "t2"
+    return evt
+
+
+def _make_task_started(task_id: str = "t1", sequence: int = 2) -> ge.Event:
+    evt = ge.Event()
+    evt.event_id = "e-task-started"
+    evt.run_id = "run-1"
+    evt.sequence = sequence
+    evt.task_started.task_id = task_id
+    evt.task_started.detail = "calling tool"
+    return evt
+
+
+def _make_drift_detected(sequence: int = 3) -> ge.Event:
+    evt = ge.Event()
+    evt.event_id = "e-drift"
+    evt.run_id = "run-1"
+    evt.sequence = sequence
+    evt.drift_detected.kind = gt.DRIFT_KIND_TOOL_ERROR
+    evt.drift_detected.severity = gt.DRIFT_SEVERITY_WARNING
+    evt.drift_detected.detail = "flaky backend"
+    evt.drift_detected.current_task_id = "t1"
+    return evt
+
+
+class TestEmit:
+    @pytest.mark.asyncio
+    async def test_emit_run_started_pushes_envelope(
+        self, sink: HarmonografSink, client: Client, made: list[FakeTransport]
+    ):
+        evt = _make_run_started()
+        await sink.emit(evt)
+        envs = _drain(client)
+        assert len(envs) == 1
+        env = envs[0]
+        assert env.kind is EnvelopeKind.GOLDFIVE_EVENT
+        assert env.span_id == ""
+        # Payload round-trips intact.
+        assert env.payload.run_id == "run-1"
+        assert env.payload.WhichOneof("payload") == "run_started"
+        assert env.payload.run_started.goal_summary == "summarize Q3"
+        # Transport was pinged so its send loop can drain the envelope.
+        assert made[0].notify_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_emit_preserves_sequence_and_run_id(
+        self, sink: HarmonografSink, client: Client
+    ):
+        await sink.emit(_make_run_started(run_id="run-xyz", sequence=0))
+        await sink.emit(_make_plan_submitted(run_id="run-xyz", sequence=1))
+        await sink.emit(_make_task_started(sequence=2))
+        envs = _drain(client)
+        assert [e.payload.sequence for e in envs] == [0, 1, 2]
+        assert {e.payload.run_id for e in envs} == {"run-xyz", "run-1"}
+
+    @pytest.mark.asyncio
+    async def test_emit_wraps_in_telemetry_up_via_transport_path(
+        self, sink: HarmonografSink, client: Client, made: list[FakeTransport]
+    ):
+        """The envelope payload the sink pushes must be compatible with the
+        ``_envelope_to_up`` serializer the transport calls at dequeue
+        time — i.e. ``TelemetryUp(goldfive_event=payload)`` must succeed
+        without a type/identity mismatch."""
+
+        from harmonograf_client.pb import telemetry_pb2
+
+        evt = _make_plan_submitted()
+        await sink.emit(evt)
+        env = _drain(client)[0]
+        up = telemetry_pb2.TelemetryUp(goldfive_event=env.payload)
+        assert up.WhichOneof("msg") == "goldfive_event"
+        assert up.goldfive_event.WhichOneof("payload") == "plan_submitted"
+        assert up.goldfive_event.plan_submitted.plan.id == "plan-1"
+        assert len(up.goldfive_event.plan_submitted.plan.tasks) == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "factory,expected_kind",
+        [
+            (_make_run_started, "run_started"),
+            (_make_plan_submitted, "plan_submitted"),
+            (_make_task_started, "task_started"),
+            (_make_drift_detected, "drift_detected"),
+        ],
+    )
+    async def test_emit_covers_each_payload_kind(
+        self,
+        sink: HarmonografSink,
+        client: Client,
+        factory,
+        expected_kind: str,
+    ):
+        await sink.emit(factory())
+        envs = _drain(client)
+        assert len(envs) == 1
+        assert envs[0].payload.WhichOneof("payload") == expected_kind
+
+
+class TestClose:
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent(self, sink: HarmonografSink):
+        await sink.close()
+        await sink.close()
+        assert sink._closed
+
+    @pytest.mark.asyncio
+    async def test_close_does_not_shut_down_client(
+        self, sink: HarmonografSink, client: Client, made: list[FakeTransport]
+    ):
+        await sink.close()
+        # Client lifecycle is orthogonal to the sink's.
+        assert made[0].shutdown_called is False
+
+    @pytest.mark.asyncio
+    async def test_emit_after_close_is_silent_drop(
+        self, sink: HarmonografSink, client: Client
+    ):
+        await sink.close()
+        await sink.emit(_make_run_started())
+        assert _drain(client) == []
+
+
+class TestBackpressure:
+    @pytest.mark.asyncio
+    async def test_emit_does_not_raise_when_buffer_full(
+        self, made: list[FakeTransport]
+    ):
+        """A tiny buffer plus enough events forces the drop policy to run.
+
+        The sink must never raise — agents depend on non-blocking emit.
+        """
+
+        small = Client(
+            name="small",
+            agent_id="a",
+            session_id="s",
+            buffer_size=2,
+            _transport_factory=make_factory(made),
+        )
+        sink = HarmonografSink(small)
+        # Push well beyond capacity; the underlying ring buffer's eviction
+        # tiers kick in. All we assert is no exception escapes.
+        for i in range(10):
+            await sink.emit(_make_run_started(sequence=i))
+        # Buffer is bounded.
+        assert len(small._events) <= 2

--- a/server/harmonograf_server/bus.py
+++ b/server/harmonograf_server/bus.py
@@ -34,6 +34,13 @@ DELTA_TASK_REPORT = "task_report"
 DELTA_TASK_PLAN = "task_plan"
 DELTA_TASK_STATUS = "task_status"
 DELTA_CONTEXT_WINDOW_SAMPLE = "context_window_sample"
+# Goldfive-originated run / drift / task-progress signals (issue #2, Phase B).
+DELTA_RUN_STARTED = "run_started"
+DELTA_RUN_COMPLETED = "run_completed"
+DELTA_RUN_ABORTED = "run_aborted"
+DELTA_GOAL_DERIVED = "goal_derived"
+DELTA_DRIFT = "drift"
+DELTA_TASK_PROGRESS = "task_progress"
 
 
 @dataclass
@@ -222,6 +229,111 @@ class SessionBus:
                     "report": report,
                     "invocation_span_id": invocation_span_id,
                     "recorded_at": recorded_at or time.time(),
+                },
+            )
+        )
+
+    # Goldfive-originated deltas (issue #2, Phase B). Payloads are plain dicts
+    # so WatchSession can route them to frontend-facing proto shapes in Phase
+    # C/D without coupling the bus to goldfive's pb types.
+
+    def publish_run_started(
+        self,
+        session_id: str,
+        run_id: str,
+        *,
+        goal_summary: str = "",
+        started_at: Optional[float] = None,
+    ) -> None:
+        self.publish(
+            Delta(
+                session_id,
+                DELTA_RUN_STARTED,
+                {
+                    "run_id": run_id,
+                    "goal_summary": goal_summary,
+                    "started_at": started_at,
+                },
+            )
+        )
+
+    def publish_run_completed(
+        self, session_id: str, run_id: str, *, outcome_summary: str = ""
+    ) -> None:
+        self.publish(
+            Delta(
+                session_id,
+                DELTA_RUN_COMPLETED,
+                {"run_id": run_id, "outcome_summary": outcome_summary},
+            )
+        )
+
+    def publish_run_aborted(
+        self, session_id: str, run_id: str, *, reason: str = ""
+    ) -> None:
+        self.publish(
+            Delta(
+                session_id,
+                DELTA_RUN_ABORTED,
+                {"run_id": run_id, "reason": reason},
+            )
+        )
+
+    def publish_goal_derived(
+        self, session_id: str, run_id: str, goals: list[dict]
+    ) -> None:
+        self.publish(
+            Delta(
+                session_id,
+                DELTA_GOAL_DERIVED,
+                {"run_id": run_id, "goals": goals},
+            )
+        )
+
+    def publish_drift(
+        self,
+        session_id: str,
+        run_id: str,
+        *,
+        kind: str,
+        severity: str,
+        detail: str = "",
+        current_task_id: str = "",
+        current_agent_id: str = "",
+    ) -> None:
+        self.publish(
+            Delta(
+                session_id,
+                DELTA_DRIFT,
+                {
+                    "run_id": run_id,
+                    "kind": kind,
+                    "severity": severity,
+                    "detail": detail,
+                    "current_task_id": current_task_id,
+                    "current_agent_id": current_agent_id,
+                },
+            )
+        )
+
+    def publish_task_progress(
+        self,
+        session_id: str,
+        run_id: str,
+        *,
+        task_id: str,
+        fraction: float,
+        detail: str = "",
+    ) -> None:
+        self.publish(
+            Delta(
+                session_id,
+                DELTA_TASK_PROGRESS,
+                {
+                    "run_id": run_id,
+                    "task_id": task_id,
+                    "fraction": fraction,
+                    "detail": detail,
                 },
             )
         )

--- a/server/harmonograf_server/convert.py
+++ b/server/harmonograf_server/convert.py
@@ -25,6 +25,9 @@ from harmonograf_server.storage import (
     SpanKind,
     SpanLink,
     SpanStatus,
+    Task,
+    TaskEdge,
+    TaskPlan,
     TaskStatus,
 )
 
@@ -346,10 +349,103 @@ def span_status_from_pb(pb_status: int) -> SpanStatus:
 
 # --- task plans -------------------------------------------------------------
 #
-# Task/TaskPlan/UpdatedTaskStatus pb conversions were removed in Phase A of
-# the goldfive migration (issue #2). Plan + task state now rides inside
-# TelemetryUp.goldfive_event (goldfive.v1.Event); the ingest-side
-# dispatcher and its storage wiring land in Phase B.
+# Plan + task state rides inside ``TelemetryUp.goldfive_event`` (a
+# ``goldfive.v1.Event``) after the Phase A migration (issue #2). The helpers
+# below translate between goldfive's ``Plan`` / ``Task`` pb messages and
+# harmonograf's storage-layer ``TaskPlan`` / ``Task`` dataclasses; the latter
+# re-export goldfive's Python dataclasses so field round-trips are mechanical.
+
+
+def goldfive_pb_task_to_storage(pb: Any) -> Task:
+    return Task(
+        id=pb.id,
+        title=pb.title,
+        description=pb.description,
+        assignee_agent_id=pb.assignee_agent_id,
+        status=task_status_from_pb(pb.status),
+        predicted_start_ms=pb.predicted_start_ms,
+        predicted_duration_ms=pb.predicted_duration_ms,
+        bound_span_id=pb.bound_span_id or "",
+    )
+
+
+def goldfive_pb_plan_to_storage(
+    pb: Any,
+    *,
+    session_id: str,
+    created_at: float,
+    invocation_span_id: str = "",
+    planner_agent_id: str = "",
+) -> TaskPlan:
+    """Translate a ``goldfive.v1.Plan`` into harmonograf's ``TaskPlan``.
+
+    Harmonograf persists a plan in its storage layer with a few
+    session-scoped fields goldfive's message does not carry
+    (``session_id``, ``invocation_span_id``, ``planner_agent_id``). Those
+    are passed in by the caller — typically the ingest pipeline, which
+    knows them from the stream context that delivered the event.
+
+    ``revision_kind`` and ``revision_severity`` are stored as enum-value
+    strings to match the existing harmonograf schema (``"tool_error"``,
+    ``"warning"``, etc.); the lookup falls back to empty string when
+    goldfive's enum is unspecified.
+    """
+
+    tasks = [goldfive_pb_task_to_storage(t) for t in pb.tasks]
+    edges = [
+        TaskEdge(from_task_id=e.from_task_id, to_task_id=e.to_task_id)
+        for e in pb.edges
+    ]
+    return TaskPlan(
+        id=pb.id,
+        session_id=session_id,
+        created_at=created_at,
+        invocation_span_id=invocation_span_id,
+        planner_agent_id=planner_agent_id,
+        summary=pb.summary,
+        tasks=tasks,
+        edges=edges,
+        revision_reason=pb.revision_reason,
+        revision_kind=_drift_kind_pb_to_string(pb.revision_kind),
+        revision_severity=_drift_severity_pb_to_string(pb.revision_severity),
+        revision_index=int(pb.revision_index),
+    )
+
+
+def _drift_kind_pb_to_string(value: int) -> str:
+    """Convert a ``goldfive.v1.DriftKind`` enum int to its lowercase value.
+
+    Returns the empty string when the enum is ``DRIFT_KIND_UNSPECIFIED`` so
+    storage does not record a meaningless revision kind on initial plans.
+    """
+
+    try:
+        name = goldfive_types_pb2.DriftKind.Name(value)
+    except (ValueError, AttributeError):
+        return ""
+    if name == "DRIFT_KIND_UNSPECIFIED":
+        return ""
+    if name.startswith("DRIFT_KIND_"):
+        return name[len("DRIFT_KIND_"):].lower()
+    return name.lower()
+
+
+def _drift_severity_pb_to_string(value: int) -> str:
+    """Convert a ``goldfive.v1.DriftSeverity`` enum int to its lowercase value.
+
+    Returns the empty string on UNSPECIFIED so initial plans keep a clean
+    severity column.
+    """
+
+    try:
+        name = goldfive_types_pb2.DriftSeverity.Name(value)
+    except (ValueError, AttributeError):
+        return ""
+    if name == "DRIFT_SEVERITY_UNSPECIFIED":
+        return ""
+    if name.startswith("DRIFT_SEVERITY_"):
+        return name[len("DRIFT_SEVERITY_"):].lower()
+    return name.lower()
 
 
 def storage_agent_to_pb(agent: Agent) -> types_pb2.Agent:

--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -27,10 +27,14 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Optional, Protocol
 
 from harmonograf_server.bus import SessionBus
 from harmonograf_server.convert import (
+    _drift_kind_pb_to_string,
+    _drift_severity_pb_to_string,
     attr_map_to_dict,
+    goldfive_pb_plan_to_storage,
     hello_to_agent,
     pb_span_to_storage,
     span_status_from_pb,
+    task_status_from_pb,
     ts_to_float,
 )
 from harmonograf_server.pb import telemetry_pb2, types_pb2
@@ -43,6 +47,7 @@ from harmonograf_server.storage import (
     SpanKind,
     SpanStatus,
     Store,
+    TaskPlan,
     TaskStatus,
 )
 
@@ -622,22 +627,278 @@ class IngestPipeline:
         )
 
     async def _handle_goldfive_event(self, ctx: StreamContext, event: Any) -> None:
-        """Placeholder dispatch for goldfive.v1.Event envelopes.
+        """Dispatch a ``goldfive.v1.Event`` to the per-kind handler.
 
-        Phase A of the goldfive migration (issue #2) wires the wire-level
-        variant through to here. The actual per-kind handlers — plan
-        ingestion, task status updates, drift markers, run lifecycle —
-        land in Phase B. For now we log at debug so tests can assert the
-        pipeline accepted the envelope without crashing.
+        Goldfive owns orchestration after the Phase A proto migration
+        (issue #2); plans, task state transitions, drift markers, and
+        run lifecycle signals all arrive here wrapped in a single
+        ``TelemetryUp.goldfive_event`` envelope. Each payload variant
+        drives a storage mutation and/or bus fan-out so the frontend
+        Gantt stays live. Unknown payload variants are logged and
+        ignored so adding a new event kind in goldfive is
+        forward-compatible with an older harmonograf server.
         """
-        kind = event.WhichOneof("payload") if event is not None else None
+        if event is None:
+            return
+        kind = event.WhichOneof("payload")
+        run_id = event.run_id
+        sequence = event.sequence
         logger.debug(
-            "goldfive event received session_id=%s run_id=%s sequence=%s kind=%s "
-            "(Phase B will wire this up)",
+            "goldfive event session_id=%s run_id=%s sequence=%s kind=%s",
             ctx.session_id,
-            getattr(event, "run_id", ""),
-            getattr(event, "sequence", 0),
+            run_id,
+            sequence,
             kind,
+        )
+        if kind == "run_started":
+            await self._on_run_started(ctx, event.run_started, run_id)
+        elif kind == "goal_derived":
+            await self._on_goal_derived(ctx, event.goal_derived, run_id)
+        elif kind == "plan_submitted":
+            await self._on_plan_submitted(ctx, event.plan_submitted, run_id)
+        elif kind == "plan_revised":
+            await self._on_plan_revised(ctx, event.plan_revised, run_id)
+        elif kind == "task_started":
+            await self._on_task_started(ctx, event.task_started, run_id)
+        elif kind == "task_progress":
+            self._on_task_progress(ctx, event.task_progress, run_id)
+        elif kind == "task_completed":
+            await self._on_task_completed(ctx, event.task_completed, run_id)
+        elif kind == "task_failed":
+            await self._on_task_failed(ctx, event.task_failed, run_id)
+        elif kind == "task_blocked":
+            await self._on_task_blocked(ctx, event.task_blocked, run_id)
+        elif kind == "task_cancelled":
+            await self._on_task_cancelled(ctx, event.task_cancelled, run_id)
+        elif kind == "drift_detected":
+            self._on_drift_detected(ctx, event.drift_detected, run_id)
+        elif kind == "run_completed":
+            self._on_run_completed(ctx, event.run_completed, run_id)
+        elif kind == "run_aborted":
+            self._on_run_aborted(ctx, event.run_aborted, run_id)
+        else:
+            logger.debug(
+                "ignoring unknown goldfive event payload kind=%s on session_id=%s",
+                kind,
+                ctx.session_id,
+            )
+
+    # ---- goldfive event handlers -------------------------------------
+
+    async def _on_run_started(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        started_at: Optional[float] = None
+        if payload.HasField("started_at"):
+            started_at = ts_to_float(payload.started_at)
+        self._bus.publish_run_started(
+            ctx.session_id,
+            run_id,
+            goal_summary=payload.goal_summary or "",
+            started_at=started_at,
+        )
+
+    async def _on_goal_derived(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        goals = [
+            {
+                "id": g.id,
+                "summary": g.summary,
+                "metadata": dict(g.metadata),
+                "has_success_predicate": bool(
+                    g.HasField("has_success_predicate") and g.has_success_predicate
+                ),
+            }
+            for g in payload.goals
+        ]
+        self._bus.publish_goal_derived(ctx.session_id, run_id, goals)
+
+    async def _on_plan_submitted(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        await self._upsert_plan(ctx, payload.plan, run_id=run_id)
+
+    async def _on_plan_revised(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        # The revision metadata lives both on ``payload.plan`` (inline in
+        # goldfive's ``Plan``) and as flattened top-level fields on the
+        # PlanRevised event. Prefer the event-level fields when the plan
+        # itself is missing them — goldfive emits the flattened copy to
+        # save sinks from unpacking the plan.
+        stored = await self._upsert_plan(ctx, payload.plan, run_id=run_id)
+        if stored is None:
+            return
+        overwrites: dict[str, Any] = {}
+        if not stored.revision_kind:
+            kind_str = _drift_kind_pb_to_string(payload.drift_kind)
+            if kind_str:
+                overwrites["revision_kind"] = kind_str
+        if not stored.revision_severity:
+            sev_str = _drift_severity_pb_to_string(payload.severity)
+            if sev_str:
+                overwrites["revision_severity"] = sev_str
+        if not stored.revision_reason and payload.reason:
+            overwrites["revision_reason"] = payload.reason
+        if payload.revision_index and not stored.revision_index:
+            overwrites["revision_index"] = int(payload.revision_index)
+        if overwrites:
+            for k, v in overwrites.items():
+                setattr(stored, k, v)
+            await self._store.put_task_plan(stored)
+            self._bus.publish_task_plan(stored)
+
+    async def _upsert_plan(
+        self, ctx: StreamContext, pb_plan: Any, *, run_id: str
+    ) -> Optional[TaskPlan]:
+        """Translate a ``goldfive.v1.Plan`` and persist + fan out the result.
+
+        Returns the stored ``TaskPlan`` so callers (PlanRevised) can
+        enrich it with the flattened revision metadata if needed.
+        """
+        if not pb_plan.id:
+            logger.warning(
+                "goldfive plan missing id on session_id=%s run_id=%s; dropping",
+                ctx.session_id,
+                run_id,
+            )
+            return None
+        created_at = ts_to_float(pb_plan.created_at) if pb_plan.HasField("created_at") else self._now()
+        stored = goldfive_pb_plan_to_storage(
+            pb_plan,
+            session_id=ctx.session_id,
+            created_at=created_at,
+            planner_agent_id=ctx.agent_id,
+        )
+        stored = await self._store.put_task_plan(stored)
+        # Refresh the task index for span-to-task binding lookups on the
+        # hot path. A re-emitted plan with the same id replaces previous
+        # index entries so stale task ids are pruned.
+        idx = self._task_index.setdefault(ctx.session_id, {})
+        # Drop prior mappings that pointed at this plan id.
+        for task_id in [tid for tid, pid in idx.items() if pid == stored.id]:
+            idx.pop(task_id, None)
+        for task in stored.tasks:
+            idx[task.id] = stored.id
+        self._bus.publish_task_plan(stored)
+        return stored
+
+    async def _on_task_started(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        await self._apply_goldfive_task_status(
+            ctx, payload.task_id, TaskStatus.RUNNING, run_id=run_id
+        )
+
+    def _on_task_progress(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        # Progress is a high-frequency, non-terminal signal — fan out on
+        # the bus so the frontend can render a progress bar, but do not
+        # persist. Matches the design note in §5.2 of the migration plan.
+        self._bus.publish_task_progress(
+            ctx.session_id,
+            run_id,
+            task_id=payload.task_id,
+            fraction=float(payload.fraction),
+            detail=payload.detail,
+        )
+
+    async def _on_task_completed(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        await self._apply_goldfive_task_status(
+            ctx, payload.task_id, TaskStatus.COMPLETED, run_id=run_id
+        )
+
+    async def _on_task_failed(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        await self._apply_goldfive_task_status(
+            ctx, payload.task_id, TaskStatus.FAILED, run_id=run_id
+        )
+
+    async def _on_task_blocked(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        await self._apply_goldfive_task_status(
+            ctx, payload.task_id, TaskStatus.BLOCKED, run_id=run_id
+        )
+
+    async def _on_task_cancelled(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        await self._apply_goldfive_task_status(
+            ctx, payload.task_id, TaskStatus.CANCELLED, run_id=run_id
+        )
+
+    async def _apply_goldfive_task_status(
+        self,
+        ctx: StreamContext,
+        task_id: str,
+        status: TaskStatus,
+        *,
+        run_id: str,
+    ) -> None:
+        if not task_id:
+            logger.debug(
+                "goldfive task status event missing task_id on session_id=%s run_id=%s",
+                ctx.session_id,
+                run_id,
+            )
+            return
+        plan_id = self._task_index.get(ctx.session_id, {}).get(task_id)
+        if plan_id is None:
+            # Fall back to a storage scan: handles pipeline restarts
+            # where the in-memory index has not been populated yet.
+            plans = await self._store.list_task_plans_for_session(ctx.session_id)
+            for p in plans:
+                for t in p.tasks:
+                    if t.id == task_id:
+                        plan_id = p.id
+                        self._task_index.setdefault(ctx.session_id, {})[
+                            task_id
+                        ] = plan_id
+                        break
+                if plan_id is not None:
+                    break
+        if plan_id is None:
+            logger.debug(
+                "goldfive task_id=%s has no matching plan in session_id=%s",
+                task_id,
+                ctx.session_id,
+            )
+            return
+        updated = await self._store.update_task_status(plan_id, task_id, status)
+        if updated is not None:
+            self._bus.publish_task_status(ctx.session_id, plan_id, updated)
+
+    def _on_drift_detected(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        self._bus.publish_drift(
+            ctx.session_id,
+            run_id,
+            kind=_drift_kind_pb_to_string(payload.kind),
+            severity=_drift_severity_pb_to_string(payload.severity),
+            detail=payload.detail,
+            current_task_id=payload.current_task_id,
+            current_agent_id=payload.current_agent_id,
+        )
+
+    def _on_run_completed(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        self._bus.publish_run_completed(
+            ctx.session_id, run_id, outcome_summary=payload.outcome_summary
+        )
+
+    def _on_run_aborted(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        self._bus.publish_run_aborted(
+            ctx.session_id, run_id, reason=payload.reason
         )
 
     async def _bind_task_to_span(

--- a/server/tests/test_goldfive_ingest.py
+++ b/server/tests/test_goldfive_ingest.py
@@ -1,0 +1,439 @@
+"""Tests for the goldfive-event ingest path (issue #3, Phase B).
+
+Harmonograf's ingest pipeline dispatches ``TelemetryUp.goldfive_event``
+envelopes to per-kind handlers that (a) persist plan/task state to the
+store and (b) fan out bus deltas to WatchSession subscribers. These
+tests drive the pipeline in-process with synthetic ``goldfive.v1.Event``
+payloads and verify both side-effects.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from goldfive.pb.goldfive.v1 import events_pb2 as ge
+from goldfive.pb.goldfive.v1 import types_pb2 as gt
+
+from harmonograf_server.bus import (
+    DELTA_DRIFT,
+    DELTA_GOAL_DERIVED,
+    DELTA_RUN_ABORTED,
+    DELTA_RUN_COMPLETED,
+    DELTA_RUN_STARTED,
+    DELTA_TASK_PLAN,
+    DELTA_TASK_PROGRESS,
+    DELTA_TASK_STATUS,
+    SessionBus,
+)
+from harmonograf_server.ingest import IngestPipeline, StreamContext
+from harmonograf_server.pb import telemetry_pb2
+from harmonograf_server.storage import (
+    Session,
+    SessionStatus,
+    TaskStatus,
+    make_store,
+)
+
+
+# ---- fixtures ------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def store():
+    s = make_store("memory")
+    await s.start()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+@pytest_asyncio.fixture
+async def pipeline(store):
+    bus = SessionBus()
+    pipe = IngestPipeline(store, bus, now_fn=lambda: 1_000_000.0)
+    yield pipe, bus, store
+
+
+def _stream_ctx(session_id: str = "sess_gf", agent_id: str = "agent_gf") -> StreamContext:
+    return StreamContext(
+        stream_id="str_test",
+        agent_id=agent_id,
+        session_id=session_id,
+        connected_at=1000.0,
+        last_heartbeat=1000.0,
+        seen_routes={(session_id, agent_id)},
+    )
+
+
+def _wrap(event: ge.Event) -> telemetry_pb2.TelemetryUp:
+    return telemetry_pb2.TelemetryUp(goldfive_event=event)
+
+
+async def _ensure_session(store, session_id: str = "sess_gf") -> None:
+    await store.create_session(
+        Session(
+            id=session_id,
+            title=session_id,
+            created_at=1.0,
+            status=SessionStatus.LIVE,
+        )
+    )
+
+
+def _subscribe(bus: SessionBus, session_id: str = "sess_gf"):
+    import asyncio
+
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(bus.subscribe(session_id))
+
+
+async def _drain(sub, kinds: set[str] | None = None) -> list:
+    out = []
+    while True:
+        try:
+            delta = sub.queue.get_nowait()
+        except Exception:
+            break
+        if kinds is None or delta.kind in kinds:
+            out.append(delta)
+    return out
+
+
+def _make_event(**kwargs) -> ge.Event:
+    evt = ge.Event()
+    evt.event_id = kwargs.get("event_id", "e1")
+    evt.run_id = kwargs.get("run_id", "run-1")
+    evt.sequence = kwargs.get("sequence", 0)
+    return evt
+
+
+def _plan_pb(
+    plan_id: str = "plan-1",
+    run_id: str = "run-1",
+    task_ids: list[str] | None = None,
+) -> gt.Plan:
+    task_ids = task_ids or ["t1", "t2"]
+    plan = gt.Plan()
+    plan.id = plan_id
+    plan.run_id = run_id
+    plan.summary = "test plan"
+    for tid in task_ids:
+        t = plan.tasks.add()
+        t.id = tid
+        t.title = f"task {tid}"
+        t.status = gt.TASK_STATUS_PENDING
+    for a, b in zip(task_ids, task_ids[1:]):
+        e = plan.edges.add()
+        e.from_task_id = a
+        e.to_task_id = b
+    return plan
+
+
+# ---- run lifecycle -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_started_publishes_delta(pipeline):
+    pipe, bus, _ = pipeline
+    sub = await bus.subscribe("sess_gf")
+    evt = _make_event()
+    evt.run_started.run_id = "run-1"
+    evt.run_started.goal_summary = "collect reports"
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_RUN_STARTED
+    assert delta.payload["run_id"] == "run-1"
+    assert delta.payload["goal_summary"] == "collect reports"
+
+
+@pytest.mark.asyncio
+async def test_run_completed_and_aborted_publish_deltas(pipeline):
+    pipe, bus, _ = pipeline
+    sub = await bus.subscribe("sess_gf")
+    completed = _make_event(event_id="e-c")
+    completed.run_completed.outcome_summary = "done"
+    aborted = _make_event(event_id="e-a", sequence=1)
+    aborted.run_aborted.reason = "user cancel"
+    await pipe.handle_message(_stream_ctx(), _wrap(completed))
+    await pipe.handle_message(_stream_ctx(), _wrap(aborted))
+    deltas = [sub.queue.get_nowait(), sub.queue.get_nowait()]
+    kinds = [d.kind for d in deltas]
+    assert DELTA_RUN_COMPLETED in kinds and DELTA_RUN_ABORTED in kinds
+    assert deltas[0].payload["outcome_summary"] == "done"
+    assert deltas[1].payload["reason"] == "user cancel"
+
+
+# ---- goal derivation -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_goal_derived_fans_out_goals(pipeline):
+    pipe, bus, _ = pipeline
+    sub = await bus.subscribe("sess_gf")
+    evt = _make_event()
+    g = evt.goal_derived.goals.add()
+    g.id = "goal-1"
+    g.summary = "ship release"
+    g.metadata["owner"] = "team"
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_GOAL_DERIVED
+    assert len(delta.payload["goals"]) == 1
+    assert delta.payload["goals"][0]["id"] == "goal-1"
+    assert delta.payload["goals"][0]["metadata"] == {"owner": "team"}
+
+
+# ---- plan submission / revision ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plan_submitted_persists_and_fans_out(pipeline, store):
+    pipe, bus, _ = pipeline
+    await _ensure_session(store)
+    sub = await bus.subscribe("sess_gf")
+    evt = _make_event()
+    evt.plan_submitted.plan.CopyFrom(_plan_pb())
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+
+    plans = await store.list_task_plans_for_session("sess_gf")
+    assert len(plans) == 1
+    plan = plans[0]
+    assert plan.id == "plan-1"
+    assert plan.session_id == "sess_gf"
+    assert plan.planner_agent_id == "agent_gf"
+    assert [t.id for t in plan.tasks] == ["t1", "t2"]
+    assert all(t.status == TaskStatus.PENDING for t in plan.tasks)
+    assert len(plan.edges) == 1
+
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_TASK_PLAN
+    assert delta.payload.id == "plan-1"
+
+    # Index populated for fast span-to-task binding lookups.
+    assert pipe._task_index["sess_gf"]["t1"] == "plan-1"
+    assert pipe._task_index["sess_gf"]["t2"] == "plan-1"
+
+
+@pytest.mark.asyncio
+async def test_plan_submitted_with_missing_id_is_dropped(pipeline, store):
+    pipe, bus, _ = pipeline
+    await _ensure_session(store)
+    sub = await bus.subscribe("sess_gf")
+    evt = _make_event()
+    # No plan.id set; harmonograf refuses to persist to avoid corrupt rows.
+    evt.plan_submitted.plan.summary = "nameless"
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    assert await store.list_task_plans_for_session("sess_gf") == []
+    # No delta should have been published either.
+    import asyncio
+
+    assert sub.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_plan_revised_increments_revision_metadata(pipeline, store):
+    pipe, bus, _ = pipeline
+    await _ensure_session(store)
+    sub = await bus.subscribe("sess_gf")
+
+    # Initial plan.
+    initial = _make_event()
+    initial.plan_submitted.plan.CopyFrom(_plan_pb(plan_id="plan-A"))
+    await pipe.handle_message(_stream_ctx(), _wrap(initial))
+
+    # Revised plan on the same id — drift metadata carried on the event.
+    revised = _make_event(sequence=1, event_id="e-rev")
+    revised_plan = _plan_pb(plan_id="plan-A", task_ids=["t1", "t2", "t3"])
+    revised_plan.revision_index = 1
+    revised_plan.revision_reason = "tool flaky"
+    revised.plan_revised.plan.CopyFrom(revised_plan)
+    revised.plan_revised.drift_kind = gt.DRIFT_KIND_TOOL_ERROR
+    revised.plan_revised.severity = gt.DRIFT_SEVERITY_WARNING
+    revised.plan_revised.reason = "tool flaky"
+    revised.plan_revised.revision_index = 1
+    await pipe.handle_message(_stream_ctx(), _wrap(revised))
+
+    stored = await store.get_task_plan("plan-A")
+    assert stored is not None
+    assert stored.revision_index == 1
+    assert stored.revision_reason == "tool flaky"
+    assert stored.revision_kind == "tool_error"
+    assert stored.revision_severity == "warning"
+    assert [t.id for t in stored.tasks] == ["t1", "t2", "t3"]
+
+    # The bus should have received at least the two plan fan-outs (initial + revised).
+    plan_deltas = []
+    while not sub.queue.empty():
+        d = sub.queue.get_nowait()
+        if d.kind == DELTA_TASK_PLAN:
+            plan_deltas.append(d)
+    assert len(plan_deltas) >= 2
+
+
+# ---- task status transitions --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_started_completed_flow(pipeline, store):
+    pipe, bus, _ = pipeline
+    await _ensure_session(store)
+    sub = await bus.subscribe("sess_gf")
+
+    plan_evt = _make_event()
+    plan_evt.plan_submitted.plan.CopyFrom(_plan_pb(plan_id="p-flow"))
+    await pipe.handle_message(_stream_ctx(), _wrap(plan_evt))
+
+    # RUNNING
+    started = _make_event(sequence=1, event_id="e-s")
+    started.task_started.task_id = "t1"
+    await pipe.handle_message(_stream_ctx(), _wrap(started))
+
+    # COMPLETED
+    completed = _make_event(sequence=2, event_id="e-c")
+    completed.task_completed.task_id = "t1"
+    completed.task_completed.summary = "ok"
+    await pipe.handle_message(_stream_ctx(), _wrap(completed))
+
+    plan = await store.get_task_plan("p-flow")
+    assert plan is not None
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.status == TaskStatus.COMPLETED
+
+    status_deltas = []
+    while not sub.queue.empty():
+        d = sub.queue.get_nowait()
+        if d.kind == DELTA_TASK_STATUS:
+            status_deltas.append(d)
+    statuses = [d.payload["task"].status for d in status_deltas]
+    assert TaskStatus.RUNNING in statuses
+    assert TaskStatus.COMPLETED in statuses
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field,expected_status",
+    [
+        ("task_failed", TaskStatus.FAILED),
+        ("task_blocked", TaskStatus.BLOCKED),
+        ("task_cancelled", TaskStatus.CANCELLED),
+    ],
+)
+async def test_task_terminal_statuses(pipeline, store, field: str, expected_status):
+    pipe, bus, _ = pipeline
+    await _ensure_session(store)
+    plan_evt = _make_event()
+    plan_evt.plan_submitted.plan.CopyFrom(_plan_pb(plan_id=f"p-{field}"))
+    await pipe.handle_message(_stream_ctx(), _wrap(plan_evt))
+
+    evt = _make_event(sequence=1)
+    sub_msg = getattr(evt, field)
+    sub_msg.task_id = "t1"
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+
+    plan = await store.get_task_plan(f"p-{field}")
+    assert plan is not None
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.status == expected_status
+
+
+@pytest.mark.asyncio
+async def test_task_status_for_unknown_task_is_logged_not_crash(pipeline, store):
+    pipe, _bus, _ = pipeline
+    # No plan submitted — task_started for an unknown id should be a no-op.
+    evt = _make_event()
+    evt.task_started.task_id = "ghost-task"
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    # Pipeline stayed alive.
+    assert pipe._task_index == {}
+
+
+@pytest.mark.asyncio
+async def test_task_progress_fans_out_without_persisting(pipeline, store):
+    pipe, bus, _ = pipeline
+    await _ensure_session(store)
+    sub = await bus.subscribe("sess_gf")
+    plan_evt = _make_event()
+    plan_evt.plan_submitted.plan.CopyFrom(_plan_pb(plan_id="p-prog"))
+    await pipe.handle_message(_stream_ctx(), _wrap(plan_evt))
+    # Drain plan delta so the progress delta is first.
+    while not sub.queue.empty():
+        sub.queue.get_nowait()
+
+    prog = _make_event(sequence=1)
+    prog.task_progress.task_id = "t1"
+    prog.task_progress.fraction = 0.4
+    prog.task_progress.detail = "40% done"
+    await pipe.handle_message(_stream_ctx(), _wrap(prog))
+
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_TASK_PROGRESS
+    assert delta.payload["task_id"] == "t1"
+    assert delta.payload["fraction"] == pytest.approx(0.4)
+    assert delta.payload["detail"] == "40% done"
+
+    # Progress does NOT flip persisted task status.
+    plan = await store.get_task_plan("p-prog")
+    assert plan is not None
+    assert all(t.status == TaskStatus.PENDING for t in plan.tasks)
+
+
+# ---- drift ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drift_detected_publishes_delta(pipeline):
+    pipe, bus, _ = pipeline
+    sub = await bus.subscribe("sess_gf")
+    evt = _make_event()
+    evt.drift_detected.kind = gt.DRIFT_KIND_TOOL_ERROR
+    evt.drift_detected.severity = gt.DRIFT_SEVERITY_CRITICAL
+    evt.drift_detected.detail = "backend flaky"
+    evt.drift_detected.current_task_id = "t1"
+    evt.drift_detected.current_agent_id = "agent_gf"
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_DRIFT
+    assert delta.payload["kind"] == "tool_error"
+    assert delta.payload["severity"] == "critical"
+    assert delta.payload["detail"] == "backend flaky"
+    assert delta.payload["current_task_id"] == "t1"
+
+
+# ---- dispatch sanity -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_payload_is_ignored(pipeline):
+    pipe, bus, _ = pipeline
+    sub = await bus.subscribe("sess_gf")
+    # An Event with no payload variant set — goldfive's forward-compat path.
+    evt = _make_event()
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    assert sub.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_task_index_repopulates_from_store_after_restart(pipeline, store):
+    """A pipeline restart drops ``_task_index``; a subsequent task event
+    must still resolve the plan via a store scan."""
+
+    pipe, bus, _ = pipeline
+    await _ensure_session(store)
+
+    plan_evt = _make_event()
+    plan_evt.plan_submitted.plan.CopyFrom(_plan_pb(plan_id="p-restart"))
+    await pipe.handle_message(_stream_ctx(), _wrap(plan_evt))
+
+    # Simulate restart: wipe the in-memory index.
+    pipe._task_index.clear()
+
+    started = _make_event(sequence=1)
+    started.task_started.task_id = "t1"
+    await pipe.handle_message(_stream_ctx(), _wrap(started))
+
+    plan = await store.get_task_plan("p-restart")
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.status == TaskStatus.RUNNING
+    # And the index got rebuilt from the store scan.
+    assert pipe._task_index["sess_gf"]["t1"] == "p-restart"


### PR DESCRIPTION
Closes #3.

## Summary

Phase B of the goldfive migration (issue #2): land the client->server seam that replaces the retired `TaskPlan` / `UpdatedTaskStatus` wire path with a single `TelemetryUp.goldfive_event` envelope. Orchestration remains goldfive's concern; harmonograf now observes it.

### Client

- **`client/harmonograf_client/sink.py`** — new `HarmonografSink` implementing goldfive's `EventSink` protocol. `emit(event_pb)` pushes onto the existing ring buffer as a `GOLDFIVE_EVENT` envelope; the transport's send loop wraps it in `TelemetryUp(goldfive_event=...)` at dequeue time. `close()` is a no-op — caller owns `Client.shutdown()`.
- Exported from `harmonograf_client.__init__`.

### Server

- **`server/harmonograf_server/ingest.py`** — `_handle_goldfive_event` now dispatches on `event.WhichOneof("payload")`:
  - Run lifecycle (`run_started` / `run_completed` / `run_aborted`) → bus fan-out.
  - `goal_derived` → bus fan-out with serialized goals list.
  - `plan_submitted` → translate `goldfive.v1.Plan` into storage `TaskPlan`, upsert, populate the `_task_index` for span-to-task binding lookups, publish `DELTA_TASK_PLAN`.
  - `plan_revised` → same + enrich with the flattened revision metadata the PlanRevised event carries.
  - `task_started` / `_completed` / `_failed` / `_blocked` / `_cancelled` → resolve plan via index (with store-scan fallback for pipeline restarts), mutate task status, publish `DELTA_TASK_STATUS`.
  - `task_progress` → bus-only fan-out (high-frequency, non-terminal; not persisted).
  - `drift_detected` → `DELTA_DRIFT`.
  - Unknown payload → logged and ignored for forward-compat.
- **`server/harmonograf_server/convert.py`** — new `goldfive_pb_plan_to_storage` + `goldfive_pb_task_to_storage` helpers; `_drift_kind_pb_to_string` / `_drift_severity_pb_to_string` normalize goldfive enum ints into the lowercase strings harmonograf persists on `revision_kind` / `revision_severity`.
- **`server/harmonograf_server/bus.py`** — new delta kinds (`DELTA_RUN_STARTED` / `_COMPLETED` / `_ABORTED`, `DELTA_GOAL_DERIVED`, `DELTA_DRIFT`, `DELTA_TASK_PROGRESS`) plus convenience publishers with dict payloads (frontend proto shapes come in a later phase).

### Storage

No schema changes. `storage/base.py` already re-exports `goldfive.types.Task` / `.TaskEdge` / `.TaskStatus` from Phase A, so the ingest handlers just build the existing `TaskPlan` wrapper dataclass.

### Tests

- **`client/tests/test_harmonograf_sink.py`** (11 cases) — envelope kind + payload round-trip, `TelemetryUp` wrap compatibility, sequence/run_id preservation, close idempotence, emit-after-close silent drop, backpressure doesn't raise.
- **`server/tests/test_goldfive_ingest.py`** (15 cases) — run lifecycle deltas, goal fan-out, plan_submitted persistence + index population, plan_submitted with missing id drops cleanly, plan_revised metadata merge, full task status transition matrix (including BLOCKED / CANCELLED), task_progress fan-out-without-persist, drift delta shape, unknown payload silent ignore, `_task_index` repopulation from store after a simulated pipeline restart.
- **Integration smoke** — `HarmonografSink.emit` → ring-buffer → `TelemetryUp(goldfive_event=...)` → `IngestPipeline.handle_message` → storage upserts the plan. Verified end-to-end.

### Test delta

- Client: 583 passed / 1 skipped (was 572 / 1 — +11 sink tests, no regressions).
- Server: 253 passed / 1 skipped (was 238 / 1 — +15 goldfive ingest tests).
- e2e: 9 passed / 2 skipped (unchanged).

### Goldfive issues filed

None — goldfive's public API (`EventSink` protocol, `events_pb2`, `types_pb2`, conv helpers) was sufficient.

## Test plan

- [x] `HarmonografSink.emit` round-trips every event payload kind via a fake transport
- [x] Server ingest persists plans and fans out deltas for each event kind
- [x] `_task_index` repopulates from storage on pipeline restart
- [x] `presentation_agent` module imports cleanly
- [x] Full client + server + e2e suites pass
