### PR TITLE
Update README + AGENTS narrative for goldfive integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,39 +4,65 @@ This file provides guidance to agents, including Claude Code, Antigravity, Openc
 
 ## Project vision
 
-Harmonograf is a console for understanding, interacting with, and coordinating multi-agent frameworks. The repository is currently a blank slate (only a README) — architectural decisions below are intent, not yet implemented.
+Harmonograf is the observability console for agent workflows orchestrated by
+[goldfive](https://github.com/pedapudi/goldfive). Goldfive owns the plan, the
+task state machine, the drift taxonomy, the reporting tools, and the re-invocation
+loop. Harmonograf owns the session, the span timeline, the canonical storage, the
+Gantt/graph frontend, and the control router that lets a human intervene on the
+same connection they observe on.
+
+The line is load-bearing: orchestration changes belong in goldfive; observability
+and UI changes belong in harmonograf. If a change has to straddle both, the
+goldfive-side change lands first and harmonograf follows.
 
 ## High-level architecture
 
-Three components are planned, and changes usually span more than one of them:
+Three components, and changes usually span more than one of them:
 
-1. **Visual frontend** — a Gantt-chart-style view. X-axis is time, Y-axis is one row per agent, and each block represents an agent activity (e.g., a tool call, a step, a span). Blocks are interactive (clickable) to drill into details. This is the human-facing surface for observing and coordinating agents.
+1. **Visual frontend** (`frontend/`) — a Gantt-chart-style view. X-axis is time, Y-axis is one row per agent, and each block represents an agent activity (span, tool call, transfer). Blocks are interactive (clickable) to drill into details. Plan and task state surfaces are rendered from goldfive events (`PlanSubmitted`, `PlanRevised`, `TaskStarted`, `TaskCompleted`, `TaskFailed`, `DriftDetected`, …) delivered through the harmonograf server. This is the human-facing surface for observing and coordinating agents.
 
-2. **Client library** — embedded inside agent implementations to emit activity to the server. It must be compatible with ADK (Google's Agent Development Kit) as a first-class integration target, so its data model and hooks should map cleanly onto ADK concepts. Multiple agents (multiple processes) will use the client library concurrently.
+2. **Client library** (`client/`) — embedded inside agent processes. Two public surfaces: `Client` handles the span transport, payload upload, control-handler registration, identity, heartbeat; `HarmonografSink` is a `goldfive.EventSink` that translates goldfive `Event` envelopes into harmonograf `TelemetryUp` frames. Users construct a `goldfive.Runner`, install a `HarmonografSink`, and the run's plan/task/drift events reach the frontend alongside the span stream. An optional `HarmonografTelemetryPlugin` (ADK `BasePlugin`) emits spans for ADK callbacks when users want framework-level telemetry.
 
-3. **Server process** — hosts the visualization frontend and terminates connections from client libraries across all participating agents. It is the fan-in point: many clients, one server, one UI. It owns the canonical timeline and is the bridge that lets the frontend coordinate agents (not just observe them).
+3. **Server process** (`server/`) — hosts the frontend and terminates connections from client libraries across all participating agents. It is the fan-in point: many clients, one server, one UI. It owns the canonical timeline (sessions, agents, spans, annotations, payloads) and the derived plan/task index built from goldfive events. It is also the bridge that lets the frontend coordinate agents, not just observe them.
 
 Key cross-cutting concerns to keep in mind when designing any piece:
-- The data model (agent, activity/block, time range, metadata payload) is shared across all three components and should be defined once.
+- The data model for observability (session, agent, span, payload, annotation, control event) is defined once in `proto/harmonograf/v1/*.proto` and shared across all three components.
+- Plan, task, drift, and reporting-tool types are defined once in `proto/goldfive/v1/*.proto` and imported into harmonograf's proto tree. Do not re-declare them in harmonograf.
 - The frontend is not read-only — interactions flow back through the server to clients, so the client library needs a bidirectional channel, not just telemetry egress.
-- "Coordinating" implies the server may mediate control, not just display — design client APIs with that in mind rather than treating it purely as an observability tool.
+- "Coordinating" implies the server may mediate control (pause, resume, steer, cancel), not just display — design client APIs with that in mind rather than treating it purely as an observability tool.
 
-## Plan execution protocol
+## Goldfive integration
 
-Harmonograf tracks task progression via three coordinated channels, not via span-lifecycle inference:
+Harmonograf's protocol carries goldfive events as a first-class variant:
 
-1. **session.state** — ADK's shared mutable dict. Harmonograf writes `harmonograf.current_task_id`, `harmonograf.plan_id`, `harmonograf.plan_summary`, `harmonograf.available_tasks`, and `harmonograf.completed_task_results` before each model call. Agents read those keys and may write back `harmonograf.task_progress`, `harmonograf.task_outcome`, `harmonograf.agent_note`, and `harmonograf.divergence_flag`. The full schema (keys, readers, writers, diffing helper) lives in `client/harmonograf_client/state_protocol.py`.
+- `proto/harmonograf/v1/telemetry.proto` imports `goldfive/v1/events.proto` and declares a `goldfive.v1.Event goldfive_event` field inside `TelemetryUp`. Plan and task state ride that variant; the old harmonograf-native `task_plan` / `task_status_update` envelopes are retired.
+- `proto/harmonograf/v1/types.proto` imports goldfive's `Plan`, `Task`, `TaskEdge`, `TaskStatus`, and `DriftKind` rather than re-declaring them. Harmonograf-owned types (Session, Agent, Span, Payload, Annotation, Control*) stay local.
+- `client/harmonograf_client/sink.py` (`HarmonografSink`) is the adapter: `emit(event)` pushes a `GOLDFIVE_EVENT` envelope through the existing ring-buffered transport, which serialises it to a `TelemetryUp(goldfive_event=...)` frame.
+- `server/harmonograf_server/ingest.py` dispatches on `event.payload` (oneof) and updates the plan/task index, storage, and the session bus so frontend subscribers see deltas.
 
-2. **Reporting tools** — `report_task_started`, `report_task_progress`, `report_task_completed`, `report_task_failed`, `report_task_blocked`, `report_new_work_discovered`, and `report_plan_divergence` are injected into every sub-agent by `HarmonografAgent`. Agents call them explicitly at task boundaries; harmonograf intercepts the calls in `before_tool_callback` and applies state transitions directly in `_AdkState` — the tool bodies themselves only return `{"acknowledged": true}`. See [`docs/reporting-tools.md`](docs/reporting-tools.md) for the full reference.
+Orchestration semantics — session-state keys, reporting tool bodies, drift
+taxonomy, refine pipeline, invariant validator, parallel DAG walker — are
+goldfive concerns. When a question is "why does the agent state machine behave
+this way?", the answer lives in the goldfive repo. When a question is "why did
+the timeline render this span where it did?", the answer lives here.
 
-3. **ADK callback inspection** — `after_model_callback` parses response content for structured signals (function_calls, explicit markers like "Task complete:", state_delta writes). `on_event_callback` watches for transfer / escalate / state_delta events. These paths exist as belt-and-suspenders for models that describe their work in prose instead of calling the reporting tools.
+## Component boundaries
 
-Spans are still emitted for every ADK callback (INVOCATION / LLM_CALL / TOOL_CALL / TRANSFER / etc.), but they are **telemetry only** — they no longer drive task state. The state machine is monotonic, walker-owned for parallel mode, and callback-driven for sequential/delegated modes.
+- **Span emission is harmonograf's job.** ADK callbacks (BEFORE/AFTER model/tool/run, state_delta, transfer, escalate) are turned into spans by `HarmonografTelemetryPlugin`. Goldfive does not produce spans.
+- **Task state is goldfive's job.** State transitions happen inside goldfive's `DefaultSteerer` when a reporting tool is called or when an ADK event implies a transition. Harmonograf learns about those transitions only through goldfive events on the sink.
+- **Control routing is harmonograf's job.** The frontend → server → agent path (pause, resume, steer, cancel, annotate) rides harmonograf's control stream. Goldfive exposes hooks that let an orchestrated run react to delivered control events, but the wire is harmonograf's.
+- **Session is harmonograf's job.** Goldfive has a `run_id`; harmonograf pairs it with a `session_id` at the storage layer. One goldfive run maps to one harmonograf session.
 
-`HarmonografAgent` runs in one of three orchestration modes:
+## Things explicitly deleted from the pre-goldfive era
 
-- **Sequential** (default, `orchestrator_mode=True, parallel_mode=False`) — the whole plan is fed as one user turn and the coordinator LLM executes it; per-task lifecycle is reported via the reporting tools.
-- **Parallel** (`orchestrator_mode=True, parallel_mode=True`) — the rigid DAG batch walker drives sub-agents directly per task using a forced `task_id` ContextVar, respecting plan edges as dependencies.
-- **Delegated** (`orchestrator_mode=False`) — a single delegation with the event observer scanning for drift afterward; the inner agent is in charge of its own task sequencing.
+If you see these in docs or code, they are retired — do not bring them back:
 
-Dynamic replan triggers: tool errors, agent refusals, context pressure, new work discovered, plan divergence, user steer/cancel, and ~15 other drift kinds fire deferential `refine` calls that produce revised plans live in the UI. The refine path calls back into the planner with the current plan + drift context and upserts the result through `TaskRegistry`, which recomputes the diff so the frontend banner/drawer can visualize exactly what changed (see `frontend/src/gantt/index.ts :: computePlanDiff`).
+- `HarmonografAgent`, `HarmonografRunner`, `attach_adk`, `make_adk_plugin`, `make_harmonograf_agent`, `make_harmonograf_runner` — replaced by `goldfive.Runner` + `HarmonografSink`.
+- `_AdkState`, `PlannerHelper`, `LLMPlanner`, `PassthroughPlanner` — replaced by goldfive's steerer/planner.
+- `state_protocol.py` with the `harmonograf.*` session-state keys — replaced by goldfive's `SessionContext`.
+- `invariants.py`, `metrics.py` in the client — invariant checking is goldfive's responsibility.
+- `TaskPlan` / `UpdatedTaskStatus` envelopes in `TelemetryUp` — replaced by `goldfive_event`.
+- Duplicate `Task` / `TaskEdge` / `TaskStatus` / `DriftKind` messages in `types.proto` — imported from goldfive instead.
+
+The full inventory of what moved, what stayed, and what was deleted is in
+[docs/goldfive-migration-plan.md](docs/goldfive-migration-plan.md).

--- a/README.md
+++ b/README.md
@@ -1,39 +1,42 @@
 # Harmonograf
 
-**A console for observing, understanding, and coordinating multi-agent systems.**
+**The observability console for agent workflows orchestrated by [goldfive](https://github.com/pedapudi/goldfive).**
 
-Harmonograf gives you a Gantt-chart-style view of what a fleet of agents is doing in
-real time — who is running, which task they are on, what tool they just called, where
-the plan has drifted, and which runs are stuck. It is not a passive log viewer: the
-server terminates bidirectional connections from every participating client, so the
-UI can steer agents back through the same channel it observes them on.
-
-The first-class integration target is [Google's Agent Development Kit
-(ADK)](https://github.com/google/adk-python). Harmonograf ships with an ADK plugin
-that wires up telemetry, reporting tools, and bidirectional control with one line of
-code and no changes to your agent graph.
+Harmonograf stores the event timeline produced by a goldfive run, renders it as a
+Gantt-chart-style view in a browser, and lets humans intervene with control
+events on the same connection it observes them on. Goldfive owns the plan, task
+state machine, drift taxonomy, and reporting tools; harmonograf owns the
+session, the span timeline, the UI, storage, and the control router.
 
 ---
 
 ## What is Harmonograf?
 
-Multi-agent systems break every assumption that single-agent observability tools are
-built on. A chat completion is no longer an "operation" — it is one beat inside a
-rollout that may span five sub-agents, parallel branches, mid-flight replans, and
-tool calls whose outputs feed tasks nobody planned ten seconds earlier. Span trees
-flatten that structure into nested boxes and then ask you to reconstruct the story.
+Multi-agent systems break every assumption that single-agent observability tools
+are built on. A chat completion is no longer an "operation" — it is one beat
+inside a rollout that may span five sub-agents, parallel branches, mid-flight
+replans, and tool calls whose outputs feed tasks nobody planned ten seconds
+earlier. Span trees flatten that structure into nested boxes and then ask you to
+reconstruct the story.
 
-Harmonograf keeps the story first-class:
+Goldfive provides the orchestration primitives that make the story first-class —
+plans are data, task state is explicit, drift is a first-class event, and
+reporting tools are the contract between agent and framework. Harmonograf is the
+screen you watch that story on:
 
-- **Plans are data.** Every run starts with a plan, every task has an explicit
-  lifecycle, and the state machine is monotonic and driven by the agent itself, not
-  inferred from when a span closed.
-- **Drift is a first-class event.** Tool errors, refusals, new work discovered,
-  plan divergence, and ~20 other drift kinds fire a deferential "refine" call that
-  produces a revised plan, live in the UI, with a visual diff against the old one.
-- **The UI talks back.** The same connection that streams telemetry up also streams
-  control down — pause, resume, send a note, steer, cancel. The frontend is a
-  coordination surface, not a read-only dashboard.
+- **One canonical timeline.** The server terminates goldfive event streams from
+  every participating agent and fans them out to any number of frontend
+  subscribers. One server, many agents, many viewers.
+- **Plan-aware UI.** The Gantt, the inspector, and the plan-diff drawer all
+  render goldfive's plan / task / drift semantics directly. When goldfive fires
+  a `PlanRevised` event, the frontend shows the diff with the old plan side by
+  side.
+- **Bidirectional by default.** The same connection that streams telemetry up
+  also streams control down — pause, resume, steer, cancel, annotate — so the
+  UI is a coordination surface, not a read-only dashboard.
+
+Integration is a single-line install: construct a `goldfive.Runner`, attach a
+`HarmonografSink`, and the run's events start materialising in the UI.
 
 ### Screenshots
 
@@ -61,15 +64,17 @@ Harmonograf keeps the story first-class:
 
 ## Architecture
 
-Harmonograf is three components that share one data model. Telemetry flows up from agents through the server to the browser; control messages flow back down on the same connections.
+Harmonograf is three components that share one data model. Telemetry (spans +
+goldfive events) flows up from agents through the server to the browser;
+control messages flow back down on the same connections.
 
 ```mermaid
 flowchart TD
     UI[Frontend<br/>Gantt + Graph + Diff]
     Server[harmonograf-server<br/>fan-in · store · control]
-    A[agent A<br/>ADK + client]
-    B[agent B<br/>ADK + client]
-    C[agent C<br/>ADK + client]
+    A[agent A<br/>goldfive.Runner<br/>+ HarmonografSink]
+    B[agent B<br/>goldfive.Runner<br/>+ HarmonografSink]
+    C[agent C<br/>goldfive.Runner<br/>+ HarmonografSink]
     UI <-- "gRPC-Web :7532" --> Server
     Server <-- "gRPC :7531" --> A
     Server <-- "gRPC :7531" --> B
@@ -80,24 +85,16 @@ flowchart TD
 |---|---|---|---|
 | **Frontend** | `frontend/` | TypeScript / React / Vite | Gantt timeline, agent topology graph, plan-diff drawer, inspector, transport bar. Talks gRPC-Web to the server. |
 | **Server** | `server/` | Python / asyncio / grpcio | Terminates connections from every client, owns the canonical timeline, stores it (SQLite or in-memory), and fans out live updates to any number of frontend subscribers. Also the control bridge. |
-| **Client library** | `client/` | Python | Embedded inside each agent. Ships with an ADK plugin (`attach_adk`), reporting tools, a DAG walker for parallel mode, session-state protocol, and a buffered transport that survives server restarts. |
+| **Client library** | `client/` | Python | Embedded inside each agent. Provides `Client` (span transport, payload upload, control handlers) and `HarmonografSink` — a `goldfive.EventSink` that forwards goldfive plan / task / drift events into the harmonograf telemetry stream. |
 
-The data model (`Session`, `Agent`, `Task`, `Plan`, `Span`, `Payload`, `ControlMessage`)
-is defined once in `proto/harmonograf/v1/*.proto` and regenerated into all three
-components via `make proto`.
+Orchestration semantics — plans, tasks, drift kinds, reporting tools, refine
+pipeline, session-state protocol — live in [goldfive](https://github.com/pedapudi/goldfive).
+Harmonograf consumes them, it does not define them.
 
-### Orchestration modes
-
-`HarmonografAgent` can run an ADK agent graph in one of three modes, selected by
-`orchestrator_mode` and `parallel_mode`:
-
-| Mode | Flags | How the plan executes |
-|---|---|---|
-| **Sequential** (default) | `orchestrator_mode=True, parallel_mode=False` | The plan is fed as one user turn and the coordinator LLM executes it; per-task lifecycle is reported via the reporting tools. |
-| **Parallel** | `orchestrator_mode=True, parallel_mode=True` | A rigid-DAG batch walker drives sub-agents directly, respecting plan edges as dependencies and using a forced `task_id` ContextVar so parallel branches never race. |
-| **Delegated** | `orchestrator_mode=False` | A single delegation with an event observer scanning for drift afterward; the inner agent is in charge of its own task sequencing. |
-
-Full protocol reference: [docs/protocol/](docs/protocol/).
+The data model shared between client, server, and frontend is defined in
+`proto/harmonograf/v1/*.proto`. Goldfive's `Event` envelope is imported from
+`goldfive/v1/events.proto` and rides through harmonograf's `TelemetryUp` as a
+first-class variant. Regenerate stubs with `make proto`.
 
 ---
 
@@ -132,9 +129,10 @@ make demo
 
 `make demo` starts three processes in one foreground shell: `harmonograf-server`
 on `127.0.0.1:7531` (gRPC) + `:7532` (gRPC-Web), the Vite frontend on
-`http://127.0.0.1:5173`, and `adk web` hosting `presentation_agent` on
-`http://127.0.0.1:8080`. Drive a presentation from the ADK tab; watch the timeline
-materialise live in the harmonograf tab. Ctrl-C tears all three down.
+`http://127.0.0.1:5173`, and `adk web` hosting the goldfive-orchestrated
+reference agent on `http://127.0.0.1:8080`. Drive a rollout from the ADK tab;
+watch the timeline materialise live in the harmonograf tab. Ctrl-C tears all
+three down.
 
 ---
 
@@ -144,21 +142,28 @@ materialise live in the harmonograf tab. Ctrl-C tears all three down.
 |---|---|
 | [docs/overview.md](docs/overview.md) | Longer-form writeup: motivation, design principles, current features, non-goals, roadmap. Start here after this README. |
 | [docs/quickstart.md](docs/quickstart.md) | Step-by-step from clone to running demo, with troubleshooting and local-LLM wiring. |
+| [docs/goldfive-integration.md](docs/goldfive-integration.md) | How harmonograf consumes goldfive: `HarmonografSink`, the `goldfive_event` envelope, the split of responsibilities. |
+| [docs/goldfive-migration-plan.md](docs/goldfive-migration-plan.md) | The design record for the harmonograf → goldfive migration; what moved, what stayed, what was deleted. |
 | [docs/operator-quickstart.md](docs/operator-quickstart.md) | Flags, retention, health probes, bearer-token auth — the ops-facing reference. |
-| [docs/reporting-tools.md](docs/reporting-tools.md) | The reporting-tool protocol agents use to communicate task state. |
 | [docs/user-guide/](docs/user-guide/) | Navigating the UI: Gantt, graph, inspector, diff drawer, transport bar, keyboard shortcuts. |
 | [docs/dev-guide/](docs/dev-guide/) | Building from source, adding a storage backend, wiring a new framework adapter, writing tests. |
-| [docs/protocol/](docs/protocol/) | Wire protocol, proto reference, session-state schema, drift taxonomy, plan-diff semantics. |
+| [docs/protocol/](docs/protocol/) | Wire protocol, proto reference, span lifecycle, control stream. |
 | [docs/design/](docs/design/) | Per-component design notes — data model, client library, server, frontend, human-interaction model, information flow. |
 | [docs/milestones.md](docs/milestones.md) | Incremental delivery plan. |
+
+Orchestration references (reporting tools, drift taxonomy, task state machine,
+session-state protocol) now live in the [goldfive](https://github.com/pedapudi/goldfive)
+docs. Pages under `docs/` that described those topics in the standalone era
+carry a DEPRECATED banner pointing to goldfive.
 
 ---
 
 ## Status
 
 Harmonograf is pre-1.0 and under active development. The demo flow (`make demo`
-against `presentation_agent`) is the canonical smoke test — if it runs green, the
-core pipeline is healthy.
+against the reference goldfive agent) is the canonical smoke test — if it runs
+green, the ingest → storage → bus → frontend pipeline is healthy for both spans
+and goldfive events.
 
 Deliberate non-goals for v0 are listed in
 [docs/overview.md](docs/overview.md#non-goals); notable ones include TLS,
@@ -169,14 +174,16 @@ clustering, and multi-tenant auth.
 ## Contributing
 
 Contributions are welcome. Before starting non-trivial work, read
-[AGENTS.md](AGENTS.md) for the project vision and the plan-execution protocol, and
-[docs/design/](docs/design/) for the component the change touches. A developer guide
-with local-dev workflows, test matrix, and release process is landing as
-[docs/dev-guide/](docs/dev-guide/).
+[AGENTS.md](AGENTS.md) for the project vision and the component split between
+harmonograf and goldfive, and [docs/design/](docs/design/) for the component the
+change touches. A developer guide with local-dev workflows, test matrix, and
+release process is landing as [docs/dev-guide/](docs/dev-guide/).
 
-Ground rules: don't invent features when existing features can be extended, prefer 
-editing existing files over creating new ones, and if you change the proto run
-`make proto` and commit the regenerated stubs alongside the source change.
+Ground rules: don't invent features when existing features can be extended,
+prefer editing existing files over creating new ones, keep orchestration changes
+in goldfive and observability changes in harmonograf, and if you change the
+proto run `make proto` and commit the regenerated stubs alongside the source
+change.
 
 ---
 

--- a/docs/adr/0011-reporting-tools-over-span-inference.md
+++ b/docs/adr/0011-reporting-tools-over-span-inference.md
@@ -1,3 +1,11 @@
+> **DEPRECATED (goldfive migration).** Reporting-tool ownership and task-state
+> logic now live in [goldfive](https://github.com/pedapudi/goldfive). This ADR
+> records the reasoning as it stood when harmonograf owned orchestration; the
+> decision itself stands (reporting tools beat span inference), it is just
+> expressed in goldfive now. See
+> [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # ADR 0011 — Reporting tools drive task state, not span lifecycle
 
 ## Status

--- a/docs/adr/0011a-span-lifecycle-inference-superseded.md
+++ b/docs/adr/0011a-span-lifecycle-inference-superseded.md
@@ -1,3 +1,8 @@
+> **DEPRECATED (goldfive migration).** Task-state concerns have moved to
+> [goldfive](https://github.com/pedapudi/goldfive); this historical record is
+> kept for context only. See
+> [../goldfive-integration.md](../goldfive-integration.md).
+
 # ADR 0011a — Span-lifecycle inference for task state (Superseded)
 
 ## Status

--- a/docs/adr/0012-three-orchestration-modes.md
+++ b/docs/adr/0012-three-orchestration-modes.md
@@ -1,3 +1,10 @@
+> **DEPRECATED (goldfive migration).** Orchestration modes now live in
+> [goldfive](https://github.com/pedapudi/goldfive) (`goldfive.executors`,
+> `goldfive.runner`). Harmonograf consumes the resulting events but does not
+> define the modes. See
+> [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # ADR 0012 — Three orchestration modes (sequential, parallel, delegated)
 
 ## Status

--- a/docs/adr/0013-drift-as-first-class.md
+++ b/docs/adr/0013-drift-as-first-class.md
@@ -1,3 +1,10 @@
+> **DEPRECATED (goldfive migration).** The drift taxonomy and refine pipeline
+> now live in [goldfive](https://github.com/pedapudi/goldfive). Harmonograf
+> renders `DriftDetected` / `PlanRevised` events from the goldfive stream but
+> no longer owns the taxonomy. See
+> [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # ADR 0013 — Drift is a first-class event
 
 ## Status

--- a/docs/adr/0014-session-state-as-coordination-channel.md
+++ b/docs/adr/0014-session-state-as-coordination-channel.md
@@ -1,3 +1,9 @@
+> **DEPRECATED (goldfive migration).** The `harmonograf.*` session-state keys
+> described here have been replaced by goldfive's `SessionContext`
+> (`goldfive.adapters.adk`). See
+> [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # ADR 0014 — `session.state` is the coordination channel
 
 ## Status

--- a/docs/adr/0015-invariants-as-safety-net.md
+++ b/docs/adr/0015-invariants-as-safety-net.md
@@ -1,3 +1,9 @@
+> **DEPRECATED (goldfive migration).** The invariant validator described here
+> (`client/harmonograf_client/invariants.py`) has been deleted; invariant
+> checking is a goldfive concern now. See
+> [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # ADR 0015 — Ship the invariant validator to production
 
 ## Status

--- a/docs/adr/0017-monotonic-task-state.md
+++ b/docs/adr/0017-monotonic-task-state.md
@@ -1,3 +1,9 @@
+> **DEPRECATED (goldfive migration).** Task-state ownership has moved to
+> [goldfive](https://github.com/pedapudi/goldfive). The monotonicity property
+> still holds, but it is enforced in goldfive's steerer now. See
+> [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # ADR 0017 — Task state is monotonic; terminal states absorb
 
 ## Status

--- a/docs/design/12-client-library-and-adk.md
+++ b/docs/design/12-client-library-and-adk.md
@@ -1,3 +1,11 @@
+> **DEPRECATED (goldfive migration).** This document describes the pre-goldfive
+> client library (HarmonografAgent, \_AdkState, attach\_adk, reporting-tool
+> injection). The orchestration pieces have moved to
+> [goldfive](https://github.com/pedapudi/goldfive); the surviving harmonograf
+> client is `Client` (span transport) + `HarmonografSink` (goldfive event
+> adapter). See [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # 12. Client Library and ADK Integration
 
 ## Executive Summary

--- a/docs/dev-guide/client-library.md
+++ b/docs/dev-guide/client-library.md
@@ -1,3 +1,11 @@
+> **DEPRECATED (goldfive migration).** This page describes the pre-goldfive
+> client library, which carried orchestration and state-machine logic. Those
+> pieces have moved to [goldfive](https://github.com/pedapudi/goldfive); the
+> surviving harmonograf client is `Client` (span transport) + `HarmonografSink`
+> (goldfive event adapter). See
+> [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # Client library internals
 
 The client library (`client/harmonograf_client/`) is the biggest and

--- a/docs/goldfive-integration.md
+++ b/docs/goldfive-integration.md
@@ -1,0 +1,67 @@
+# Goldfive integration
+
+**Status:** stub. Full reference lands in Phase D of the migration. Until then,
+this page is a short map of how harmonograf consumes goldfive and where each
+responsibility lives.
+
+For the design record and file-by-file migration rationale, see
+[goldfive-migration-plan.md](goldfive-migration-plan.md).
+
+---
+
+## Split of responsibilities
+
+| Concern | Owner | Where |
+|---|---|---|
+| Plan representation (`Plan`, `Task`, `TaskEdge`, `TaskStatus`, `DriftKind`) | goldfive | `proto/goldfive/v1/types.proto` |
+| Task state machine and drift taxonomy | goldfive | `goldfive.DefaultSteerer`, `goldfive.drift` |
+| Reporting tools (`report_task_started`, `report_task_completed`, …) | goldfive | `goldfive.reporting` |
+| Session-state protocol (`SessionContext` on ADK state) | goldfive | `goldfive.adapters.adk` |
+| Orchestration modes (sequential, parallel DAG walker, delegated) | goldfive | `goldfive.executors`, `goldfive.runner` |
+| Span timeline, session, storage | harmonograf | `server/`, `client/harmonograf_client/client.py` |
+| Gantt / graph / inspector / plan-diff UI | harmonograf | `frontend/` |
+| Control routing (pause, resume, steer, cancel, annotate) | harmonograf | `proto/harmonograf/v1/control.proto`, `server/harmonograf_server/control.py` |
+| `goldfive.EventSink` adapter | harmonograf | `client/harmonograf_client/sink.py` |
+
+## Wire shape
+
+Goldfive events travel through harmonograf's existing telemetry stream. The
+variant lives in `TelemetryUp`:
+
+```proto
+message TelemetryUp {
+  // ... span / payload / heartbeat variants unchanged ...
+  goldfive.v1.Event goldfive_event = 11;
+}
+```
+
+`HarmonografSink.emit(event)` pushes a `GOLDFIVE_EVENT` envelope through the
+client's ring buffer; the transport serialises it as a `TelemetryUp` frame; the
+server's ingest dispatches on `event.payload` (oneof) and updates the plan/task
+index + session bus.
+
+## Wiring a goldfive run to harmonograf
+
+```python
+import goldfive
+from harmonograf_client import Client, HarmonografSink
+
+client = Client(agent_name="my-agent")
+runner = goldfive.Runner(
+    # ... planner, steerer, executor as usual ...
+    sinks=[HarmonografSink(client)],
+)
+await runner.run(task)
+```
+
+Optional: install `HarmonografTelemetryPlugin` on the ADK agent graph to emit
+spans for every ADK callback. Goldfive orchestration and harmonograf
+observability are independent; either works without the other, but the demo
+flow runs both.
+
+## Further reading
+
+- [goldfive-migration-plan.md](goldfive-migration-plan.md) — the design record.
+- [../AGENTS.md](../AGENTS.md) — project vision and component boundaries.
+- [protocol/telemetry-stream.md](protocol/telemetry-stream.md) — the wire stream that now carries goldfive events.
+- goldfive repo — orchestration semantics: <https://github.com/pedapudi/goldfive>.

--- a/docs/internals/adk-plugin-tour.md
+++ b/docs/internals/adk-plugin-tour.md
@@ -1,3 +1,10 @@
+> **DEPRECATED (goldfive migration).** `client/harmonograf_client/adk.py` has
+> been deleted. ADK integration now comes from goldfive's `ADKAdapter`
+> (`goldfive.adapters.adk`) plus a slim `HarmonografTelemetryPlugin` that
+> emits spans on the harmonograf side. See
+> [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # An annotated tour of `adk.py`
 
 `client/harmonograf_client/adk.py` is the single densest file in the repo, at

--- a/docs/internals/drift-taxonomy-catalog.md
+++ b/docs/internals/drift-taxonomy-catalog.md
@@ -1,3 +1,9 @@
+> **DEPRECATED (goldfive migration).** The drift taxonomy has moved to
+> [goldfive](https://github.com/pedapudi/goldfive). Harmonograf renders drift
+> events from the goldfive stream but does not define the kinds. See
+> [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # Drift taxonomy catalog
 
 Every drift kind that harmonograf fires during a run. A drift is a

--- a/docs/internals/harmonograf-agent-tour.md
+++ b/docs/internals/harmonograf-agent-tour.md
@@ -1,3 +1,10 @@
+> **DEPRECATED (goldfive migration).** `HarmonografAgent` has been deleted.
+> The three execution modes (sequential, parallel, delegated) now live in
+> [goldfive](https://github.com/pedapudi/goldfive) (`goldfive.Runner` +
+> `goldfive.executors`). Turn-boundary invariant checks are likewise goldfive's
+> concern. See [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # An annotated tour of `HarmonografAgent`
 
 `client/harmonograf_client/agent.py` (~1900 lines) is the thin orchestration

--- a/docs/internals/invariant-validator.md
+++ b/docs/internals/invariant-validator.md
@@ -1,3 +1,8 @@
+> **DEPRECATED (goldfive migration).** `client/harmonograf_client/invariants.py`
+> has been deleted. Invariant checking is a goldfive responsibility now. See
+> [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # The invariant validator
 
 `client/harmonograf_client/invariants.py` (427 lines) is a small, high-leverage

--- a/docs/protocol/task-state-machine.md
+++ b/docs/protocol/task-state-machine.md
@@ -1,3 +1,10 @@
+> **DEPRECATED (goldfive migration).** The task state machine, drift taxonomy,
+> and reporting-tool protocol have moved to
+> [goldfive](https://github.com/pedapudi/goldfive). Harmonograf receives these
+> as goldfive events on the telemetry stream — see
+> [../goldfive-integration.md](../goldfive-integration.md) and
+> [../goldfive-migration-plan.md](../goldfive-migration-plan.md).
+
 # Task state machine and plan-execution protocol
 
 Harmonograf tracks task progression via **three coordinated channels**,

--- a/docs/reporting-tools.md
+++ b/docs/reporting-tools.md
@@ -1,3 +1,11 @@
+> **DEPRECATED (goldfive migration).** Reporting tools now live in
+> [goldfive](https://github.com/pedapudi/goldfive) and are injected through
+> `goldfive.reporting` + the ADK adapter there. Harmonograf no longer owns the
+> reporting-tool surface or the `before_tool_callback` interception described
+> below. See [goldfive-integration.md](goldfive-integration.md) for the current
+> split of responsibilities and [goldfive-migration-plan.md](goldfive-migration-plan.md)
+> for the design record.
+
 # Reporting tools reference
 
 Harmonograf injects a small set of **reporting tools** into every sub-agent wrapped by `HarmonografAgent`. These tools are how an agent explicitly communicates task state to the orchestrator instead of making harmonograf guess from span lifecycle or prose output.


### PR DESCRIPTION
## Summary

Re-pitches harmonograf's user-facing narrative to match its post-goldfive role: observability console (GUI + storage + control routing) for agent workflows orchestrated by [goldfive](https://github.com/pedapudi/goldfive). Phases A+B have already landed (goldfive dependency + `HarmonografSink` + ingest path); Phase C (deleting the orchestration code and rewiring demos) is in flight on a sibling branch.

- Rewrite top-line pitch in `README.md` and the project-vision section of `AGENTS.md`. Keep architecture/component-boundary detail, but explicitly route orchestration semantics (plan, task state, drift, reporting tools, session-state protocol) to goldfive.
- Add `docs/goldfive-integration.md` as a stub — split of responsibilities, wire shape, wiring example, forward link to the full Phase-D reference.
- Mark orchestration-era pages as DEPRECATED with pointers to `goldfive-integration.md` / `goldfive-migration-plan.md`: `docs/reporting-tools.md`, `docs/protocol/task-state-machine.md`, `docs/adr/0011*`, `0012`, `0013`, `0014`, `0015`, `0017`, `docs/design/12-client-library-and-adk.md`, `docs/dev-guide/client-library.md`, `docs/internals/{adk-plugin-tour,harmonograf-agent-tour,drift-taxonomy-catalog,invariant-validator}.md`.

No code, protocol, or `goldfive-migration-plan.md` changes. Phase C's deletions and demo rewiring are explicitly out of scope for this PR.

## Test plan

- [ ] `README.md` renders cleanly on GitHub; screenshots + mermaid intact.
- [ ] `AGENTS.md` component-boundary section matches the new reality (goldfive owns orchestration, harmonograf owns observability + UI + control routing).
- [ ] Every DEPRECATED banner links resolve (`goldfive-integration.md`, `goldfive-migration-plan.md`).
- [ ] `docs/goldfive-integration.md` renders and its links resolve.
