### PR TITLE
Default Client server_addr to :7531 (match server + docs)

### DIFF
--- a/client/harmonograf_client/__init__.py
+++ b/client/harmonograf_client/__init__.py
@@ -16,7 +16,7 @@ ADK app for per-span observability::
     from goldfive.adapters.adk import ADKAdapter
     from harmonograf_client import Client, HarmonografSink
 
-    client = Client(name="research", server_addr="127.0.0.1:50431")
+    client = Client(name="research", server_addr="127.0.0.1:7531")
     runner = Runner(
         agent=ADKAdapter(root_agent),
         planner=LLMPlanner(call_llm=...),

--- a/client/harmonograf_client/client.py
+++ b/client/harmonograf_client/client.py
@@ -78,7 +78,7 @@ class Client:
         framework: str = "CUSTOM",
         framework_version: str = "",
         capabilities: Iterable[str | Capability] = (),
-        server_addr: str = "127.0.0.1:50431",
+        server_addr: str = "127.0.0.1:7531",
         buffer_size: int = 2000,
         payload_buffer_bytes: int = 16 * 1024 * 1024,
         payload_chunk_bytes: int = 256 * 1024,

--- a/client/harmonograf_client/sink.py
+++ b/client/harmonograf_client/sink.py
@@ -28,7 +28,7 @@ class HarmonografSink:
         from goldfive import Runner
         from harmonograf_client import Client, HarmonografSink
 
-        client = Client(name="research", server_addr="localhost:50431")
+        client = Client(name="research", server_addr="127.0.0.1:7531")
         sink = HarmonografSink(client)
         runner = Runner(..., sinks=[sink])
         await runner.run(user_request)

--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -12,7 +12,7 @@ plugin to the ADK ``App`` that ``adk web`` / ``adk run`` builds::
     from google.adk.apps.app import App
     from harmonograf_client import Client, HarmonografTelemetryPlugin
 
-    client = Client(name="research", server_addr="127.0.0.1:50431")
+    client = Client(name="research", server_addr="127.0.0.1:7531")
     app = App(root_agent=..., plugins=[HarmonografTelemetryPlugin(client)])
 
 The plugin is safe to install alongside ``goldfive.adapters.adk`` 's

--- a/client/harmonograf_client/transport.py
+++ b/client/harmonograf_client/transport.py
@@ -63,7 +63,7 @@ BREAKER_HALF_OPEN = "half_open"
 
 @dataclasses.dataclass
 class TransportConfig:
-    server_addr: str = "127.0.0.1:50431"
+    server_addr: str = "127.0.0.1:7531"
     heartbeat_interval_s: float = HEARTBEAT_INTERVAL_S
     reconnect_initial_ms: int = RECONNECT_INITIAL_MS
     reconnect_max_ms: int = RECONNECT_MAX_MS


### PR DESCRIPTION
## Summary
- `harmonograf_client.Client`'s internal default `server_addr` was `127.0.0.1:50431`, but the real server and all user-facing docs use `127.0.0.1:7531`. Users constructing `Client()` with no args got broken behavior.
- Align the library default with the server's default listen port (`server/harmonograf_server/config.py` / `cli.py`), and update the docstring examples in the client package (`client.py`, `transport.py`, `__init__.py`, `sink.py`, `telemetry_plugin.py`) to match.
- The `HARMONOGRAF_SERVER` env-var override pattern used by callers (e.g. `tests/reference_agents/presentation_agent/agent.py`) is unaffected — the client library accepts `server_addr` as a constructor arg and doesn't read the env var itself.

## Test plan
- [x] `make server-test` — 254 passed, 1 skipped
- [x] `make client-test` — 119 passed
- [x] `grep -rn 50431 client/ server/ tests/` — no matches remain
