### PR TITLE
docs: purge stale :50431 port references

### DIFF
--- a/docs/design/02-client-library.md
+++ b/docs/design/02-client-library.md
@@ -22,7 +22,7 @@ This doc presupposes the wire protocol in `01-data-model-and-rpc.md`. Anything w
 2. **One-line ADK integration.** `harmonograf_client.attach_adk(runner)` is the whole onboarding story for the most common case. Custom frameworks get a thin manual API and the same primitives the ADK adapter uses.
 3. **Crash-safe identity.** A restarted agent reclaims its row in the Gantt chart. Restarts don't fragment the timeline.
 4. **Visible failure.** When the client drops events or evicts payloads, the user sees it in the Gantt agent header — not in a log file the user will never read.
-5. **No required configuration.** `Client()` with zero args produces a working setup against `127.0.0.1:50431` (the default local server port) with sensible defaults for everything.
+5. **No required configuration.** `Client()` with zero args produces a working setup against `127.0.0.1:7531` (the default local server port) with sensible defaults for everything.
 
 ---
 
@@ -117,7 +117,7 @@ client = Client(
     name="research-agent",        # required, display name
     session_id=None,              # None → auto-generate or join
     agent_id=None,                # None → load-or-create from disk
-    server_addr="127.0.0.1:50431",
+    server_addr="127.0.0.1:7531",
     capabilities={Capability.PAUSE_RESUME, Capability.STEERING},
     framework="custom",
     framework_version="0.1.0",
@@ -507,7 +507,7 @@ This keeps the Gantt y-axis count manageable: one row per process, not one row p
 
 | Field | Default | Env var |
 |---|---|---|
-| `server_addr` | `"127.0.0.1:50431"` | `HARMONOGRAF_SERVER_ADDR` |
+| `server_addr` | `"127.0.0.1:7531"` | `HARMONOGRAF_SERVER_ADDR` |
 | `event_buffer_capacity` | 2000 | `HARMONOGRAF_EVENT_BUFFER` |
 | `payload_buffer_bytes` | 16 << 20 (16 MiB) | `HARMONOGRAF_PAYLOAD_BUFFER` |
 | `chunk_size_bytes` | 256 << 10 (256 KiB) | `HARMONOGRAF_CHUNK_SIZE` |

--- a/docs/design/03-server.md
+++ b/docs/design/03-server.md
@@ -468,7 +468,7 @@ usage: harmonograf-server [-h] [--port PORT] [--data-dir DATA_DIR]
 Harmonograf coordination console server.
 
 options:
-  --port PORT          gRPC port (default: 50431)
+  --port PORT          gRPC port (default: 7531)
   --data-dir DIR       Data directory for sqlite + payloads
                        (default: ~/.harmonograf/data)
   --store BACKEND      Storage backend: memory | sqlite (default: sqlite)
@@ -477,7 +477,7 @@ options:
   --log-level LEVEL    DEBUG | INFO | WARNING | ERROR (default: INFO)
 ```
 
-Defaults are chosen so `harmonograf-server` with no arguments runs a working server against a local SQLite store under `~/.harmonograf/data/` on port 50431. The client library defaults match.
+Defaults are chosen so `harmonograf-server` with no arguments runs a working server against a local SQLite store under `~/.harmonograf/data/` on port 7531. The client library defaults match.
 
 ### 8.1 Static frontend serving
 

--- a/docs/goldfive-integration.md
+++ b/docs/goldfive-integration.md
@@ -57,7 +57,7 @@ from harmonograf_client import Client, HarmonografSink
 
 root = Agent(name="researcher", model="openai/gpt-4o-mini")
 
-client = Client(name="researcher", server_addr="127.0.0.1:50431")
+client = Client(name="researcher", server_addr="127.0.0.1:7531")
 sink = HarmonografSink(client)
 
 runner = Runner(

--- a/docs/goldfive-migration-plan.md
+++ b/docs/goldfive-migration-plan.md
@@ -347,7 +347,7 @@ HarmonografAgent's value was the re-invocation loop + orchestration-mode switchi
 Old:
 ```python
 from harmonograf_client import Client, HarmonografAgent, make_harmonograf_runner
-client = Client(name="research", server_addr="localhost:50431")
+client = Client(name="research", server_addr="127.0.0.1:7531")
 wrapper = make_harmonograf_runner(agent=inner_agent, client=client)
 async for ev in wrapper.run_async(...):
     ...
@@ -359,7 +359,7 @@ from harmonograf_client import Client, HarmonografSink
 from goldfive import Runner, SequentialExecutor, LLMPlanner
 from goldfive.adapters.adk import ADKAdapter
 
-client = Client(name="research", server_addr="localhost:50431")
+client = Client(name="research", server_addr="127.0.0.1:7531")
 runner = Runner(
     agent=ADKAdapter(inner_agent),
     planner=LLMPlanner(...),
@@ -428,7 +428,7 @@ from harmonograf_client import make_runner
 
 runner, client = make_runner(
     inner_agent=root_agent,
-    server_addr=os.environ.get("HARMONOGRAF_SERVER", "localhost:50431"),
+    server_addr=os.environ.get("HARMONOGRAF_SERVER", "127.0.0.1:7531"),
     planner=goldfive.LLMPlanner(call_llm=..., model=root_agent.model),
 )
 # `app` is rebuilt to point at the goldfive Runner's underlying ADK runner.


### PR DESCRIPTION
## Summary

Cross-repo consistency pass after the harmonograf/goldfive docs audits. Canonical \`harmonograf-server\` port is \`:7531\` (set in \`server/harmonograf_server/config.py\` + \`cli.py\`; the client default in \`client/harmonograf_client/client.py\` already agrees). README, AGENTS, and recent PRs (#16, #65) all use \`:7531\`. Four docs still referenced the old default \`:50431\` — reconcile them so any snippet a reader copies connects to the real port:

- \`docs/goldfive-integration.md\` — worked example at line 60
- \`docs/design/02-client-library.md\` — design doc principle + constructor snippet + config table
- \`docs/design/03-server.md\` — CLI help output + defaults prose
- \`docs/goldfive-migration-plan.md\` — three migration snippets

Goldfive gets a sibling PR on its side that fixes the matching \`:50431\` reference in \`docs/guides/choosing-a-sink.md\`.

## Test plan

- [x] \`grep -rn 50431 docs\` returns nothing
- [x] Sample: \`Client(name=\"researcher\", server_addr=\"127.0.0.1:7531\")\` in \`goldfive-integration.md\` matches what the client defaults to
