### PR TITLE
Fix task-status persistence beyond first event (fixes #18)

### DIFF
--- a/client/harmonograf_client/transport.py
+++ b/client/harmonograf_client/transport.py
@@ -52,6 +52,10 @@ RECONNECT_INITIAL_MS = 100
 RECONNECT_MAX_MS = 30_000
 SEND_BATCH_MAX = 64
 PAYLOAD_CHUNK_INTERLEAVE = 10  # one chunk per N span messages
+# Upper bound on the shutdown-time wait for the server to close its
+# response stream after we sent Goodbye + EOF. Keeps a flush_timeout=5s
+# Client.shutdown from stalling indefinitely on a hung server.
+_SHUTDOWN_DRAIN_TIMEOUT_S = 2.0
 BREAKER_FAILURE_THRESHOLD = 10
 BREAKER_COOLDOWN_MS = 60_000
 
@@ -450,6 +454,24 @@ class Transport:
             {recv_task, control_task, send_task},
             return_when=asyncio.FIRST_COMPLETED,
         )
+        # On clean shutdown — send_task exited because ``_stop`` was set —
+        # the send_loop has already drained the ring buffer and put Goodbye
+        # + EOF on the queue. gRPC is still yielding those items to the
+        # server; cancelling recv_task now would abort the bidi call and
+        # drop pending events in transit. Wait for the server to close
+        # its side (recv_task returns naturally) before tearing down.
+        if (
+            self._stop.is_set()
+            and send_task in done
+            and not send_task.cancelled()
+            and recv_task not in done
+        ):
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(recv_task), timeout=_SHUTDOWN_DRAIN_TIMEOUT_S
+                )
+            except (asyncio.TimeoutError, Exception):
+                pass
         for t in pending:
             t.cancel()
         for t in pending:
@@ -457,15 +479,6 @@ class Transport:
                 await t
             except Exception:
                 pass
-        # If the stop flag is set, send a Goodbye and close the queue.
-        if self._stop.is_set():
-            try:
-                await send_queue.put(
-                    telemetry_pb2.TelemetryUp(goodbye=telemetry_pb2.Goodbye(reason="shutdown"))
-                )
-            except Exception:
-                pass
-            await send_queue.put(None)
         for t in done:
             exc = t.exception()
             if exc is not None and not isinstance(exc, asyncio.CancelledError):
@@ -479,43 +492,72 @@ class Transport:
         from .pb import telemetry_pb2
 
         last_hb = time.monotonic()
-        while not self._stop.is_set():
-            try:
-                await asyncio.wait_for(self._wake.wait(), timeout=self._config.heartbeat_interval_s)
-            except asyncio.TimeoutError:
-                pass
-            self._wake.clear()
+        try:
+            while not self._stop.is_set():
+                try:
+                    await asyncio.wait_for(self._wake.wait(), timeout=self._config.heartbeat_interval_s)
+                except asyncio.TimeoutError:
+                    pass
+                self._wake.clear()
 
-            # Drain envelopes in small batches, interleaving payload chunks.
-            sent_since_chunk = 0
-            batch = self._events.pop_batch(SEND_BATCH_MAX)
-            for env in batch:
-                up = self._envelope_to_up(env, telemetry_pb2)
-                if up is not None:
-                    # Track resume token: server will ack via normal
-                    # downstream, but we also keep the last span id we
-                    # sent so reconnect can resume from there.
-                    self._resume_token = env.span_id or self._resume_token
-                    await send_queue.put(up)
+                # Drain envelopes in small batches, interleaving payload chunks.
+                sent_since_chunk = 0
+                batch = self._events.pop_batch(SEND_BATCH_MAX)
+                for env in batch:
+                    up = self._envelope_to_up(env, telemetry_pb2)
+                    if up is not None:
+                        # Track resume token: server will ack via normal
+                        # downstream, but we also keep the last span id we
+                        # sent so reconnect can resume from there.
+                        self._resume_token = env.span_id or self._resume_token
+                        await send_queue.put(up)
+                        self._mark_healthy()
+                        sent_since_chunk += 1
+                    if sent_since_chunk >= PAYLOAD_CHUNK_INTERLEAVE:
+                        await self._maybe_send_chunk(send_queue, telemetry_pb2)
+                        sent_since_chunk = 0
+
+                # Flush any leftover payload chunks if we weren't busy.
+                while True:
+                    pushed = await self._maybe_send_chunk(send_queue, telemetry_pb2)
+                    if not pushed:
+                        break
+
+                # Heartbeat tick.
+                now = time.monotonic()
+                if now - last_hb >= self._config.heartbeat_interval_s:
+                    last_hb = now
+                    hb = self._build_heartbeat(telemetry_pb2)
+                    await send_queue.put(telemetry_pb2.TelemetryUp(heartbeat=hb))
                     self._mark_healthy()
-                    sent_since_chunk += 1
-                if sent_since_chunk >= PAYLOAD_CHUNK_INTERLEAVE:
-                    await self._maybe_send_chunk(send_queue, telemetry_pb2)
-                    sent_since_chunk = 0
-
-            # Flush any leftover payload chunks if we weren't busy.
-            while True:
-                pushed = await self._maybe_send_chunk(send_queue, telemetry_pb2)
-                if not pushed:
-                    break
-
-            # Heartbeat tick.
-            now = time.monotonic()
-            if now - last_hb >= self._config.heartbeat_interval_s:
-                last_hb = now
-                hb = self._build_heartbeat(telemetry_pb2)
-                await send_queue.put(telemetry_pb2.TelemetryUp(heartbeat=hb))
-                self._mark_healthy()
+        finally:
+            # Shutdown path. Drain any envelopes still in the ring buffer —
+            # Client.shutdown spins until the buffer is empty, but a race
+            # can leave a trailing batch that the while-loop never observed
+            # (stop was set between the last pop_batch and the next check).
+            # Without this flush, events the caller *successfully emitted*
+            # get silently dropped. Then send Goodbye + EOF so gRPC closes
+            # the request side cleanly after yielding every queued item.
+            try:
+                remaining = self._events.pop_batch(self._events.capacity)
+                for env in remaining:
+                    up = self._envelope_to_up(env, telemetry_pb2)
+                    if up is not None:
+                        self._resume_token = env.span_id or self._resume_token
+                        await send_queue.put(up)
+                try:
+                    await send_queue.put(
+                        telemetry_pb2.TelemetryUp(
+                            goodbye=telemetry_pb2.Goodbye(reason="shutdown")
+                        )
+                    )
+                except Exception:
+                    pass
+                await send_queue.put(None)
+            except Exception:
+                # Best-effort: if the loop is tearing down for any reason,
+                # don't mask the original error.
+                pass
 
     async def _maybe_send_chunk(self, send_queue: asyncio.Queue, telemetry_pb2: Any) -> bool:
         with self._chunk_lock:

--- a/tests/e2e/test_presentation_agent.py
+++ b/tests/e2e/test_presentation_agent.py
@@ -184,6 +184,105 @@ class TestPresentationGoldfiveRunner:
         finally:
             client.shutdown(flush_timeout=2.0)
 
+    @pytest.mark.asyncio
+    async def test_all_task_status_events_persist(
+        self,
+        presentation_agent_module: Any,
+        harmonograf_server: dict,
+    ) -> None:
+        """Regression for issue #18: every task_completed event the sink
+        observes must also land in harmonograf's storage with the matching
+        terminal status.
+
+        The original bug was a shutdown race in the Client transport:
+        Client.shutdown waited for the ring buffer to empty, but the
+        buffered events had only been moved onto an in-process gRPC
+        send_queue — not yet serialized to the wire. Cancelling recv_task
+        then aborted the bidirectional call and dropped every event in
+        flight, leaving research=COMPLETED but build/review still stuck
+        in RUNNING/PENDING.
+        """
+        from harmonograf_client import Client
+        from harmonograf_server.storage import TaskStatus
+
+        client = Client(
+            name="pres-e2e-regress",
+            server_addr=harmonograf_server["addr"],
+            framework="ADK",
+        )
+        try:
+            runner, memory_sink, _, _ = (
+                presentation_agent_module.build_goldfive_runner(
+                    topic="waffles",
+                    mock=True,
+                    client=client,
+                )
+            )
+            outcome = await runner.run("make a presentation about waffles")
+            await runner.close()
+            assert outcome.success is True, outcome.reason
+
+            completed_task_ids = {
+                evt.task_completed.task_id
+                for evt in memory_sink.events
+                if evt.WhichOneof("payload") == "task_completed"
+            }
+            assert completed_task_ids == {"research", "build", "review", "debug"}, (
+                f"goldfive sink did not observe all four task_completed events: "
+                f"{completed_task_ids}"
+            )
+        finally:
+            # ``Client.shutdown`` is synchronous and internally joins the
+            # transport thread. Running it from the event loop would block
+            # the same loop that the in-process harmonograf_server fixture
+            # uses to drain the wire, so queued events would never reach
+            # the servicer before the stream closed. Hand it off to a
+            # worker thread so the main loop keeps draining the socket.
+            await asyncio.to_thread(client.shutdown, 5.0)
+
+        # After the client flushes, storage must agree with the sink.
+        store = harmonograf_server["store"]
+        plans = await _wait_for_plan_with_tasks(
+            store, expected_task_ids=completed_task_ids, timeout=5.0
+        )
+        assert plans, "no plan landed on the server after mock run"
+        # Only the waffles plan should exist — no phantom plans from past runs.
+        assert len(plans) == 1
+        plan = plans[0]
+        assert "waffles" in plan.summary.lower()
+        task_by_id = {t.id: t for t in plan.tasks}
+        for tid in completed_task_ids:
+            assert task_by_id[tid].status == TaskStatus.COMPLETED, (
+                f"task {tid!r} persisted with status {task_by_id[tid].status.value} "
+                f"but the sink saw task_completed for it"
+            )
+
+
+async def _wait_for_plan_with_tasks(
+    store: Any, *, expected_task_ids: set, timeout: float
+) -> list[Any]:
+    """Poll until a plan whose tasks are all in a terminal state lands."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        sessions = await store.list_sessions()
+        for s in sessions or []:
+            plans = await store.list_task_plans_for_session(s.id)
+            for p in plans:
+                task_by_id = {t.id: t for t in p.tasks}
+                if expected_task_ids.issubset(task_by_id.keys()) and all(
+                    task_by_id[tid].status.value == "COMPLETED"
+                    for tid in expected_task_ids
+                ):
+                    return list(plans)
+        await asyncio.sleep(0.1)
+    # Timed out — return whatever we have so the assertion reports the
+    # actual persisted state.
+    sessions = await store.list_sessions()
+    plans: list[Any] = []
+    for s in sessions or []:
+        plans.extend(await store.list_task_plans_for_session(s.id))
+    return plans
+
 
 async def _wait_for_any_plan(store: Any, *, timeout: float) -> list[Any]:
     """Poll every session in the store until a plan is persisted. The


### PR DESCRIPTION
## Summary
- Root cause: the client's ``_send_loop`` exited on ``_stop`` without draining the ring buffer and ``_serve`` cancelled ``recv_task`` the moment ``send_task`` completed, aborting the bidi call and dropping every queued ``TelemetryUp`` still in flight. Result: research=COMPLETED but build/review/debug stuck in RUNNING/PENDING and the UI showed 1/4 DONE.
- Fix: ``_send_loop`` now drains the buffer and pushes ``Goodbye`` + EOF in a ``finally`` (single writer, stable ordering on the stop path), and ``_serve`` waits up to 2s for ``recv_task`` to return naturally on a clean shutdown so gRPC finishes shipping the queued events and the server closes its side.
- No goldfive changes needed: the sink already forwards every event; the disease was in the client's teardown.

## Test plan
- [x] ``make server-test`` (254 passed, 1 skipped)
- [x] ``make client-test`` (119 passed)
- [x] ``tests/e2e/test_presentation_agent.py`` — new ``test_all_task_status_events_persist`` asserts the four ``task_completed`` events the sink observes also land as ``COMPLETED`` in storage, and that no phantom plans appear from this run.
- [x] Manual: waffles reproducer from issue #18 against a sqlite-backed server now persists all four tasks as COMPLETED with only the waffles plan present.
