### PR TITLE
Add harmonograf_client.observe(runner) explicit observability helper (closes #22)

### DIFF
--- a/client/harmonograf_client/__init__.py
+++ b/client/harmonograf_client/__init__.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 from .client import Client
 from .enums import Capability, SpanKind, SpanStatus
+from .observe import observe
 from .sink import HarmonografSink
 from .telemetry_plugin import HarmonografTelemetryPlugin
 from .transport import ControlAckSpec
@@ -49,6 +50,7 @@ __all__ = [
     "HarmonografTelemetryPlugin",
     "SpanKind",
     "SpanStatus",
+    "observe",
 ]
 
 __version__ = "0.0.0"

--- a/client/harmonograf_client/observe.py
+++ b/client/harmonograf_client/observe.py
@@ -1,0 +1,89 @@
+"""Explicit observability-only helper for goldfive Runners.
+
+``harmonograf_client.observe(runner)`` attaches a :class:`HarmonografSink`
+to an existing :class:`goldfive.Runner`. It does **not** modify planning,
+steering, goal derivation, or execution — those concerns belong to
+``goldfive.wrap``. The two responsibilities stay crystal-clear::
+
+    import goldfive
+    import harmonograf_client
+
+    runner = harmonograf_client.observe(goldfive.wrap(root_agent))
+    outcome = await runner.run("make a presentation about waffles")
+
+See issue #22 for the motivation.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from .client import Client
+from .sink import HarmonografSink
+
+if TYPE_CHECKING:
+    import goldfive
+
+
+def observe(
+    runner: "goldfive.Runner",
+    *,
+    client: Client | None = None,
+    name: str | None = None,
+    framework: str = "CUSTOM",
+    server_addr: str | None = None,
+) -> "goldfive.Runner":
+    """Attach a :class:`HarmonografSink` to ``runner`` and return it.
+
+    This helper is observability-only. It mutates ``runner.sinks`` by
+    appending a single :class:`HarmonografSink`; it never touches the
+    planner, steerer, executor, goal deriver, or any other orchestration
+    component.
+
+    Parameters
+    ----------
+    runner:
+        An existing :class:`goldfive.Runner`, typically produced by
+        :func:`goldfive.wrap`.
+    client:
+        Optional pre-built :class:`Client` to reuse (e.g. shared across
+        multiple runners). When omitted, a new ``Client`` is constructed
+        from ``name`` / ``framework`` / ``server_addr``.
+    name:
+        Client display name. Defaults to ``"agent"``. Ignored when
+        ``client`` is provided.
+    framework:
+        Client framework tag (shown in the UI). Defaults to
+        ``"CUSTOM"``. Ignored when ``client`` is provided.
+    server_addr:
+        Harmonograf server address. When omitted, reads the
+        ``HARMONOGRAF_SERVER`` environment variable; falls back to
+        ``Client``'s own default (``127.0.0.1:7531``). Ignored when
+        ``client`` is provided.
+
+    Returns
+    -------
+    The same ``runner`` object (mutated), so callers can chain the two
+    idiomatic calls on one line::
+
+        runner = harmonograf_client.observe(goldfive.wrap(agent))
+
+    Notes
+    -----
+    Calling ``observe`` twice on the same runner appends two sinks.
+    That's deliberate — the caller is responsible for deciding whether
+    deduping makes sense in their context.
+    """
+    if client is None:
+        resolved_addr = server_addr or os.environ.get("HARMONOGRAF_SERVER")
+        client_kwargs: dict[str, Any] = {
+            "name": name or "agent",
+            "framework": framework,
+        }
+        if resolved_addr:
+            client_kwargs["server_addr"] = resolved_addr
+        client = Client(**client_kwargs)
+
+    runner.sinks.append(HarmonografSink(client))
+    return runner

--- a/client/tests/test_observe.py
+++ b/client/tests/test_observe.py
@@ -1,0 +1,145 @@
+"""Tests for :func:`harmonograf_client.observe`.
+
+``observe(runner)`` is strictly observability — it appends exactly one
+:class:`HarmonografSink` to ``runner.sinks`` and returns the same runner
+object. It must never touch planning, steering, goal derivation, or
+execution (those belong to :func:`goldfive.wrap`).
+
+See issue #22 for the rationale: the two-line form
+``observe(goldfive.wrap(agent))`` makes the layering crystal-clear, and
+conflating the two under a single ``wrap`` call is explicitly out of
+scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from harmonograf_client import observe
+from harmonograf_client.client import Client
+from harmonograf_client.sink import HarmonografSink
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+class _FakeRunner:
+    """Minimal stand-in for :class:`goldfive.Runner`.
+
+    ``observe`` only touches ``runner.sinks``; a plain list is enough to
+    verify the contract without spinning up a real Runner + planner +
+    executor.
+    """
+
+    def __init__(self, sinks: list[Any] | None = None) -> None:
+        self.sinks: list[Any] = list(sinks) if sinks else []
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="preset-client",
+        agent_id="agent-observe",
+        session_id="sess-observe",
+        framework="ADK",
+        buffer_size=8,
+        _transport_factory=make_factory(made),
+    )
+
+
+def test_observe_returns_same_runner_and_appends_sink() -> None:
+    runner = _FakeRunner()
+    result = observe(runner, name="unit", framework="CUSTOM")
+
+    assert result is runner
+    assert len(runner.sinks) == 1
+    assert isinstance(runner.sinks[0], HarmonografSink)
+
+    runner.sinks[0]._client.shutdown(flush_timeout=0.1)
+
+
+def test_observe_preserves_existing_sinks() -> None:
+    preexisting = object()
+    runner = _FakeRunner(sinks=[preexisting])
+
+    observe(runner, name="unit", framework="CUSTOM")
+
+    assert runner.sinks[0] is preexisting
+    assert isinstance(runner.sinks[1], HarmonografSink)
+    assert len(runner.sinks) == 2
+
+    runner.sinks[1]._client.shutdown(flush_timeout=0.1)
+
+
+def test_observe_reuses_provided_client(client: Client) -> None:
+    runner = _FakeRunner()
+
+    observe(runner, client=client)
+
+    sink = runner.sinks[0]
+    assert isinstance(sink, HarmonografSink)
+    assert sink._client is client
+
+
+def test_observe_respects_harmonograf_server_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    original_init = Client.__init__
+
+    def spy_init(self: Client, **kwargs: Any) -> None:
+        captured.update(kwargs)
+        # Use the fake transport so Client construction doesn't open a socket.
+        kwargs["_transport_factory"] = make_factory([])
+        original_init(self, **kwargs)
+
+    monkeypatch.setattr(Client, "__init__", spy_init)
+    monkeypatch.setenv("HARMONOGRAF_SERVER", "remote.example:9999")
+
+    runner = _FakeRunner()
+    observe(runner, name="env-client")
+
+    assert captured["server_addr"] == "remote.example:9999"
+    runner.sinks[0]._client.shutdown(flush_timeout=0.1)
+
+
+def test_observe_forwards_name_and_framework(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    original_init = Client.__init__
+
+    def spy_init(self: Client, **kwargs: Any) -> None:
+        captured.update(kwargs)
+        kwargs["_transport_factory"] = make_factory([])
+        original_init(self, **kwargs)
+
+    monkeypatch.setattr(Client, "__init__", spy_init)
+    monkeypatch.delenv("HARMONOGRAF_SERVER", raising=False)
+
+    runner = _FakeRunner()
+    observe(runner, name="presentation", framework="ADK")
+
+    assert captured["name"] == "presentation"
+    assert captured["framework"] == "ADK"
+    # server_addr not forwarded => Client's own default applies.
+    assert "server_addr" not in captured
+    runner.sinks[0]._client.shutdown(flush_timeout=0.1)
+
+
+def test_observe_twice_appends_two_sinks(client: Client) -> None:
+    runner = _FakeRunner()
+
+    observe(runner, client=client)
+    observe(runner, client=client)
+
+    assert len(runner.sinks) == 2
+    assert all(isinstance(s, HarmonografSink) for s in runner.sinks)
+    # Deliberately no dedupe — caller's responsibility.
+    assert runner.sinks[0] is not runner.sinks[1]

--- a/docs/goldfive-integration.md
+++ b/docs/goldfive-integration.md
@@ -44,36 +44,105 @@ the server's ingest dispatches on `event.payload` (a protobuf `oneof` over
 
 ## Minimal worked example
 
+The target form is two lines of setup — one for orchestration, one for
+observability:
+
+```python
+import goldfive
+import harmonograf_client
+
+runner = harmonograf_client.observe(goldfive.wrap(root_agent))
+outcome = await runner.run("make a presentation about waffles")
+```
+
+**First `goldfive.wrap` for orchestration, then `harmonograf_client.observe`
+for observability.** The layering is crystal-clear and each call owns exactly
+one concern:
+
+- `goldfive.wrap(agent)` — the *only* planning/steering injection. Picks a
+  default `LLMPlanner`, `SequentialExecutor`, adapter, and goal deriver, and
+  returns a ready-to-run `goldfive.Runner`.
+- `harmonograf_client.observe(runner)` — the *only* observability wiring.
+  Constructs a `Client`, appends a `HarmonografSink` to `runner.sinks`, and
+  returns the same runner for chaining. Nothing about the runner's planning,
+  steering, goal derivation, or execution is touched.
+
+Neither call is implicit — if you want both you write both, and you can skip
+either one when you don't.
+
+### End-to-end
+
 ```python
 from __future__ import annotations
 
 import asyncio
 
 import goldfive
-from goldfive import LLMPlanner, Runner, SequentialExecutor
-from goldfive.adapters.adk import ADKAdapter
+import harmonograf_client
 from google.adk.agents import Agent
-from harmonograf_client import Client, HarmonografSink
+
 
 async def main() -> None:
     root = Agent(name="researcher", model="openai/gpt-4o-mini")
 
-    client = Client(name="researcher")  # defaults to 127.0.0.1:7531
-
-    runner = Runner(
-        agent=ADKAdapter(root),
-        planner=LLMPlanner(call_llm=my_llm_call, model="openai/gpt-4o-mini"),
-        executor=SequentialExecutor(),
-        sinks=[HarmonografSink(client), goldfive.sinks.LoggingSink()],
-    )
+    runner = harmonograf_client.observe(goldfive.wrap(root))
 
     outcome = await runner.run("Summarise recent observability research.")
     print("ok" if outcome.success else outcome.reason)
-    await runner.close()           # flushes every sink, including ours
-    client.shutdown(flush_timeout=5.0)
+    await runner.close()  # flushes every sink, including harmonograf's
 
 
 asyncio.run(main())
+```
+
+### Reusing a Client or tagging the run
+
+`observe` accepts the same identity knobs as `Client`:
+
+```python
+# Reuse a pre-built Client (e.g. shared across many runners)
+client = harmonograf_client.Client(
+    name="prod-agent", framework="ADK", server_addr="remote:7531"
+)
+runner = harmonograf_client.observe(goldfive.wrap(root_agent), client=client)
+
+# Or let observe construct the Client, passing just the tags
+runner = harmonograf_client.observe(
+    goldfive.wrap(root_agent), name="presentation", framework="ADK"
+)
+```
+
+When `server_addr` is omitted, `observe` reads `$HARMONOGRAF_SERVER` and
+otherwise falls back to `Client`'s default (`127.0.0.1:7531`).
+
+### Composing with other sinks
+
+Because `observe` *appends* to `runner.sinks` it composes cleanly with any
+sinks `goldfive.wrap` already configured:
+
+```python
+from goldfive.sinks import JSONLPersistenceSink
+
+runner = goldfive.wrap(root_agent, sinks=[JSONLPersistenceSink("runs/log.jsonl")])
+runner = harmonograf_client.observe(runner)  # HarmonografSink appended alongside
+```
+
+### Fully manual wiring (pre-`wrap`)
+
+If you need to override a goldfive internal that `wrap` doesn't expose, build
+the `Runner` yourself and skip `wrap` — `observe` still works the same:
+
+```python
+from goldfive import LLMPlanner, Runner, SequentialExecutor
+from goldfive.adapters.adk import ADKAdapter
+import harmonograf_client
+
+runner = Runner(
+    agent=ADKAdapter(root),
+    planner=LLMPlanner(call_llm=my_llm_call, model="openai/gpt-4o-mini"),
+    executor=SequentialExecutor(),
+)
+runner = harmonograf_client.observe(runner, name="researcher")
 ```
 
 While `main()` runs, the frontend (started by `make demo`, served at

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ wheels = [
 
 [[package]]
 name = "goldfive"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "../goldfive" }
 
 [package.metadata]


### PR DESCRIPTION
## Summary

Introduces `harmonograf_client.observe(runner)` so the two-concern layering is
explicit at the call site:

```python
import goldfive
import harmonograf_client

runner = harmonograf_client.observe(goldfive.wrap(root_agent))
outcome = await runner.run("make a presentation about waffles")
```

- `goldfive.wrap(agent)` — the only planning/steering injection.
- `harmonograf_client.observe(runner)` — the only observability wiring (appends a `HarmonografSink` to `runner.sinks` and returns the same runner).

No `harmonograf_client.wrap(agent)` is added — that would conflate the two concerns, which was the whole motivation for issue #22.

## Design notes

- `observe(runner, *, client=None, name=None, framework="CUSTOM", server_addr=None) -> goldfive.Runner`
- Lazy-imports `goldfive` so users who never install it can still use `Client` / `HarmonografSink` directly.
- Mutates `runner.sinks` in place (the `goldfive.Runner.sinks` is `list[EventSink]`, mutable by contract).
- Constructs a `Client` from `name` / `framework` / `server_addr` only when `client` isn't passed in; honors `$HARMONOGRAF_SERVER`.
- Repeated calls append repeated sinks — deliberate, no dedupe.

## Test delta

- `client/tests/test_observe.py` — 6 new tests covering:
  - identity return (`observe(r) is r`)
  - `HarmonografSink` appended, pre-existing sinks preserved
  - pre-built `Client` reused
  - `$HARMONOGRAF_SERVER` flows into `Client` construction
  - `name` / `framework` forwarded to `Client`
  - two `observe()` calls = two sinks
- `make client-test server-test` stays green: **125 client tests (+6), 254 server tests.**

## Test plan

- [x] `make client-test` — 125 passed
- [x] `make server-test` — 254 passed, 1 skipped
- [x] Import smoke: `harmonograf_client.observe` + `goldfive.wrap` both resolve; the 2-line form mutates `runner.sinks` exactly once.
