### PR TITLE
CI: vendor goldfive as sibling checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Vendor google/adk-python
         run: git clone --depth 1 https://github.com/google/adk-python.git third_party/adk-python
 
+      - name: Vendor goldfive (editable sibling)
+        run: git clone --depth 1 https://github.com/pedapudi/goldfive.git "$GITHUB_WORKSPACE/../goldfive"
+
       - name: Install server deps
         run: make server-install
 
@@ -65,6 +68,9 @@ jobs:
       - name: Vendor google/adk-python
         run: git clone --depth 1 https://github.com/google/adk-python.git third_party/adk-python
 
+      - name: Vendor goldfive (editable sibling)
+        run: git clone --depth 1 https://github.com/pedapudi/goldfive.git "$GITHUB_WORKSPACE/../goldfive"
+
       - name: Install client deps
         run: make client-install
 
@@ -92,6 +98,23 @@ jobs:
           node-version: "20"
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install uv (needed for proto-ts to resolve goldfive proto dir)
+        uses: astral-sh/setup-uv@v8.0.0
+
+      - name: Set up Python (needed for uv to sync goldfive)
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Vendor google/adk-python
+        run: git clone --depth 1 https://github.com/google/adk-python.git third_party/adk-python
+
+      - name: Vendor goldfive (editable sibling)
+        run: git clone --depth 1 https://github.com/pedapudi/goldfive.git "$GITHUB_WORKSPACE/../goldfive"
+
+      - name: Install harmonograf (resolves goldfive path for proto-ts)
+        run: uv sync --frozen || uv sync
 
       - name: Install frontend deps
         run: make frontend-install


### PR DESCRIPTION
All 3 CI jobs were failing because the editable goldfive dep (`../goldfive`) expected a sibling checkout that CI wasn't producing. Added a `Vendor goldfive` step to each job mirroring the existing ADK vendor step. Frontend job gains uv + Python so `make proto-ts` can resolve the goldfive proto dir via uv.