### PR TITLE
Bridge goldfive ControlChannel to harmonograf ControlRouter (fixes #24)

### DIFF
--- a/client/harmonograf_client/_control_bridge.py
+++ b/client/harmonograf_client/_control_bridge.py
@@ -1,0 +1,292 @@
+"""Bridge harmonograf ``ControlEvent``\\s into a goldfive ``ControlChannel``.
+
+The harmonograf server delivers control events over a dedicated
+``SubscribeControl`` gRPC stream; goldfive's :class:`goldfive.control.ControlChannel`
+is the in-process primitive a :class:`goldfive.Runner` consumes live
+steering messages from. :class:`ControlBridge` is the wire between them.
+
+Responsibilities:
+
+1. Attach a :class:`ControlChannel` to the runner if one isn't already
+   present (``runner.control`` / ``runner._control``).
+2. Intercept every raw ``ControlEvent`` from the client (via
+   :meth:`Client.set_control_forward`) and translate it to a goldfive
+   :class:`ControlMessage`, preserving ``control_id`` as the message
+   ``id`` for ack correlation.
+3. Forward the ``ControlMessage`` into ``runner.control`` on the user's
+   event loop (the transport delivers events on its own loop, so a
+   thread-safe hop is required).
+4. Mirror goldfive acks back out as harmonograf ``ControlAck`` frames
+   via :meth:`Client.send_control_ack`.
+5. Tear down cleanly when :meth:`Runner.close` is called — forward
+   hook uninstalled, both forwarding tasks cancelled, and the goldfive
+   channel closed so any in-flight ``runner.control.acks()`` consumer
+   exits its iterator.
+
+Phase-1 kind coverage mirrors goldfive issue #71: PAUSE, RESUME, CANCEL,
+STEER, REWIND_TO translate one-to-one. INJECT_MESSAGE, APPROVE, REJECT
+are out of scope and ack UNSUPPORTED directly back to the server. Any
+kind goldfive does not know (e.g. STATUS_QUERY, INTERCEPT_TRANSFER —
+both legal harmonograf kinds) also acks UNSUPPORTED.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from .client import Client
+
+log = logging.getLogger("harmonograf_client._control_bridge")
+
+
+# harmonograf ControlKind name → goldfive ControlKind name.
+# Any harmonograf kind not in this table is acked UNSUPPORTED. Membership
+# here is a necessary but not sufficient condition — the goldfive enum
+# may still reject the value (e.g. if goldfive drops a kind in a later
+# release), in which case we also ack UNSUPPORTED.
+_KIND_MAP: dict[str, str] = {
+    "PAUSE": "PAUSE",
+    "RESUME": "RESUME",
+    "CANCEL": "CANCEL",
+    "STEER": "STEER",
+    "REWIND_TO": "REWIND_TO",
+}
+
+
+class ControlBridge:
+    """Wire harmonograf control events into a goldfive ``ControlChannel``.
+
+    The bridge is single-use: :meth:`start` installs the forward hook
+    and spawns two asyncio tasks (one for incoming events, one for
+    outgoing acks); :meth:`stop` tears everything down. ``observe()``
+    also monkey-patches ``runner.close`` so the bridge shuts down when
+    the runner is closed by its owner — no manual wiring required from
+    the user.
+    """
+
+    def __init__(
+        self,
+        client: "Client",
+        runner: Any,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        self._client = client
+        self._runner = runner
+        self._loop = loop
+        self._inbox: asyncio.Queue = asyncio.Queue()
+        self._events_task: Optional[asyncio.Task] = None
+        self._acks_task: Optional[asyncio.Task] = None
+        self._started = False
+        self._closed = False
+        self._original_close: Any = None
+
+    def start(self) -> None:
+        """Attach a ``ControlChannel`` and spin up forwarding tasks.
+
+        Idempotent — calling ``start`` twice is a no-op. Safe to call
+        from the user's event loop; all three side effects (attach
+        channel, install forward hook, wrap ``runner.close``) are
+        synchronous.
+        """
+        if self._started:
+            return
+        self._started = True
+
+        # Lazy-import goldfive so the module stays cheap to import in
+        # tests that never use the bridge.
+        from goldfive.control import ControlChannel
+
+        # Attach a channel if the runner doesn't have one. Store on
+        # both the public attribute (for user code + tests) and the
+        # private one in case a future Runner version ever protects
+        # the field.
+        if getattr(self._runner, "control", None) is None:
+            chan = ControlChannel()
+            try:
+                self._runner.control = chan
+            except AttributeError:
+                self._runner._control = chan  # type: ignore[attr-defined]
+
+        self._client.set_control_forward(self._on_event_from_transport)
+        self._events_task = self._loop.create_task(self._events_loop())
+        self._acks_task = self._loop.create_task(self._acks_loop())
+        self._wrap_runner_close()
+
+    # ------------------------------------------------------------------
+    # Transport-thread callback
+    # ------------------------------------------------------------------
+
+    def _on_event_from_transport(self, event: Any) -> None:
+        """Hand off a raw ``ControlEvent`` to our loop (thread-safe)."""
+        try:
+            self._loop.call_soon_threadsafe(self._inbox.put_nowait, event)
+        except RuntimeError:
+            # Our loop is shutting down — dropping is correct; the
+            # server will re-send on next subscribe.
+            pass
+
+    # ------------------------------------------------------------------
+    # Forwarding coroutines
+    # ------------------------------------------------------------------
+
+    async def _events_loop(self) -> None:
+        from goldfive.control import ControlKind, ControlMessage
+
+        from .pb import types_pb2
+
+        while True:
+            try:
+                event = await self._inbox.get()
+            except asyncio.CancelledError:
+                return
+
+            h_kind_name = _h_kind_name(event.kind, types_pb2)
+            g_kind_name = _KIND_MAP.get(h_kind_name)
+            if g_kind_name is None:
+                self._client.send_control_ack(
+                    event.id,
+                    "unsupported",
+                    f"harmonograf ControlKind {h_kind_name} "
+                    "is not supported by this bridge",
+                )
+                continue
+
+            try:
+                g_kind = ControlKind(g_kind_name)
+            except ValueError:
+                self._client.send_control_ack(
+                    event.id,
+                    "unsupported",
+                    f"goldfive has no ControlKind.{g_kind_name}",
+                )
+                continue
+
+            payload = _decode_payload(h_kind_name, event.payload)
+            msg = ControlMessage(kind=g_kind, id=event.id, payload=payload)
+            chan = getattr(self._runner, "control", None)
+            if chan is None:
+                self._client.send_control_ack(
+                    event.id, "failure", "runner has no control channel"
+                )
+                continue
+            try:
+                await chan.send(msg)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("failed to forward control to runner: %s", exc)
+                self._client.send_control_ack(event.id, "failure", repr(exc))
+
+    async def _acks_loop(self) -> None:
+        chan = getattr(self._runner, "control", None)
+        if chan is None:
+            return
+        try:
+            async for ack in chan.acks():
+                result_name = _ack_result_name(ack.result)
+                self._client.send_control_ack(
+                    ack.control_id, result_name, getattr(ack, "detail", "") or ""
+                )
+        except asyncio.CancelledError:
+            return
+        except Exception:  # noqa: BLE001
+            log.exception("ack forwarding loop failed")
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
+
+    def _wrap_runner_close(self) -> None:
+        """Monkey-patch ``runner.close`` so it also stops the bridge.
+
+        Goldfive's :meth:`Runner.close` is async and closes sinks; we
+        chain ``stop()`` in front so the bridge tears down first. The
+        original callable is stashed so a stop-only callsite still
+        invokes it.
+        """
+        original_close = getattr(self._runner, "close", None)
+        if original_close is None or not callable(original_close):
+            return
+        self._original_close = original_close
+        bridge = self
+
+        async def close_with_bridge_teardown() -> None:
+            try:
+                await bridge.stop()
+            finally:
+                await original_close()
+
+        try:
+            self._runner.close = close_with_bridge_teardown  # type: ignore[method-assign]
+        except AttributeError:
+            # Runner type forbids reassignment — best-effort, owner can
+            # still call ``bridge.stop()`` explicitly.
+            pass
+
+    async def stop(self) -> None:
+        """Cancel forwarding tasks, uninstall the hook, close the channel.
+
+        Idempotent. Safe to call from any coroutine running on the same
+        loop the bridge was started on.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._client.set_control_forward(None)
+
+        tasks = [t for t in (self._events_task, self._acks_task) if t is not None]
+        for t in tasks:
+            t.cancel()
+        for t in tasks:
+            with contextlib.suppress(BaseException):
+                await t
+
+        chan = getattr(self._runner, "control", None)
+        if chan is not None:
+            try:
+                chan.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _h_kind_name(kind_value: int, types_pb2: Any) -> str:
+    """Return the short harmonograf ``ControlKind`` name (e.g. ``PAUSE``)."""
+    try:
+        raw = types_pb2.ControlKind.Name(kind_value)
+    except Exception:
+        return "UNSPECIFIED"
+    return raw.removeprefix("CONTROL_KIND_")
+
+
+def _ack_result_name(result: Any) -> str:
+    """Map a goldfive ``AckResult`` to the lowercase harmonograf wire name."""
+    # AckResult is a StrEnum; its value is the uppercase name.
+    try:
+        return str(result.value).lower()
+    except AttributeError:
+        return str(result).split(".")[-1].lower()
+
+
+def _decode_payload(h_kind_name: str, payload: bytes) -> dict[str, Any]:
+    """Decode a harmonograf control payload into goldfive's dict shape.
+
+    Harmonograf delivers payloads as ``bytes`` (see ``ControlEvent.payload``
+    in ``proto/harmonograf/v1/types.proto``); goldfive's
+    :class:`ControlMessage` expects a ``dict``. The shape per kind is
+    defined in goldfive issue #71.
+    """
+    if not payload:
+        return {}
+    text = payload.decode("utf-8", errors="replace")
+    if h_kind_name == "STEER":
+        return {"note": text}
+    if h_kind_name == "REWIND_TO":
+        return {"task_id": text}
+    return {"data": text}

--- a/client/harmonograf_client/client.py
+++ b/client/harmonograf_client/client.py
@@ -311,6 +311,23 @@ class Client:
     def on_control(self, kind: str, callback: ControlCallback) -> None:
         self._transport.register_control_handler(kind.upper(), callback)
 
+    def set_control_forward(self, fn: Optional[Callable[[Any], None]]) -> None:
+        """Install a raw ``ControlEvent`` forwarder. ``None`` uninstalls.
+
+        While a forwarder is active, events bypass the per-kind callbacks
+        registered via :meth:`on_control` — ack responsibility moves to
+        the forwarder, which must call :meth:`send_control_ack` for every
+        event. This is the hook the goldfive bridge in
+        ``harmonograf_client._control_bridge`` uses.
+        """
+        self._transport.set_control_forward(fn)
+
+    def send_control_ack(
+        self, control_id: str, result: str, detail: str = ""
+    ) -> None:
+        """Send a ``ControlAck`` upstream. Thread-safe and non-blocking."""
+        self._transport.send_control_ack(control_id, result, detail)
+
     def emit_goldfive_event(self, event_pb: Any) -> None:
         """Ship a ``goldfive.v1.Event`` to the server.
 

--- a/client/harmonograf_client/observe.py
+++ b/client/harmonograf_client/observe.py
@@ -16,6 +16,8 @@ See issue #22 for the motivation.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -24,6 +26,8 @@ from .sink import HarmonografSink
 
 if TYPE_CHECKING:
     import goldfive
+
+log = logging.getLogger("harmonograf_client.observe")
 
 
 def observe(
@@ -86,4 +90,29 @@ def observe(
         client = Client(**client_kwargs)
 
     runner.sinks.append(HarmonografSink(client))
+
+    # Attach a goldfive ControlChannel bridge so pause/resume/cancel/
+    # steer/rewind issued from the harmonograf UI reach the live runner.
+    # The bridge needs a running asyncio loop to consume events on; when
+    # ``observe()`` is called outside async context (e.g. from a sync
+    # script), we skip it — the sink half of ``observe`` still works.
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None:
+        from ._control_bridge import ControlBridge
+
+        bridge = ControlBridge(client, runner, loop)
+        bridge.start()
+        # Stash for test + introspection access. Underscore prefix so
+        # it's clear this is private plumbing, not part of the Runner's
+        # public contract.
+        runner._harmonograf_control_bridge = bridge  # type: ignore[attr-defined]
+    else:
+        log.debug(
+            "observe(): no running event loop — control bridge not started"
+        )
+
     return runner

--- a/client/harmonograf_client/transport.py
+++ b/client/harmonograf_client/transport.py
@@ -128,6 +128,17 @@ class Transport:
         self._handlers: dict[str, ControlHandler] = {}
         self._handlers_lock = threading.Lock()
 
+        # Optional raw-event forwarder. When set, _control_loop routes every
+        # ControlEvent to this callback instead of _dispatch_control — the
+        # forwarder is then responsible for producing acks via
+        # :meth:`send_control_ack`. Used by the goldfive ControlChannel
+        # bridge (see ``harmonograf_client._control_bridge``).
+        self._control_forward: Optional[Callable[[Any], None]] = None
+        # Cached reference to the live bidi send queue, set at the start of
+        # each ``_serve`` call so ``send_control_ack`` can thread-safely
+        # push acks from the bridge's loop onto the transport's loop.
+        self._send_queue: Optional[asyncio.Queue] = None
+
         self._thread: Optional[threading.Thread] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._loop_ready = threading.Event()
@@ -208,6 +219,47 @@ class Transport:
     def register_control_handler(self, kind: str, cb: ControlHandler) -> None:
         with self._handlers_lock:
             self._handlers[kind] = cb
+
+    def set_control_forward(self, fn: Optional[Callable[[Any], None]]) -> None:
+        """Install a raw-event forwarder. Pass ``None`` to uninstall.
+
+        When set, every incoming ``ControlEvent`` is handed to ``fn``
+        (on the transport's own loop) instead of being dispatched to the
+        per-kind handlers registered via :meth:`register_control_handler`.
+        The forwarder is responsible for eventually producing a
+        :class:`ControlAck` via :meth:`send_control_ack` — the transport
+        no longer acks synchronously on its behalf.
+        """
+        self._control_forward = fn
+
+    def send_control_ack(
+        self, control_id: str, result: str, detail: str = ""
+    ) -> None:
+        """Thread-safe ack push onto the current bidi send queue.
+
+        Safe to call from any thread. If no stream is currently live
+        (e.g. during a reconnect) the ack is dropped — the server will
+        re-deliver the ``ControlEvent`` on the next subscribe.
+        """
+        from .pb import telemetry_pb2, types_pb2
+
+        result_enum = {
+            "success": types_pb2.CONTROL_ACK_RESULT_SUCCESS,
+            "failure": types_pb2.CONTROL_ACK_RESULT_FAILURE,
+            "unsupported": types_pb2.CONTROL_ACK_RESULT_UNSUPPORTED,
+        }.get(result.lower(), types_pb2.CONTROL_ACK_RESULT_UNSUPPORTED)
+        ack = types_pb2.ControlAck(
+            control_id=control_id, result=result_enum, detail=detail
+        )
+        up = telemetry_pb2.TelemetryUp(control_ack=ack)
+        loop = self._loop
+        sq = self._send_queue
+        if loop is None or sq is None:
+            return
+        try:
+            loop.call_soon_threadsafe(sq.put_nowait, up)
+        except RuntimeError:
+            pass
 
     def shutdown(self, timeout: float = 5.0) -> None:
         self._stop.set()
@@ -404,6 +456,7 @@ class Transport:
 
         hello = self._build_hello(telemetry_pb2)
         send_queue: asyncio.Queue = asyncio.Queue()
+        self._send_queue = send_queue
         await send_queue.put(telemetry_pb2.TelemetryUp(hello=hello))
 
         async def request_iter():
@@ -482,7 +535,11 @@ class Transport:
         for t in done:
             exc = t.exception()
             if exc is not None and not isinstance(exc, asyncio.CancelledError):
+                # Clear send_queue so late bridge acks are not posted
+                # onto a stream that is already dead.
+                self._send_queue = None
                 raise exc
+        self._send_queue = None
 
     # ------------------------------------------------------------------
     # Send loop
@@ -677,6 +734,13 @@ class Transport:
         try:
             call = stub.SubscribeControl(req, **sub_kwargs)
             async for event in call:
+                fwd = self._control_forward
+                if fwd is not None:
+                    try:
+                        fwd(event)
+                    except Exception:
+                        log.exception("control forward raised")
+                    continue
                 ack = self._dispatch_control(event, types_pb2)
                 await send_queue.put(
                     telemetry_pb2.TelemetryUp(control_ack=ack)

--- a/client/tests/_fixtures.py
+++ b/client/tests/_fixtures.py
@@ -66,6 +66,9 @@ class FakeTransport:
         self.handlers: dict[str, Callable[[Any], Any]] = {}
         self.assigned_session_id: str = session_id
         self.payload_accept = True
+        self.control_forward: Optional[Callable[[Any], None]] = None
+        # (control_id, result, detail) tuples pushed via send_control_ack.
+        self.sent_acks: list[tuple[str, str, str]] = []
 
     # --- public surface Client depends on -----------------------------
 
@@ -84,6 +87,22 @@ class FakeTransport:
 
     def register_control_handler(self, kind: str, cb: Callable[[Any], Any]) -> None:
         self.handlers[kind] = cb
+
+    def set_control_forward(self, fn: Optional[Callable[[Any], None]]) -> None:
+        self.control_forward = fn
+
+    def send_control_ack(
+        self, control_id: str, result: str, detail: str = ""
+    ) -> None:
+        self.sent_acks.append((control_id, result, detail))
+
+    # Bridge tests simulate a ControlEvent arriving on the control stream
+    # by calling this directly. Matches the real transport's call path —
+    # set_control_forward's callable receives a ControlEvent proto.
+    def deliver_control_event(self, event: Any) -> None:
+        fwd = self.control_forward
+        if fwd is not None:
+            fwd(event)
 
 
 def make_factory(store: list[FakeTransport]) -> Callable[..., FakeTransport]:

--- a/client/tests/test_control_bridge.py
+++ b/client/tests/test_control_bridge.py
@@ -1,0 +1,342 @@
+"""Tests for :class:`harmonograf_client._control_bridge.ControlBridge`.
+
+The bridge sits between harmonograf's ``SubscribeControl`` gRPC stream
+and a goldfive ``ControlChannel`` attached to a :class:`Runner`. These
+tests verify the kind-by-kind translation table, ack round-trip, the
+UNSUPPORTED-kind fast path, and cleanup on ``runner.close``. They use a
+:class:`FakeTransport` so no gRPC sockets open, and they construct
+``ControlEvent`` messages by hand from the generated ``types_pb2``
+module so the integration stays honest about the wire format.
+
+Scope covered here:
+
+- Every Phase-1 kind (PAUSE / RESUME / CANCEL / STEER / REWIND_TO)
+  translates to the matching goldfive ``ControlKind`` and preserves
+  the ``control_id`` for ack correlation.
+- ``STEER`` and ``REWIND_TO`` payloads land in the goldfive
+  ``ControlMessage.payload`` dict under the keys goldfive expects
+  (``note`` and ``task_id``).
+- Each UNSUPPORTED harmonograf kind (INJECT_MESSAGE, APPROVE, REJECT,
+  STATUS_QUERY, INTERCEPT_TRANSFER) acks UNSUPPORTED back to the server
+  without touching the runner.
+- Goldfive ``ControlAck`` objects published via ``channel.ack()`` flow
+  back out to the server as harmonograf ``ControlAck``\\s with the
+  right result enum and detail string.
+- ``observe(runner)`` attaches a bridge when called inside an event
+  loop; ``runner.close()`` tears it down (forward hook cleared,
+  forwarding tasks finished).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from goldfive.control import (
+    AckResult,
+    ControlAck,
+    ControlChannel,
+    ControlKind,
+    ControlMessage,
+)
+
+from harmonograf_client import observe
+from harmonograf_client._control_bridge import ControlBridge, _KIND_MAP
+from harmonograf_client.client import Client
+from harmonograf_client.pb import types_pb2
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _make_event(
+    kind_name: str, *, control_id: str = "c-1", payload: bytes = b""
+) -> Any:
+    """Build a ``types_pb2.ControlEvent`` with the given kind + payload."""
+    kind_enum = getattr(types_pb2, f"CONTROL_KIND_{kind_name}")
+    return types_pb2.ControlEvent(
+        id=control_id,
+        kind=kind_enum,
+        payload=payload,
+    )
+
+
+class _FakeRunner:
+    """Stand-in for :class:`goldfive.Runner` — ``close`` + optional channel."""
+
+    def __init__(self) -> None:
+        self.sinks: list[Any] = []
+        self.control: ControlChannel | None = None
+        self.close_calls = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="bridge-client",
+        agent_id="agent-bridge",
+        session_id="sess-bridge",
+        framework="ADK",
+        buffer_size=8,
+        _transport_factory=make_factory(made),
+    )
+
+
+async def _drain(loop_count: int = 4) -> None:
+    """Yield control enough times for call_soon_threadsafe hand-offs to land."""
+    for _ in range(loop_count):
+        await asyncio.sleep(0)
+
+
+# ----------------------------------------------------------------------
+# Kind-by-kind translation
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "h_kind, expected_g_kind",
+    [
+        ("PAUSE", ControlKind.PAUSE),
+        ("RESUME", ControlKind.RESUME),
+        ("CANCEL", ControlKind.CANCEL),
+        ("STEER", ControlKind.STEER),
+        ("REWIND_TO", ControlKind.REWIND_TO),
+    ],
+)
+async def test_supported_kind_forwards_to_channel(
+    client: Client,
+    made: list[FakeTransport],
+    h_kind: str,
+    expected_g_kind: ControlKind,
+) -> None:
+    runner = _FakeRunner()
+    loop = asyncio.get_running_loop()
+    bridge = ControlBridge(client, runner, loop)
+    bridge.start()
+
+    transport = made[0]
+    transport.deliver_control_event(_make_event(h_kind, control_id="cid-123"))
+
+    assert runner.control is not None
+    msg = await asyncio.wait_for(runner.control.receive(), timeout=1.0)
+    assert msg is not None
+    assert msg.kind is expected_g_kind
+    # Preserve control_id → goldfive message id for ack correlation.
+    assert msg.id == "cid-123"
+
+    await bridge.stop()
+
+
+@pytest.mark.asyncio
+async def test_steer_payload_lands_under_note(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    runner = _FakeRunner()
+    bridge = ControlBridge(client, runner, asyncio.get_running_loop())
+    bridge.start()
+
+    made[0].deliver_control_event(
+        _make_event("STEER", control_id="s-1", payload=b"focus on the last slide")
+    )
+
+    msg = await asyncio.wait_for(runner.control.receive(), timeout=1.0)
+    assert msg.kind is ControlKind.STEER
+    assert msg.payload == {"note": "focus on the last slide"}
+
+    await bridge.stop()
+
+
+@pytest.mark.asyncio
+async def test_rewind_to_payload_lands_under_task_id(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    runner = _FakeRunner()
+    bridge = ControlBridge(client, runner, asyncio.get_running_loop())
+    bridge.start()
+
+    made[0].deliver_control_event(
+        _make_event("REWIND_TO", control_id="r-1", payload=b"task-42")
+    )
+
+    msg = await asyncio.wait_for(runner.control.receive(), timeout=1.0)
+    assert msg.kind is ControlKind.REWIND_TO
+    assert msg.payload == {"task_id": "task-42"}
+
+    await bridge.stop()
+
+
+# ----------------------------------------------------------------------
+# Unsupported kinds
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "h_kind",
+    ["INJECT_MESSAGE", "APPROVE", "REJECT", "STATUS_QUERY", "INTERCEPT_TRANSFER"],
+)
+async def test_unsupported_kind_acks_unsupported(
+    client: Client, made: list[FakeTransport], h_kind: str
+) -> None:
+    runner = _FakeRunner()
+    bridge = ControlBridge(client, runner, asyncio.get_running_loop())
+    bridge.start()
+
+    transport = made[0]
+    transport.deliver_control_event(
+        _make_event(h_kind, control_id=f"u-{h_kind}", payload=b"anything")
+    )
+
+    # Give the events_loop a tick to process and push the ack.
+    await _drain()
+
+    # Runner's channel must not receive any message for unsupported kinds.
+    assert runner.control is not None
+    maybe = await runner.control.receive(timeout=0.05)
+    assert maybe is None
+
+    assert len(transport.sent_acks) == 1
+    ack_id, result, detail = transport.sent_acks[0]
+    assert ack_id == f"u-{h_kind}"
+    assert result == "unsupported"
+    assert detail  # non-empty explanatory string
+
+    await bridge.stop()
+
+
+# ----------------------------------------------------------------------
+# Ack round-trip
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "g_result, expected_name",
+    [
+        (AckResult.SUCCESS, "success"),
+        (AckResult.FAILURE, "failure"),
+        (AckResult.UNSUPPORTED, "unsupported"),
+    ],
+)
+async def test_goldfive_ack_flows_back_to_server(
+    client: Client,
+    made: list[FakeTransport],
+    g_result: AckResult,
+    expected_name: str,
+) -> None:
+    runner = _FakeRunner()
+    bridge = ControlBridge(client, runner, asyncio.get_running_loop())
+    bridge.start()
+
+    assert runner.control is not None
+    await runner.control.ack(
+        ControlAck(control_id="ack-1", result=g_result, detail="because reasons")
+    )
+
+    # Give acks_loop a chance to see it and push to the fake transport.
+    await _drain()
+
+    transport = made[0]
+    assert any(
+        aid == "ack-1" and res == expected_name and det == "because reasons"
+        for aid, res, det in transport.sent_acks
+    ), transport.sent_acks
+
+    await bridge.stop()
+
+
+# ----------------------------------------------------------------------
+# Runner.close shutdown path
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runner_close_tears_down_bridge(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    runner = _FakeRunner()
+    bridge = ControlBridge(client, runner, asyncio.get_running_loop())
+    bridge.start()
+
+    # Precondition — forward hook installed, tasks running.
+    transport = made[0]
+    assert transport.control_forward is not None
+    assert bridge._events_task is not None
+    assert not bridge._events_task.done()
+    assert bridge._acks_task is not None
+    assert not bridge._acks_task.done()
+
+    await runner.close()
+
+    # The wrapped close first awaits bridge.stop, then the original.
+    assert runner.close_calls == 1
+    assert transport.control_forward is None
+    assert bridge._events_task.done()
+    assert bridge._acks_task.done()
+    assert bridge._closed is True
+
+
+# ----------------------------------------------------------------------
+# observe() integration
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_observe_attaches_bridge_inside_event_loop(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    runner = _FakeRunner()
+    observe(runner, client=client)
+
+    bridge = getattr(runner, "_harmonograf_control_bridge", None)
+    assert isinstance(bridge, ControlBridge)
+    assert runner.control is not None  # attached by the bridge
+
+    # Forward a STEER event end-to-end through observe's bridge.
+    made[0].deliver_control_event(
+        _make_event("STEER", control_id="o-1", payload=b"try again")
+    )
+    msg = await asyncio.wait_for(runner.control.receive(), timeout=1.0)
+    assert msg.kind is ControlKind.STEER
+    assert msg.payload == {"note": "try again"}
+
+    await runner.close()
+    assert bridge._closed is True
+
+
+def test_observe_without_running_loop_skips_bridge(
+    client: Client,
+) -> None:
+    """observe() stays usable from sync call sites — just no bridge."""
+    runner = _FakeRunner()
+    observe(runner, client=client)
+
+    # Sink still attached (observability path unchanged).
+    assert len(runner.sinks) == 1
+    # Bridge deliberately not started outside an event loop.
+    assert getattr(runner, "_harmonograf_control_bridge", None) is None
+
+
+# ----------------------------------------------------------------------
+# Kind map invariant
+# ----------------------------------------------------------------------
+
+
+def test_kind_map_only_contains_goldfive_phase1_kinds() -> None:
+    """If goldfive adds/removes a Phase-1 kind, fail loudly here."""
+    assert set(_KIND_MAP.values()) == {k.value for k in ControlKind}


### PR DESCRIPTION
## Summary

- Wires harmonograf's ``SubscribeControl`` stream into the new goldfive ``ControlChannel`` primitive (goldfive #71) so live pause/resume/cancel/steer/rewind from the harmonograf UI reach a running ``Runner`` end-to-end.
- Adds ``harmonograf_client._control_bridge.ControlBridge`` plus transport + Client hooks (``set_control_forward`` / ``send_control_ack``) the bridge rides on.
- ``observe(runner)`` now starts the bridge when called from async context and wraps ``runner.close`` so teardown is automatic.

## Kind map

| harmonograf | goldfive | notes |
|---|---|---|
| PAUSE / RESUME / CANCEL | same | pass-through |
| STEER | ``ControlKind.STEER`` | payload → ``{"note": utf8}`` |
| REWIND_TO | ``ControlKind.REWIND_TO`` | payload → ``{"task_id": utf8}`` |
| INJECT_MESSAGE / APPROVE / REJECT / STATUS_QUERY / INTERCEPT_TRANSFER | — | bridge acks UNSUPPORTED (Phase-2 follow-up) |

## Test plan

- [x] ``make client-test`` — 144 passed (19 new in ``test_control_bridge.py``)
- [x] ``make server-test`` — 254 passed, 1 skipped (unchanged — no server-side code touched)
- [x] Bridge kind-by-kind translation, STEER/REWIND_TO payload decoding, UNSUPPORTED acks, ack round-trip (SUCCESS / FAILURE / UNSUPPORTED), ``runner.close()`` teardown, ``observe()`` integration, kind-map invariant vs. goldfive ``ControlKind``.
