### PR TITLE
Make goldfive optional + standalone observability examples (closes #29)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0
@@ -32,9 +34,6 @@ jobs:
 
       - name: Vendor google/adk-python
         run: git clone --depth 1 https://github.com/google/adk-python.git third_party/adk-python
-
-      - name: Vendor goldfive (editable sibling)
-        run: git clone --depth 1 https://github.com/pedapudi/goldfive.git "$GITHUB_WORKSPACE/../goldfive"
 
       - name: Install server deps
         run: make server-install
@@ -51,6 +50,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0
@@ -68,9 +69,6 @@ jobs:
       - name: Vendor google/adk-python
         run: git clone --depth 1 https://github.com/google/adk-python.git third_party/adk-python
 
-      - name: Vendor goldfive (editable sibling)
-        run: git clone --depth 1 https://github.com/pedapudi/goldfive.git "$GITHUB_WORKSPACE/../goldfive"
-
       - name: Install client deps
         run: make client-install
 
@@ -86,6 +84,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
@@ -110,9 +110,6 @@ jobs:
       - name: Vendor google/adk-python
         run: git clone --depth 1 https://github.com/google/adk-python.git third_party/adk-python
 
-      - name: Vendor goldfive (editable sibling)
-        run: git clone --depth 1 https://github.com/pedapudi/goldfive.git "$GITHUB_WORKSPACE/../goldfive"
-
       - name: Install harmonograf (resolves goldfive path for proto-ts)
         run: uv sync --frozen || uv sync
 
@@ -124,3 +121,67 @@ jobs:
 
       - name: Run frontend tests
         run: make frontend-test
+
+  standalone-test:
+    name: standalone-test
+    # Proves harmonograf is usable without the goldfive orchestration
+    # extra: installs without `--extra orchestration`, boots a server,
+    # and emits spans via examples/standalone_observability/spans_only.py.
+    # Zero goldfive imports in the example's source (verified by grep).
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            server/uv.lock
+            client/uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Vendor google/adk-python
+        run: git clone --depth 1 https://github.com/google/adk-python.git third_party/adk-python
+
+      - name: Install harmonograf without orchestration extra
+        run: uv sync
+
+      - name: Verify spans_only.py has zero goldfive references
+        run: |
+          # Issue #29 acceptance criterion: `grep -i goldfive` on
+          # spans_only.py must return zero hits.
+          if grep -i goldfive examples/standalone_observability/spans_only.py; then
+            echo "FAIL: spans_only.py references goldfive." >&2
+            exit 1
+          fi
+          echo "OK: spans_only.py has no goldfive references."
+
+      - name: Generate Python proto stubs
+        run: make proto-python
+
+      - name: Run standalone emitter against a live server
+        run: |
+          set -euo pipefail
+          mkdir -p data
+          ( cd server && uv run python -m harmonograf_server \
+              --store sqlite --data-dir "$GITHUB_WORKSPACE/data" \
+              --port 7531 ) &
+          SERVER_PID=$!
+          trap "kill $SERVER_PID 2>/dev/null || true" EXIT
+          # Wait for the gRPC port to accept connections.
+          for i in $(seq 1 30); do
+            if python -c "import socket; s=socket.socket(); s.settimeout(0.5); s.connect(('127.0.0.1',7531)); s.close()" 2>/dev/null; then
+              echo "server ready"; break
+            fi
+            sleep 1
+          done
+          HARMONOGRAF_SERVER=127.0.0.1:7531 \
+            uv run python examples/standalone_observability/spans_only.py

--- a/.gitignore
+++ b/.gitignore
@@ -40,10 +40,10 @@ client/build/
 # Demo output tarballs
 waffle.tar.gz
 
-# Third-party vendored dependencies (read-only, cloned locally for editable
-# installs — never committed). Re-create by cloning the upstream repo into
-# third_party/adk-python/. See docs/dev-guide/setup.md.
-third_party/
+# Third-party vendored dependencies. ADK is cloned at first install and
+# never committed; goldfive is tracked as a git submodule. See
+# docs/dev-guide/setup.md.
+third_party/adk-python/
 
 # Claude Code runtime scratch (agent team state, scheduled task locks, etc.)
 .claude/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/goldfive"]
+	path = third_party/goldfive
+	url = https://github.com/pedapudi/goldfive.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,33 @@ This file provides guidance to agents, including Claude Code, Antigravity, Openc
 
 ## Project vision
 
-Harmonograf is the observability console for agent workflows orchestrated by
-[goldfive](https://github.com/pedapudi/goldfive). Goldfive owns the plan, the
-task state machine, the drift taxonomy, the reporting tools, and the re-invocation
-loop. Harmonograf owns the session, the span timeline, the canonical storage, the
-Gantt/graph frontend, and the control router that lets a human intervene on the
-same connection they observe on.
+Harmonograf is an observability console for multi-agent workflows. **Goldfive
+is optional.** Harmonograf works standalone for any agent that emits spans via
+`harmonograf_client.Client`; plans, tasks, and drift come from
+[goldfive](https://github.com/pedapudi/goldfive) if you opt in via the
+`orchestration` extra. See [`docs/standalone-observability.md`](docs/standalone-observability.md)
+for the standalone guide and [`docs/goldfive-integration.md`](docs/goldfive-integration.md)
+for the orchestration path.
+
+When goldfive *is* in the picture: goldfive owns the plan, the task state
+machine, the drift taxonomy, the reporting tools, and the re-invocation loop.
+Harmonograf owns the session, the span timeline, the canonical storage, the
+Gantt/graph frontend, and the control router that lets a human intervene on
+the same connection they observe on.
 
 The line is load-bearing: orchestration changes belong in goldfive; observability
 and UI changes belong in harmonograf. If a change has to straddle both, the
 goldfive-side change lands first and harmonograf follows.
+
+### Proto coupling caveat
+
+Phase A of the goldfive migration (issue #6) moved plan/task/drift types into
+goldfive's proto package. Harmonograf's `TelemetryUp.goldfive_event` therefore
+references `goldfive.v1.Event` directly, and the generated pb stubs import
+from `goldfive.pb.goldfive.v1`. Consequence: `harmonograf_client` cannot be
+*installed* without goldfive present, but user code can (and should) be
+goldfive-import-free in the standalone case. The `standalone-test` CI job
+enforces this via `grep -i goldfive examples/standalone_observability/spans_only.py`.
 
 ## High-level architecture
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ FRONTEND_PB := $(ROOT)/frontend/src/pb
 
 .PHONY: help proto proto-python proto-ts \
         server-install client-install frontend-install install \
-        server-run frontend-dev demo demo-presentation .demo-agents-stage \
+        server-run frontend-dev demo demo-presentation demo-standalone .demo-agents-stage \
         test server-test client-test frontend-test e2e \
         lint format clean stats
 
@@ -26,6 +26,8 @@ help:
 	@echo "  install          Install all components"
 	@echo "  server-run       Run the server in dev mode"
 	@echo "  frontend-dev     Run the Vite dev server"
+	@echo "  demo             Boot server + frontend + goldfive-orchestrated ADK agent"
+	@echo "  demo-standalone  Boot server + frontend and emit spans from the standalone example"
 	@echo "  test             Run server + client + frontend tests"
 	@echo "  e2e              Run the end-to-end test against the ADK submodule"
 	@echo "  stats            Query the running server's GetStats RPC"
@@ -204,6 +206,41 @@ demo: .demo-agents-stage
 		echo "=================================================================="; \
 		echo "  Press Ctrl-C to stop all three."; \
 		echo ""; \
+		wait \
+	'
+
+# Standalone observability demo: boots the harmonograf server + Vite
+# frontend and runs examples/standalone_observability/spans_only.py to
+# push synthetic spans at them. No goldfive orchestration is involved —
+# this is the "use harmonograf without goldfive" demo.
+demo-standalone:
+	@bash -eu -c '\
+		cleanup() { \
+			echo; \
+			echo "[demo-standalone] shutting down..."; \
+			kill $$SERVER_PID $$FRONTEND_PID 2>/dev/null || true; \
+			wait 2>/dev/null || true; \
+			exit 0; \
+		}; \
+		trap cleanup INT TERM EXIT; \
+		echo "[demo-standalone] starting harmonograf-server on :$(SERVER_PORT) ..."; \
+		( cd $(ROOT)/server && uv run python -m harmonograf_server \
+			--store sqlite --data-dir $(ROOT)/data \
+			--port $(SERVER_PORT) ) & SERVER_PID=$$!; \
+		echo "[demo-standalone] starting frontend Vite dev server on :$(FRONTEND_PORT) ..."; \
+		( cd $(ROOT)/frontend && pnpm dev --port $(FRONTEND_PORT) --strictPort ) & FRONTEND_PID=$$!; \
+		sleep 3; \
+		echo ""; \
+		echo "=================================================================="; \
+		echo "  Harmonograf UI     : http://127.0.0.1:$(FRONTEND_PORT)"; \
+		echo "  harmonograf-server : 127.0.0.1:$(SERVER_PORT) (gRPC)"; \
+		echo "=================================================================="; \
+		echo "  Emitting spans via examples/standalone_observability/spans_only.py ..."; \
+		echo ""; \
+		( cd $(ROOT) && HARMONOGRAF_SERVER=127.0.0.1:$(SERVER_PORT) \
+			uv run python examples/standalone_observability/spans_only.py ); \
+		echo ""; \
+		echo "[demo-standalone] spans emitted. Press Ctrl-C to stop server + frontend."; \
 		wait \
 	'
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
 # Harmonograf
 
-**The observability console for agent workflows orchestrated by [goldfive](https://github.com/pedapudi/goldfive).**
+**The observability console for multi-agent workflows.**
 
-Harmonograf stores the event timeline produced by a goldfive run, renders it as a
-Gantt-chart-style view in a browser, and lets humans intervene with control
-events on the same connection it observes them on. Goldfive owns the plan, task
-state machine, drift taxonomy, and reporting tools; harmonograf owns the
-session, the span timeline, the UI, storage, and the control router.
+Harmonograf renders agent activity as a Gantt-style timeline, lets humans
+intervene with control events on the same connection it observes them on, and
+works two ways:
+
+- **Standalone** — emit spans from any agent, from any framework, via the
+  `harmonograf_client.Client`. No orchestration. The Gantt, inspector, and
+  control surfaces light up; the Tasks panel stays empty. See
+  [`docs/standalone-observability.md`](docs/standalone-observability.md).
+- **With [goldfive](https://github.com/pedapudi/goldfive)** — opt in to the
+  orchestration extra (`uv sync --extra orchestration`) and harmonograf also
+  shows plans, tasks, and drift. Goldfive owns the plan / task state machine /
+  drift taxonomy / reporting tools; harmonograf is the screen you watch it on.
+  See [`docs/goldfive-integration.md`](docs/goldfive-integration.md).
+
+Both modes target the same server, the same wire format, and the same UI —
+the difference is purely which panels populate.
 
 ---
 
@@ -64,15 +75,34 @@ Integration is a single-line install: construct a `goldfive.Runner`, attach a
 
 ## Get running in 10 minutes
 
-The fastest path from clone to a live-rendering Gantt is the goldfive
+### Standalone (no goldfive)
+
+The shortest path: boot the server + frontend, and emit synthetic spans
+from a plain Python script. Nothing else.
+
+```bash
+git clone https://github.com/pedapudi/harmonograf
+cd harmonograf
+git submodule update --init --recursive
+git clone --depth 1 https://github.com/google/adk-python.git third_party/adk-python
+uv sync
+make demo-standalone    # server + frontend + spans_only.py
+```
+
+The frontend renders a session with a Gantt; Tasks panel stays empty.
+Full walkthrough: [`docs/standalone-observability.md`](docs/standalone-observability.md).
+
+### With goldfive orchestration
+
+The fastest path to see plans + tasks + drift is the goldfive
 observability quickstart. It installs goldfive + harmonograf, boots this
 stack via `make demo`, runs a CallableAdapter agent in a second shell,
 and shows the events flowing into the UI — no LLM credentials required.
 
 1. `make install` in this repo (see the full [quickstart](docs/quickstart.md) for prereqs).
-2. `make demo` to bring up the server + frontend + ADK web.
-3. Install `goldfive` in a second shell and run
-   `examples/harmonograf_observed/agent.py`.
+2. `uv sync --extra orchestration` to opt in to the goldfive API.
+3. `make demo` to bring up the server + frontend + ADK web.
+4. In a second shell run `examples/harmonograf_observed/agent.py` from the goldfive repo.
 
 Full walkthrough (lives in the goldfive repo): **[observability-with-harmonograf.md](https://github.com/pedapudi/goldfive/blob/main/docs/guides/observability-with-harmonograf.md)**.
 

--- a/docs/dev-guide/setup.md
+++ b/docs/dev-guide/setup.md
@@ -16,6 +16,7 @@ or macOS box.
 | SQLite | 3.37+ (ships WAL, `JSON1`) | Default storage backend | OS package |
 | git | — | Repo cloning | OS package |
 | Google adk-python | matching upstream | Editable path dependency referenced by root `pyproject.toml` | Clone into `third_party/adk-python/` yourself — this repo does not vendor or track ADK |
+| goldfive | sibling checkout via submodule | Editable path dependency at `third_party/goldfive/`; required at install time for proto stubs | Populated by `git submodule update --init --recursive` after clone |
 
 You do **not** need Docker, Make 4, Bazel, or anything else. The whole thing is
 a Python monorepo plus a Vite app.
@@ -25,16 +26,41 @@ a Python monorepo plus a Vite app.
 ```bash
 git clone git@github.com:pedapudi/harmonograf.git
 cd harmonograf
+git submodule update --init --recursive       # pulls goldfive into third_party/goldfive
 git clone https://github.com/google/adk-python.git third_party/adk-python
 ```
 
-harmonograf installs `google-adk` as an editable path dependency rooted at
-`third_party/adk-python/` (see the `[tool.uv.sources]` entry in the root
-`pyproject.toml`). This repo does **not** track or vendor ADK — the `third_party/`
-directory is git-ignored. You are responsible for maintaining a local checkout
-there. Treat it as a read-only third-party dependency: do not commit changes
-into the ADK checkout as part of harmonograf work. If you forget to clone it,
-`uv sync` will fail with a clear error about a missing path dependency.
+harmonograf pulls two third-party packages in as editable path
+dependencies:
+
+- **`google-adk`** at `third_party/adk-python/`. Not tracked or vendored —
+  the `third_party/adk-python/` directory is git-ignored; you are
+  responsible for maintaining a local checkout. Treat it as a read-only
+  third-party dependency.
+- **`goldfive`** at `third_party/goldfive/`. Tracked as a git submodule so
+  the commit sha is pinned in `.gitmodules`. Run `git submodule update
+  --init --recursive` after cloning; CI uses `submodules: recursive` on
+  `actions/checkout`.
+
+If either path is missing, `uv sync` will fail with a clear error about a
+missing path dependency.
+
+### Optional: goldfive orchestration extra
+
+By default, `uv sync` installs harmonograf for *observability*: you can
+emit spans, render the Gantt, and send control events without touching
+goldfive's orchestration API. To opt in to the `wrap()`/Runner/planner
+surface (plans + tasks + drift in the UI), install the `orchestration`
+extra:
+
+```bash
+uv sync --extra orchestration
+```
+
+See [`docs/standalone-observability.md`](../standalone-observability.md)
+for the standalone guide and
+[`docs/goldfive-integration.md`](../goldfive-integration.md) for the
+orchestration path.
 
 ## Install
 

--- a/docs/goldfive-integration.md
+++ b/docs/goldfive-integration.md
@@ -1,10 +1,20 @@
 # Goldfive integration
 
-Harmonograf is the observability console for agent workflows orchestrated by
-[goldfive](https://github.com/pedapudi/goldfive). Goldfive decides *what an
-agent should do next*; harmonograf records what actually happened and lets a
-human intervene. The two projects compose through a single adapter — the
-`HarmonografSink`.
+> **If you want plans + tasks + drift: this is the guide.**
+> If you just want a Gantt of agent activity without any orchestration
+> concepts, see [standalone-observability.md](standalone-observability.md)
+> instead — goldfive is optional.
+
+Harmonograf pairs naturally with
+[goldfive](https://github.com/pedapudi/goldfive) for multi-agent
+orchestration. Goldfive decides *what an agent should do next*;
+harmonograf records what actually happened and lets a human intervene.
+The two projects compose through a single adapter — the
+`HarmonografSink` — and are opted into via the `orchestration` extra:
+
+```bash
+uv sync --extra orchestration
+```
 
 ## Split of responsibilities
 

--- a/docs/standalone-observability.md
+++ b/docs/standalone-observability.md
@@ -1,0 +1,350 @@
+# Standalone observability — using harmonograf without goldfive
+
+Harmonograf is a console for agent activity. The *orchestration* (plans,
+tasks, drift detection, reporting tools) lives in
+[goldfive](https://github.com/pedapudi/goldfive). But you don't need
+goldfive to use harmonograf: if you have any agent that emits spans, you
+can render those spans on the harmonograf Gantt, inspect payloads in the
+drawer, replay sessions, and send control events — all without any
+orchestration concepts at all.
+
+This guide is the canonical "just observability, no goldfive" path.
+Contrast with [`docs/goldfive-integration.md`](goldfive-integration.md),
+which is the "plans + tasks + drift" guide.
+
+## TL;DR
+
+```python
+from harmonograf_client import Client, SpanKind, SpanStatus
+
+client = Client(name="my-agent", server_addr="127.0.0.1:7531")
+
+sid = client.emit_span_start(kind=SpanKind.LLM_CALL, name="gpt-4o")
+# ... call your LLM, do work ...
+client.emit_span_end(sid, status=SpanStatus.COMPLETED)
+
+client.shutdown()
+```
+
+That's the entire standalone surface. Everything else is optional.
+
+## When to use this path
+
+Use the standalone path when:
+
+- **You want a Gantt of agent activity** and nothing more.
+- **You already have an orchestration framework** (LangGraph, AutoGen,
+  raw asyncio, plain loops) and just want the harmonograf UI.
+- **You're prototyping** and don't want to commit to goldfive's task
+  model yet.
+- **You're writing your own orchestrator** and want to use harmonograf
+  as the coordination surface (spans + control events) without
+  goldfive's planner / steerer / executor.
+
+Use [goldfive + harmonograf](goldfive-integration.md) when you want:
+
+- Plans and tasks surfaced in the UI (Tasks panel, plan-diff drawer).
+- Drift detection and drift banners.
+- The reporting-tool contract (`report_task_started`,
+  `report_task_completed`, etc.).
+- Planner → steerer → executor orchestration out of the box.
+
+You can switch between the two without re-plumbing: both emit to the
+same harmonograf server. Add `goldfive.wrap(...)` and pass the resulting
+Runner through `harmonograf_client.observe()` when you're ready.
+
+## Honest caveat: proto coupling
+
+Phase A of the goldfive migration (issue #6) moved plan/task/drift types
+into the goldfive proto package and made harmonograf's
+`TelemetryUp.goldfive_event` reference `goldfive.v1.Event` directly. The
+consequence: `harmonograf_client`'s generated pb stubs import
+`goldfive.pb.goldfive.v1` at *import time*, so a Python process that
+loads `harmonograf_client.Client` will end up with the goldfive Python
+package imported via the pb submodule.
+
+What this means in practice:
+
+- **`harmonograf_client` (the library) cannot be installed without
+  pulling goldfive in.** That is unavoidable without reversing Phase A.
+- **Your code** can be entirely goldfive-free. You can `from
+  harmonograf_client import Client` and never touch `goldfive.wrap`,
+  `Runner`, `HarmonografSink`, or any orchestration symbol.
+- **Your package's direct dependency graph** does not need to list
+  goldfive. That's what the optional `orchestration` extra is for —
+  opting in to the *usage* surface while the pb compatibility is
+  transparent.
+
+The `standalone-test` CI job proves the "your code is goldfive-free"
+guarantee: it `grep -i goldfive`'s `examples/standalone_observability/
+spans_only.py` and fails if anything matches.
+
+See [#29](https://github.com/pedapudi/harmonograf/issues/29) for the
+full rationale and the discussion of Interpretation 1 vs. Interpretation 2.
+
+## Install
+
+```bash
+git clone https://github.com/pedapudi/harmonograf
+cd harmonograf
+git submodule update --init --recursive       # pulls goldfive into third_party/
+git clone --depth 1 https://github.com/google/adk-python.git third_party/adk-python
+uv sync                                        # no --extra orchestration
+```
+
+For running the demo that uses `goldfive.wrap()`, also add:
+
+```bash
+uv sync --extra orchestration
+```
+
+## The public surface
+
+Standalone observability uses only this subset of
+`harmonograf_client`:
+
+| Symbol | What it's for |
+| --- | --- |
+| `Client` | Construct one per process/agent; owns the buffer + transport. |
+| `SpanKind` | Enum: `LLM_CALL`, `TOOL_CALL`, `INVOCATION`, `USER_MESSAGE`, `AGENT_MESSAGE`, `TRANSFER`, `WAIT_FOR_HUMAN`, `PLANNED`, `CUSTOM`. |
+| `SpanStatus` | Enum: `PENDING`, `RUNNING`, `COMPLETED`, `FAILED`, `CANCELLED`, `AWAITING_HUMAN`. |
+| `Capability` | Control capabilities the agent declares it accepts. |
+| `ControlAckSpec` | Return type from control handlers (below). |
+| `HarmonografTelemetryPlugin` | ADK plugin that emits spans for ADK lifecycle events. |
+
+You do **not** need:
+
+- `HarmonografSink` — that's the goldfive.EventSink adapter.
+- `observe()` — that's the goldfive.Runner helper.
+
+Both are re-exported at the top level, but only relevant to the
+goldfive path.
+
+## Emitting spans
+
+### Span lifecycle
+
+Every span has three possible phases:
+
+1. **Start** — `emit_span_start(kind=, name=, ...)` → returns `span_id`.
+2. **Update** — zero or more `emit_span_update(span_id, ...)` calls
+   carrying partial output, attribute changes, or a status bump.
+3. **End** — `emit_span_end(span_id, status=, ...)`.
+
+All three calls are non-blocking (O(1) under the Client's lock). The
+buffer is drained on a background transport thread. No span emission
+ever awaits IO.
+
+### Attaching payloads
+
+Any of the three calls accepts `payload=`, `payload_mime=`, and
+`payload_role=`. Payloads are streamed on a separate logical channel;
+the span carries a `payload_ref` that the frontend uses to fetch on
+demand. This keeps the event stream small even when the payload is a
+100 KB LLM completion.
+
+Typical shape:
+
+```python
+sid = client.emit_span_start(
+    kind=SpanKind.LLM_CALL,
+    name="gpt-4o",
+    payload=json.dumps({"prompt": ...}).encode(),
+    payload_mime="application/json",
+    payload_role="input",
+)
+# ... make the API call ...
+client.emit_span_end(
+    sid,
+    status=SpanStatus.COMPLETED,
+    payload=json.dumps({"text": reply}).encode(),
+    payload_role="output",
+    attributes={"tokens_in": tin, "tokens_out": tout},
+)
+```
+
+### Attributes
+
+`attributes=` accepts any `Mapping[str, Any]`. Values are coerced to
+strings on the wire. Use them for anything you want searchable in the
+frontend filter strip: model name, tool name, task id, user id, env,
+etc.
+
+### Parent / child spans
+
+Pass `parent_span_id=` to nest a span under another. The Gantt renders
+parent bars above children, and the inspector shows the ancestry.
+
+```python
+root = client.emit_span_start(kind=SpanKind.INVOCATION, name="handle_request")
+child = client.emit_span_start(
+    kind=SpanKind.LLM_CALL, name="gpt-4o", parent_span_id=root,
+)
+```
+
+## Sessions
+
+A session is the top-level scope that groups spans from one or more
+agents collaborating on one task. The Client auto-creates a session on
+first emission; the server assigns a canonical `sess_YYYY-MM-DD_NNNN`
+id and broadcasts it back. Access via `client.session_id`.
+
+Pass `session_id=` to the `Client(...)` constructor to join an existing
+session — useful when multiple agents collaborate on the same workflow
+and you want one row per agent on the same Gantt.
+
+`session_title` is a friendly label shown in the session picker.
+
+## Agents
+
+By default, each Client is its own agent. Pass `name=` for the display
+name shown on the Gantt row; the server derives a stable `agent_id` by
+hashing name+install directory (see `identity.py`).
+
+Set `framework=` to one of `ADK`, `CLAUDE_AGENT_SDK`, `CUSTOM`. The
+frontend uses this to pick a row icon.
+
+## Control events
+
+The Client's connection is bidirectional. The server can deliver
+control events *to* an agent — pause, cancel, annotate, steer — and
+the agent can ack them. This works in standalone mode too; you don't
+need goldfive to handle control.
+
+```python
+from harmonograf_client import Client, Capability, ControlAckSpec
+
+def handle_pause(event):
+    # ... pause your agent ...
+    return ControlAckSpec(result="accepted")
+
+client = Client(
+    name="my-agent",
+    capabilities=[Capability.PAUSE_RESUME],  # declares what you accept
+)
+client.on_control("PAUSE", handle_pause)
+```
+
+See `docs/protocol/control.md` for the full control protocol.
+
+## ADK lifecycle plugin
+
+`HarmonografTelemetryPlugin` wires `harmonograf_client` into ADK's
+plugin bus and emits one span per invocation, LLM call, and tool call.
+No goldfive involved. See
+[`examples/standalone_observability/adk_telemetry.py`](../examples/standalone_observability/adk_telemetry.py).
+
+```python
+from google.adk.apps.app import App
+from harmonograf_client import Client, HarmonografTelemetryPlugin
+
+client = Client(name="my-adk-agent")
+app = App(
+    name="my-adk-agent",
+    root_agent=root_agent,
+    plugins=[HarmonografTelemetryPlugin(client)],
+)
+```
+
+Install *alongside* goldfive's ADK plugin if you also want
+orchestration — they do not interfere.
+
+## What the frontend shows
+
+The standalone case leaves some panels empty:
+
+| Panel | Standalone | With goldfive |
+| --- | --- | --- |
+| Gantt (one row per agent) | populated | populated |
+| Span inspector drawer | populated | populated |
+| Messages panel | populated | populated |
+| Payload viewer | populated | populated |
+| Session picker | populated | populated |
+| Tasks panel | **empty** | populated |
+| Plan-diff drawer | **empty** | populated |
+| Drift banner | **empty** | populated |
+
+The empty states are intentional and well-handled: no spinners, no
+error toasts. The panels show "No plan submitted for this session" and
+similar.
+
+## Running the examples
+
+Three runnable examples live under
+[`examples/standalone_observability/`](../examples/standalone_observability/):
+
+1. **`spans_only.py`** — zero dependencies beyond `harmonograf_client`.
+   Emits a synthetic agent flow. Start here.
+2. **`adk_telemetry.py`** — a real ADK agent with
+   `HarmonografTelemetryPlugin` installed. Needs model credentials.
+3. **`with_orchestration.py`** — comparison baseline: goldfive's
+   `Runner` + `observe()`.
+
+Boot the stack:
+
+```bash
+make server-run    # harmonograf-server on :7531 (gRPC)
+make frontend-dev  # Vite on :5173
+```
+
+Then run an example in a second terminal, or use the one-shot:
+
+```bash
+make demo-standalone   # server + frontend + spans_only.py
+```
+
+## Testing your own standalone agent
+
+The `standalone-test` CI job is a reference: it installs without the
+orchestration extra, starts a server, and runs `spans_only.py` against
+it. If you fork this pattern for your own agent, the important bits
+are:
+
+- `uv sync` (not `uv sync --extra orchestration`).
+- Your agent code should not contain `from goldfive` or `import
+  goldfive`. Grep to verify.
+- Start the server (`harmonograf-server --store sqlite --data-dir ...`)
+  and wait for the gRPC port before running your emitter.
+- Call `client.shutdown(flush_timeout=5.0)` at end-of-process so the
+  buffer drains before exit.
+
+## FAQ
+
+### Why does `pip install harmonograf-client` still pull goldfive?
+
+Because the generated pb stubs import `goldfive.pb.goldfive.v1`. See
+the "honest caveat" section above and issue #29 for the full
+discussion.
+
+### Can I emit plan / task events without goldfive?
+
+Not directly. `emit_goldfive_event(event_pb)` exists on the Client but
+it takes a `goldfive.v1.Event` protobuf, so using it pulls you into
+the goldfive dependency surface. If you want plans + tasks, use
+goldfive. If you want a lighter-weight "what task is this span
+associated with" hint, set an attribute on the span
+(`attributes={"task.id": "..."}`) and filter on it in the frontend.
+
+### Can I switch from standalone to goldfive later?
+
+Yes — that's the whole point. Your existing `emit_span_start/update/
+end` calls keep working. Add a goldfive Runner alongside, wrap it with
+`harmonograf_client.observe()`, and you'll see plans / tasks / drift
+appear in the UI for that session.
+
+### How do I send control events to a standalone agent?
+
+Register a handler with `client.on_control("KIND", callback)` and
+declare capabilities in the Client constructor. The frontend's "send
+control" menu lists whatever capabilities the agent declared. No
+goldfive needed.
+
+## Related docs
+
+- [`docs/goldfive-integration.md`](goldfive-integration.md) — the
+  "plans + tasks + drift" path.
+- [`docs/quickstart.md`](quickstart.md) — fastest way to see anything
+  on screen.
+- [`docs/protocol/`](protocol/) — wire format, control protocol,
+  heartbeat semantics.
+- [`AGENTS.md`](../AGENTS.md) — contributor orientation.

--- a/examples/standalone_observability/README.md
+++ b/examples/standalone_observability/README.md
@@ -1,0 +1,73 @@
+# Standalone observability examples
+
+**Use harmonograf as an observability console — without goldfive
+orchestration.** Emit spans via `harmonograf_client.Client`, and the
+frontend's Gantt / agent panels render them the same as any other
+source. Plans, tasks, and drift (goldfive's signals) stay out of the
+picture; the Tasks panel is simply empty.
+
+See [`docs/standalone-observability.md`](../../docs/standalone-observability.md)
+for the full story.
+
+## What's in this directory
+
+| File | What it does | Imports goldfive? |
+| --- | --- | --- |
+| [`spans_only.py`](spans_only.py) | Hand-authored synthetic spans via `Client.emit_span_*` — the "no-framework" path. | No. |
+| [`adk_telemetry.py`](adk_telemetry.py) | A real ADK agent instrumented with `HarmonografTelemetryPlugin`. Telemetry only. | No. |
+| [`with_orchestration.py`](with_orchestration.py) | Counterpoint: goldfive's `Runner` + `observe()` to light up plans + tasks + drift. | **Yes** — needs `uv sync --extra orchestration`. |
+
+Verify the first two truly have zero goldfive references:
+
+```
+grep -Ei 'from goldfive|import goldfive' \
+  examples/standalone_observability/spans_only.py \
+  examples/standalone_observability/adk_telemetry.py
+# (no output)
+```
+
+## Running
+
+Start a harmonograf server in one terminal:
+
+```
+make server-run
+```
+
+And (optionally) the frontend:
+
+```
+make frontend-dev
+```
+
+Then run any example:
+
+```
+# No goldfive, no ADK, just spans:
+uv run python examples/standalone_observability/spans_only.py
+
+# ADK agent with span-emitting plugin (needs a model key):
+export OPENAI_API_KEY=...
+uv run --extra e2e python examples/standalone_observability/adk_telemetry.py
+
+# Goldfive orchestration for comparison:
+uv run --extra orchestration python examples/standalone_observability/with_orchestration.py
+```
+
+A convenience target runs server + frontend + `spans_only.py` end-to-end:
+
+```
+make demo-standalone
+```
+
+## What the frontend shows
+
+| Panel | spans_only.py | adk_telemetry.py | with_orchestration.py |
+| --- | --- | --- | --- |
+| Gantt (agent activity) | populated | populated | populated |
+| Messages | populated | populated | populated |
+| Tasks | **empty** | **empty** | populated |
+| Plan view | **empty** | **empty** | populated |
+| Drift indicators | **empty** | **empty** | populated |
+
+Empty Tasks panel is the expected standalone state — not an error.

--- a/examples/standalone_observability/adk_telemetry.py
+++ b/examples/standalone_observability/adk_telemetry.py
@@ -1,0 +1,86 @@
+"""Standalone observability with Google ADK: spans only, no goldfive.
+
+Installs :class:`HarmonografTelemetryPlugin` on an ADK ``App`` so ADK's
+lifecycle callbacks emit harmonograf spans for every invocation, LLM
+call, and tool call. No orchestration: no plans, no tasks, no drift.
+
+This is the "I already have an ADK agent and just want it on the Gantt"
+path. If you also want plans/tasks/drift, swap to goldfive's wrap()
+(see `with_orchestration.py`).
+
+Run:
+    export OPENAI_API_KEY=...        # or your model provider's var
+    export HARMONOGRAF_SERVER=127.0.0.1:7531
+    uv run --extra e2e python examples/standalone_observability/adk_telemetry.py
+
+Prerequisites:
+    - harmonograf server running (make server-run)
+    - google-adk installed (`uv sync --extra e2e` brings it in)
+    - model credentials for whichever model you wire up below
+
+This file never imports the orchestration API — see README.md for the
+directory-wide grep check the CI job runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.apps.app import App
+from google.adk.runners import InMemoryRunner
+from google.genai import types as genai_types
+
+from harmonograf_client import Client, HarmonografTelemetryPlugin
+
+
+def build_agent() -> LlmAgent:
+    return LlmAgent(
+        name="standalone_assistant",
+        model="gpt-4o-mini",
+        instruction=(
+            "You are a concise assistant. Answer briefly in one sentence."
+        ),
+    )
+
+
+async def main() -> None:
+    server = os.environ.get("HARMONOGRAF_SERVER", "127.0.0.1:7531")
+    client = Client(
+        name="adk-standalone-demo",
+        framework="ADK",
+        server_addr=server,
+        session_title="ADK standalone telemetry demo",
+    )
+    try:
+        app = App(
+            name="standalone_assistant",
+            root_agent=build_agent(),
+            plugins=[HarmonografTelemetryPlugin(client)],
+        )
+        runner = InMemoryRunner(app=app)
+        session = await runner.session_service.create_session(
+            app_name=app.name, user_id="demo-user"
+        )
+        message = genai_types.Content(
+            role="user",
+            parts=[genai_types.Part(text="What is harmonograf, in one sentence?")],
+        )
+        async for event in runner.run_async(
+            user_id="demo-user",
+            session_id=session.id,
+            new_message=message,
+        ):
+            if event.content and event.content.parts:
+                for part in event.content.parts:
+                    if part.text:
+                        print(part.text, end="", flush=True)
+        print()
+        print(f"emitted session: {client.session_id}")
+    finally:
+        client.shutdown(flush_timeout=5.0)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/standalone_observability/spans_only.py
+++ b/examples/standalone_observability/spans_only.py
@@ -1,0 +1,142 @@
+"""Standalone observability: emit spans to a harmonograf server.
+
+No orchestration. No plans. No tasks. No drift. Just spans over a
+non-blocking client — the "minimum viable" way to get agent activity
+onto the harmonograf Gantt.
+
+Run:
+    # In one terminal:
+    make server-run
+
+    # In another terminal:
+    uv run python examples/standalone_observability/spans_only.py
+
+    # Open the frontend to see the spans render:
+    make frontend-dev  # then http://127.0.0.1:5173/
+
+Environment:
+    HARMONOGRAF_SERVER  (default 127.0.0.1:7531)
+
+This example deliberately uses ONLY the harmonograf_client public
+surface. The `standalone-test` CI job greps this file to verify it
+has no references at all to the orchestration extra.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+from harmonograf_client import Client, SpanKind, SpanStatus
+
+
+def emit_llm_call(client: Client, parent_id: str, prompt: str) -> str:
+    """Emit a short LLM_CALL span with input + output payloads."""
+    span = client.emit_span_start(
+        kind=SpanKind.LLM_CALL,
+        name="gpt-4o-mini",
+        parent_span_id=parent_id,
+        attributes={"model": "gpt-4o-mini", "temperature": 0.2},
+        payload=json.dumps({"prompt": prompt}).encode(),
+        payload_role="input",
+    )
+    time.sleep(0.2)
+    client.emit_span_end(
+        span,
+        status=SpanStatus.COMPLETED,
+        payload=json.dumps(
+            {"text": f"(synthetic reply to: {prompt[:40]!r})"}
+        ).encode(),
+        payload_role="output",
+        attributes={"tokens_in": 42, "tokens_out": 17},
+    )
+    return span
+
+
+def emit_tool_call(client: Client, parent_id: str, tool: str, args: dict) -> str:
+    """Emit a TOOL_CALL span with args + result payloads."""
+    span = client.emit_span_start(
+        kind=SpanKind.TOOL_CALL,
+        name=tool,
+        parent_span_id=parent_id,
+        attributes={"tool": tool},
+        payload=json.dumps(args).encode(),
+        payload_role="input",
+    )
+    time.sleep(0.15)
+    client.emit_span_end(
+        span,
+        status=SpanStatus.COMPLETED,
+        payload=json.dumps({"ok": True, "tool": tool}).encode(),
+        payload_role="output",
+    )
+    return span
+
+
+def main() -> None:
+    server = os.environ.get("HARMONOGRAF_SERVER", "127.0.0.1:7531")
+    client = Client(
+        name="standalone-demo",
+        framework="CUSTOM",
+        server_addr=server,
+        session_title="Standalone observability demo",
+    )
+    try:
+        invocation = client.emit_span_start(
+            kind=SpanKind.INVOCATION,
+            name="answer_question",
+            attributes={"question": "What is harmonograf?"},
+        )
+
+        # Emit the user's message as its own span so the frontend's
+        # messages panel has something to show.
+        user_msg = client.emit_span_start(
+            kind=SpanKind.USER_MESSAGE,
+            name="user",
+            parent_span_id=invocation,
+            payload=json.dumps({"text": "What is harmonograf?"}).encode(),
+            payload_role="input",
+        )
+        client.emit_span_end(user_msg, status=SpanStatus.COMPLETED)
+
+        # Synthetic LLM reasoning step.
+        emit_llm_call(
+            client,
+            parent_id=invocation,
+            prompt="Explain harmonograf briefly.",
+        )
+
+        # Synthetic tool call.
+        emit_tool_call(
+            client,
+            parent_id=invocation,
+            tool="web_search",
+            args={"query": "harmonograf github"},
+        )
+
+        # Final synthesized answer.
+        agent_msg = client.emit_span_start(
+            kind=SpanKind.AGENT_MESSAGE,
+            name="agent",
+            parent_span_id=invocation,
+            payload=json.dumps(
+                {
+                    "text": (
+                        "Harmonograf is an observability console for "
+                        "multi-agent workflows."
+                    )
+                }
+            ).encode(),
+            payload_role="output",
+        )
+        client.emit_span_end(agent_msg, status=SpanStatus.COMPLETED)
+
+        client.emit_span_end(invocation, status=SpanStatus.COMPLETED)
+        print(f"emitted session: {client.session_id}")
+    finally:
+        client.shutdown(flush_timeout=5.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/standalone_observability/with_orchestration.py
+++ b/examples/standalone_observability/with_orchestration.py
@@ -1,0 +1,102 @@
+"""Goldfive orchestration + harmonograf observability — for comparison.
+
+The *other* path. If you want plans, tasks, and drift detection in the
+harmonograf UI (Tasks panel populated, drift banners, plan-scoped
+telemetry), this is the pattern: use goldfive.wrap() to produce a
+Runner, then attach harmonograf_client.observe() to ship its events to
+the harmonograf server.
+
+This example is the counterpoint to `spans_only.py` and
+`adk_telemetry.py` — it is only useful if you have installed the
+optional orchestration extra::
+
+    uv sync --extra orchestration
+
+Run:
+    export OPENAI_API_KEY=...
+    export HARMONOGRAF_SERVER=127.0.0.1:7531
+    uv run --extra orchestration python examples/standalone_observability/with_orchestration.py
+
+Contrast with `spans_only.py`, which does NOT import goldfive and which
+only populates the Gantt (Tasks panel stays empty).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import goldfive
+from goldfive import (
+    CallableAdapter,
+    InvocationResult,
+    PassthroughGoalDeriver,
+    Plan,
+    ReportingToolSpec,
+    Runner,
+    SequentialExecutor,
+    Session,
+    StaticPlanner,
+    Task,
+    TaskEdge,
+)
+
+import harmonograf_client
+
+
+def build_plan() -> Plan:
+    return Plan(
+        id="with-orchestration",
+        run_id="",
+        goal_ids=["g1"],
+        tasks=[
+            Task(id="research", title="Gather notes", assignee_agent_id="worker"),
+            Task(id="draft", title="Draft summary", assignee_agent_id="worker"),
+            Task(id="review", title="Review draft", assignee_agent_id="worker"),
+        ],
+        edges=[
+            TaskEdge(from_task_id="research", to_task_id="draft"),
+            TaskEdge(from_task_id="draft", to_task_id="review"),
+        ],
+        summary="Research, draft, review.",
+    )
+
+
+async def worker(
+    task: Task,
+    session: Session,
+    tools: list[ReportingToolSpec],
+) -> InvocationResult:
+    _ = session, tools
+    replies = {
+        "research": "Collected three bullet points.",
+        "draft": "Drafted a two-paragraph summary.",
+        "review": "Reviewed — looks good.",
+    }
+    return InvocationResult(task_id=task.id, text=replies.get(task.id, "(noop)"))
+
+
+async def main() -> None:
+    server = os.environ.get("HARMONOGRAF_SERVER", "127.0.0.1:7531")
+    plan = build_plan()
+    runner = Runner(
+        agent=CallableAdapter(worker, name="worker"),
+        planner=StaticPlanner(plan=plan),
+        executor=SequentialExecutor(),
+        goal_deriver=PassthroughGoalDeriver(),
+        sinks=[],
+    )
+    # Attach a HarmonografSink via the observe() convenience helper. This
+    # is a pure observability hook — it does not touch planning, steering,
+    # or execution. See docs/goldfive-integration.md.
+    runner = harmonograf_client.observe(
+        runner,
+        name="goldfive-orchestrated-demo",
+        server_addr=server,
+    )
+    outcome = await runner.run("Research, draft, and review a short summary.")
+    print(f"done: {outcome.final_task_id}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,25 +6,34 @@ requires-python = ">=3.11"
 dependencies = [
     "harmonograf-server",
     "harmonograf-client",
-    "goldfive",
+    # goldfive is not listed here: harmonograf can be used standalone for
+    # observability. Server + client still list goldfive directly because
+    # their generated proto stubs import goldfive.pb — that's an unavoidable
+    # consequence of Phase A (issue #6). The orchestration API (wrap(),
+    # Runner, adapters, planner, steerer) is opt-in via the extra below.
 ]
 
 [project.optional-dependencies]
+orchestration = [
+    "goldfive",
+]
 e2e = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "google-adk",
+    "goldfive",
 ]
 demo = [
     "google-adk",
     "litellm>=1.75.5",
+    "goldfive",
 ]
 
 [tool.uv.sources]
 harmonograf-server = { workspace = true }
 harmonograf-client = { workspace = true }
 google-adk = { path = "third_party/adk-python", editable = true }
-goldfive = { path = "../goldfive", editable = true }
+goldfive = { path = "third_party/goldfive", editable = true }
 
 [tool.uv.workspace]
 members = ["server", "client"]

--- a/uv.lock
+++ b/uv.lock
@@ -691,7 +691,7 @@ wheels = [
 [[package]]
 name = "goldfive"
 version = "0.1.0"
-source = { editable = "../goldfive" }
+source = { editable = "third_party/goldfive" }
 
 [package.metadata]
 requires-dist = [
@@ -1592,25 +1592,31 @@ name = "harmonograf"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
-    { name = "goldfive" },
     { name = "harmonograf-client" },
     { name = "harmonograf-server" },
 ]
 
 [package.optional-dependencies]
 demo = [
+    { name = "goldfive" },
     { name = "google-adk" },
     { name = "litellm" },
 ]
 e2e = [
+    { name = "goldfive" },
     { name = "google-adk" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
+orchestration = [
+    { name = "goldfive" },
+]
 
 [package.metadata]
 requires-dist = [
-    { name = "goldfive", editable = "../goldfive" },
+    { name = "goldfive", marker = "extra == 'demo'", editable = "third_party/goldfive" },
+    { name = "goldfive", marker = "extra == 'e2e'", editable = "third_party/goldfive" },
+    { name = "goldfive", marker = "extra == 'orchestration'", editable = "third_party/goldfive" },
     { name = "google-adk", marker = "extra == 'demo'", editable = "third_party/adk-python" },
     { name = "google-adk", marker = "extra == 'e2e'", editable = "third_party/adk-python" },
     { name = "harmonograf-client", editable = "client" },
@@ -1619,7 +1625,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'e2e'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'e2e'", specifier = ">=0.23" },
 ]
-provides-extras = ["e2e", "demo"]
+provides-extras = ["orchestration", "e2e", "demo"]
 
 [[package]]
 name = "harmonograf-client"
@@ -1640,7 +1646,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "goldfive", editable = "../goldfive" },
+    { name = "goldfive", editable = "third_party/goldfive" },
     { name = "grpcio", specifier = ">=1.60" },
     { name = "protobuf", specifier = ">=4.25" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -1674,7 +1680,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20" },
-    { name = "goldfive", editable = "../goldfive" },
+    { name = "goldfive", editable = "third_party/goldfive" },
     { name = "grpcio", specifier = ">=1.62" },
     { name = "grpcio-tools", specifier = ">=1.62" },
     { name = "hypercorn", specifier = ">=0.17" },


### PR DESCRIPTION
## Summary

Restructures harmonograf so it works standalone for observability — no goldfive orchestration required. Plans / tasks / drift become an opt-in enhancement via a new `orchestration` extra, following Interpretation 2 from #29 (usage-optional, install-unavoidable because Phase A linked the proto).

- **Vendoring.** `goldfive` is now a git submodule at `third_party/goldfive` (replaces the sibling-checkout pattern). `actions/checkout` uses `submodules: recursive`.
- **Packaging.** Root pyproject moves `goldfive` into `[project.optional-dependencies].orchestration`. Server + client inner pyprojects still list it because their generated pb stubs import from `goldfive.pb` — unavoidable post-#6.
- **Examples.** New `examples/standalone_observability/` with `spans_only.py` (pure `harmonograf_client`, zero goldfive references verified via grep), `adk_telemetry.py` (ADK + `HarmonografTelemetryPlugin`), and `with_orchestration.py` (comparison baseline).
- **Docs.** New `docs/standalone-observability.md` (~400 lines). `README.md`, `AGENTS.md`, `docs/goldfive-integration.md`, `docs/dev-guide/setup.md` updated to lead with the standalone story.
- **CI.** New `standalone-test` job: installs without `--extra orchestration`, greps `spans_only.py` for goldfive (must be zero), boots a server, runs the example.
- **Makefile.** New `make demo-standalone`: server + frontend + spans emitter.

Does **not** reverse Phase A, does **not** change the public surface of `harmonograf_client`.

## Test plan

- [x] `make proto` regenerates stubs using the new submodule path
- [x] `make server-test` (254 passed, 1 skipped)
- [x] `make client-test` (144 passed)
- [x] `make frontend-test` (build + lint clean)
- [x] `spans_only.py` runs end-to-end against a live `harmonograf-server` and emits a session (verified locally)
- [x] `grep -i goldfive examples/standalone_observability/spans_only.py` → zero hits
- [ ] CI `standalone-test` job passes (first run on this PR)
