### PR TITLE
UI Approve/Reject drawer for goldfive ApprovalRequested events (closes #31)

### DIFF
--- a/frontend/src/__tests__/components/ApprovalDrawer.test.tsx
+++ b/frontend/src/__tests__/components/ApprovalDrawer.test.tsx
@@ -1,0 +1,205 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { applyGoldfiveEvent } from '../../rpc/goldfiveEvent';
+import { SessionStore } from '../../gantt/index';
+import {
+  EventSchema,
+  ApprovalRequestedSchema,
+  ApprovalGrantedSchema,
+} from '../../pb/goldfive/v1/events_pb';
+import { useApprovalsStore } from '../../state/approvalsStore';
+
+const sendSpy = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../rpc/hooks', () => ({
+  useSendControl: () => sendSpy,
+}));
+
+let mockSessionId: string | null = 'sess-1';
+vi.mock('../../state/uiStore', () => ({
+  useUiStore: <T,>(selector: (s: { currentSessionId: string | null }) => T) =>
+    selector({ currentSessionId: mockSessionId }),
+}));
+
+import { ApprovalDrawer } from '../../components/Interaction/ApprovalDrawer';
+
+function synthRequest(opts: {
+  sessionId?: string;
+  targetId: string;
+  kind?: string;
+  prompt: string;
+  taskId?: string;
+  metadata?: Record<string, string>;
+}) {
+  const store = new SessionStore();
+  applyGoldfiveEvent(
+    create(EventSchema, {
+      eventId: `ev-${opts.targetId}`,
+      runId: 'run-1',
+      sequence: 0n,
+      payload: {
+        case: 'approvalRequested',
+        value: create(ApprovalRequestedSchema, {
+          targetId: opts.targetId,
+          kind: opts.kind ?? 'task',
+          prompt: opts.prompt,
+          taskId: opts.taskId ?? opts.targetId,
+          metadata: opts.metadata ?? {},
+        }),
+      },
+    }),
+    store,
+    0,
+    opts.sessionId ?? 'sess-1',
+  );
+}
+
+function synthGrant(targetId: string, sessionId = 'sess-1') {
+  const store = new SessionStore();
+  applyGoldfiveEvent(
+    create(EventSchema, {
+      eventId: `ev-g-${targetId}`,
+      runId: 'run-1',
+      sequence: 1n,
+      payload: {
+        case: 'approvalGranted',
+        value: create(ApprovalGrantedSchema, { targetId, detail: 'ok' }),
+      },
+    }),
+    store,
+    0,
+    sessionId,
+  );
+}
+
+describe('<ApprovalDrawer />', () => {
+  beforeEach(() => {
+    useApprovalsStore.setState({ bySession: new Map() });
+    mockSessionId = 'sess-1';
+    sendSpy.mockClear();
+  });
+  afterEach(() => {
+    useApprovalsStore.setState({ bySession: new Map() });
+  });
+
+  it('renders nothing when there is no current session', () => {
+    mockSessionId = null;
+    const { container } = render(<ApprovalDrawer />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when no approvals pending', () => {
+    const { container } = render(<ApprovalDrawer />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows a card with the prompt and tool args for a pending tool-level approval', () => {
+    act(() => {
+      synthRequest({
+        targetId: 'adk-1',
+        kind: 'tool',
+        prompt: 'Run write_file(path=/etc/passwd)?',
+        taskId: 't-parent',
+        metadata: {
+          tool_name: 'write_file',
+          args_json: '{"path":"/etc/passwd"}',
+        },
+      });
+    });
+    render(<ApprovalDrawer />);
+    expect(screen.getByTestId('approval-drawer')).toBeInTheDocument();
+    const card = screen.getByTestId('approval-card');
+    expect(card).toHaveAttribute('data-target-id', 'adk-1');
+    expect(card).toHaveAttribute('data-kind', 'tool');
+    expect(screen.getByTestId('approval-prompt')).toHaveTextContent(
+      'Run write_file(path=/etc/passwd)?',
+    );
+    expect(screen.getByTestId('approval-tool-name')).toHaveTextContent(
+      'write_file',
+    );
+    // args_json is pretty-printed.
+    expect(screen.getByTestId('approval-args').textContent).toContain(
+      '/etc/passwd',
+    );
+  });
+
+  it('clicking Approve dispatches APPROVE via sendControl with the targetId payload', async () => {
+    act(() => {
+      synthRequest({
+        targetId: 'adk-2',
+        kind: 'tool',
+        prompt: 'ok?',
+        taskId: 't-2',
+      });
+    });
+    render(<ApprovalDrawer />);
+    fireEvent.click(screen.getByTestId('approval-approve'));
+    await waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1));
+    const call = sendSpy.mock.calls[0][0];
+    expect(call.kind).toBe('APPROVE');
+    expect(call.sessionId).toBe('sess-1');
+    const payload = JSON.parse(new TextDecoder().decode(call.payload));
+    expect(payload.target_id).toBe('adk-2');
+  });
+
+  it('clicking Reject dispatches REJECT via sendControl', async () => {
+    act(() => {
+      synthRequest({
+        targetId: 't-3',
+        kind: 'task',
+        prompt: 'proceed?',
+      });
+    });
+    render(<ApprovalDrawer />);
+    fireEvent.click(screen.getByTestId('approval-reject'));
+    await waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1));
+    expect(sendSpy.mock.calls[0][0].kind).toBe('REJECT');
+  });
+
+  it('dismisses the card when the matching ApprovalGranted arrives', async () => {
+    act(() => {
+      synthRequest({ targetId: 't-4', kind: 'task', prompt: 'yes?' });
+    });
+    render(<ApprovalDrawer />);
+    expect(screen.getByTestId('approval-card')).toBeInTheDocument();
+
+    act(() => {
+      synthGrant('t-4');
+    });
+    await waitFor(() =>
+      expect(screen.queryByTestId('approval-card')).toBeNull(),
+    );
+    // With zero approvals the whole drawer collapses.
+    expect(screen.queryByTestId('approval-drawer')).toBeNull();
+  });
+
+  it('surfaces dispatch errors inline and leaves the card open', async () => {
+    sendSpy.mockRejectedValueOnce(new Error('network down'));
+    act(() => {
+      synthRequest({ targetId: 't-5', kind: 'task', prompt: 'proceed?' });
+    });
+    render(<ApprovalDrawer />);
+    fireEvent.click(screen.getByTestId('approval-approve'));
+    await waitFor(() =>
+      expect(screen.getByTestId('approval-error')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('approval-error').textContent).toContain(
+      'network down',
+    );
+    // Card stays open for retry.
+    expect(screen.getByTestId('approval-card')).toBeInTheDocument();
+  });
+
+  it('shows multiple pending approvals at once, ordered by requestedAtMs', () => {
+    act(() => {
+      synthRequest({ targetId: 'a', prompt: 'first' });
+      synthRequest({ targetId: 'b', prompt: 'second' });
+    });
+    render(<ApprovalDrawer />);
+    const cards = screen.getAllByTestId('approval-card');
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toHaveAttribute('data-target-id', 'a');
+    expect(cards[1]).toHaveAttribute('data-target-id', 'b');
+  });
+});

--- a/frontend/src/__tests__/rpc/goldfiveEvent.test.ts
+++ b/frontend/src/__tests__/rpc/goldfiveEvent.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { create } from '@bufbuild/protobuf';
 import { SessionStore } from '../../gantt/index';
 import { applyGoldfiveEvent } from '../../rpc/goldfiveEvent';
@@ -13,6 +13,9 @@ import {
   TaskCancelledSchema,
   DriftDetectedSchema,
   RunStartedSchema,
+  ApprovalRequestedSchema,
+  ApprovalGrantedSchema,
+  ApprovalRejectedSchema,
 } from '../../pb/goldfive/v1/events_pb';
 import {
   PlanSchema,
@@ -21,6 +24,7 @@ import {
   DriftKind,
   DriftSeverity,
 } from '../../pb/goldfive/v1/types_pb';
+import { useApprovalsStore } from '../../state/approvalsStore';
 
 function makePbTask(id: string, status: TaskStatus = TaskStatus.PENDING) {
   return create(TaskSchema, {
@@ -194,6 +198,198 @@ describe('applyGoldfiveEvent', () => {
       ),
     ).not.toThrow();
     expect(store.tasks.size).toBe(0);
+  });
+
+  describe('approval events', () => {
+    beforeEach(() => {
+      useApprovalsStore.setState({ bySession: new Map() });
+    });
+
+    it('approvalRequested pushes a PendingApproval into the approvals store', () => {
+      const store = new SessionStore();
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-ar',
+          runId: 'run-1',
+          sequence: 0n,
+          payload: {
+            case: 'approvalRequested',
+            value: create(ApprovalRequestedSchema, {
+              targetId: 'adk-call-1',
+              kind: 'tool',
+              prompt: 'Run write_file(path=/etc/passwd)?',
+              taskId: 't-1',
+              metadata: {
+                tool_name: 'write_file',
+                args_json: '{"path": "/etc/passwd"}',
+              },
+            }),
+          },
+        }),
+        store,
+        0,
+        'sess-x',
+      );
+
+      const list = useApprovalsStore.getState().list('sess-x');
+      expect(list).toHaveLength(1);
+      expect(list[0].targetId).toBe('adk-call-1');
+      expect(list[0].kind).toBe('tool');
+      expect(list[0].prompt).toBe('Run write_file(path=/etc/passwd)?');
+      expect(list[0].taskId).toBe('t-1');
+      expect(list[0].metadata.tool_name).toBe('write_file');
+      expect(list[0].metadata.args_json).toBe('{"path": "/etc/passwd"}');
+    });
+
+    it('approvalRequested without a sessionId is a no-op', () => {
+      const store = new SessionStore();
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-ar',
+          runId: 'run-1',
+          sequence: 0n,
+          payload: {
+            case: 'approvalRequested',
+            value: create(ApprovalRequestedSchema, {
+              targetId: 't-1',
+              kind: 'task',
+              prompt: 'ok?',
+              taskId: 't-1',
+            }),
+          },
+        }),
+        store,
+        0,
+      );
+      expect(useApprovalsStore.getState().bySession.size).toBe(0);
+    });
+
+    it('approvalGranted dismisses the matching ApprovalRequested', () => {
+      const store = new SessionStore();
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-ar',
+          runId: 'run-1',
+          sequence: 0n,
+          payload: {
+            case: 'approvalRequested',
+            value: create(ApprovalRequestedSchema, {
+              targetId: 't-1',
+              kind: 'task',
+              prompt: 'ok?',
+              taskId: 't-1',
+            }),
+          },
+        }),
+        store,
+        0,
+        'sess-x',
+      );
+      expect(useApprovalsStore.getState().list('sess-x')).toHaveLength(1);
+
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-ag',
+          runId: 'run-1',
+          sequence: 1n,
+          payload: {
+            case: 'approvalGranted',
+            value: create(ApprovalGrantedSchema, {
+              targetId: 't-1',
+              detail: 'user approved',
+            }),
+          },
+        }),
+        store,
+        0,
+        'sess-x',
+      );
+      expect(useApprovalsStore.getState().list('sess-x')).toHaveLength(0);
+    });
+
+    it('approvalRejected dismisses the matching ApprovalRequested', () => {
+      const store = new SessionStore();
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-ar',
+          runId: 'run-1',
+          sequence: 0n,
+          payload: {
+            case: 'approvalRequested',
+            value: create(ApprovalRequestedSchema, {
+              targetId: 't-1',
+              kind: 'task',
+              prompt: 'ok?',
+              taskId: 't-1',
+            }),
+          },
+        }),
+        store,
+        0,
+        'sess-x',
+      );
+
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-aj',
+          runId: 'run-1',
+          sequence: 1n,
+          payload: {
+            case: 'approvalRejected',
+            value: create(ApprovalRejectedSchema, {
+              targetId: 't-1',
+              detail: 'nope',
+            }),
+          },
+        }),
+        store,
+        0,
+        'sess-x',
+      );
+      expect(useApprovalsStore.getState().list('sess-x')).toHaveLength(0);
+    });
+
+    it('binds the approval to the assignee agent when the plan has seen the task', () => {
+      const store = new SessionStore();
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-plan',
+          runId: 'run-1',
+          sequence: 0n,
+          payload: {
+            case: 'planSubmitted',
+            value: create(PlanSubmittedSchema, {
+              plan: makePbPlan('p1', ['t-1']),
+            }),
+          },
+        }),
+        store,
+        0,
+        'sess-x',
+      );
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-ar',
+          runId: 'run-1',
+          sequence: 1n,
+          payload: {
+            case: 'approvalRequested',
+            value: create(ApprovalRequestedSchema, {
+              targetId: 't-1',
+              kind: 'task',
+              prompt: 'ok?',
+              taskId: 't-1',
+            }),
+          },
+        }),
+        store,
+        0,
+        'sess-x',
+      );
+      const [entry] = useApprovalsStore.getState().list('sess-x');
+      // makePbTask sets assigneeAgentId = 'agent-a'.
+      expect(entry.agentId).toBe('agent-a');
+    });
   });
 
   it('drift_detected / run_started are accepted without mutating the task store', () => {

--- a/frontend/src/__tests__/state/approvalsStore.test.ts
+++ b/frontend/src/__tests__/state/approvalsStore.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  useApprovalsStore,
+  type PendingApproval,
+} from '../../state/approvalsStore';
+
+function entry(overrides: Partial<PendingApproval> = {}): PendingApproval {
+  return {
+    sessionId: 'sess-1',
+    targetId: 't-1',
+    kind: 'task',
+    prompt: 'ok to spend $500?',
+    taskId: 't-1',
+    metadata: {},
+    requestedAtMs: 0,
+    agentId: 'agent-a',
+    spanId: '',
+    ...overrides,
+  };
+}
+
+describe('approvalsStore', () => {
+  beforeEach(() => {
+    useApprovalsStore.setState({ bySession: new Map() });
+  });
+
+  it('request() pushes a new entry and list() returns it', () => {
+    useApprovalsStore.getState().request(entry());
+    const list = useApprovalsStore.getState().list('sess-1');
+    expect(list).toHaveLength(1);
+    expect(list[0].targetId).toBe('t-1');
+    expect(list[0].prompt).toBe('ok to spend $500?');
+  });
+
+  it('request() replaces an entry with the same targetId rather than duplicating', () => {
+    const store = useApprovalsStore.getState();
+    store.request(entry({ prompt: 'first' }));
+    store.request(entry({ prompt: 'second' }));
+    const list = useApprovalsStore.getState().list('sess-1');
+    expect(list).toHaveLength(1);
+    expect(list[0].prompt).toBe('second');
+  });
+
+  it('entries sort by requestedAtMs', () => {
+    const store = useApprovalsStore.getState();
+    store.request(entry({ targetId: 'b', requestedAtMs: 2000 }));
+    store.request(entry({ targetId: 'a', requestedAtMs: 1000 }));
+    store.request(entry({ targetId: 'c', requestedAtMs: 3000 }));
+    const ids = useApprovalsStore
+      .getState()
+      .list('sess-1')
+      .map((e) => e.targetId);
+    expect(ids).toEqual(['a', 'b', 'c']);
+  });
+
+  it('resolve() removes matching targetId; mismatched resolve is a no-op', () => {
+    const store = useApprovalsStore.getState();
+    store.request(entry({ targetId: 't-1' }));
+    store.request(entry({ targetId: 't-2' }));
+    store.resolve('sess-1', 't-1');
+    const remaining = useApprovalsStore.getState().list('sess-1');
+    expect(remaining.map((e) => e.targetId)).toEqual(['t-2']);
+    // Resolve with unknown id: no change.
+    store.resolve('sess-1', 'never-existed');
+    expect(useApprovalsStore.getState().list('sess-1')).toHaveLength(1);
+  });
+
+  it('clear() drops all entries for a session', () => {
+    const store = useApprovalsStore.getState();
+    store.request(entry({ targetId: 't-1' }));
+    store.request(entry({ targetId: 't-2', sessionId: 'sess-2' }));
+    store.clear('sess-1');
+    expect(useApprovalsStore.getState().list('sess-1')).toEqual([]);
+    expect(useApprovalsStore.getState().list('sess-2')).toHaveLength(1);
+  });
+
+  it('list(null) returns empty array', () => {
+    expect(useApprovalsStore.getState().list(null)).toEqual([]);
+  });
+});

--- a/frontend/src/components/Interaction/ApprovalDrawer.tsx
+++ b/frontend/src/components/Interaction/ApprovalDrawer.tsx
@@ -1,0 +1,220 @@
+import { useMemo, useState } from 'react';
+import { useApprovalsStore, type PendingApproval } from '../../state/approvalsStore';
+import { useUiStore } from '../../state/uiStore';
+import { useSendControl } from '../../rpc/hooks';
+
+// Stable sentinel so the zustand selector below returns a referentially
+// stable value when the session has no pending approvals — otherwise
+// useSyncExternalStore tears on every render.
+const EMPTY_APPROVALS: PendingApproval[] = [];
+
+// Surfaces goldfive ApprovalRequested events queued on the approvalsStore.
+//
+// One entry per pending approval; entries are removed client-side when the
+// matching ApprovalGranted / ApprovalRejected arrives, so a submit-then-
+// acknowledge round-trip auto-dismisses without an explicit close.
+//
+// Two flows share this surface:
+//   * Flow A (task-level): `kind` = "task", `target_id` = task id, metadata
+//     carries whatever the reporting tool chose to pack.
+//   * Flow B (tool-level): `kind` = "tool", `target_id` = ADK function-call
+//     id, metadata carries "tool_name" and "args_json".
+// The drawer renders Flow B with the tool/name args preview card, Flow A with
+// the prompt alone.
+
+export function ApprovalDrawer() {
+  const sessionId = useUiStore((s) => s.currentSessionId);
+  const approvals = useApprovalsStore((s) =>
+    sessionId ? s.bySession.get(sessionId) ?? EMPTY_APPROVALS : EMPTY_APPROVALS,
+  );
+  if (!sessionId || approvals.length === 0) return null;
+  return (
+    <aside
+      className="hg-approval-drawer"
+      data-testid="approval-drawer"
+      role="region"
+      aria-label="Pending approvals"
+      style={{
+        position: 'fixed',
+        top: 72,
+        right: 16,
+        width: 380,
+        maxHeight: '70vh',
+        overflowY: 'auto',
+        zIndex: 40,
+        background: 'var(--md-sys-color-surface-container-high, #232832)',
+        color: 'var(--md-sys-color-on-surface, #e2e2e9)',
+        border: '1px solid var(--md-sys-color-outline-variant, #43474e)',
+        borderRadius: 12,
+        boxShadow: '0 8px 28px rgba(0,0,0,0.5)',
+        padding: 8,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <div
+        style={{
+          padding: '4px 8px',
+          fontSize: 11,
+          textTransform: 'uppercase',
+          letterSpacing: '0.08em',
+          opacity: 0.7,
+        }}
+      >
+        Pending approvals · {approvals.length}
+      </div>
+      {approvals.map((a) => (
+        <ApprovalCard key={`${a.sessionId}:${a.targetId}`} approval={a} />
+      ))}
+    </aside>
+  );
+}
+
+function ApprovalCard({ approval }: { approval: PendingApproval }) {
+  const send = useSendControl();
+  const [busy, setBusy] = useState<'APPROVE' | 'REJECT' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const toolName = approval.metadata['tool_name'] ?? '';
+  const argsJson = approval.metadata['args_json'] ?? '';
+
+  const prettyArgs = useMemo(() => {
+    if (!argsJson) return '';
+    try {
+      return JSON.stringify(JSON.parse(argsJson), null, 2);
+    } catch {
+      return argsJson;
+    }
+  }, [argsJson]);
+
+  const dispatch = async (kind: 'APPROVE' | 'REJECT') => {
+    setBusy(kind);
+    setError(null);
+    try {
+      // Encode target_id in the payload body so the server-side
+      // ControlChannel bridge can quote it back onto the
+      // pending-approval waiter regardless of which agent/span we
+      // happened to observe.
+      const payload = new TextEncoder().encode(
+        JSON.stringify({ target_id: approval.targetId }),
+      );
+      await send({
+        sessionId: approval.sessionId,
+        agentId: approval.agentId,
+        spanId: approval.spanId,
+        kind,
+        payload,
+      });
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div
+      data-testid="approval-card"
+      data-target-id={approval.targetId}
+      data-kind={approval.kind}
+      style={{
+        padding: 10,
+        borderRadius: 8,
+        background: 'var(--md-sys-color-error-container, #5c1a1b)',
+        color: 'var(--md-sys-color-on-error-container, #ffdad6)',
+        border: '1px solid var(--md-sys-color-error, #ffb4ab)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        fontSize: 12,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+        <span style={{ fontWeight: 700 }}>Approval required</span>
+        <span
+          style={{
+            fontSize: 10,
+            padding: '1px 6px',
+            borderRadius: 8,
+            border: '1px solid currentColor',
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+            opacity: 0.85,
+          }}
+        >
+          {approval.kind || 'task'}
+        </span>
+        {toolName && (
+          <code
+            data-testid="approval-tool-name"
+            style={{ fontSize: 11, opacity: 0.9 }}
+          >
+            {toolName}
+          </code>
+        )}
+      </div>
+      <div
+        data-testid="approval-prompt"
+        style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+      >
+        {approval.prompt || '(no prompt)'}
+      </div>
+      {prettyArgs && (
+        <pre
+          data-testid="approval-args"
+          style={{
+            margin: 0,
+            padding: 6,
+            background: 'rgba(0,0,0,0.3)',
+            borderRadius: 6,
+            maxHeight: 160,
+            overflow: 'auto',
+            fontSize: 11,
+            fontFamily: "ui-monospace, 'SF Mono', Consolas, monospace",
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
+          {prettyArgs}
+        </pre>
+      )}
+      {approval.taskId && approval.taskId !== approval.targetId && (
+        <div style={{ fontSize: 10, opacity: 0.75 }}>
+          task <code>{approval.taskId}</code>
+        </div>
+      )}
+      {error && (
+        <div
+          data-testid="approval-error"
+          style={{ fontSize: 11, opacity: 0.9 }}
+        >
+          {error}
+        </div>
+      )}
+      <div
+        style={{
+          display: 'flex',
+          gap: 6,
+          justifyContent: 'flex-end',
+          paddingTop: 2,
+        }}
+      >
+        <button
+          data-testid="approval-reject"
+          onClick={() => void dispatch('REJECT')}
+          disabled={busy !== null}
+        >
+          {busy === 'REJECT' ? 'Rejecting…' : 'Reject'}
+        </button>
+        <button
+          data-testid="approval-approve"
+          onClick={() => void dispatch('APPROVE')}
+          disabled={busy !== null}
+        >
+          {busy === 'APPROVE' ? 'Approving…' : 'Approve'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shell/Shell.tsx
+++ b/frontend/src/components/shell/Shell.tsx
@@ -7,6 +7,7 @@ import { SessionPicker } from '../SessionPicker/SessionPicker';
 import { HelpOverlay } from './HelpOverlay';
 import { GanttLegend } from '../Gantt/GanttLegend';
 import { ShellErrorBoundary } from './ErrorBoundary';
+import { ApprovalDrawer } from '../Interaction/ApprovalDrawer';
 import { SessionsSyncer } from '../../rpc/SessionsSyncer';
 import { useGlobalShortcuts } from '../../lib/shortcuts';
 import { useUiStore } from '../../state/uiStore';
@@ -39,6 +40,7 @@ export function Shell() {
       <SessionPicker />
       <HelpOverlay />
       <GanttLegend />
+      <ApprovalDrawer />
     </div>
   );
 }

--- a/frontend/src/pb/goldfive/v1/events_pb.ts
+++ b/frontend/src/pb/goldfive/v1/events_pb.ts
@@ -26,7 +26,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file goldfive/v1/events.proto.
  */
 export const file_goldfive_v1_events: GenFile = /*@__PURE__*/
-  fileDesc("Chhnb2xkZml2ZS92MS9ldmVudHMucHJvdG8SC2dvbGRmaXZlLnYxIo4GCgVFdmVudBIQCghldmVudF9pZBgBIAEoCRIOCgZydW5faWQYAiABKAkSEAoIc2VxdWVuY2UYAyABKAQSLgoKZW1pdHRlZF9hdBgEIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoLcnVuX3N0YXJ0ZWQYCiABKAsyFy5nb2xkZml2ZS52MS5SdW5TdGFydGVkSAASMAoMZ29hbF9kZXJpdmVkGAsgASgLMhguZ29sZGZpdmUudjEuR29hbERlcml2ZWRIABI0Cg5wbGFuX3N1Ym1pdHRlZBgMIAEoCzIaLmdvbGRmaXZlLnYxLlBsYW5TdWJtaXR0ZWRIABIwCgxwbGFuX3JldmlzZWQYDSABKAsyGC5nb2xkZml2ZS52MS5QbGFuUmV2aXNlZEgAEjAKDHRhc2tfc3RhcnRlZBgOIAEoCzIYLmdvbGRmaXZlLnYxLlRhc2tTdGFydGVkSAASMgoNdGFza19wcm9ncmVzcxgPIAEoCzIZLmdvbGRmaXZlLnYxLlRhc2tQcm9ncmVzc0gAEjQKDnRhc2tfY29tcGxldGVkGBAgASgLMhouZ29sZGZpdmUudjEuVGFza0NvbXBsZXRlZEgAEi4KC3Rhc2tfZmFpbGVkGBEgASgLMhcuZ29sZGZpdmUudjEuVGFza0ZhaWxlZEgAEjAKDHRhc2tfYmxvY2tlZBgSIAEoCzIYLmdvbGRmaXZlLnYxLlRhc2tCbG9ja2VkSAASNAoOdGFza19jYW5jZWxsZWQYEyABKAsyGi5nb2xkZml2ZS52MS5UYXNrQ2FuY2VsbGVkSAASNAoOZHJpZnRfZGV0ZWN0ZWQYFCABKAsyGi5nb2xkZml2ZS52MS5EcmlmdERldGVjdGVkSAASMgoNcnVuX2NvbXBsZXRlZBgVIAEoCzIZLmdvbGRmaXZlLnYxLlJ1bkNvbXBsZXRlZEgAEi4KC3J1bl9hYm9ydGVkGBYgASgLMhcuZ29sZGZpdmUudjEuUnVuQWJvcnRlZEgAQgkKB3BheWxvYWQiYgoKUnVuU3RhcnRlZBIOCgZydW5faWQYASABKAkSFAoMZ29hbF9zdW1tYXJ5GAIgASgJEi4KCnN0YXJ0ZWRfYXQYAyABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIi8KC0dvYWxEZXJpdmVkEiAKBWdvYWxzGAEgAygLMhEuZ29sZGZpdmUudjEuR29hbCIwCg1QbGFuU3VibWl0dGVkEh8KBHBsYW4YASABKAsyES5nb2xkZml2ZS52MS5QbGFuIrABCgtQbGFuUmV2aXNlZBIfCgRwbGFuGAEgASgLMhEuZ29sZGZpdmUudjEuUGxhbhIqCgpkcmlmdF9raW5kGAIgASgOMhYuZ29sZGZpdmUudjEuRHJpZnRLaW5kEiwKCHNldmVyaXR5GAMgASgOMhouZ29sZGZpdmUudjEuRHJpZnRTZXZlcml0eRIOCgZyZWFzb24YBCABKAkSFgoOcmV2aXNpb25faW5kZXgYBSABKA0iLgoLVGFza1N0YXJ0ZWQSDwoHdGFza19pZBgBIAEoCRIOCgZkZXRhaWwYAiABKAkiQQoMVGFza1Byb2dyZXNzEg8KB3Rhc2tfaWQYASABKAkSEAoIZnJhY3Rpb24YAiABKAISDgoGZGV0YWlsGAMgASgJIqEBCg1UYXNrQ29tcGxldGVkEg8KB3Rhc2tfaWQYASABKAkSDwoHc3VtbWFyeRgCIAEoCRI8CglhcnRpZmFjdHMYAyADKAsyKS5nb2xkZml2ZS52MS5UYXNrQ29tcGxldGVkLkFydGlmYWN0c0VudHJ5GjAKDkFydGlmYWN0c0VudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiQgoKVGFza0ZhaWxlZBIPCgd0YXNrX2lkGAEgASgJEg4KBnJlYXNvbhgCIAEoCRITCgtyZWNvdmVyYWJsZRgDIAEoCCI/CgtUYXNrQmxvY2tlZBIPCgd0YXNrX2lkGAEgASgJEg8KB2Jsb2NrZXIYAiABKAkSDgoGbmVlZGVkGAMgASgJIjAKDVRhc2tDYW5jZWxsZWQSDwoHdGFza19pZBgBIAEoCRIOCgZyZWFzb24YAiABKAkipgEKDURyaWZ0RGV0ZWN0ZWQSJAoEa2luZBgBIAEoDjIWLmdvbGRmaXZlLnYxLkRyaWZ0S2luZBIsCghzZXZlcml0eRgCIAEoDjIaLmdvbGRmaXZlLnYxLkRyaWZ0U2V2ZXJpdHkSDgoGZGV0YWlsGAMgASgJEhcKD2N1cnJlbnRfdGFza19pZBgEIAEoCRIYChBjdXJyZW50X2FnZW50X2lkGAUgASgJIicKDFJ1bkNvbXBsZXRlZBIXCg9vdXRjb21lX3N1bW1hcnkYASABKAkiHAoKUnVuQWJvcnRlZBIOCgZyZWFzb24YASABKAlCOVo3Z2l0aHViLmNvbS9wZWRhcHVkaS9nb2xkZml2ZS9nZW4vZ29sZGZpdmUvdjE7Z29sZGZpdmV2MWIGcHJvdG8z", [file_google_protobuf_timestamp, file_goldfive_v1_types]);
+  fileDesc("Chhnb2xkZml2ZS92MS9ldmVudHMucHJvdG8SC2dvbGRmaXZlLnYxIsIICgVFdmVudBIQCghldmVudF9pZBgBIAEoCRIOCgZydW5faWQYAiABKAkSEAoIc2VxdWVuY2UYAyABKAQSLgoKZW1pdHRlZF9hdBgEIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLgoLcnVuX3N0YXJ0ZWQYCiABKAsyFy5nb2xkZml2ZS52MS5SdW5TdGFydGVkSAASMAoMZ29hbF9kZXJpdmVkGAsgASgLMhguZ29sZGZpdmUudjEuR29hbERlcml2ZWRIABI0Cg5wbGFuX3N1Ym1pdHRlZBgMIAEoCzIaLmdvbGRmaXZlLnYxLlBsYW5TdWJtaXR0ZWRIABIwCgxwbGFuX3JldmlzZWQYDSABKAsyGC5nb2xkZml2ZS52MS5QbGFuUmV2aXNlZEgAEjAKDHRhc2tfc3RhcnRlZBgOIAEoCzIYLmdvbGRmaXZlLnYxLlRhc2tTdGFydGVkSAASMgoNdGFza19wcm9ncmVzcxgPIAEoCzIZLmdvbGRmaXZlLnYxLlRhc2tQcm9ncmVzc0gAEjQKDnRhc2tfY29tcGxldGVkGBAgASgLMhouZ29sZGZpdmUudjEuVGFza0NvbXBsZXRlZEgAEi4KC3Rhc2tfZmFpbGVkGBEgASgLMhcuZ29sZGZpdmUudjEuVGFza0ZhaWxlZEgAEjAKDHRhc2tfYmxvY2tlZBgSIAEoCzIYLmdvbGRmaXZlLnYxLlRhc2tCbG9ja2VkSAASNAoOdGFza19jYW5jZWxsZWQYEyABKAsyGi5nb2xkZml2ZS52MS5UYXNrQ2FuY2VsbGVkSAASNAoOZHJpZnRfZGV0ZWN0ZWQYFCABKAsyGi5nb2xkZml2ZS52MS5EcmlmdERldGVjdGVkSAASMgoNcnVuX2NvbXBsZXRlZBgVIAEoCzIZLmdvbGRmaXZlLnYxLlJ1bkNvbXBsZXRlZEgAEi4KC3J1bl9hYm9ydGVkGBYgASgLMhcuZ29sZGZpdmUudjEuUnVuQWJvcnRlZEgAEkAKFGNvbnZlcnNhdGlvbl9zdGFydGVkGBcgASgLMiAuZ29sZGZpdmUudjEuQ29udmVyc2F0aW9uU3RhcnRlZEgAEjwKEmNvbnZlcnNhdGlvbl9lbmRlZBgYIAEoCzIeLmdvbGRmaXZlLnYxLkNvbnZlcnNhdGlvbkVuZGVkSAASPAoSYXBwcm92YWxfcmVxdWVzdGVkGBkgASgLMh4uZ29sZGZpdmUudjEuQXBwcm92YWxSZXF1ZXN0ZWRIABI4ChBhcHByb3ZhbF9ncmFudGVkGBogASgLMhwuZ29sZGZpdmUudjEuQXBwcm92YWxHcmFudGVkSAASOgoRYXBwcm92YWxfcmVqZWN0ZWQYGyABKAsyHS5nb2xkZml2ZS52MS5BcHByb3ZhbFJlamVjdGVkSABCCQoHcGF5bG9hZCJiCgpSdW5TdGFydGVkEg4KBnJ1bl9pZBgBIAEoCRIUCgxnb2FsX3N1bW1hcnkYAiABKAkSLgoKc3RhcnRlZF9hdBgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAiLwoLR29hbERlcml2ZWQSIAoFZ29hbHMYASADKAsyES5nb2xkZml2ZS52MS5Hb2FsIjAKDVBsYW5TdWJtaXR0ZWQSHwoEcGxhbhgBIAEoCzIRLmdvbGRmaXZlLnYxLlBsYW4isAEKC1BsYW5SZXZpc2VkEh8KBHBsYW4YASABKAsyES5nb2xkZml2ZS52MS5QbGFuEioKCmRyaWZ0X2tpbmQYAiABKA4yFi5nb2xkZml2ZS52MS5EcmlmdEtpbmQSLAoIc2V2ZXJpdHkYAyABKA4yGi5nb2xkZml2ZS52MS5EcmlmdFNldmVyaXR5Eg4KBnJlYXNvbhgEIAEoCRIWCg5yZXZpc2lvbl9pbmRleBgFIAEoDSIuCgtUYXNrU3RhcnRlZBIPCgd0YXNrX2lkGAEgASgJEg4KBmRldGFpbBgCIAEoCSJBCgxUYXNrUHJvZ3Jlc3MSDwoHdGFza19pZBgBIAEoCRIQCghmcmFjdGlvbhgCIAEoAhIOCgZkZXRhaWwYAyABKAkioQEKDVRhc2tDb21wbGV0ZWQSDwoHdGFza19pZBgBIAEoCRIPCgdzdW1tYXJ5GAIgASgJEjwKCWFydGlmYWN0cxgDIAMoCzIpLmdvbGRmaXZlLnYxLlRhc2tDb21wbGV0ZWQuQXJ0aWZhY3RzRW50cnkaMAoOQXJ0aWZhY3RzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASJCCgpUYXNrRmFpbGVkEg8KB3Rhc2tfaWQYASABKAkSDgoGcmVhc29uGAIgASgJEhMKC3JlY292ZXJhYmxlGAMgASgIIj8KC1Rhc2tCbG9ja2VkEg8KB3Rhc2tfaWQYASABKAkSDwoHYmxvY2tlchgCIAEoCRIOCgZuZWVkZWQYAyABKAkiMAoNVGFza0NhbmNlbGxlZBIPCgd0YXNrX2lkGAEgASgJEg4KBnJlYXNvbhgCIAEoCSKmAQoNRHJpZnREZXRlY3RlZBIkCgRraW5kGAEgASgOMhYuZ29sZGZpdmUudjEuRHJpZnRLaW5kEiwKCHNldmVyaXR5GAIgASgOMhouZ29sZGZpdmUudjEuRHJpZnRTZXZlcml0eRIOCgZkZXRhaWwYAyABKAkSFwoPY3VycmVudF90YXNrX2lkGAQgASgJEhgKEGN1cnJlbnRfYWdlbnRfaWQYBSABKAkiJwoMUnVuQ29tcGxldGVkEhcKD291dGNvbWVfc3VtbWFyeRgBIAEoCSIcCgpSdW5BYm9ydGVkEg4KBnJlYXNvbhgBIAEoCSJeChNDb252ZXJzYXRpb25TdGFydGVkEhcKD2NvbnZlcnNhdGlvbl9pZBgBIAEoCRIuCgpzdGFydGVkX2F0GAIgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCJQChFDb252ZXJzYXRpb25FbmRlZBIXCg9jb252ZXJzYXRpb25faWQYASABKAkSEgoKdHVybl9jb3VudBgCIAEoDRIOCgZyZWFzb24YAyABKAkixgEKEUFwcHJvdmFsUmVxdWVzdGVkEhEKCXRhcmdldF9pZBgBIAEoCRIMCgRraW5kGAIgASgJEg4KBnByb21wdBgDIAEoCRIPCgd0YXNrX2lkGAQgASgJEj4KCG1ldGFkYXRhGAUgAygLMiwuZ29sZGZpdmUudjEuQXBwcm92YWxSZXF1ZXN0ZWQuTWV0YWRhdGFFbnRyeRovCg1NZXRhZGF0YUVudHJ5EgsKA2tleRgBIAEoCRINCgV2YWx1ZRgCIAEoCToCOAEiNAoPQXBwcm92YWxHcmFudGVkEhEKCXRhcmdldF9pZBgBIAEoCRIOCgZkZXRhaWwYAiABKAkiNQoQQXBwcm92YWxSZWplY3RlZBIRCgl0YXJnZXRfaWQYASABKAkSDgoGZGV0YWlsGAIgASgJQjlaN2dpdGh1Yi5jb20vcGVkYXB1ZGkvZ29sZGZpdmUvZ2VuL2dvbGRmaXZlL3YxO2dvbGRmaXZldjFiBnByb3RvMw", [file_google_protobuf_timestamp, file_goldfive_v1_types]);
 
 /**
  * Event is the uniform envelope wrapping every goldfive event. Sinks
@@ -148,6 +148,36 @@ export type Event = Message<"goldfive.v1.Event"> & {
      */
     value: RunAborted;
     case: "runAborted";
+  } | {
+    /**
+     * @generated from field: goldfive.v1.ConversationStarted conversation_started = 23;
+     */
+    value: ConversationStarted;
+    case: "conversationStarted";
+  } | {
+    /**
+     * @generated from field: goldfive.v1.ConversationEnded conversation_ended = 24;
+     */
+    value: ConversationEnded;
+    case: "conversationEnded";
+  } | {
+    /**
+     * @generated from field: goldfive.v1.ApprovalRequested approval_requested = 25;
+     */
+    value: ApprovalRequested;
+    case: "approvalRequested";
+  } | {
+    /**
+     * @generated from field: goldfive.v1.ApprovalGranted approval_granted = 26;
+     */
+    value: ApprovalGranted;
+    case: "approvalGranted";
+  } | {
+    /**
+     * @generated from field: goldfive.v1.ApprovalRejected approval_rejected = 27;
+     */
+    value: ApprovalRejected;
+    case: "approvalRejected";
   } | { case: undefined; value?: undefined };
 };
 
@@ -536,4 +566,175 @@ export type RunAborted = Message<"goldfive.v1.RunAborted"> & {
  */
 export const RunAbortedSchema: GenMessage<RunAborted> = /*@__PURE__*/
   messageDesc(file_goldfive_v1_events, 13);
+
+/**
+ * Emitted once per Conversation on the first turn that uses it. Sinks
+ * that render cross-turn chat history use this to open a new
+ * conversation context. `run_id` on the envelope is the first turn's
+ * run_id; `conversation_id` below is the stable identifier shared by
+ * every turn in the conversation.
+ *
+ * @generated from message goldfive.v1.ConversationStarted
+ */
+export type ConversationStarted = Message<"goldfive.v1.ConversationStarted"> & {
+  /**
+   * @generated from field: string conversation_id = 1;
+   */
+  conversationId: string;
+
+  /**
+   * @generated from field: google.protobuf.Timestamp started_at = 2;
+   */
+  startedAt?: Timestamp;
+};
+
+/**
+ * Describes the message goldfive.v1.ConversationStarted.
+ * Use `create(ConversationStartedSchema)` to create a new message.
+ */
+export const ConversationStartedSchema: GenMessage<ConversationStarted> = /*@__PURE__*/
+  messageDesc(file_goldfive_v1_events, 14);
+
+/**
+ * Emitted when a caller invokes `Runner.new_conversation()` or closes
+ * the Runner. Signals that no further turns will share this
+ * conversation_id. `turn_count` is the number of turns that ran before
+ * the reset, so sinks can render "3-turn conversation ended".
+ *
+ * @generated from message goldfive.v1.ConversationEnded
+ */
+export type ConversationEnded = Message<"goldfive.v1.ConversationEnded"> & {
+  /**
+   * @generated from field: string conversation_id = 1;
+   */
+  conversationId: string;
+
+  /**
+   * @generated from field: uint32 turn_count = 2;
+   */
+  turnCount: number;
+
+  /**
+   * @generated from field: string reason = 3;
+   */
+  reason: string;
+};
+
+/**
+ * Describes the message goldfive.v1.ConversationEnded.
+ * Use `create(ConversationEndedSchema)` to create a new message.
+ */
+export const ConversationEndedSchema: GenMessage<ConversationEnded> = /*@__PURE__*/
+  messageDesc(file_goldfive_v1_events, 15);
+
+/**
+ * A human yes/no is required before the run can proceed. Surfaced by:
+ *   * the `report_awaiting_approval` reporting tool (task-level, Flow A),
+ *     where `target_id` is the task id and `kind` = "task";
+ *   * the ADKAdapter's before_tool_callback on a `require_confirmation=True`
+ *     tool (tool-level, Flow B), where `target_id` is the ADK function-call
+ *     id and `kind` = "tool".
+ * Either flow resolves with a ControlMessage(APPROVE|REJECT, {"target_id": ...})
+ * which the executor dispatches back onto `session.pending_approvals`.
+ *
+ * @generated from message goldfive.v1.ApprovalRequested
+ */
+export type ApprovalRequested = Message<"goldfive.v1.ApprovalRequested"> & {
+  /**
+   * Target the APPROVE/REJECT control must quote back: task_id for Flow A,
+   * ADK function-call id (e.g. "adk-<uuid>") for Flow B.
+   *
+   * @generated from field: string target_id = 1;
+   */
+  targetId: string;
+
+  /**
+   * "task" or "tool".
+   *
+   * @generated from field: string kind = 2;
+   */
+  kind: string;
+
+  /**
+   * Human-readable question the UI should render to the human ("ok to spend
+   * $500?", "Run write_file(path='/etc/passwd')?").
+   *
+   * @generated from field: string prompt = 3;
+   */
+  prompt: string;
+
+  /**
+   * The goldfive task context in which the approval arose. Same as
+   * `target_id` for Flow A; the task the agent was working on for Flow B.
+   *
+   * @generated from field: string task_id = 4;
+   */
+  taskId: string;
+
+  /**
+   * Free-form metadata. Tool-level approvals set "tool_name" and
+   * "args_json"; task-level approvals may set custom keys.
+   *
+   * @generated from field: map<string, string> metadata = 5;
+   */
+  metadata: { [key: string]: string };
+};
+
+/**
+ * Describes the message goldfive.v1.ApprovalRequested.
+ * Use `create(ApprovalRequestedSchema)` to create a new message.
+ */
+export const ApprovalRequestedSchema: GenMessage<ApprovalRequested> = /*@__PURE__*/
+  messageDesc(file_goldfive_v1_events, 16);
+
+/**
+ * APPROVE resolution for an ApprovalRequested. Emitted after the control
+ * dispatcher sets the pending-approval waiter.
+ *
+ * @generated from message goldfive.v1.ApprovalGranted
+ */
+export type ApprovalGranted = Message<"goldfive.v1.ApprovalGranted"> & {
+  /**
+   * @generated from field: string target_id = 1;
+   */
+  targetId: string;
+
+  /**
+   * @generated from field: string detail = 2;
+   */
+  detail: string;
+};
+
+/**
+ * Describes the message goldfive.v1.ApprovalGranted.
+ * Use `create(ApprovalGrantedSchema)` to create a new message.
+ */
+export const ApprovalGrantedSchema: GenMessage<ApprovalGranted> = /*@__PURE__*/
+  messageDesc(file_goldfive_v1_events, 17);
+
+/**
+ * REJECT resolution for an ApprovalRequested. The agent (Flow A) decides
+ * whether this maps to TaskFailed; the adapter (Flow B) returns a skipped-
+ * tool response to the model.
+ *
+ * @generated from message goldfive.v1.ApprovalRejected
+ */
+export type ApprovalRejected = Message<"goldfive.v1.ApprovalRejected"> & {
+  /**
+   * @generated from field: string target_id = 1;
+   */
+  targetId: string;
+
+  /**
+   * @generated from field: string detail = 2;
+   */
+  detail: string;
+};
+
+/**
+ * Describes the message goldfive.v1.ApprovalRejected.
+ * Use `create(ApprovalRejectedSchema)` to create a new message.
+ */
+export const ApprovalRejectedSchema: GenMessage<ApprovalRejected> = /*@__PURE__*/
+  messageDesc(file_goldfive_v1_events, 18);
 

--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -20,6 +20,7 @@ import {
   DriftSeverity as GoldfiveDriftSeverityEnum,
 } from '../pb/goldfive/v1/types_pb.js';
 import type { Event as GoldfiveEvent } from '../pb/goldfive/v1/events_pb.js';
+import { useApprovalsStore } from '../state/approvalsStore';
 
 // goldfive.v1.TaskStatus enum values are identical to harmonograf's
 // TaskStatus strings at indices 0..5, plus BLOCKED = 6 (goldfive-only).
@@ -109,6 +110,7 @@ export function applyGoldfiveEvent(
   event: GoldfiveEvent,
   store: SessionStore,
   sessionStartMs: number,
+  sessionId: string | null = null,
 ): void {
   const payload = event.payload;
   if (!payload.case) return;
@@ -136,15 +138,55 @@ export function applyGoldfiveEvent(
     case 'taskCancelled':
       store.tasks.updateTaskStatusByTaskId(payload.value.taskId, 'CANCELLED');
       return;
+    case 'approvalRequested': {
+      if (!sessionId) return;
+      const r = payload.value;
+      // Best-effort binding back to the originating span: if goldfive has
+      // already emitted a TaskStarted for the same task_id, the plan's task
+      // row has a boundSpanId set — use that agent/span so APPROVE/REJECT
+      // routes to the exact executor. Falls back to empty strings when the
+      // span isn't known yet; the server-side ControlChannel bridge accepts
+      // session-level approvals without a specific agentId/spanId.
+      const found = r.taskId ? store.tasks.findPlanForTask(r.taskId) : null;
+      const boundSpanId = found?.task.boundSpanId ?? '';
+      const span = boundSpanId ? store.spans.get(boundSpanId) : null;
+      const requestedAtMs = event.emittedAt
+        ? Number(event.emittedAt.seconds) * 1000 +
+          Math.floor(event.emittedAt.nanos / 1_000_000) -
+          sessionStartMs
+        : 0;
+      useApprovalsStore.getState().request({
+        sessionId,
+        targetId: r.targetId,
+        kind: r.kind,
+        prompt: r.prompt,
+        taskId: r.taskId,
+        metadata: { ...r.metadata },
+        requestedAtMs,
+        agentId: span?.agentId ?? found?.task.assigneeAgentId ?? '',
+        spanId: boundSpanId,
+      });
+      return;
+    }
+    case 'approvalGranted':
+    case 'approvalRejected': {
+      if (!sessionId) return;
+      useApprovalsStore
+        .getState()
+        .resolve(sessionId, payload.value.targetId);
+      return;
+    }
     case 'taskProgress':
     case 'driftDetected':
     case 'runStarted':
     case 'goalDerived':
     case 'runCompleted':
     case 'runAborted':
-      // No-op. task_progress / drift / run_* are observable on the wire
-      // (useful for analytics or a future drift timeline), but the
-      // Gantt renderer does not consume them today.
+    case 'conversationStarted':
+    case 'conversationEnded':
+      // No-op. task_progress / drift / run_* / conversation_* are
+      // observable on the wire (useful for analytics or a future drift
+      // timeline), but the Gantt renderer does not consume them today.
       return;
   }
 }

--- a/frontend/src/rpc/hooks.ts
+++ b/frontend/src/rpc/hooks.ts
@@ -343,7 +343,12 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
               // PR #14). Dispatch lives in goldfiveEvent.ts so the
               // translation is testable without standing up a mocked
               // Connect transport.
-              applyGoldfiveEvent(kind.value, store, origin?.startMs ?? 0);
+              applyGoldfiveEvent(
+                kind.value,
+                store,
+                origin?.startMs ?? 0,
+                sessionId,
+              );
               break;
             }
             case 'taskReport': {

--- a/frontend/src/state/approvalsStore.ts
+++ b/frontend/src/state/approvalsStore.ts
@@ -1,0 +1,86 @@
+import { create } from 'zustand';
+
+// Per-session HITL approval queue fed by goldfive ApprovalRequested events.
+//
+// ApprovalRequested adds a pending entry keyed by target_id; the matching
+// ApprovalGranted / ApprovalRejected (same target_id) clears it. target_id is
+// a task id for Flow A (report_awaiting_approval) or an ADK function-call id
+// for Flow B (before_tool_callback) — the kind string tells the UI which.
+//
+// Entries carry the `agentId` observed on the most recent goldfive span for
+// the same target so the UI's Approve/Reject click can route the
+// ControlEvent to the exact agent (ControlRouter target = agentId + spanId).
+// If we haven't seen such a span, agentId stays empty; SendControl with an
+// empty agentId still reaches the session-level ControlChannel bridge.
+
+export interface PendingApproval {
+  sessionId: string;
+  targetId: string;
+  kind: string;
+  prompt: string;
+  taskId: string;
+  metadata: Record<string, string>;
+  // Session-relative ms when the ApprovalRequested event was observed, so
+  // the UI can show a "waiting for Xs" timer without a separate wall clock.
+  requestedAtMs: number;
+  // Agent id to quote back on APPROVE/REJECT. Derived later from the span
+  // context in the caller when known; empty string is valid (session-level).
+  agentId: string;
+  // Optional span id for the approval anchor (same derivation).
+  spanId: string;
+}
+
+interface ApprovalsState {
+  bySession: Map<string, PendingApproval[]>;
+  list(sessionId: string | null): PendingApproval[];
+  // Push a new ApprovalRequested, or replace an existing entry with the same
+  // targetId (server replay during reconnect may resend the same request).
+  request(entry: PendingApproval): void;
+  // Dismiss by targetId. Called on ApprovalGranted / ApprovalRejected.
+  resolve(sessionId: string, targetId: string): void;
+  // Clear all pending approvals for a session (e.g. on session switch).
+  clear(sessionId: string): void;
+}
+
+export const useApprovalsStore = create<ApprovalsState>((set, get) => ({
+  bySession: new Map(),
+
+  list(sessionId) {
+    if (!sessionId) return [];
+    return get().bySession.get(sessionId) ?? [];
+  },
+
+  request(entry) {
+    set((state) => {
+      const next = new Map(state.bySession);
+      const arr = (next.get(entry.sessionId) ?? []).slice();
+      const idx = arr.findIndex((a) => a.targetId === entry.targetId);
+      if (idx >= 0) arr[idx] = entry;
+      else arr.push(entry);
+      arr.sort((a, b) => a.requestedAtMs - b.requestedAtMs);
+      next.set(entry.sessionId, arr);
+      return { bySession: next };
+    });
+  },
+
+  resolve(sessionId, targetId) {
+    set((state) => {
+      const arr = state.bySession.get(sessionId);
+      if (!arr) return state;
+      const filtered = arr.filter((a) => a.targetId !== targetId);
+      if (filtered.length === arr.length) return state;
+      const next = new Map(state.bySession);
+      next.set(sessionId, filtered);
+      return { bySession: next };
+    });
+  },
+
+  clear(sessionId) {
+    set((state) => {
+      if (!state.bySession.has(sessionId)) return state;
+      const next = new Map(state.bySession);
+      next.delete(sessionId);
+      return { bySession: next };
+    });
+  },
+}));


### PR DESCRIPTION
## Summary

- Consume the new goldfive `ApprovalRequested` / `ApprovalGranted` / `ApprovalRejected` event oneof variants (goldfive #83) inside the WatchSession dispatcher and push pending entries onto a new per-session `approvalsStore` keyed by `target_id`.
- Render every pending approval as a card in a fixed top-right `ApprovalDrawer`, showing the prompt plus (for Flow B / tool-level approvals) the tool name and pretty-printed args. Approve / Reject buttons dispatch `ControlEvent(APPROVE|REJECT)` through the existing `sendControl` RPC with a JSON `{target_id}` payload so the server-side ControlChannel bridge can quote it back onto the pending-approval waiter.
- Approvals auto-dismiss when the matching `ApprovalGranted` / `ApprovalRejected` arrives on the same stream.

Also bumps the `third_party/goldfive` submodule to pick up the new proto surface and regenerates the frontend TS stubs (`pb/goldfive/v1/events_pb.ts` now includes `ApprovalRequestedSchema`, `ApprovalGrantedSchema`, `ApprovalRejectedSchema`, plus the preexisting `ConversationStarted` / `ConversationEnded` types from goldfive main).

Closes #31.

## Test plan

- [x] `pnpm build && pnpm lint`
- [x] `pnpm exec vitest run` — 18 files / 187 tests pass, including 6 new approval-flow cases in `goldfiveEvent.test.ts`, 6 store cases in `approvalsStore.test.ts`, and 7 component cases in `ApprovalDrawer.test.tsx`.
- [x] `make frontend-test`
- [ ] Manual smoke: run a goldfive session with a `require_confirmation=True` tool, confirm the drawer surfaces the prompt + args and that clicking Approve sends a `SendControl(APPROVE)` that goldfive dispatches onto `session.pending_approvals`.
