### PR TITLE
Add APPROVE/REJECT to control bridge kind map

### DIFF
--- a/client/harmonograf_client/_control_bridge.py
+++ b/client/harmonograf_client/_control_bridge.py
@@ -54,6 +54,8 @@ _KIND_MAP: dict[str, str] = {
     "CANCEL": "CANCEL",
     "STEER": "STEER",
     "REWIND_TO": "REWIND_TO",
+    "APPROVE": "APPROVE",
+    "REJECT": "REJECT",
 }
 
 


### PR DESCRIPTION
goldfive #83 introduced APPROVE/REJECT ControlKind values; harmonograf's bridge kind-map invariant test caught that the mapping wasn't extended.