### PR TITLE
Bridge APPROVE/REJECT + fix test drift

### DIFF
--- a/client/harmonograf_client/_control_bridge.py
+++ b/client/harmonograf_client/_control_bridge.py
@@ -54,6 +54,8 @@ _KIND_MAP: dict[str, str] = {
     "CANCEL": "CANCEL",
     "STEER": "STEER",
     "REWIND_TO": "REWIND_TO",
+    "APPROVE": "APPROVE",
+    "REJECT": "REJECT",
 }
 
 

--- a/client/tests/test_control_bridge.py
+++ b/client/tests/test_control_bridge.py
@@ -188,7 +188,10 @@ async def test_rewind_to_payload_lands_under_task_id(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "h_kind",
-    ["INJECT_MESSAGE", "APPROVE", "REJECT", "STATUS_QUERY", "INTERCEPT_TRANSFER"],
+    # APPROVE and REJECT are now bridged to goldfive (landed alongside
+    # goldfive #83). INJECT_MESSAGE, STATUS_QUERY, INTERCEPT_TRANSFER
+    # remain out of scope and still ack UNSUPPORTED.
+    ["INJECT_MESSAGE", "STATUS_QUERY", "INTERCEPT_TRANSFER"],
 )
 async def test_unsupported_kind_acks_unsupported(
     client: Client, made: list[FakeTransport], h_kind: str


### PR DESCRIPTION
Paired fix: wire APPROVE/REJECT through the goldfive bridge (extends _KIND_MAP) AND drop them from the parametrized unsupported-kinds test so the assertion stops failing. Two-file diff.