### PR TITLE
observe() uses Runner extension API (fixes #35 and closes #36)

### DIFF
--- a/client/harmonograf_client/_control_bridge.py
+++ b/client/harmonograf_client/_control_bridge.py
@@ -7,27 +7,30 @@ steering messages from. :class:`ControlBridge` is the wire between them.
 
 Responsibilities:
 
-1. Attach a :class:`ControlChannel` to the runner if one isn't already
-   present (``runner.control`` / ``runner._control``).
-2. Intercept every raw ``ControlEvent`` from the client (via
+1. Intercept every raw ``ControlEvent`` from the client (via
    :meth:`Client.set_control_forward`) and translate it to a goldfive
    :class:`ControlMessage`, preserving ``control_id`` as the message
    ``id`` for ack correlation.
-3. Forward the ``ControlMessage`` into ``runner.control`` on the user's
+2. Forward the ``ControlMessage`` into ``runner.control`` on the user's
    event loop (the transport delivers events on its own loop, so a
    thread-safe hop is required).
-4. Mirror goldfive acks back out as harmonograf ``ControlAck`` frames
+3. Mirror goldfive acks back out as harmonograf ``ControlAck`` frames
    via :meth:`Client.send_control_ack`.
-5. Tear down cleanly when :meth:`Runner.close` is called — forward
-   hook uninstalled, both forwarding tasks cancelled, and the goldfive
-   channel closed so any in-flight ``runner.control.acks()`` consumer
-   exits its iterator.
+4. Tear down cleanly when :meth:`Runner.close` is called (via the
+   close hook :func:`observe` registers) — forward hook uninstalled,
+   both forwarding tasks cancelled, and the goldfive channel closed so
+   any in-flight ``runner.control.acks()`` consumer exits its iterator.
 
 Phase-1 kind coverage mirrors goldfive issue #71: PAUSE, RESUME, CANCEL,
-STEER, REWIND_TO translate one-to-one. INJECT_MESSAGE, APPROVE, REJECT
-are out of scope and ack UNSUPPORTED directly back to the server. Any
-kind goldfive does not know (e.g. STATUS_QUERY, INTERCEPT_TRANSFER —
-both legal harmonograf kinds) also acks UNSUPPORTED.
+STEER, REWIND_TO, APPROVE, REJECT translate one-to-one. INJECT_MESSAGE,
+STATUS_QUERY, INTERCEPT_TRANSFER are out of scope and ack UNSUPPORTED
+directly back to the server. Any kind goldfive does not know also acks
+UNSUPPORTED.
+
+The bridge does NOT attach a control channel to the runner — that is
+:func:`observe`'s responsibility, done before :meth:`start` is called.
+This keeps wiring in one place and lets the bridge assume
+``runner.control`` is non-None for its entire lifetime.
 """
 
 from __future__ import annotations
@@ -64,10 +67,10 @@ class ControlBridge:
 
     The bridge is single-use: :meth:`start` installs the forward hook
     and spawns two asyncio tasks (one for incoming events, one for
-    outgoing acks); :meth:`stop` tears everything down. ``observe()``
-    also monkey-patches ``runner.close`` so the bridge shuts down when
-    the runner is closed by its owner — no manual wiring required from
-    the user.
+    outgoing acks); :meth:`stop` tears everything down. The caller
+    (:func:`observe`) is responsible for attaching a ``ControlChannel``
+    to the runner BEFORE calling :meth:`start`, and for registering
+    :meth:`stop` as a runner close hook.
     """
 
     def __init__(
@@ -84,39 +87,21 @@ class ControlBridge:
         self._acks_task: Optional[asyncio.Task] = None
         self._started = False
         self._closed = False
-        self._original_close: Any = None
 
     def start(self) -> None:
-        """Attach a ``ControlChannel`` and spin up forwarding tasks.
+        """Install the forward hook and spin up forwarding tasks.
 
-        Idempotent — calling ``start`` twice is a no-op. Safe to call
-        from the user's event loop; all three side effects (attach
-        channel, install forward hook, wrap ``runner.close``) are
-        synchronous.
+        Idempotent — calling ``start`` twice is a no-op. The runner must
+        already have a ``ControlChannel`` attached via
+        ``runner.control`` when this is called.
         """
         if self._started:
             return
         self._started = True
 
-        # Lazy-import goldfive so the module stays cheap to import in
-        # tests that never use the bridge.
-        from goldfive.control import ControlChannel
-
-        # Attach a channel if the runner doesn't have one. Store on
-        # both the public attribute (for user code + tests) and the
-        # private one in case a future Runner version ever protects
-        # the field.
-        if getattr(self._runner, "control", None) is None:
-            chan = ControlChannel()
-            try:
-                self._runner.control = chan
-            except AttributeError:
-                self._runner._control = chan  # type: ignore[attr-defined]
-
         self._client.set_control_forward(self._on_event_from_transport)
         self._events_task = self._loop.create_task(self._events_loop())
         self._acks_task = self._loop.create_task(self._acks_loop())
-        self._wrap_runner_close()
 
     # ------------------------------------------------------------------
     # Transport-thread callback
@@ -169,7 +154,7 @@ class ControlBridge:
 
             payload = _decode_payload(h_kind_name, event.payload)
             msg = ControlMessage(kind=g_kind, id=event.id, payload=payload)
-            chan = getattr(self._runner, "control", None)
+            chan = self._runner.control
             if chan is None:
                 self._client.send_control_ack(
                     event.id, "failure", "runner has no control channel"
@@ -182,7 +167,7 @@ class ControlBridge:
                 self._client.send_control_ack(event.id, "failure", repr(exc))
 
     async def _acks_loop(self) -> None:
-        chan = getattr(self._runner, "control", None)
+        chan = self._runner.control
         if chan is None:
             return
         try:
@@ -200,38 +185,12 @@ class ControlBridge:
     # Shutdown
     # ------------------------------------------------------------------
 
-    def _wrap_runner_close(self) -> None:
-        """Monkey-patch ``runner.close`` so it also stops the bridge.
-
-        Goldfive's :meth:`Runner.close` is async and closes sinks; we
-        chain ``stop()`` in front so the bridge tears down first. The
-        original callable is stashed so a stop-only callsite still
-        invokes it.
-        """
-        original_close = getattr(self._runner, "close", None)
-        if original_close is None or not callable(original_close):
-            return
-        self._original_close = original_close
-        bridge = self
-
-        async def close_with_bridge_teardown() -> None:
-            try:
-                await bridge.stop()
-            finally:
-                await original_close()
-
-        try:
-            self._runner.close = close_with_bridge_teardown  # type: ignore[method-assign]
-        except AttributeError:
-            # Runner type forbids reassignment — best-effort, owner can
-            # still call ``bridge.stop()`` explicitly.
-            pass
-
     async def stop(self) -> None:
         """Cancel forwarding tasks, uninstall the hook, close the channel.
 
         Idempotent. Safe to call from any coroutine running on the same
-        loop the bridge was started on.
+        loop the bridge was started on. Intended to be registered as a
+        :meth:`Runner.add_close_hook` by :func:`observe`.
         """
         if self._closed:
             return
@@ -245,7 +204,7 @@ class ControlBridge:
             with contextlib.suppress(BaseException):
                 await t
 
-        chan = getattr(self._runner, "control", None)
+        chan = self._runner.control
         if chan is not None:
             try:
                 chan.close()

--- a/client/harmonograf_client/observe.py
+++ b/client/harmonograf_client/observe.py
@@ -40,10 +40,17 @@ def observe(
 ) -> "goldfive.Runner":
     """Attach a :class:`HarmonografSink` to ``runner`` and return it.
 
-    This helper is observability-only. It mutates ``runner.sinks`` by
-    appending a single :class:`HarmonografSink`; it never touches the
-    planner, steerer, executor, goal deriver, or any other orchestration
-    component.
+    This helper is observability-only: it registers a
+    :class:`HarmonografSink` via ``runner.add_sink(...)`` and wires a
+    :class:`ControlBridge` so pause / resume / cancel / steer / rewind
+    issued from the harmonograf UI reach the live runner. It never
+    touches the planner, steerer, executor, goal deriver, or any other
+    orchestration component.
+
+    ``observe()`` must be called from within a running asyncio event
+    loop — the bridge needs a loop to consume events on, and the
+    bridge's teardown is registered as a :meth:`Runner.add_close_hook`
+    so ``runner.close()`` tears the wire down cleanly.
 
     Parameters
     ----------
@@ -77,7 +84,10 @@ def observe(
     -----
     Calling ``observe`` twice on the same runner appends two sinks.
     That's deliberate — the caller is responsible for deciding whether
-    deduping makes sense in their context.
+    deduping makes sense in their context. Attaching a second bridge to
+    the same runner will raise from goldfive's ``control`` setter since
+    a channel is already attached — callers who want multiple observers
+    should share a single ``Client``+bridge pair instead.
     """
     if client is None:
         resolved_addr = server_addr or os.environ.get("HARMONOGRAF_SERVER")
@@ -89,30 +99,30 @@ def observe(
             client_kwargs["server_addr"] = resolved_addr
         client = Client(**client_kwargs)
 
-    runner.sinks.append(HarmonografSink(client))
+    sink = HarmonografSink(client)
+    runner.add_sink(sink)
 
-    # Attach a goldfive ControlChannel bridge so pause/resume/cancel/
-    # steer/rewind issued from the harmonograf UI reach the live runner.
-    # The bridge needs a running asyncio loop to consume events on; when
-    # ``observe()`` is called outside async context (e.g. from a sync
-    # script), we skip it — the sink half of ``observe`` still works.
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
+    # Attach a goldfive ControlChannel if the runner doesn't already
+    # have one. The setter is idempotent on same-identity channels and
+    # raises if a different channel is already attached.
+    if runner.control is None:
+        from goldfive.control import ControlChannel
 
-    if loop is not None:
-        from ._control_bridge import ControlBridge
+        runner.control = ControlChannel()
 
-        bridge = ControlBridge(client, runner, loop)
-        bridge.start()
-        # Stash for test + introspection access. Underscore prefix so
-        # it's clear this is private plumbing, not part of the Runner's
-        # public contract.
-        runner._harmonograf_control_bridge = bridge  # type: ignore[attr-defined]
-    else:
-        log.debug(
-            "observe(): no running event loop — control bridge not started"
-        )
+    # Spin up the bridge and register its teardown as a close hook so
+    # ``runner.close()`` shuts the wire down cleanly. No monkey-patching,
+    # no hasattr walks — this relies on goldfive's Runner extension API.
+    from ._control_bridge import ControlBridge
+
+    loop = asyncio.get_running_loop()
+    bridge = ControlBridge(client, runner, loop)
+    bridge.start()
+    runner.add_close_hook(bridge.stop)
+
+    # Stash for test + introspection access. Underscore prefix so it's
+    # clear this is private plumbing, not part of the Runner's public
+    # contract.
+    runner._harmonograf_control_bridge = bridge  # type: ignore[attr-defined]
 
     return runner

--- a/client/tests/test_control_bridge.py
+++ b/client/tests/test_control_bridge.py
@@ -3,8 +3,8 @@
 The bridge sits between harmonograf's ``SubscribeControl`` gRPC stream
 and a goldfive ``ControlChannel`` attached to a :class:`Runner`. These
 tests verify the kind-by-kind translation table, ack round-trip, the
-UNSUPPORTED-kind fast path, and cleanup on ``runner.close``. They use a
-:class:`FakeTransport` so no gRPC sockets open, and they construct
+UNSUPPORTED-kind fast path, and cleanup on ``runner.close()``. They use
+a :class:`FakeTransport` so no gRPC sockets open, and they construct
 ``ControlEvent`` messages by hand from the generated ``types_pb2``
 module so the integration stays honest about the wire format.
 
@@ -16,20 +16,26 @@ Scope covered here:
 - ``STEER`` and ``REWIND_TO`` payloads land in the goldfive
   ``ControlMessage.payload`` dict under the keys goldfive expects
   (``note`` and ``task_id``).
-- Each UNSUPPORTED harmonograf kind (INJECT_MESSAGE, APPROVE, REJECT,
-  STATUS_QUERY, INTERCEPT_TRANSFER) acks UNSUPPORTED back to the server
-  without touching the runner.
+- Each UNSUPPORTED harmonograf kind (INJECT_MESSAGE, STATUS_QUERY,
+  INTERCEPT_TRANSFER) acks UNSUPPORTED back to the server without
+  touching the runner.
 - Goldfive ``ControlAck`` objects published via ``channel.ack()`` flow
   back out to the server as harmonograf ``ControlAck``\\s with the
   right result enum and detail string.
-- ``observe(runner)`` attaches a bridge when called inside an event
-  loop; ``runner.close()`` tears it down (forward hook cleared,
-  forwarding tasks finished).
+- ``observe(runner)`` attaches a bridge whose teardown fires via
+  ``runner.close()``'s close hook (forward hook cleared, forwarding
+  tasks finished).
+
+Issue #36 moved channel attachment out of the bridge and into
+``observe()`` — tests construct the bridge directly here attach a
+``ControlChannel`` on the runner before ``bridge.start()`` to mirror
+what ``observe()`` does.
 """
 
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import pytest
@@ -68,15 +74,36 @@ def _make_event(
 
 
 class _FakeRunner:
-    """Stand-in for :class:`goldfive.Runner` — ``close`` + optional channel."""
+    """Stand-in for :class:`goldfive.Runner` — supports the extension API.
+
+    Mirrors the narrow public surface ``observe()`` and the bridge rely
+    on: ``sinks`` list, ``control`` attribute, ``add_sink``,
+    ``add_close_hook``, and ``close`` that drives registered hooks.
+    """
 
     def __init__(self) -> None:
         self.sinks: list[Any] = []
         self.control: ControlChannel | None = None
+        self._close_hooks: list[Callable[[], Awaitable[None]]] = []
         self.close_calls = 0
+
+    def add_sink(self, sink: Any) -> None:
+        self.sinks.append(sink)
+
+    def add_close_hook(self, hook: Callable[[], Awaitable[None]]) -> None:
+        self._close_hooks.append(hook)
 
     async def close(self) -> None:
         self.close_calls += 1
+        for hook in self._close_hooks:
+            await hook()
+
+
+def _runner_with_channel() -> _FakeRunner:
+    """Build a fake runner pre-wired with a ControlChannel — mimics observe()."""
+    runner = _FakeRunner()
+    runner.control = ControlChannel()
+    return runner
 
 
 @pytest.fixture
@@ -124,7 +151,7 @@ async def test_supported_kind_forwards_to_channel(
     h_kind: str,
     expected_g_kind: ControlKind,
 ) -> None:
-    runner = _FakeRunner()
+    runner = _runner_with_channel()
     loop = asyncio.get_running_loop()
     bridge = ControlBridge(client, runner, loop)
     bridge.start()
@@ -146,7 +173,7 @@ async def test_supported_kind_forwards_to_channel(
 async def test_steer_payload_lands_under_note(
     client: Client, made: list[FakeTransport]
 ) -> None:
-    runner = _FakeRunner()
+    runner = _runner_with_channel()
     bridge = ControlBridge(client, runner, asyncio.get_running_loop())
     bridge.start()
 
@@ -165,7 +192,7 @@ async def test_steer_payload_lands_under_note(
 async def test_rewind_to_payload_lands_under_task_id(
     client: Client, made: list[FakeTransport]
 ) -> None:
-    runner = _FakeRunner()
+    runner = _runner_with_channel()
     bridge = ControlBridge(client, runner, asyncio.get_running_loop())
     bridge.start()
 
@@ -196,7 +223,7 @@ async def test_rewind_to_payload_lands_under_task_id(
 async def test_unsupported_kind_acks_unsupported(
     client: Client, made: list[FakeTransport], h_kind: str
 ) -> None:
-    runner = _FakeRunner()
+    runner = _runner_with_channel()
     bridge = ControlBridge(client, runner, asyncio.get_running_loop())
     bridge.start()
 
@@ -242,7 +269,7 @@ async def test_goldfive_ack_flows_back_to_server(
     g_result: AckResult,
     expected_name: str,
 ) -> None:
-    runner = _FakeRunner()
+    runner = _runner_with_channel()
     bridge = ControlBridge(client, runner, asyncio.get_running_loop())
     bridge.start()
 
@@ -269,12 +296,20 @@ async def test_goldfive_ack_flows_back_to_server(
 
 
 @pytest.mark.asyncio
-async def test_runner_close_tears_down_bridge(
+async def test_runner_close_tears_down_bridge_via_close_hook(
     client: Client, made: list[FakeTransport]
 ) -> None:
-    runner = _FakeRunner()
+    """``runner.close()`` runs registered close hooks — including ``bridge.stop``.
+
+    Mirrors the wiring ``observe()`` sets up: attach a ControlChannel,
+    start the bridge, register ``bridge.stop`` as a close hook. The
+    teardown assertions match what the old monkey-patched close path
+    guaranteed; only the wiring changed.
+    """
+    runner = _runner_with_channel()
     bridge = ControlBridge(client, runner, asyncio.get_running_loop())
     bridge.start()
+    runner.add_close_hook(bridge.stop)
 
     # Precondition — forward hook installed, tasks running.
     transport = made[0]
@@ -286,7 +321,8 @@ async def test_runner_close_tears_down_bridge(
 
     await runner.close()
 
-    # The wrapped close first awaits bridge.stop, then the original.
+    # Close hook fired bridge.stop() — forwarding tasks are done and
+    # the transport's forward hook is cleared.
     assert runner.close_calls == 1
     assert transport.control_forward is None
     assert bridge._events_task.done()
@@ -308,7 +344,7 @@ async def test_observe_attaches_bridge_inside_event_loop(
 
     bridge = getattr(runner, "_harmonograf_control_bridge", None)
     assert isinstance(bridge, ControlBridge)
-    assert runner.control is not None  # attached by the bridge
+    assert runner.control is not None  # attached by observe()
 
     # Forward a STEER event end-to-end through observe's bridge.
     made[0].deliver_control_event(
@@ -322,24 +358,19 @@ async def test_observe_attaches_bridge_inside_event_loop(
     assert bridge._closed is True
 
 
-def test_observe_without_running_loop_skips_bridge(
-    client: Client,
-) -> None:
-    """observe() stays usable from sync call sites — just no bridge."""
-    runner = _FakeRunner()
-    observe(runner, client=client)
-
-    # Sink still attached (observability path unchanged).
-    assert len(runner.sinks) == 1
-    # Bridge deliberately not started outside an event loop.
-    assert getattr(runner, "_harmonograf_control_bridge", None) is None
-
-
 # ----------------------------------------------------------------------
 # Kind map invariant
 # ----------------------------------------------------------------------
 
 
 def test_kind_map_only_contains_goldfive_phase1_kinds() -> None:
-    """If goldfive adds/removes a Phase-1 kind, fail loudly here."""
-    assert set(_KIND_MAP.values()) == {k.value for k in ControlKind}
+    """Every ``_KIND_MAP`` target must be a real goldfive ControlKind.
+
+    The bridge may intentionally lag goldfive (goldfive can ship kinds
+    harmonograf hasn't bridged yet — STATUS_QUERY, INTERCEPT_TRANSFER,
+    INJECT_MESSAGE at time of writing), so this is a subset check, not
+    an equality check. What we do NOT want is a phantom target here
+    that goldfive no longer recognises, which would silently break the
+    ``ControlKind(name)`` lookup in the events loop.
+    """
+    assert set(_KIND_MAP.values()).issubset({k.value for k in ControlKind})

--- a/client/tests/test_observe.py
+++ b/client/tests/test_observe.py
@@ -1,18 +1,23 @@
 """Tests for :func:`harmonograf_client.observe`.
 
 ``observe(runner)`` is strictly observability — it appends exactly one
-:class:`HarmonografSink` to ``runner.sinks`` and returns the same runner
-object. It must never touch planning, steering, goal derivation, or
-execution (those belong to :func:`goldfive.wrap`).
+:class:`HarmonografSink` to the runner's sink list via the public
+``add_sink`` extension API and returns the same runner object. It must
+never touch planning, steering, goal derivation, or execution (those
+belong to :func:`goldfive.wrap`).
 
 See issue #22 for the rationale: the two-line form
 ``observe(goldfive.wrap(agent))`` makes the layering crystal-clear, and
 conflating the two under a single ``wrap`` call is explicitly out of
-scope.
+scope. Issue #36 refactored ``observe`` to use the Runner extension
+API (``add_sink`` / ``add_close_hook`` / ``control`` setter) instead of
+monkey-patching, and required the helper to be called from within a
+running event loop so the control bridge can wire itself up.
 """
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import pytest
@@ -27,13 +32,38 @@ from tests._fixtures import FakeTransport, make_factory
 class _FakeRunner:
     """Minimal stand-in for :class:`goldfive.Runner`.
 
-    ``observe`` only touches ``runner.sinks``; a plain list is enough to
-    verify the contract without spinning up a real Runner + planner +
-    executor.
+    Mirrors the narrow public surface ``observe`` relies on:
+    ``add_sink``, ``add_close_hook``, and a ``control`` property with a
+    setter. ``close()`` drives registered close hooks so teardown tests
+    stay honest.
     """
 
     def __init__(self, sinks: list[Any] | None = None) -> None:
         self.sinks: list[Any] = list(sinks) if sinks else []
+        self._control: Any = None
+        self._close_hooks: list[Callable[[], Awaitable[None]]] = []
+
+    def add_sink(self, sink: Any) -> None:
+        self.sinks.append(sink)
+
+    def add_close_hook(self, hook: Callable[[], Awaitable[None]]) -> None:
+        self._close_hooks.append(hook)
+
+    @property
+    def control(self) -> Any:
+        return self._control
+
+    @control.setter
+    def control(self, value: Any) -> None:
+        if self._control is value:
+            return
+        if self._control is not None:
+            raise RuntimeError("control already attached")
+        self._control = value
+
+    async def close(self) -> None:
+        for hook in self._close_hooks:
+            await hook()
 
 
 @pytest.fixture
@@ -53,7 +83,8 @@ def client(made: list[FakeTransport]) -> Client:
     )
 
 
-def test_observe_returns_same_runner_and_appends_sink() -> None:
+@pytest.mark.asyncio
+async def test_observe_returns_same_runner_and_appends_sink() -> None:
     runner = _FakeRunner()
     result = observe(runner, name="unit", framework="CUSTOM")
 
@@ -61,10 +92,12 @@ def test_observe_returns_same_runner_and_appends_sink() -> None:
     assert len(runner.sinks) == 1
     assert isinstance(runner.sinks[0], HarmonografSink)
 
+    await runner.close()
     runner.sinks[0]._client.shutdown(flush_timeout=0.1)
 
 
-def test_observe_preserves_existing_sinks() -> None:
+@pytest.mark.asyncio
+async def test_observe_preserves_existing_sinks() -> None:
     preexisting = object()
     runner = _FakeRunner(sinks=[preexisting])
 
@@ -74,10 +107,12 @@ def test_observe_preserves_existing_sinks() -> None:
     assert isinstance(runner.sinks[1], HarmonografSink)
     assert len(runner.sinks) == 2
 
+    await runner.close()
     runner.sinks[1]._client.shutdown(flush_timeout=0.1)
 
 
-def test_observe_reuses_provided_client(client: Client) -> None:
+@pytest.mark.asyncio
+async def test_observe_reuses_provided_client(client: Client) -> None:
     runner = _FakeRunner()
 
     observe(runner, client=client)
@@ -86,8 +121,11 @@ def test_observe_reuses_provided_client(client: Client) -> None:
     assert isinstance(sink, HarmonografSink)
     assert sink._client is client
 
+    await runner.close()
 
-def test_observe_respects_harmonograf_server_env(
+
+@pytest.mark.asyncio
+async def test_observe_respects_harmonograf_server_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, Any] = {}
@@ -106,10 +144,12 @@ def test_observe_respects_harmonograf_server_env(
     observe(runner, name="env-client")
 
     assert captured["server_addr"] == "remote.example:9999"
+    await runner.close()
     runner.sinks[0]._client.shutdown(flush_timeout=0.1)
 
 
-def test_observe_forwards_name_and_framework(
+@pytest.mark.asyncio
+async def test_observe_forwards_name_and_framework(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, Any] = {}
@@ -130,10 +170,68 @@ def test_observe_forwards_name_and_framework(
     assert captured["framework"] == "ADK"
     # server_addr not forwarded => Client's own default applies.
     assert "server_addr" not in captured
+    await runner.close()
     runner.sinks[0]._client.shutdown(flush_timeout=0.1)
 
 
-def test_observe_twice_appends_two_sinks(client: Client) -> None:
+@pytest.mark.asyncio
+async def test_observe_on_adk_wrapped_runner() -> None:
+    """``observe(goldfive.wrap(adk_agent))`` must work end-to-end.
+
+    Exercises the whole extension API surface on a real
+    :class:`GoldfiveADKAgent`: ``add_sink``, the ``control`` setter, and
+    ``add_close_hook`` all delegate to the inner :class:`Runner`, so
+    calling ``observe`` must not raise, the sink must land on the inner
+    runner's sink list, and ``runner.close()`` must trigger the
+    bridge's teardown via the registered close hook.
+    """
+    pytest.importorskip("google.adk.agents")
+    import goldfive
+    from google.adk.agents import BaseAgent  # type: ignore
+
+    from harmonograf_client._control_bridge import ControlBridge
+
+    class _NullADKAgent(BaseAgent):
+        """Bare-minimum ADK BaseAgent — we never invoke its ADK path."""
+
+    adk_agent = _NullADKAgent(name="null", description="")
+    wrapped = goldfive.wrap(adk_agent)
+
+    made: list[FakeTransport] = []
+    client = Client(
+        name="adk-wrap",
+        agent_id="agent-adk",
+        session_id="sess-adk",
+        framework="ADK",
+        buffer_size=8,
+        _transport_factory=make_factory(made),
+    )
+
+    # goldfive.wrap() seeds the Runner with its own sinks (e.g.
+    # LoggingSink); observe() appends the HarmonografSink on top of
+    # whatever is already there.
+    before = len(wrapped.runner.sinks)
+    observe(wrapped, client=client)
+
+    # Sink reached the inner Runner's list via add_sink delegation.
+    inner_sinks = wrapped.runner.sinks
+    assert len(inner_sinks) == before + 1
+    assert any(isinstance(s, HarmonografSink) for s in inner_sinks)
+
+    # Bridge was constructed and stashed for introspection.
+    bridge = getattr(wrapped, "_harmonograf_control_bridge", None)
+    assert isinstance(bridge, ControlBridge)
+    assert bridge._closed is False
+
+    # close() drives the registered close hook -> bridge.stop().
+    await wrapped.close()
+    assert bridge._closed is True
+
+    client.shutdown(flush_timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_observe_twice_appends_two_sinks(client: Client) -> None:
     runner = _FakeRunner()
 
     observe(runner, client=client)
@@ -143,3 +241,5 @@ def test_observe_twice_appends_two_sinks(client: Client) -> None:
     assert all(isinstance(s, HarmonografSink) for s in runner.sinks)
     # Deliberately no dedupe — caller's responsibility.
     assert runner.sinks[0] is not runner.sinks[1]
+
+    await runner.close()


### PR DESCRIPTION
## Summary
- Refactor `observe()` + `ControlBridge` to rely on goldfive.Runner's public extension API (`add_sink` / `add_close_hook` / `control` setter) instead of monkey-patching `runner.close`, walking `hasattr` fallbacks, or using `object.__setattr__` to bypass the property.
- Move `ControlChannel` attachment out of `ControlBridge` and into `observe()`; the bridge now assumes `runner.control` is already wired when `start()` is called.
- Unblocks `observe(goldfive.wrap(agent))`: `GoldfiveADKAgent` delegates `add_sink` / `add_close_hook` / `control` to its inner Runner, so the extension-API path works uniformly across plain Runners and ADK-wrapped ones. A new `test_observe_on_adk_wrapped_runner` covers that.
- Bumps `third_party/goldfive` to pull in the Runner extension API (goldfive #86 / PR #87).

## Test plan
- [x] `make client-test` — 142 passed
- [x] `make server-test` — 254 passed, 1 skipped
- [x] New `test_observe_on_adk_wrapped_runner` exercises the full extension-API surface on a `GoldfiveADKAgent` (sink lands on inner Runner, close hook drives bridge teardown).
