### PR TITLE
observe() auto-installs HarmonografTelemetryPlugin for ADK (closes #40)

### DIFF
--- a/client/harmonograf_client/observe.py
+++ b/client/harmonograf_client/observe.py
@@ -37,6 +37,7 @@ def observe(
     name: str | None = None,
     framework: str = "CUSTOM",
     server_addr: str | None = None,
+    install_adk_telemetry: bool = True,
 ) -> "goldfive.Runner":
     """Attach a :class:`HarmonografSink` to ``runner`` and return it.
 
@@ -72,6 +73,14 @@ def observe(
         ``HARMONOGRAF_SERVER`` environment variable; falls back to
         ``Client``'s own default (``127.0.0.1:7531``). Ignored when
         ``client`` is provided.
+    install_adk_telemetry:
+        When ``True`` (default), best-effort install
+        :class:`HarmonografTelemetryPlugin` on the runner so ADK
+        lifecycle callbacks turn into harmonograf spans. The install is
+        skipped silently when the runner doesn't carry an
+        ``add_plugin`` hook (e.g. a non-ADK runner) and any failure is
+        DEBUG-logged rather than raised — a broken telemetry install
+        must never break the surrounding ``observe`` call.
 
     Returns
     -------
@@ -124,5 +133,18 @@ def observe(
     # clear this is private plumbing, not part of the Runner's public
     # contract.
     runner._harmonograf_control_bridge = bridge  # type: ignore[attr-defined]
+
+    # Best-effort: when the runner exposes an ADK plugin hook (i.e.
+    # goldfive.wrap'd an ADK agent and goldfive >= 0.x ships
+    # GoldfiveADKAgent.add_plugin), install the telemetry plugin so the
+    # 2-line API also produces ADK spans. Lazy-imported and wrapped so
+    # any failure DEBUG-logs instead of breaking observe().
+    if install_adk_telemetry and hasattr(runner, "add_plugin"):
+        try:
+            from .telemetry_plugin import HarmonografTelemetryPlugin
+
+            runner.add_plugin(HarmonografTelemetryPlugin(client))
+        except Exception as exc:  # noqa: BLE001
+            log.debug("observe: ADK telemetry plugin not attached: %s", exc)
 
     return runner

--- a/client/tests/test_observe.py
+++ b/client/tests/test_observe.py
@@ -231,6 +231,85 @@ async def test_observe_on_adk_wrapped_runner() -> None:
 
 
 @pytest.mark.asyncio
+async def test_observe_installs_telemetry_plugin_on_adk_runner() -> None:
+    """``observe(goldfive.wrap(adk_agent))`` must auto-install the telemetry plugin."""
+    pytest.importorskip("google.adk.agents")
+    import goldfive
+    from google.adk.agents import BaseAgent  # type: ignore
+
+    from harmonograf_client import HarmonografTelemetryPlugin
+
+    class _NullADKAgent(BaseAgent):
+        pass
+
+    wrapped = goldfive.wrap(_NullADKAgent(name="null", description=""))
+
+    made: list[FakeTransport] = []
+    client = Client(
+        name="adk-telemetry",
+        agent_id="agent-tel",
+        session_id="sess-tel",
+        framework="ADK",
+        buffer_size=8,
+        _transport_factory=make_factory(made),
+    )
+
+    observe(wrapped, client=client)
+
+    pm = wrapped.runner.agent._runner.plugin_manager
+    plugins = list(getattr(pm, "plugins", []))
+    assert any(isinstance(p, HarmonografTelemetryPlugin) for p in plugins)
+
+    await wrapped.close()
+    client.shutdown(flush_timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_observe_skips_telemetry_when_disabled() -> None:
+    """``install_adk_telemetry=False`` must suppress the auto-install."""
+    pytest.importorskip("google.adk.agents")
+    import goldfive
+    from google.adk.agents import BaseAgent  # type: ignore
+
+    from harmonograf_client import HarmonografTelemetryPlugin
+
+    class _NullADKAgent(BaseAgent):
+        pass
+
+    wrapped = goldfive.wrap(_NullADKAgent(name="null", description=""))
+
+    made: list[FakeTransport] = []
+    client = Client(
+        name="adk-telemetry-off",
+        agent_id="agent-tel-off",
+        session_id="sess-tel-off",
+        framework="ADK",
+        buffer_size=8,
+        _transport_factory=make_factory(made),
+    )
+
+    observe(wrapped, client=client, install_adk_telemetry=False)
+
+    pm = wrapped.runner.agent._runner.plugin_manager
+    plugins = list(getattr(pm, "plugins", []))
+    assert not any(isinstance(p, HarmonografTelemetryPlugin) for p in plugins)
+
+    await wrapped.close()
+    client.shutdown(flush_timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_observe_no_op_when_runner_lacks_add_plugin(client: Client) -> None:
+    """A runner without ``add_plugin`` (e.g. plain non-ADK Runner) must not raise."""
+    runner = _FakeRunner()  # _FakeRunner has no add_plugin attr
+
+    observe(runner, client=client)  # must not raise
+
+    assert not hasattr(runner, "add_plugin")
+    await runner.close()
+
+
+@pytest.mark.asyncio
 async def test_observe_twice_appends_two_sinks(client: Client) -> None:
     runner = _FakeRunner()
 

--- a/docs/goldfive-integration.md
+++ b/docs/goldfive-integration.md
@@ -65,6 +65,14 @@ runner = harmonograf_client.observe(goldfive.wrap(root_agent))
 outcome = await runner.run("make a presentation about waffles")
 ```
 
+These two lines produce **both** halves of full observability in one shot:
+
+- `HarmonografSink` attached to the goldfive `Runner` — plan rows, task
+  rows, drift markers, and lifecycle events show up in the harmonograf UI.
+- `HarmonografTelemetryPlugin` auto-installed on the underlying ADK
+  `Runner` (when `goldfive.wrap` wrapped an ADK agent) — invocation,
+  LLM-call, and tool-call spans render on the Gantt timeline.
+
 **First `goldfive.wrap` for orchestration, then `harmonograf_client.observe`
 for observability.** The layering is crystal-clear and each call owns exactly
 one concern:
@@ -73,12 +81,14 @@ one concern:
   default `LLMPlanner`, `SequentialExecutor`, adapter, and goal deriver, and
   returns a ready-to-run `goldfive.Runner`.
 - `harmonograf_client.observe(runner)` — the *only* observability wiring.
-  Constructs a `Client`, appends a `HarmonografSink` to `runner.sinks`, and
-  returns the same runner for chaining. Nothing about the runner's planning,
-  steering, goal derivation, or execution is touched.
+  Constructs a `Client`, appends a `HarmonografSink` to `runner.sinks`,
+  installs `HarmonografTelemetryPlugin` on the inner ADK runner if there is
+  one, and returns the same runner for chaining. Nothing about the runner's
+  planning, steering, goal derivation, or execution is touched.
 
 Neither call is implicit — if you want both you write both, and you can skip
-either one when you don't.
+either one when you don't. To opt out of the telemetry plugin (e.g. when one
+is already installed elsewhere), pass `install_adk_telemetry=False`.
 
 ### End-to-end
 
@@ -161,11 +171,22 @@ as the planner emits, each task's spans fill in as the adapter invokes the
 agent, and any `DriftDetected` event the steerer raises shows as a marker on
 the timeline.
 
-## Optional: ADK span telemetry
+## ADK span telemetry
 
-If the agent tree is wired through ADK's `App` (as `adk web` / `adk run` do),
-add `HarmonografTelemetryPlugin` so ADK lifecycle callbacks (invocation,
-LLM call, tool call) turn into harmonograf spans:
+When the wrapped agent is an ADK `BaseAgent`, `harmonograf_client.observe`
+auto-installs `HarmonografTelemetryPlugin` on the underlying ADK `Runner`,
+so invocation / LLM-call / tool-call spans render on the Gantt timeline
+without any extra setup. Opt out with `install_adk_telemetry=False`:
+
+```python
+runner = harmonograf_client.observe(
+    goldfive.wrap(root_agent), install_adk_telemetry=False
+)
+```
+
+For agent trees driven through ADK's `App` (as `adk web` / `adk run` do),
+add the plugin to the `App` directly — that path doesn't go through
+`goldfive.wrap`:
 
 ```python
 from google.adk.apps.app import App


### PR DESCRIPTION
## Summary
- `observe()` now best-effort installs `HarmonografTelemetryPlugin` on the runner when the runner exposes `add_plugin` (i.e. the goldfive >= 775f865 case where `goldfive.wrap` returned a `GoldfiveADKAgent`). The clean 2-line API now produces both halves of full observability — `HarmonografSink` for plans/tasks/drift **and** ADK lifecycle spans on the Gantt timeline.
- New `install_adk_telemetry: bool = True` kwarg for explicit opt-out (e.g. when a plugin is already installed elsewhere).
- Install is wrapped in try/except + DEBUG-logged so a broken telemetry install never breaks the surrounding `observe()` call.
- Bumps `third_party/goldfive` to pick up the `ADKAdapter.add_plugin` / `GoldfiveADKAgent.add_plugin` API (goldfive #91).
- Tests cover happy path on an ADK-wrapped runner, the `install_adk_telemetry=False` opt-out, and the no-op path on a non-ADK runner.
- Docs (`docs/goldfive-integration.md`) updated to reflect the auto-install in the minimal example and to clarify when manual `App(plugins=[...])` is still needed (the `adk web` / `adk run` path).

Closes #40 — see goldfive #90 for the design.

## Test plan
- [x] `make client-test` (146 passed)
- [x] `ruff check client/harmonograf_client/observe.py client/tests/test_observe.py` (clean)
