### PR TITLE
Capture reasoning_content in spans (closes #42)

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -54,6 +54,78 @@ def _serialize_args(args: Any) -> bytes | None:
         return None
 
 
+# Reasoning content above this byte size is attached as a blob payload_ref
+# (fetched on-demand by the span drawer); smaller content rides inline as
+# a span attribute so the default drawer render does not pay a round trip.
+# 2 KiB is roughly 500 tokens -- large enough for short chain-of-thought
+# like o1-mini's reasoning summary, small enough to keep span-stream bytes
+# bounded.
+REASONING_INLINE_MAX_BYTES: int = 2048
+
+
+def _extract_reasoning(llm_response: Any) -> str:
+    """Best-effort per-provider reasoning-content extraction.
+
+    Surfaces chain-of-thought exposed by the three families of backends
+    ADK drives today:
+
+    * **Google / Gemini** — thought parts flagged with
+      ``part.thought=True`` inside ``response.content.parts``.
+    * **OpenAI-compatible** — ``response.choices[0].message.reasoning_content``
+      (Qwen3.5 via LiteLLM, some o1-series, Deepseek).
+    * **Anthropic** — ``content[i].type == "thinking"`` blocks on the
+      extended-thinking surface (``block.thinking``).
+
+    Returns the reasoning text as a ``str`` or ``""`` when the response
+    carries no chain-of-thought. Callers compare against the empty
+    string to decide whether to emit a payload.
+    """
+    # Google / Gemini-style thought parts.
+    content = _safe_attr(llm_response, "content")
+    if content is not None:
+        parts = _safe_attr(content, "parts") or []
+        thoughts: list[str] = []
+        for part in parts:
+            if not _safe_attr(part, "thought", False):
+                continue
+            text = _safe_attr(part, "text") or ""
+            if text:
+                thoughts.append(str(text))
+        if thoughts:
+            return "\n".join(thoughts)
+
+    # OpenAI-compatible: response.choices[0].message.reasoning_content.
+    try:
+        choices = _safe_attr(llm_response, "choices") or []
+        if choices:
+            msg = _safe_attr(choices[0], "message")
+            if msg is not None:
+                rc = _safe_attr(msg, "reasoning_content") or _safe_attr(
+                    msg, "reasoning"
+                )
+                if rc:
+                    return str(rc)
+    except Exception:  # noqa: BLE001 -- best-effort extraction
+        pass
+
+    # Anthropic: content blocks of type "thinking".
+    blocks = _safe_attr(llm_response, "content")
+    if isinstance(blocks, list):
+        for block in blocks:
+            if _safe_attr(block, "type") == "thinking":
+                t = _safe_attr(block, "thinking") or ""
+                if t:
+                    return str(t)
+
+    # Fallback: flat attribute.
+    for attr in ("reasoning_content", "reasoning", "thinking"):
+        v = _safe_attr(llm_response, attr)
+        if isinstance(v, str) and v:
+            return v
+
+    return ""
+
+
 class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     """Emit one harmonograf span per ADK lifecycle boundary.
 
@@ -140,8 +212,38 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
                 status=SpanStatus.FAILED,
                 error={"type": "LlmError", "message": str(error_info)},
             )
-        else:
-            self._client.emit_span_end(sid, status=SpanStatus.COMPLETED)
+            return
+
+        reasoning = _extract_reasoning(llm_response)
+        attributes: dict[str, Any] = {}
+        payload: bytes | None = None
+        payload_mime: str = "application/json"
+        payload_role: str = "output"
+        if reasoning:
+            encoded = reasoning.encode("utf-8")
+            # has_reasoning is always set so the drawer can render a
+            # disclosure even when the reasoning is large enough to
+            # ride as a payload_ref instead of an inline attribute.
+            attributes["has_reasoning"] = True
+            if len(encoded) <= REASONING_INLINE_MAX_BYTES:
+                # Small reasoning: inline as a span attribute so the
+                # default drawer render doesn't fetch a blob.
+                attributes["llm.reasoning"] = reasoning
+            else:
+                # Large reasoning: upload as a blob and attach a
+                # payload_ref with role="reasoning".
+                payload = encoded
+                payload_mime = "text/plain"
+                payload_role = "reasoning"
+
+        self._client.emit_span_end(
+            sid,
+            status=SpanStatus.COMPLETED,
+            attributes=attributes or None,
+            payload=payload,
+            payload_mime=payload_mime,
+            payload_role=payload_role,
+        )
 
     # ------------------------------------------------------------------
     # Tool call lifecycle

--- a/client/tests/test_telemetry_plugin.py
+++ b/client/tests/test_telemetry_plugin.py
@@ -1,0 +1,271 @@
+"""Tests for :mod:`harmonograf_client.telemetry_plugin` — specifically
+the ``reasoning_content`` extraction + span attachment path.
+
+The plugin's ``after_model_callback`` is exercised against fabricated
+response shapes for the three backends (OpenAI-compat, Anthropic,
+Google) to confirm:
+
+* Small reasoning rides inline as a ``llm.reasoning`` span attribute.
+* Reasoning above :data:`REASONING_INLINE_MAX_BYTES` is attached as a
+  payload_ref with ``role="reasoning"``.
+* Responses without reasoning leave the span attribute-clean.
+* Error responses short-circuit before reasoning extraction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from harmonograf_client.buffer import EnvelopeKind
+from harmonograf_client.client import Client
+from harmonograf_client.telemetry_plugin import (
+    REASONING_INLINE_MAX_BYTES,
+    HarmonografTelemetryPlugin,
+    _extract_reasoning,
+)
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+# ---------------------------------------------------------------------------
+# Helpers: fabricated response shapes
+# ---------------------------------------------------------------------------
+
+
+class _Part:
+    def __init__(self, text: str = "", thought: bool = False) -> None:
+        self.text = text
+        self.thought = thought
+
+
+class _Content:
+    def __init__(self, parts: list[_Part]) -> None:
+        self.parts = parts
+
+
+class _Gemini:
+    """ADK-style LlmResponse with thought parts."""
+
+    def __init__(self, parts: list[_Part]) -> None:
+        self.content = _Content(parts)
+
+
+class _OpenAIMsg:
+    def __init__(self, reasoning_content: str) -> None:
+        self.reasoning_content = reasoning_content
+
+
+class _OpenAIChoice:
+    def __init__(self, reasoning_content: str) -> None:
+        self.message = _OpenAIMsg(reasoning_content)
+
+
+class _OpenAI:
+    def __init__(self, reasoning_content: str) -> None:
+        self.choices = [_OpenAIChoice(reasoning_content)]
+
+
+class _AnthropicBlock:
+    def __init__(
+        self, type: str = "text", thinking: str = "", text: str = ""
+    ) -> None:
+        self.type = type
+        self.thinking = thinking
+        self.text = text
+
+
+class _Anthropic:
+    def __init__(self, blocks: list[_AnthropicBlock]) -> None:
+        self.content = blocks
+
+
+class _CallbackContext:
+    """Opaque-enough stand-in; the plugin keys span lookup by id()."""
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="telemetry-test",
+        agent_id="agent-T",
+        session_id="sess-T",
+        buffer_size=64,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def plugin(client: Client) -> HarmonografTelemetryPlugin:
+    return HarmonografTelemetryPlugin(client)
+
+
+def _drain(client: Client) -> list:
+    return list(client._events.drain())
+
+
+def _first_span_end(client: Client) -> Any:
+    """Return the first SpanEnd envelope's payload (a SpanEnd proto)."""
+    for env in _drain(client):
+        if env.kind is EnvelopeKind.SPAN_END:
+            return env.payload
+    raise AssertionError("no SPAN_END envelope emitted")
+
+
+# ---------------------------------------------------------------------------
+# _extract_reasoning unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_reasoning_from_gemini_thought_parts() -> None:
+    resp = _Gemini(
+        [
+            _Part("visible text"),
+            _Part("internal reasoning step 1", thought=True),
+            _Part("more visible text"),
+        ]
+    )
+    assert _extract_reasoning(resp) == "internal reasoning step 1"
+
+
+def test_extract_reasoning_from_openai_compat_response() -> None:
+    resp = _OpenAI("step-by-step chain of thought")
+    assert _extract_reasoning(resp) == "step-by-step chain of thought"
+
+
+def test_extract_reasoning_from_anthropic_thinking_block() -> None:
+    resp = _Anthropic(
+        [
+            _AnthropicBlock(type="text", text="hi"),
+            _AnthropicBlock(type="thinking", thinking="claude's reasoning"),
+        ]
+    )
+    assert _extract_reasoning(resp) == "claude's reasoning"
+
+
+def test_extract_reasoning_returns_empty_for_plain_response() -> None:
+    resp = _Gemini([_Part("no thought here", thought=False)])
+    assert _extract_reasoning(resp) == ""
+
+
+def test_extract_reasoning_fallback_flat_attribute() -> None:
+    class _Plain:
+        reasoning = "flat reasoning string"
+
+    assert _extract_reasoning(_Plain()) == "flat reasoning string"
+
+
+# ---------------------------------------------------------------------------
+# Plugin integration: span attributes + payload_refs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_short_reasoning_rides_as_span_attribute(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    ctx = _CallbackContext()
+    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
+    await plugin.after_model_callback(
+        callback_context=ctx, llm_response=_OpenAI("short reasoning")
+    )
+    span_end = _first_span_end(client)
+    assert span_end.attributes["llm.reasoning"].string_value == "short reasoning"
+    assert span_end.attributes["has_reasoning"].bool_value is True
+    assert list(span_end.payload_refs) == []
+
+
+@pytest.mark.asyncio
+async def test_large_reasoning_attaches_as_payload_ref(
+    plugin: HarmonografTelemetryPlugin, client: Client, made: list[FakeTransport]
+) -> None:
+    ctx = _CallbackContext()
+    big = "x" * (REASONING_INLINE_MAX_BYTES + 1024)
+    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
+    await plugin.after_model_callback(
+        callback_context=ctx, llm_response=_OpenAI(big)
+    )
+    span_end = _first_span_end(client)
+    # No inline attribute for the reasoning text.
+    assert "llm.reasoning" not in span_end.attributes
+    # Disclosure flag is still set so the UI can render the section.
+    assert span_end.attributes["has_reasoning"].bool_value is True
+    # Exactly one payload_ref with role="reasoning".
+    refs = list(span_end.payload_refs)
+    assert len(refs) == 1
+    assert refs[0].role == "reasoning"
+    assert refs[0].mime == "text/plain"
+    assert refs[0].size == len(big.encode("utf-8"))
+    # And the bytes were enqueued to the transport.
+    assert any(p.digest == refs[0].digest for p in made[0].enqueued)
+
+
+@pytest.mark.asyncio
+async def test_response_without_reasoning_leaves_span_clean(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    ctx = _CallbackContext()
+    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
+    await plugin.after_model_callback(
+        callback_context=ctx, llm_response=_Gemini([_Part("hello")])
+    )
+    span_end = _first_span_end(client)
+    assert "llm.reasoning" not in span_end.attributes
+    assert "has_reasoning" not in span_end.attributes
+    assert list(span_end.payload_refs) == []
+
+
+@pytest.mark.asyncio
+async def test_error_response_short_circuits_before_reasoning(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    ctx = _CallbackContext()
+
+    class _ErrorResp:
+        error_message = "rate limited"
+        reasoning_content = "this should not be recorded"
+
+    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
+    await plugin.after_model_callback(callback_context=ctx, llm_response=_ErrorResp())
+    span_end = _first_span_end(client)
+    # On error, reasoning extraction is skipped; the error path runs instead.
+    assert "llm.reasoning" not in span_end.attributes
+    assert "has_reasoning" not in span_end.attributes
+    assert span_end.error.type == "LlmError"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_thinking_rides_inline_when_small(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    ctx = _CallbackContext()
+    resp = _Anthropic(
+        [_AnthropicBlock(type="thinking", thinking="reflective thought")]
+    )
+    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
+    await plugin.after_model_callback(callback_context=ctx, llm_response=resp)
+    span_end = _first_span_end(client)
+    assert span_end.attributes["llm.reasoning"].string_value == "reflective thought"
+
+
+@pytest.mark.asyncio
+async def test_gemini_thought_parts_inline_when_small(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    ctx = _CallbackContext()
+    resp = _Gemini(
+        [
+            _Part("visible"),
+            _Part("private thought", thought=True),
+        ]
+    )
+    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
+    await plugin.after_model_callback(callback_context=ctx, llm_response=resp)
+    span_end = _first_span_end(client)
+    assert span_end.attributes["llm.reasoning"].string_value == "private thought"

--- a/frontend/src/__tests__/components/Drawer.reasoning.test.tsx
+++ b/frontend/src/__tests__/components/Drawer.reasoning.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PayloadRef } from '../../gantt/types';
+
+// usePayload is the hook the ReasoningSection calls for large reasoning
+// blobs. We swap it for a spy so tests can assert behavior without a real
+// transport.
+const usePayloadSpy = vi.fn<(digest: string | null) => {
+  bytes: Uint8Array | null;
+  mimeType: string;
+  loading: boolean;
+  error: string | null;
+}>();
+
+vi.mock('../../rpc/hooks', () => ({
+  usePayload: (digest: string | null) => usePayloadSpy(digest),
+}));
+
+import { ReasoningSection } from '../../components/shell/Drawer';
+
+beforeEach(() => {
+  usePayloadSpy.mockReset();
+  usePayloadSpy.mockReturnValue({
+    bytes: null,
+    mimeType: '',
+    loading: false,
+    error: null,
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ReasoningSection', () => {
+  it('is collapsed by default and does not request the payload until opened', () => {
+    render(
+      <ReasoningSection
+        inline="inline reasoning trace"
+        payloadRef={undefined}
+      />,
+    );
+    // Body is not in the DOM until toggled open.
+    expect(screen.queryByTestId('drawer-reasoning-body')).toBeNull();
+    // Toggle exists with the Reasoning label.
+    expect(screen.getByTestId('drawer-reasoning-toggle').textContent).toMatch(
+      /Reasoning/i,
+    );
+  });
+
+  it('renders the inline reasoning attribute when the toggle is opened', () => {
+    render(
+      <ReasoningSection
+        inline="the model deliberated about step A then step B"
+        payloadRef={undefined}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('drawer-reasoning-toggle'));
+    const body = screen.getByTestId('drawer-reasoning-body');
+    expect(body.textContent).toContain('step A then step B');
+    // The inline path should not have asked for a payload fetch.
+    expect(usePayloadSpy).toHaveBeenCalledWith(null);
+  });
+
+  it('fetches the payload by digest when reasoning rides as a payload_ref', async () => {
+    const ref: PayloadRef = {
+      digest: 'deadbeef1234',
+      size: 4096,
+      mime: 'text/plain',
+      summary: 'long reasoning...',
+      role: 'reasoning',
+      evicted: false,
+    };
+    usePayloadSpy.mockImplementation((digest) => ({
+      bytes:
+        digest === 'deadbeef1234'
+          ? new TextEncoder().encode('fetched long reasoning body')
+          : null,
+      mimeType: digest === 'deadbeef1234' ? 'text/plain' : '',
+      loading: false,
+      error: null,
+    }));
+
+    render(<ReasoningSection inline={undefined} payloadRef={ref} />);
+    // Before opening: the hook is called with null (no fetch in flight).
+    expect(usePayloadSpy).toHaveBeenCalledWith(null);
+
+    fireEvent.click(screen.getByTestId('drawer-reasoning-toggle'));
+    await waitFor(() => {
+      expect(usePayloadSpy).toHaveBeenCalledWith('deadbeef1234');
+    });
+    const body = screen.getByTestId('drawer-reasoning-body');
+    expect(body.textContent).toContain('fetched long reasoning body');
+  });
+
+  it('shows a loading indicator while the payload is in flight', () => {
+    const ref: PayloadRef = {
+      digest: 'dead',
+      size: 4096,
+      mime: 'text/plain',
+      summary: '',
+      role: 'reasoning',
+      evicted: false,
+    };
+    usePayloadSpy.mockReturnValue({
+      bytes: null,
+      mimeType: '',
+      loading: true,
+      error: null,
+    });
+    render(<ReasoningSection inline={undefined} payloadRef={ref} />);
+    fireEvent.click(screen.getByTestId('drawer-reasoning-toggle'));
+    expect(screen.getByTestId('drawer-reasoning-body').textContent).toMatch(
+      /loading reasoning/i,
+    );
+  });
+
+  it('surfaces fetch errors from usePayload', () => {
+    const ref: PayloadRef = {
+      digest: 'dead',
+      size: 4096,
+      mime: 'text/plain',
+      summary: '',
+      role: 'reasoning',
+      evicted: false,
+    };
+    usePayloadSpy.mockReturnValue({
+      bytes: null,
+      mimeType: '',
+      loading: false,
+      error: 'network exploded',
+    });
+    render(<ReasoningSection inline={undefined} payloadRef={ref} />);
+    fireEvent.click(screen.getByTestId('drawer-reasoning-toggle'));
+    expect(screen.getByTestId('drawer-reasoning-body').textContent).toContain(
+      'network exploded',
+    );
+  });
+
+  it('truncates display at 5000 chars and annotates the remainder', () => {
+    const huge = 'a'.repeat(6000);
+    render(<ReasoningSection inline={huge} payloadRef={undefined} />);
+    fireEvent.click(screen.getByTestId('drawer-reasoning-toggle'));
+    const body = screen.getByTestId('drawer-reasoning-body');
+    expect(body.textContent).toMatch(/truncated \(1000 more chars\)/);
+  });
+});

--- a/frontend/src/components/shell/Drawer.tsx
+++ b/frontend/src/components/shell/Drawer.tsx
@@ -334,6 +334,10 @@ function TaskOverviewPanel({ span, sessionId }: { span: Span; sessionId: string 
   const hasThinking = span.attributes['has_thinking']?.kind === 'bool' && span.attributes['has_thinking'].value;
   const isRunning = span.endMs == null;
   const agentDesc = (span.attributes['agent_description']?.kind === 'string' ? span.attributes['agent_description'].value : undefined);
+  const reasoningInline = (span.attributes['llm.reasoning']?.kind === 'string' ? span.attributes['llm.reasoning'].value : undefined);
+  const hasReasoningAttr = span.attributes['has_reasoning']?.kind === 'bool' && span.attributes['has_reasoning'].value;
+  const reasoningRef = (span.payloadRefs ?? []).find((r) => r.role === 'reasoning');
+  const showReasoning = Boolean(reasoningInline || reasoningRef || hasReasoningAttr);
 
   return (
     <div style={{ padding: '12px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -393,7 +397,18 @@ function TaskOverviewPanel({ span, sessionId }: { span: Span; sessionId: string 
         </section>
       )}
 
-      {(!taskReport && !llmThought && !thinkingText && !thinkingPreview && !agentDesc) && (
+      {/* Reasoning — chain-of-thought captured by the telemetry plugin.
+          Small reasoning rides as the ``llm.reasoning`` span attribute;
+          large reasoning lives in a payload_ref (role="reasoning") and
+          is fetched on-demand. */}
+      {showReasoning && (
+        <ReasoningSection
+          inline={reasoningInline}
+          payloadRef={reasoningRef}
+        />
+      )}
+
+      {(!taskReport && !llmThought && !thinkingText && !thinkingPreview && !agentDesc && !showReasoning) && (
         <div style={{ fontSize: 12, opacity: 0.5, textAlign: 'center', padding: '24px 0' }}>
           No task information available.
         </div>
@@ -408,6 +423,111 @@ function TaskOverviewPanel({ span, sessionId }: { span: Span; sessionId: string 
         <OrchestrationTimeline sessionId={sessionId} limit={20} />
       </section>
     </div>
+  );
+}
+
+// Reasoning section: surfaces `llm.reasoning` inline (small) or a
+// payload_ref with role="reasoning" (large, fetched on click). Collapsed
+// by default — reasoning traces can be long, and users usually only want
+// them when investigating a surprising decision.
+const REASONING_PREVIEW_CHARS = 5000;
+
+export function ReasoningSection({
+  inline,
+  payloadRef,
+}: {
+  inline: string | undefined;
+  payloadRef: PayloadRef | undefined;
+}) {
+  const [open, setOpen] = useState(false);
+  // When the reasoning rides inline we don't need to fetch; when it comes
+  // as a payload_ref we trigger the load on first open via the toggle
+  // handler so we stay out of useEffect (react-hooks/set-state-in-effect).
+  const needsFetch = !inline && payloadRef != null;
+  const { bytes, loading, error } = usePayload(
+    open && needsFetch && payloadRef ? payloadRef.digest : null,
+  );
+
+  const fetchedText = useMemo(() => {
+    if (!bytes) return null;
+    try {
+      return new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+    } catch {
+      return null;
+    }
+  }, [bytes]);
+
+  const fullText = inline ?? fetchedText ?? '';
+  const truncated = fullText.length > REASONING_PREVIEW_CHARS;
+  const previewText = truncated
+    ? fullText.slice(0, REASONING_PREVIEW_CHARS)
+    : fullText;
+
+  return (
+    <section data-testid="drawer-reasoning">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        data-testid="drawer-reasoning-toggle"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          width: '100%',
+          background: 'transparent',
+          border: 'none',
+          padding: 0,
+          cursor: 'pointer',
+          color: 'inherit',
+          fontSize: 10,
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+          opacity: 0.6,
+          marginBottom: 4,
+        }}
+      >
+        <span style={{ transform: open ? 'rotate(90deg)' : 'none', transition: 'transform 0.1s' }}>▸</span>
+        <span>Reasoning</span>
+        {payloadRef && !inline && (
+          <span style={{ marginLeft: 'auto', fontSize: 9, opacity: 0.7 }}>
+            {formatBytes(payloadRef.size)}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div data-testid="drawer-reasoning-body">
+          {loading && <div style={{ fontSize: 11, opacity: 0.6 }}>Loading reasoning…</div>}
+          {error && <div className="hg-drawer__error" style={{ fontSize: 11 }}>{error}</div>}
+          {!loading && !error && fullText && (
+            <div
+              style={{
+                fontSize: 11,
+                lineHeight: 1.6,
+                background: 'rgba(168,200,255,0.05)',
+                borderRadius: 6,
+                padding: '8px 10px',
+                fontFamily: "ui-monospace, 'SF Mono', Consolas, 'Liberation Mono', monospace",
+                color: 'rgba(226,226,233,0.85)',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                maxHeight: 400,
+                overflow: 'auto',
+              }}
+            >
+              {previewText}
+              {truncated && (
+                <div style={{ fontSize: 10, opacity: 0.6, marginTop: 6 }}>
+                  … truncated ({fullText.length - REASONING_PREVIEW_CHARS} more chars)
+                </div>
+              )}
+            </div>
+          )}
+          {!loading && !error && !fullText && !needsFetch && (
+            <div style={{ fontSize: 11, opacity: 0.5 }}>No reasoning captured.</div>
+          )}
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/frontend/src/lib/thinking.ts
+++ b/frontend/src/lib/thinking.ts
@@ -8,6 +8,14 @@
 //   - ``thinking_text``     — full text captured by the plugin on span end.
 //   - ``thinking_preview``  — first 300 chars (set as a fallback).
 //   - ``has_thinking``      — bool flag set as soon as any reasoning lands.
+//   - ``llm.reasoning``     — per-response reasoning_content / thinking-block
+//                             capture emitted by
+//                             ``HarmonografTelemetryPlugin.after_model_callback``.
+//                             Small reasoning rides as a string attribute;
+//                             large reasoning lives in a payload_ref with
+//                             ``role="reasoning"`` (rendered by the Drawer's
+//                             ReasoningSection, not this helper).
+//   - ``has_reasoning``     — bool flag for the Drawer's Reasoning toggle.
 //
 // Every reader in the app (SpanPopover, Drawer, renderer, timeline, etc.)
 // routes through the functions here so that fallbacks are consistent and we


### PR DESCRIPTION
## Summary

- `HarmonografTelemetryPlugin.after_model_callback` now extracts per-provider reasoning content (Google thought parts, OpenAI-compat `reasoning_content`, Anthropic `thinking` blocks, flat-attribute fallback) and attaches it to the LLM_CALL span.
- Small reasoning (≤ 2 KB encoded) rides inline as the `llm.reasoning` string attribute so the default drawer render doesn't pay a blob fetch; larger reasoning lives in a payload_ref with `role="reasoning"`. `has_reasoning` bool is always set so the drawer can render the disclosure either way.
- Drawer's Task tab gains a collapsed-by-default "Reasoning" section that renders the inline attribute immediately or fetches the payload_ref by digest on first open. Display caps at 5000 chars with a "truncated" annotation to keep long traces readable.

Pairs with goldfive #96 (reasoning-based drift detection, merged in goldfive#97) — same extraction path, two consumers.

## Test plan

- [x] `make client-test` — 157 passed (new suite: `client/tests/test_telemetry_plugin.py` with 11 tests covering per-provider extraction + inline / payload_ref / error paths).
- [x] `pnpm test` — 193 passed (new suite: `frontend/src/__tests__/components/Drawer.reasoning.test.tsx` with 6 tests covering collapsible behavior, inline render, payload fetch, loading / error / truncation).
- [x] `pnpm build` + `pnpm lint` clean.
