### PR TITLE
observe(): advertise STEERING + HUMAN_IN_LOOP capabilities by default

### DIFF
--- a/client/harmonograf_client/observe.py
+++ b/client/harmonograf_client/observe.py
@@ -103,6 +103,15 @@ def observe(
         client_kwargs: dict[str, Any] = {
             "name": name or "agent",
             "framework": framework,
+            # observe() attaches a ControlBridge below, which means this
+            # runner can receive STEER / CANCEL / PAUSE / APPROVE /
+            # REJECT control messages from the harmonograf UI. Advertise
+            # the matching capabilities so the UI's Steer and Approve
+            # buttons light up (frontend checks ``hasCapability(span,
+            # 'STEERING')`` before enabling the action). Callers who
+            # want a narrower capability set can pass their own pre-
+            # built ``client=`` with custom capabilities.
+            "capabilities": ["STEERING", "HUMAN_IN_LOOP"],
         }
         if resolved_addr:
             client_kwargs["server_addr"] = resolved_addr


### PR DESCRIPTION
## Summary

``harmonograf_client.observe()`` constructs a Client with empty capabilities, which disables the UI's STEER and APPROVE/REJECT actions (frontend checks ``hasCapability(span, 'STEERING')``). But ``observe()`` also attaches a ``ControlBridge`` — the runner IS wired to receive those messages. The capability advertisement was just missing.

This PR sets default capabilities to ``["STEERING", "HUMAN_IN_LOOP"]`` when ``observe()`` constructs the Client itself. Callers passing a pre-built ``client=`` still control their own capability set.

## Test plan

- [x] ``uv run --extra e2e pytest client/tests/test_observe.py`` → 10 passed
- [ ] Live verification: open harmonograf UI against a goldfive run wrapped with ``observe()``; the STEER button should be enabled on the running agent's span.
