### PR TITLE
Fix reasoning_content extraction when provider response comes through LiteLlm

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -24,10 +24,27 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import deque
+from dataclasses import dataclass, field
 from typing import Any
 
 from .client import Client
 from .enums import SpanKind, SpanStatus
+
+
+@dataclass
+class _ModelSpanSlot:
+    """Per-LLM-call bookkeeping kept in ``_model_spans[invocation_id]``.
+
+    ``reasoning_chunks`` accumulates partial reasoning text yielded by
+    streaming providers (LiteLlm emits one ``LlmResponse`` per chunk in
+    SSE mode); the non-partial finalize stitches them together and
+    attaches the result as ``llm.reasoning`` on the span.
+    """
+
+    span_id: str
+    reasoning_chunks: list[str] = field(default_factory=list)
+
 
 log = logging.getLogger("harmonograf_client.telemetry_plugin")
 
@@ -126,6 +143,32 @@ def _extract_reasoning(llm_response: Any) -> str:
     return ""
 
 
+def _join_reasoning(chunks: list[str]) -> str:
+    """Deduplicate and stitch reasoning fragments collected across partials.
+
+    LiteLlm streaming yields one ``LlmResponse`` per reasoning delta, so
+    the plugin sees ``["Let me ", "think step by ", "step."]``. The
+    finalize chunk also carries the aggregated reasoning as a thought
+    part, which would otherwise appear twice if we concatenated
+    naively; we drop the finalize duplicate when it is a prefix-equal
+    superstring of the stitched partials (LiteLlm's finalize path
+    always reproduces the full running buffer).
+    """
+    if not chunks:
+        return ""
+    if len(chunks) == 1:
+        return chunks[0]
+    stitched_partials = "".join(chunks[:-1])
+    last = chunks[-1]
+    if last == stitched_partials:
+        return stitched_partials
+    # Finalize may include the aggregated reasoning plus a trailing
+    # newline/punct; collapse the duplicate prefix when present.
+    if last.startswith(stitched_partials):
+        return last
+    return stitched_partials + last
+
+
 class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     """Emit one harmonograf span per ADK lifecycle boundary.
 
@@ -136,10 +179,12 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     * ``TOOL_CALL`` — one per ``before_tool`` / ``after_tool`` or
       ``on_tool_error`` pair.
 
-    Span IDs are keyed off the ADK callback objects so nested calls are
-    balanced even when the same plugin instance handles multiple
-    concurrent invocations (ADK guarantees one callback object per
-    lifecycle pair).
+    Invocation and tool spans are balanced via the Python object id
+    of the shared ADK context (``invocation_context`` / ``tool_context``).
+    Model-call spans are balanced via a per-``invocation_id`` FIFO
+    queue because ADK rebuilds the ``CallbackContext`` between
+    ``before_model`` and ``after_model``, making object identity
+    unreliable for that lifecycle pair.
     """
 
     def __init__(self, client: Client) -> None:
@@ -151,7 +196,20 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             pass
         self._client = client
         self._invocation_spans: dict[str, str] = {}
-        self._model_spans: dict[int, str] = {}
+        # Model-call spans are keyed by ``invocation_id`` and tracked as
+        # FIFO queues: ADK rebuilds the ``CallbackContext`` between
+        # ``before_model`` and ``after_model`` (see
+        # ``flows/llm_flows/base_llm_flow.py::_handle_after_model_callback``),
+        # so ``id(callback_context)`` is never stable across a single LLM
+        # call. An agent invocation never overlaps LLM calls on its own
+        # flow, so a per-invocation FIFO balances before/after pairs
+        # correctly while still supporting concurrent invocations.
+        #
+        # Each queue entry also carries a reasoning accumulator so
+        # streaming partials (``LlmResponse.partial=True``) can be
+        # stitched into a single ``llm.reasoning`` attribute at the
+        # span's non-partial finalize.
+        self._model_spans: dict[str, deque[_ModelSpanSlot]] = {}
         self._tool_spans: dict[int, str] = {}
 
     @property
@@ -179,7 +237,28 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
 
     async def after_run_callback(self, *, invocation_context: Any) -> None:
         inv_id = str(_safe_attr(invocation_context, "invocation_id", "") or "")
-        key = inv_id if inv_id in self._invocation_spans else str(id(invocation_context))
+        # Close any model-call spans that never saw a non-partial
+        # finalize (error paths, client disconnect mid-stream). Without
+        # this sweep such spans would leak forever.
+        if inv_id:
+            leftover = self._model_spans.pop(inv_id, None)
+            if leftover:
+                for slot in leftover:
+                    reasoning = _join_reasoning(slot.reasoning_chunks)
+                    attributes = (
+                        {"has_reasoning": True, "llm.reasoning": reasoning}
+                        if reasoning
+                        and len(reasoning.encode("utf-8")) <= REASONING_INLINE_MAX_BYTES
+                        else ({"has_reasoning": True} if reasoning else None)
+                    )
+                    self._client.emit_span_end(
+                        slot.span_id,
+                        status=SpanStatus.COMPLETED,
+                        attributes=attributes,
+                    )
+        key = (
+            inv_id if inv_id in self._invocation_spans else str(id(invocation_context))
+        )
         sid = self._invocation_spans.pop(key, None)
         if sid is not None:
             self._client.emit_span_end(sid, status=SpanStatus.COMPLETED)
@@ -187,6 +266,25 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     # ------------------------------------------------------------------
     # LLM call lifecycle
     # ------------------------------------------------------------------
+
+    def _model_span_key(self, callback_context: Any) -> str:
+        """Stable key for pairing ``before_model`` / ``after_model``.
+
+        ``CallbackContext`` is rebuilt between the two callbacks
+        (``_handle_after_model_callback`` in ADK's base flow constructs
+        a fresh ``CallbackContext(invocation_context)`` before running
+        plugin callbacks), so ``id(callback_context)`` changes. We fall
+        back to the invocation id — stable for the lifetime of an ADK
+        invocation — and multiplex via a FIFO queue so sequential LLM
+        calls within an invocation balance correctly.
+        """
+        inv_id = str(_safe_attr(callback_context, "invocation_id", "") or "")
+        if inv_id:
+            return inv_id
+        # Last-ditch fallback: use object id so we still *start* a span
+        # and will eventually close it on teardown. This path only
+        # triggers if ADK breaks the invocation_id contract.
+        return f"_ctx:{id(callback_context)}"
 
     async def before_model_callback(
         self, *, callback_context: Any, llm_request: Any
@@ -197,24 +295,46 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             name=model or "llm_call",
             attributes={"llm.model": model} if model else None,
         )
-        self._model_spans[id(callback_context)] = sid
+        key = self._model_span_key(callback_context)
+        self._model_spans.setdefault(key, deque()).append(_ModelSpanSlot(span_id=sid))
 
     async def after_model_callback(
         self, *, callback_context: Any, llm_response: Any
     ) -> None:
-        sid = self._model_spans.pop(id(callback_context), None)
-        if sid is None:
+        key = self._model_span_key(callback_context)
+        queue = self._model_spans.get(key)
+        if not queue:
             return
+        slot = queue[0]
+        # Streaming providers (LiteLlm SSE) deliver partials first and a
+        # non-partial finalize last. Accumulate reasoning from every
+        # partial so the finalize can attach the full chain-of-thought,
+        # but only close the span on the finalize.
+        chunk = _extract_reasoning(llm_response)
+        if chunk:
+            slot.reasoning_chunks.append(chunk)
+
+        partial = bool(_safe_attr(llm_response, "partial", False))
+        if partial:
+            return
+
+        # Non-partial: close the span. Pop the slot from the queue so
+        # the next before_model_callback within the same invocation
+        # gets its own entry.
+        queue.popleft()
+        if not queue:
+            self._model_spans.pop(key, None)
+
         error_info = _safe_attr(llm_response, "error_message")
         if error_info:
             self._client.emit_span_end(
-                sid,
+                slot.span_id,
                 status=SpanStatus.FAILED,
                 error={"type": "LlmError", "message": str(error_info)},
             )
             return
 
-        reasoning = _extract_reasoning(llm_response)
+        reasoning = _join_reasoning(slot.reasoning_chunks)
         attributes: dict[str, Any] = {}
         payload: bytes | None = None
         payload_mime: str = "application/json"
@@ -237,7 +357,7 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
                 payload_role = "reasoning"
 
         self._client.emit_span_end(
-            sid,
+            slot.span_id,
             status=SpanStatus.COMPLETED,
             attributes=attributes or None,
             payload=payload,

--- a/client/tests/test_telemetry_plugin.py
+++ b/client/tests/test_telemetry_plugin.py
@@ -68,9 +68,7 @@ class _OpenAI:
 
 
 class _AnthropicBlock:
-    def __init__(
-        self, type: str = "text", thinking: str = "", text: str = ""
-    ) -> None:
+    def __init__(self, type: str = "text", thinking: str = "", text: str = "") -> None:
         self.type = type
         self.thinking = thinking
         self.text = text
@@ -82,7 +80,30 @@ class _Anthropic:
 
 
 class _CallbackContext:
-    """Opaque-enough stand-in; the plugin keys span lookup by id()."""
+    """ADK-shaped stand-in carrying an ``invocation_id``.
+
+    The plugin pairs ``before_model`` / ``after_model`` calls via
+    ``invocation_id``, not object identity — ADK reconstructs the
+    ``CallbackContext`` between the two callbacks, so ``id(ctx)`` is
+    unreliable. Tests pass distinct Python objects with matching
+    ``invocation_id`` to mirror that production shape.
+    """
+
+    def __init__(self, invocation_id: str = "inv-1") -> None:
+        self.invocation_id = invocation_id
+
+
+def _ctx_pair(
+    invocation_id: str = "inv-1",
+) -> tuple[_CallbackContext, _CallbackContext]:
+    """Return (before_ctx, after_ctx) sharing an ``invocation_id``.
+
+    ADK builds a fresh ``CallbackContext`` object for each plugin
+    callback invocation, so the two contexts a plugin sees across one
+    LLM call are *not* the same Python object. Use this helper in
+    tests to mirror that.
+    """
+    return _CallbackContext(invocation_id), _CallbackContext(invocation_id)
 
 
 @pytest.fixture
@@ -170,10 +191,12 @@ def test_extract_reasoning_fallback_flat_attribute() -> None:
 async def test_short_reasoning_rides_as_span_attribute(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
-    ctx = _CallbackContext()
-    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
+    before_ctx, after_ctx = _ctx_pair()
+    await plugin.before_model_callback(
+        callback_context=before_ctx, llm_request=object()
+    )
     await plugin.after_model_callback(
-        callback_context=ctx, llm_response=_OpenAI("short reasoning")
+        callback_context=after_ctx, llm_response=_OpenAI("short reasoning")
     )
     span_end = _first_span_end(client)
     assert span_end.attributes["llm.reasoning"].string_value == "short reasoning"
@@ -185,11 +208,13 @@ async def test_short_reasoning_rides_as_span_attribute(
 async def test_large_reasoning_attaches_as_payload_ref(
     plugin: HarmonografTelemetryPlugin, client: Client, made: list[FakeTransport]
 ) -> None:
-    ctx = _CallbackContext()
+    before_ctx, after_ctx = _ctx_pair()
     big = "x" * (REASONING_INLINE_MAX_BYTES + 1024)
-    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
+    await plugin.before_model_callback(
+        callback_context=before_ctx, llm_request=object()
+    )
     await plugin.after_model_callback(
-        callback_context=ctx, llm_response=_OpenAI(big)
+        callback_context=after_ctx, llm_response=_OpenAI(big)
     )
     span_end = _first_span_end(client)
     # No inline attribute for the reasoning text.
@@ -210,10 +235,12 @@ async def test_large_reasoning_attaches_as_payload_ref(
 async def test_response_without_reasoning_leaves_span_clean(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
-    ctx = _CallbackContext()
-    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
+    before_ctx, after_ctx = _ctx_pair()
+    await plugin.before_model_callback(
+        callback_context=before_ctx, llm_request=object()
+    )
     await plugin.after_model_callback(
-        callback_context=ctx, llm_response=_Gemini([_Part("hello")])
+        callback_context=after_ctx, llm_response=_Gemini([_Part("hello")])
     )
     span_end = _first_span_end(client)
     assert "llm.reasoning" not in span_end.attributes
@@ -225,14 +252,18 @@ async def test_response_without_reasoning_leaves_span_clean(
 async def test_error_response_short_circuits_before_reasoning(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
-    ctx = _CallbackContext()
+    before_ctx, after_ctx = _ctx_pair()
 
     class _ErrorResp:
         error_message = "rate limited"
         reasoning_content = "this should not be recorded"
 
-    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
-    await plugin.after_model_callback(callback_context=ctx, llm_response=_ErrorResp())
+    await plugin.before_model_callback(
+        callback_context=before_ctx, llm_request=object()
+    )
+    await plugin.after_model_callback(
+        callback_context=after_ctx, llm_response=_ErrorResp()
+    )
     span_end = _first_span_end(client)
     # On error, reasoning extraction is skipped; the error path runs instead.
     assert "llm.reasoning" not in span_end.attributes
@@ -244,12 +275,12 @@ async def test_error_response_short_circuits_before_reasoning(
 async def test_anthropic_thinking_rides_inline_when_small(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
-    ctx = _CallbackContext()
-    resp = _Anthropic(
-        [_AnthropicBlock(type="thinking", thinking="reflective thought")]
+    before_ctx, after_ctx = _ctx_pair()
+    resp = _Anthropic([_AnthropicBlock(type="thinking", thinking="reflective thought")])
+    await plugin.before_model_callback(
+        callback_context=before_ctx, llm_request=object()
     )
-    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
-    await plugin.after_model_callback(callback_context=ctx, llm_response=resp)
+    await plugin.after_model_callback(callback_context=after_ctx, llm_response=resp)
     span_end = _first_span_end(client)
     assert span_end.attributes["llm.reasoning"].string_value == "reflective thought"
 
@@ -258,14 +289,166 @@ async def test_anthropic_thinking_rides_inline_when_small(
 async def test_gemini_thought_parts_inline_when_small(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
-    ctx = _CallbackContext()
+    before_ctx, after_ctx = _ctx_pair()
     resp = _Gemini(
         [
             _Part("visible"),
             _Part("private thought", thought=True),
         ]
     )
-    await plugin.before_model_callback(callback_context=ctx, llm_request=object())
-    await plugin.after_model_callback(callback_context=ctx, llm_response=resp)
+    await plugin.before_model_callback(
+        callback_context=before_ctx, llm_request=object()
+    )
+    await plugin.after_model_callback(callback_context=after_ctx, llm_response=resp)
     span_end = _first_span_end(client)
     assert span_end.attributes["llm.reasoning"].string_value == "private thought"
+
+
+# ---------------------------------------------------------------------------
+# LiteLlm-wrapping regression (issue: PR #43 shipped with zero
+# reasoning attributes on Qwen3.5-via-LiteLLM runs because the plugin
+# keyed spans by ``id(callback_context)`` and ADK rebuilds the context
+# between before_model and after_model).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_litellm_shape_openai_reasoning_content_pairs_before_after(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """ADK's LiteLlm converts provider ``reasoning_content`` into a
+    Gemini-style ``types.Part(text=..., thought=True)`` prepended to
+    ``content.parts``. This reproduces that shape and verifies the
+    plugin pairs a fresh before-context with a fresh after-context.
+    """
+    before_ctx, after_ctx = _ctx_pair(invocation_id="inv-litellm")
+    # Distinct Python objects: matches what ADK actually passes.
+    assert id(before_ctx) != id(after_ctx)
+    resp = _Gemini(
+        [
+            _Part("Let me think step by step. 6*7=42.", thought=True),
+            _Part("The answer is 42."),
+        ]
+    )
+    await plugin.before_model_callback(
+        callback_context=before_ctx, llm_request=object()
+    )
+    await plugin.after_model_callback(callback_context=after_ctx, llm_response=resp)
+    span_end = _first_span_end(client)
+    assert (
+        span_end.attributes["llm.reasoning"].string_value
+        == "Let me think step by step. 6*7=42."
+    )
+    assert span_end.attributes["has_reasoning"].bool_value is True
+
+
+@pytest.mark.asyncio
+async def test_litellm_streaming_partials_accumulate_then_finalize(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """LiteLlm SSE streaming yields one ``LlmResponse`` per reasoning
+    delta with ``partial=True``, and a final non-partial aggregated
+    response. The plugin must accumulate partial reasoning and only
+    close the span on the finalize.
+    """
+    before_ctx = _CallbackContext(invocation_id="inv-stream")
+    partial_ctx_1 = _CallbackContext(invocation_id="inv-stream")
+    partial_ctx_2 = _CallbackContext(invocation_id="inv-stream")
+    final_ctx = _CallbackContext(invocation_id="inv-stream")
+
+    def _partial(chunk_text: str) -> _Gemini:
+        r = _Gemini([_Part(chunk_text, thought=True)])
+        r.partial = True  # type: ignore[attr-defined]
+        return r
+
+    await plugin.before_model_callback(
+        callback_context=before_ctx, llm_request=object()
+    )
+    await plugin.after_model_callback(
+        callback_context=partial_ctx_1, llm_response=_partial("Let me think ")
+    )
+    await plugin.after_model_callback(
+        callback_context=partial_ctx_2, llm_response=_partial("step by step.")
+    )
+    # No SPAN_END should have been emitted yet.
+    envelopes = list(client._events.drain())
+    client._events.drain()  # no-op: drain already consumed
+    assert all(env.kind is not EnvelopeKind.SPAN_END for env in envelopes)
+    # Re-enqueue what we popped (drain is destructive) — put them back
+    # by just re-running; instead, assert that the SPAN_START was the
+    # only LLM-related envelope, which is what we actually need.
+    assert any(env.kind is EnvelopeKind.SPAN_START for env in envelopes)
+
+    # Now the finalize. LiteLlm's finalize carries the aggregated
+    # reasoning as a single thought part (reproducing the concatenation
+    # of all previously streamed deltas).
+    final = _Gemini([_Part("Let me think step by step.", thought=True)])
+    final.partial = False  # type: ignore[attr-defined]
+    await plugin.after_model_callback(callback_context=final_ctx, llm_response=final)
+    span_end = _first_span_end(client)
+    assert (
+        span_end.attributes["llm.reasoning"].string_value
+        == "Let me think step by step."
+    )
+
+
+@pytest.mark.asyncio
+async def test_sequential_llm_calls_within_invocation_balance(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """A single invocation may make multiple sequential LLM calls
+    (tool-calling loop). Each before/after pair in the invocation's
+    FIFO queue must match the correct span.
+    """
+    inv_id = "inv-multi"
+    # Call 1
+    await plugin.before_model_callback(
+        callback_context=_CallbackContext(inv_id), llm_request=object()
+    )
+    # Call 2 (starts before call 1 finishes would violate ADK's
+    # serialization, but we still test proper FIFO ordering).
+    await plugin.before_model_callback(
+        callback_context=_CallbackContext(inv_id), llm_request=object()
+    )
+    # After call 1
+    await plugin.after_model_callback(
+        callback_context=_CallbackContext(inv_id),
+        llm_response=_OpenAI("reasoning for call 1"),
+    )
+    # After call 2
+    await plugin.after_model_callback(
+        callback_context=_CallbackContext(inv_id),
+        llm_response=_OpenAI("reasoning for call 2"),
+    )
+    ends = [env.payload for env in _drain(client) if env.kind is EnvelopeKind.SPAN_END]
+    assert len(ends) == 2
+    assert ends[0].attributes["llm.reasoning"].string_value == "reasoning for call 1"
+    assert ends[1].attributes["llm.reasoning"].string_value == "reasoning for call 2"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_invocations_do_not_cross_talk(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Two agents running concurrently produce interleaved before/after
+    callbacks with distinct ``invocation_id`` values. Reasoning must
+    land on the correct span."""
+    await plugin.before_model_callback(
+        callback_context=_CallbackContext("inv-A"), llm_request=object()
+    )
+    await plugin.before_model_callback(
+        callback_context=_CallbackContext("inv-B"), llm_request=object()
+    )
+    await plugin.after_model_callback(
+        callback_context=_CallbackContext("inv-B"),
+        llm_response=_OpenAI("B's reasoning"),
+    )
+    await plugin.after_model_callback(
+        callback_context=_CallbackContext("inv-A"),
+        llm_response=_OpenAI("A's reasoning"),
+    )
+    ends = [env.payload for env in _drain(client) if env.kind is EnvelopeKind.SPAN_END]
+    assert len(ends) == 2
+    # Order follows finalize order (B first, then A).
+    assert ends[0].attributes["llm.reasoning"].string_value == "B's reasoning"
+    assert ends[1].attributes["llm.reasoning"].string_value == "A's reasoning"


### PR DESCRIPTION
## Summary

- PR #43 shipped `llm.reasoning` span capture that passed unit tests but produced zero populated attributes on 133+ LLM_CALL spans in live Qwen3.5-via-LiteLLM runs. Root cause: the plugin paired `before_model_callback` / `after_model_callback` by `id(callback_context)`, but ADK's `base_llm_flow._handle_after_model_callback` builds a **fresh** `CallbackContext(invocation_context)` before running plugin callbacks, so the ids never match. `self._model_spans.pop(id(ctx))` always returned `None`, the span was never ended with attributes, and the reasoning was dropped.
- LiteLlm itself is fine — it extracts `reasoning_content` / `reasoning` / `thinking_blocks` from the provider message and prepends them to `LlmResponse.content.parts` as `types.Part(text=..., thought=True)`. The extractor's existing Gemini-thought-parts branch already handles that shape; the bug was purely in the span-pairing layer. The old tests hid it by passing the same Python object to both callbacks.
- Fix keys model-span bookkeeping on `callback_context.invocation_id` (stable across the LLM-call lifecycle) via a FIFO queue, accumulates reasoning across SSE streaming partials, only emits `llm.reasoning` on the non-partial finalize, and sweeps orphans on `after_run_callback` so a mid-stream disconnect cannot leak.

## What LiteLlm was doing with `reasoning_content`

LiteLlm **does preserve reasoning**. In `adk-python/src/google/adk/models/lite_llm.py`:

1. `_extract_reasoning_value(message)` reads `thinking_blocks` (Anthropic), then `reasoning_content` (Qwen/Azure/Ollama via LiteLLM), then `reasoning` (LM Studio, vLLM) from the raw provider message.
2. `_convert_reasoning_value_to_parts` turns each text fragment into `types.Part(text=..., thought=True)`.
3. `_message_to_generate_content_response` prepends those thought parts to `content.parts` and returns a standard ADK `LlmResponse` (whose pydantic config is `extra='forbid'`, so no ad-hoc field could have carried reasoning anyway).

So when the plugin receives the response, `llm_response.content.parts[0].thought == True` and `.text` is the reasoning. The extractor's first branch handles this — it was always working. What wasn't working was the span pairing that decides which span ID the extracted reasoning gets attached to.

## Test plan

- [x] `uv run --extra e2e pytest client/tests/test_telemetry_plugin.py -q` — 15 passed (was 11; 4 new regression tests cover LiteLlm shape, streaming partials, sequential tool-loop calls, concurrent invocations).
- [x] `uv run --extra e2e pytest client/tests/ -q` — 161 passed.
- [x] `ruff check` and `ruff format --check` clean on both changed files.
- [x] End-to-end sanity: drove a mocked LiteLlm/openai provider through the real ADK `InMemoryRunner` with the plugin installed and confirmed the LLM_CALL SPAN_END envelope now carries `attributes["llm.reasoning"]="Thinking out loud: 6*7=42."` and `attributes["has_reasoning"]=true`.