### PR TITLE
Add orchestration-mode presentation_agent sibling (shares tree with goldfive)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ FRONTEND_PB := $(ROOT)/frontend/src/pb
 
 .PHONY: help proto proto-python proto-ts \
         server-install client-install frontend-install install \
-        server-run frontend-dev demo demo-presentation demo-standalone .demo-agents-stage \
+        server-run frontend-dev demo demo-presentation demo-presentation-orchestrated demo-standalone .demo-agents-stage \
         test server-test client-test frontend-test e2e \
         lint format clean stats
 
@@ -26,7 +26,9 @@ help:
 	@echo "  install          Install all components"
 	@echo "  server-run       Run the server in dev mode"
 	@echo "  frontend-dev     Run the Vite dev server"
-	@echo "  demo             Boot server + frontend + goldfive-orchestrated ADK agent"
+	@echo "  demo             Boot server + frontend + adk web (shows both presentation_agent variants)"
+	@echo "  demo-presentation              Boot adk web alone (both presentation_agent variants in picker)"
+	@echo "  demo-presentation-orchestrated Alias for demo-presentation (picker lists both variants)"
 	@echo "  demo-standalone  Boot server + frontend and emit spans from the standalone example"
 	@echo "  test             Run server + client + frontend tests"
 	@echo "  e2e              Run the end-to-end test against the ADK submodule"
@@ -115,21 +117,25 @@ server-run:
 frontend-dev:
 	@cd $(ROOT)/frontend && pnpm dev
 
-# Run the presentation_agent sample under the canonical `adk web` CLI
+# Run the presentation_agent samples under the canonical `adk web` CLI
 # with a harmonograf server at $(HARMONOGRAF_SERVER). Instrumentation
-# lives inside tests/reference_agents/presentation_agent/agent.py (the exported `app` attaches
-# a harmonograf plugin), so simply running the agent under adk web is
-# enough to emit spans.
+# lives inside each reference module (both modules export an `app` that
+# attaches a harmonograf plugin), so simply pointing adk web at the
+# staged agents dir is enough to emit spans.
 #
 # adk web expects an AGENTS_DIR where each subdirectory is one agent.
-# We stage a dedicated .demo-agents/presentation_agent/ as a real
-# passthrough package: a symlink would be rejected by ADK's
-# _resolve_agent_dir which calls Path.resolve() and refuses any
-# resolved path that escapes the agents_root sandbox. The passthrough
-# loads the real presentation_agent.agent module by absolute file path
-# from tests/reference_agents/presentation_agent/agent.py (not by package
-# import) to avoid colliding with the .demo-agents entry that ADK puts
-# on sys.path[0].
+# We stage two sibling packages under .demo-agents/ — both real
+# passthrough packages, not symlinks, because ADK's _resolve_agent_dir
+# calls Path.resolve() and refuses any resolved path that escapes the
+# agents_root sandbox. The passthroughs load their real modules by
+# absolute file path (not package import) to avoid colliding with the
+# .demo-agents entry that ADK puts on sys.path[0].
+#
+# .demo-agents/
+#   presentation_agent/               — observation mode (no goldfive.wrap)
+#   presentation_agent_orchestrated/  — orchestration mode (goldfive.wrap + plan)
+#
+# ADK's picker lists both by name so the user chooses at load time.
 #
 # Override HARMONOGRAF_SERVER / ADK_WEB_PORT as needed:
 #   make demo-presentation ADK_WEB_PORT=8080 HARMONOGRAF_SERVER=127.0.0.1:7531
@@ -138,11 +144,12 @@ ADK_WEB_PORT ?= 8080
 SERVER_PORT ?= 7531
 FRONTEND_PORT ?= 5173
 
-# Stage a real (non-symlink) passthrough agent dir at .demo-agents/presentation_agent.
-# Regenerated fresh on every invocation so edits to the real module are picked up.
+# Stage both real (non-symlink) passthrough agent dirs under .demo-agents/.
+# Regenerated fresh on every invocation so edits to the real modules are picked up.
 .demo-agents-stage:
 	@rm -rf $(ROOT)/.demo-agents
 	@mkdir -p $(ROOT)/.demo-agents/presentation_agent
+	@mkdir -p $(ROOT)/.demo-agents/presentation_agent_orchestrated
 	@printf '' > $(ROOT)/.demo-agents/presentation_agent/__init__.py
 	@printf '%s\n' \
 		'"""Passthrough so adk web can run presentation_agent under .demo-agents/.' \
@@ -168,11 +175,42 @@ FRONTEND_PORT ?= 5173
 		'root_agent = _mod.root_agent' \
 		'app = _mod.app' \
 		> $(ROOT)/.demo-agents/presentation_agent/agent.py
+	@printf '' > $(ROOT)/.demo-agents/presentation_agent_orchestrated/__init__.py
+	@printf '%s\n' \
+		'"""Passthrough so adk web can run presentation_agent_orchestrated under .demo-agents/.' \
+		'' \
+		'Orchestration-mode sibling of the observation-mode passthrough above.' \
+		'Loads the real module by absolute file path under a private name so' \
+		'ADK resolves agent_dir inside .demo-agents while the code lives in' \
+		'tests/reference_agents/presentation_agent_orchestrated/.' \
+		'"""' \
+		'from __future__ import annotations' \
+		'' \
+		'import importlib.util' \
+		'from pathlib import Path' \
+		'' \
+		'_real = Path(__file__).resolve().parents[2] / "tests" / "reference_agents" / "presentation_agent_orchestrated" / "agent.py"' \
+		'_spec = importlib.util.spec_from_file_location("_real_presentation_agent_orchestrated", _real)' \
+		'_mod = importlib.util.module_from_spec(_spec)' \
+		'assert _spec.loader is not None' \
+		'_spec.loader.exec_module(_mod)' \
+		'' \
+		'root_agent = _mod.root_agent' \
+		'app = _mod.app' \
+		> $(ROOT)/.demo-agents/presentation_agent_orchestrated/agent.py
 
+# Boot adk web alone (both reference-agent variants appear in the picker).
+# `adk web` lists every subdir of .demo-agents/ — observation and
+# orchestrated both show up after .demo-agents-stage runs.
 demo-presentation: .demo-agents-stage
 	@cd $(ROOT) && HARMONOGRAF_SERVER=$(HARMONOGRAF_SERVER) \
 		OPENAI_API_KEY="$${OPENAI_API_KEY:-dummy}" \
 		uv run --extra demo adk web --host 127.0.0.1 --port $(ADK_WEB_PORT) .demo-agents
+
+# Convenience alias. The picker behaviour is identical to demo-presentation
+# because both packages stage together; this target just makes it easy to
+# remember there is an orchestrated variant.
+demo-presentation-orchestrated: demo-presentation
 
 # Boot the full Harmonograf demo stack: backend server + Vite frontend +
 # adk web presentation_agent. Prints both URLs on startup and kills all
@@ -193,7 +231,7 @@ demo: .demo-agents-stage
 			--port $(SERVER_PORT) ) & SERVER_PID=$$!; \
 		echo "[demo] starting frontend Vite dev server on :$(FRONTEND_PORT) ..."; \
 		( cd $(ROOT)/frontend && pnpm dev --port $(FRONTEND_PORT) --strictPort ) & FRONTEND_PID=$$!; \
-		echo "[demo] starting adk web presentation_agent on :$(ADK_WEB_PORT) ..."; \
+		echo "[demo] starting adk web presentation_agent + presentation_agent_orchestrated on :$(ADK_WEB_PORT) ..."; \
 		( cd $(ROOT) && HARMONOGRAF_SERVER=127.0.0.1:$(SERVER_PORT) \
 			OPENAI_API_KEY="$${OPENAI_API_KEY:-dummy}" \
 			uv run --extra demo adk web --host 127.0.0.1 --port $(ADK_WEB_PORT) .demo-agents ) & ADK_PID=$$!; \

--- a/README.md
+++ b/README.md
@@ -175,10 +175,12 @@ make demo
 
 `make demo` starts three processes in one foreground shell: `harmonograf-server`
 on `127.0.0.1:7531` (gRPC) + `:7532` (gRPC-Web), the Vite frontend on
-`http://127.0.0.1:5173`, and `adk web` hosting the goldfive-orchestrated
-reference agent on `http://127.0.0.1:8080`. Drive a rollout from the ADK tab;
-watch the timeline materialise live in the harmonograf tab. Ctrl-C tears all
-three down.
+`http://127.0.0.1:5173`, and `adk web` hosting two reference-agent variants on
+`http://127.0.0.1:8080` — `presentation_agent` (observation; plain ADK +
+telemetry plugin) and `presentation_agent_orchestrated` (the same tree wrapped
+with `goldfive.wrap(...)` so you see the full plan / dispatch / drift stream).
+Pick a variant in the ADK picker, drive a rollout, and watch the timeline
+materialise live in the harmonograf tab. Ctrl-C tears all three down.
 
 ---
 

--- a/docs/dev-guide/testing.md
+++ b/docs/dev-guide/testing.md
@@ -153,9 +153,10 @@ ingest dispatch, all at once.
 
 Guidelines:
 
-- Use `build_goldfive_runner(mock=True)` from the reference agent for a
-  deterministic offline run — canned plan, canned LLM responses, fixed
-  timing.
+- Use `build_goldfive_runner(mock=True)` from the orchestrated
+  reference agent (`tests.reference_agents.presentation_agent_orchestrated`)
+  for a deterministic offline run — canned plan, canned LLM responses,
+  fixed timing.
 - Assert on the resulting stored state (spans, plan rows, task rows,
   drift annotations) via the server's `GetSession` / `GetSpanTree` RPCs.
   Don't assert on model prose.
@@ -171,7 +172,7 @@ Guidelines:
 | `tests/e2e/test_scenarios.py` | Scripted multi-task scenarios through a real harmonograf server. |
 | `tests/e2e/test_adk_hello.py` | Basic ADK integration smoke — agent connects, emits one span, server stores it. |
 | `tests/e2e/test_planner_e2e.py` | goldfive `LLMPlanner` + real ADK. Requires an LLM endpoint. |
-| `tests/e2e/test_presentation_agent.py` | Full presentation agent demo via `build_goldfive_runner`. |
+| `tests/e2e/test_presentation_agent.py` | Full presentation agent demo — observation-mode app + orchestration-mode app + `build_goldfive_runner` end-to-end. |
 | `tests/e2e/test_goldfive_end_to_end.py` | `HarmonografSink` → server ingest → store round-trip for every goldfive event variant. |
 
 ### Local LLM env for e2e

--- a/docs/goldfive-integration.md
+++ b/docs/goldfive-integration.md
@@ -208,13 +208,22 @@ composes cleanly with goldfive's own ADK adapter.
 wired to goldfive + harmonograf. Boot the stack with:
 
 ```bash
-make demo                       # server + frontend + adk web presentation_agent
+make demo                       # server + frontend + adk web (both variants in picker)
 make demo-presentation          # just adk web; point at an existing server via HARMONOGRAF_SERVER
 ```
 
-`presentation_agent.agent.build_goldfive_runner(mock=True)` also exposes an
-offline runnable Runner (no LLM, canned plan) that exercises the same event
-stream — useful for integration smoke tests.
+`adk web` lists two agents in the picker:
+
+* `presentation_agent` — observation mode: plain ADK tree, coordinator
+  routes via instruction text, harmonograf attaches a telemetry plugin.
+* `presentation_agent_orchestrated` — orchestration mode: same tree
+  wrapped with `goldfive.wrap(...)`, so goldfive plans the specialists,
+  dispatches them, and fires drift when the adapter return doesn't
+  match. This is the path that exercises the full goldfive event stream.
+
+`presentation_agent_orchestrated.agent.build_goldfive_runner(mock=True)`
+also exposes an offline runnable Runner (no LLM, canned plan) that
+exercises the same event stream — useful for integration smoke tests.
 
 ## Further reading
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -135,7 +135,7 @@ trap-on-exit, so Ctrl-C takes all three down together:
 |---|---|---|
 | `harmonograf-server` | `127.0.0.1:7531` (gRPC) / `127.0.0.1:7532` (gRPC-Web) | The canonical timeline. Writes to `./data/` via SQLite. |
 | Vite frontend | `http://127.0.0.1:5173` | The harmonograf UI. Talks gRPC-Web to `:7532`. |
-| `adk web` | `http://127.0.0.1:8080` | ADK's own UI, hosting a staged copy of `presentation_agent` under `.demo-agents/`. |
+| `adk web` | `http://127.0.0.1:8080` | ADK's own UI. The picker lists **two** staged variants under `.demo-agents/`: `presentation_agent` (observation mode — plain ADK + harmonograf telemetry plugin) and `presentation_agent_orchestrated` (the same tree wrapped with `goldfive.wrap(...)` so you see the full plan / dispatch / drift stream). |
 
 Once all three are up `make demo` prints a summary block with the three URLs and
 waits. The harmonograf frontend is the one you care about; the ADK tab is where
@@ -150,7 +150,10 @@ make demo SERVER_PORT=17531 FRONTEND_PORT=15173 ADK_WEB_PORT=18080
 ## Step 5 — Drive a rollout
 
 1. Open the **ADK tab** at `http://127.0.0.1:8080`. You should see ADK's chat UI
-   with `presentation_agent` available.
+   with two agents in the picker: `presentation_agent` (observation mode)
+   and `presentation_agent_orchestrated` (orchestration mode). Pick the
+   orchestrated one to see the full goldfive plan / dispatch / drift stream;
+   pick the observation one if you only want per-span telemetry.
 2. In the ADK chat, type a prompt like:
 
    ```
@@ -184,7 +187,7 @@ A healthy first run looks like this on stdout:
 ```text
 [demo] starting harmonograf-server on :7531 ...
 [demo] starting frontend Vite dev server on :5173 ...
-[demo] starting adk web presentation_agent on :8080 ...
+[demo] starting adk web presentation_agent + presentation_agent_orchestrated on :8080 ...
 
 ==================================================================
   Harmonograf UI     : http://127.0.0.1:5173
@@ -208,8 +211,9 @@ In the harmonograf frontend, a successful rollout looks like:
 
 ## Troubleshooting
 
-**The ADK tab loads but `presentation_agent` is not listed.**
-`.demo-agents/` is regenerated fresh on every `make demo` invocation. If it is
+**The ADK tab loads but `presentation_agent` / `presentation_agent_orchestrated`
+are not listed.** `.demo-agents/` is regenerated fresh on every `make demo`
+invocation and stages both variants as sibling subdirectories. If either is
 missing, something interrupted the `.demo-agents-stage` step. Run `make demo`
 again; on a clean second invocation the stage step should succeed. If it keeps
 failing, look for a stale `.demo-agents/` directory and remove it manually, then

--- a/docs/runbooks/demo-wont-start.md
+++ b/docs/runbooks/demo-wont-start.md
@@ -33,7 +33,7 @@ flowchart TD
 - **Terminal**: `make demo` prints one of:
   - `[demo] starting harmonograf-server on :7531 ...`
   - `[demo] starting frontend Vite dev server on :5173 ...`
-  - `[demo] starting adk web presentation_agent on :8080 ...`
+  - `[demo] starting adk web presentation_agent + presentation_agent_orchestrated on :8080 ...`
   - `[demo] shutting down...` (unexpectedly soon)
 - **Processes**: `ps axf | grep -E 'harmonograf|adk web|vite'` shows
   one or more missing.
@@ -77,11 +77,13 @@ curl -s $OPENAI_API_BASE/models 2>/dev/null || echo "unreachable"
    to a dead port. See `Makefile:110`.
 4. **`uv` / Python environment broken** — `uv run --extra demo`
    fails because the extras aren't installed, or the venv got wiped.
-5. **`.demo-agents/` staging broken** — the Makefile stages a real
-   (non-symlink) `presentation_agent` directory under `.demo-agents/`
-   before boot (`Makefile:117` target `.demo-agents-stage`). If a
-   previous run crashed partway through, the directory may be in a
-   bad state.
+5. **`.demo-agents/` staging broken** — the Makefile stages two real
+   (non-symlink) sibling directories under `.demo-agents/`:
+   `presentation_agent` (observation mode) and
+   `presentation_agent_orchestrated` (orchestration mode). Both are
+   regenerated on every `make demo` invocation (`Makefile` target
+   `.demo-agents-stage`). If either is missing, ADK's picker may not
+   list the corresponding variant.
 6. **pnpm / Node mismatch** — the frontend's Vite dev server refuses
    to start because `node_modules` is stale or Node version is wrong.
 7. **CORS blocking in the browser** — processes are up, but the
@@ -128,9 +130,10 @@ Either import failing → run `uv sync --extra demo`.
 ### 5. .demo-agents staging
 
 ```bash
-ls -la .demo-agents/presentation_agent/
+ls -la .demo-agents/presentation_agent/ .demo-agents/presentation_agent_orchestrated/
 cat .demo-agents/presentation_agent/__init__.py
 head .demo-agents/presentation_agent/agent.py
+head .demo-agents/presentation_agent_orchestrated/agent.py
 ```
 
 If the staging looks wrong, blow it away and rerun:

--- a/docs/user-guide/tasks-and-plans.md
+++ b/docs/user-guide/tasks-and-plans.md
@@ -87,6 +87,18 @@ without metadata don't render a chip.
 Which mode runs is determined by how the agent's `goldfive.Runner` was
 constructed, not by anything the UI controls.
 
+!!! tip "Observation vs orchestration in the demo"
+    The reference demo ships two ADK agents side by side:
+    `presentation_agent` (observation — plain ADK tree with
+    `HarmonografTelemetryPlugin`) and `presentation_agent_orchestrated`
+    (orchestration — the same tree wrapped with `goldfive.wrap(...)`).
+    Orchestration mode is where you actually see goldfive plan,
+    dispatch, fire drift, and surface HITL/steering seams end-to-end.
+    In observation mode the coordinator's instruction text does the
+    routing and harmonograf only sees per-span telemetry — no plan, no
+    drift events. Both variants appear in `adk web`'s picker once
+    `make demo` has staged them.
+
 ## PlanRevisionBanner
 
 Whenever a plan's `revisionReason` changes, a pill appears in the

--- a/tests/e2e/test_presentation_agent.py
+++ b/tests/e2e/test_presentation_agent.py
@@ -1,28 +1,25 @@
 """End-to-end: presentation_agent sample on goldfive + harmonograf.
 
-Post-migration (issue #4) the presentation_agent module no longer owns
-orchestration. The smoke test here verifies the new wiring:
+Split across the two reference-agent packages:
 
-* ``presentation_agent.agent`` imports cleanly.
-* ``app`` exports a live :class:`google.adk.apps.app.App` with the
-  :class:`HarmonografTelemetryPlugin` installed when a Client is built.
-* ``build_goldfive_runner(mock=True)`` assembles a runnable
-  :class:`goldfive.Runner` with ``ADKAdapter`` + ``HarmonografSink`` +
-  a mocked ADK model + a canned LLMPlanner / LLMGoalDeriver.
-* Driving that runner emits the full goldfive event stream
-  (``RunStarted`` → ``PlanSubmitted`` → per-task ``TaskStarted`` /
-  ``TaskCompleted`` → ``RunCompleted``) into ``InMemorySink``.
-* When wired to a real in-process harmonograf server fixture, the
-  events land as ``TelemetryUp(goldfive_event=...)`` frames that the
-  server's ingest pipeline translates into storage + bus deltas.
+* **Observation mode** — ``tests.reference_agents.presentation_agent`` —
+  plain ADK tree with ``HarmonografTelemetryPlugin``. No
+  ``goldfive.wrap``. The smoke tests here verify the tree + lazy ``app``
+  still assemble now that the tree is sourced from goldfive's
+  ``examples/presentation_agent/agent.py``.
+* **Orchestration mode** — ``tests.reference_agents.presentation_agent_orchestrated`` —
+  the same tree wrapped with ``goldfive.wrap(...)`` before ``App()``
+  sees it, plus a programmatic ``build_goldfive_runner`` helper for
+  headless runs. The runner tests exercise the full goldfive event
+  stream end-to-end.
 
 The legacy scenario suites (scripted multi-turn ADK runs, concurrent
 sessions, awaiting-human steering) were tightly coupled to
 ``attach_adk`` and the old ``HarmonografAgent`` orchestration and were
-deleted in this Phase C cut. Restoring a scripted-model e2e against the
+deleted in the Phase C cut. Restoring a scripted-model e2e against the
 new stack is Phase D cleanup work — goldfive's own
-``examples/adk_presentation`` covers the same shape with a non-scripted
-mock.
+``examples/presentation_agent`` covers the same shape with a
+non-scripted mock.
 """
 
 from __future__ import annotations
@@ -50,7 +47,7 @@ _PRES_DIR = Path(__file__).resolve().parent.parent / "reference_agents"
 
 @pytest.fixture
 def presentation_agent_module() -> Any:
-    """Import ``presentation_agent.agent`` as a top-level module.
+    """Import observation-mode ``presentation_agent.agent`` as a top-level module.
 
     The module is normally consumed by ``adk web presentation_agent``
     which puts the containing directory on ``sys.path``; here we do the
@@ -74,8 +71,31 @@ def presentation_agent_module() -> Any:
         pass
 
 
+@pytest.fixture
+def presentation_agent_orchestrated_module() -> Any:
+    """Import orchestration-mode ``presentation_agent_orchestrated.agent``."""
+    if str(_PRES_DIR) not in sys.path:
+        sys.path.insert(0, str(_PRES_DIR))
+    for stale in (
+        "presentation_agent_orchestrated",
+        "presentation_agent_orchestrated.agent",
+    ):
+        sys.modules.pop(stale, None)
+    import presentation_agent_orchestrated.agent as agent_mod  # type: ignore
+
+    try:
+        agent_mod._reset_for_testing()
+    except Exception:
+        pass
+    yield agent_mod
+    try:
+        agent_mod._reset_for_testing()
+    except Exception:
+        pass
+
+
 class TestPresentationAppExport:
-    """Verify ``presentation_agent.agent.app`` builds without a server."""
+    """Verify observation-mode ``presentation_agent.agent.app`` still builds."""
 
     def test_module_exports_root_agent(self, presentation_agent_module: Any) -> None:
         root = presentation_agent_module.root_agent
@@ -109,16 +129,54 @@ class TestPresentationAppExport:
         assert "harmonograf-telemetry" in plugin_names
 
 
+class TestOrchestratedAppExport:
+    """Verify orchestration-mode ``presentation_agent_orchestrated.agent.app`` wraps the tree."""
+
+    def test_orchestrated_app_builds(
+        self,
+        presentation_agent_orchestrated_module: Any,
+        harmonograf_server: dict,
+    ) -> None:
+        from goldfive.adapters.adk_wrap import GoldfiveADKAgent
+        from google.adk.agents.base_agent import BaseAgent
+
+        # Force mock-mode (no OPENAI_API_KEY) so the lazy ``app`` build
+        # stays offline. The fixture still exercises live-mode indirectly
+        # via other tests.
+        prev = os.environ.pop("OPENAI_API_KEY", None)
+        os.environ["HARMONOGRAF_SERVER"] = harmonograf_server["addr"]
+        try:
+            app = presentation_agent_orchestrated_module.app
+        finally:
+            os.environ.pop("HARMONOGRAF_SERVER", None)
+            if prev is not None:
+                os.environ["OPENAI_API_KEY"] = prev
+
+        assert app is not None
+        assert app.name == "presentation_agent_orchestrated"
+        # ``goldfive.wrap`` of an ADK BaseAgent returns a GoldfiveADKAgent
+        # (itself a BaseAgent subclass); confirm both invariants.
+        assert isinstance(app.root_agent, BaseAgent)
+        assert isinstance(app.root_agent, GoldfiveADKAgent)
+        plugin_names = {getattr(p, "name", "") for p in (app.plugins or [])}
+        assert "harmonograf-telemetry" in plugin_names
+
+
 class TestPresentationGoldfiveRunner:
-    """End-to-end: goldfive Runner + HarmonografSink via build_goldfive_runner."""
+    """End-to-end: goldfive Runner + HarmonografSink via build_goldfive_runner.
+
+    The helper lives on the orchestration-mode sibling now — that's the
+    only module that knows how to drive a goldfive Runner around the
+    tree. Observation mode never had a runner.
+    """
 
     @pytest.mark.asyncio
-    async def test_mock_run_emits_goldfive_event_stream(
+    async def test_orchestrated_mock_run_emits_goldfive_events(
         self,
-        presentation_agent_module: Any,
+        presentation_agent_orchestrated_module: Any,
     ) -> None:
         runner, memory_sink, client, _sink = (
-            presentation_agent_module.build_goldfive_runner(
+            presentation_agent_orchestrated_module.build_goldfive_runner(
                 topic="espresso machines",
                 mock=True,
                 client=None,  # no harmonograf server wiring in this variant
@@ -145,10 +203,21 @@ class TestPresentationGoldfiveRunner:
         assert any(k == "task_started" for k in payload_kinds)
         assert any(k == "task_completed" for k in payload_kinds)
 
+        # One TaskStarted + TaskCompleted per specialist.
+        completed_task_ids = {
+            evt.task_completed.task_id
+            for evt in memory_sink.events
+            if hasattr(evt, "WhichOneof")
+            and evt.WhichOneof("payload") == "task_completed"
+        }
+        assert completed_task_ids == {"research", "build", "review", "debug"}, (
+            f"expected TaskCompleted for each specialist, got {completed_task_ids}"
+        )
+
     @pytest.mark.asyncio
     async def test_mock_run_ships_events_to_harmonograf_server(
         self,
-        presentation_agent_module: Any,
+        presentation_agent_orchestrated_module: Any,
         harmonograf_server: dict,
     ) -> None:
         from harmonograf_client import Client, HarmonografSink
@@ -160,7 +229,7 @@ class TestPresentationGoldfiveRunner:
         )
         try:
             runner, memory_sink, bound_client, harmonograf_sink = (
-                presentation_agent_module.build_goldfive_runner(
+                presentation_agent_orchestrated_module.build_goldfive_runner(
                     topic="espresso machines",
                     mock=True,
                     client=client,
@@ -187,7 +256,7 @@ class TestPresentationGoldfiveRunner:
     @pytest.mark.asyncio
     async def test_all_task_status_events_persist(
         self,
-        presentation_agent_module: Any,
+        presentation_agent_orchestrated_module: Any,
         harmonograf_server: dict,
     ) -> None:
         """Regression for issue #18: every task_completed event the sink
@@ -212,7 +281,7 @@ class TestPresentationGoldfiveRunner:
         )
         try:
             runner, memory_sink, _, _ = (
-                presentation_agent_module.build_goldfive_runner(
+                presentation_agent_orchestrated_module.build_goldfive_runner(
                     topic="waffles",
                     mock=True,
                     client=client,

--- a/tests/reference_agents/presentation_agent/agent.py
+++ b/tests/reference_agents/presentation_agent/agent.py
@@ -1,236 +1,112 @@
-"""ADK multi-agent presentation demo, driven by goldfive.
+"""ADK multi-agent presentation demo — observation mode.
 
-Post-migration (issue #4) this module no longer owns any orchestration.
-The ADK tree (coordinator → research / web_developer / reviewer /
-debugger) is plain ADK. Orchestration — planning, task dispatch, drift
-detection, steering — lives in goldfive. Harmonograf observes the run
-via :class:`harmonograf_client.HarmonografSink` (plan + task events)
-and :class:`harmonograf_client.HarmonografTelemetryPlugin` (per-span
-LLM_CALL / TOOL_CALL observability).
+Post-migration (issue #4) this module no longer owns any orchestration,
+and as of the split-out of the orchestrated sibling it no longer even
+owns the agent tree: the coordinator + research + web_developer +
+reviewer + debugger tree (along with the ``write_webpage`` /
+``read_presentation_files`` / ``patch_file`` tools) is canonicalised in
+``goldfive/examples/presentation_agent/`` and loaded here by absolute
+file path so the two stay byte-identical.
+
+This module is the **observation-mode** variant: the ADK coordinator
+agent does its own routing via instruction text, and harmonograf
+observes via :class:`harmonograf_client.HarmonografTelemetryPlugin`.
+No ``goldfive.wrap`` — the runtime plan / drift / refine behaviour
+lives in the sibling ``presentation_agent_orchestrated`` package.
 
 The module exports:
 
-* ``root_agent`` — the ADK coordinator agent.
-* ``app`` — a lazily-built :class:`google.adk.apps.app.App` that
-  installs :class:`HarmonografTelemetryPlugin` so ``adk web`` /
-  ``adk run`` emit spans automatically. ``app`` is created on first
-  access (PEP 562 module-level ``__getattr__``) so callers that only
-  want ``root_agent`` don't pay transport setup cost.
-* ``build_goldfive_runner`` — convenience wrapper that assembles a
-  :class:`goldfive.Runner` around the coordinator with an
-  :class:`ADKAdapter`, :class:`HarmonografSink`, optional mock planner
-  / goal deriver, and a logging sink. Mirrors the ``--mock`` pattern
-  from ``goldfive/examples/adk_presentation/agent.py`` so the demo
-  runs without credentials when needed.
+* ``root_agent`` — the ADK coordinator agent, shared with goldfive's
+  example.
+* ``app`` — a lazily-built :class:`google.adk.apps.app.App` with
+  :class:`HarmonografTelemetryPlugin` installed so ``adk web`` /
+  ``adk run`` emit spans automatically. Construction is lazy (PEP 562)
+  so importing the module is side-effect free.
 """
 
 from __future__ import annotations
 
 import atexit
-import json
+import importlib.util
 import logging
 import os
-from collections.abc import AsyncGenerator
-from typing import Any, Callable, Optional
-
-from google.adk.agents import Agent
-from google.adk.tools import AgentTool, FunctionTool
+from pathlib import Path
+from typing import Any, Optional
 
 log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Tools
+# Shared tree — loaded from goldfive's example by absolute file path so
+# the two modules stay byte-identical without relying on
+# ``third_party/goldfive`` being on ``sys.path`` at import time.
 # ---------------------------------------------------------------------------
 
 
-def write_webpage(
-    topic: str, html_content: str, css_content: str, js_content: str
-) -> str:
-    """Write an interactive webpage (HTML, CSS, JS) under ``output/``."""
-    try:
-        topic_filename = topic.lower().replace(" ", "_").replace("/", "_")
-        output_dir = os.path.join(os.path.dirname(__file__), "output", topic_filename)
-        os.makedirs(output_dir, exist_ok=True)
+def _load_goldfive_presentation_module() -> Any:
+    """Return goldfive's ``examples/presentation_agent/agent.py`` as a module.
 
-        with open(os.path.join(output_dir, "index.html"), "w") as f:
-            f.write(html_content)
-        with open(os.path.join(output_dir, "styles.css"), "w") as f:
-            f.write(css_content)
-        with open(os.path.join(output_dir, "script.js"), "w") as f:
-            f.write(js_content)
-
-        return f"Successfully created presentation on '{topic}' at {output_dir}"
-    except OSError as e:
-        return f"Error writing file: {e}"
-
-
-def read_presentation_files(topic: str) -> dict[str, str]:
-    """Read the generated presentation files and return name → contents."""
-    topic_filename = topic.lower().replace(" ", "_").replace("/", "_")
-    output_dir = os.path.join(os.path.dirname(__file__), "output", topic_filename)
-    files: dict[str, str] = {}
-    for name in ("index.html", "styles.css", "script.js"):
-        path = os.path.join(output_dir, name)
-        try:
-            with open(path, "r") as f:
-                files[name] = f.read()
-        except OSError as e:
-            files[name] = f"<error reading {path}: {e}>"
-    return files
-
-
-def patch_file(path: str, new_content: str) -> str:
-    """Overwrite ``path`` with ``new_content`` in place.
-
-    Relative paths resolve against ``output/`` so the debugger cannot
-    scribble outside the sandbox.
+    Loaded by absolute file path under a private name so we don't collide
+    with any ``examples`` package on ``sys.path`` and don't force the
+    caller to manipulate ``sys.path`` themselves.
     """
-    try:
-        if not os.path.isabs(path):
-            path = os.path.join(os.path.dirname(__file__), "output", path)
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "w") as f:
-            f.write(new_content)
-        return f"Successfully patched {path}"
-    except OSError as e:
-        return f"Error patching file: {e}"
+    here = Path(__file__).resolve()
+    candidates = [
+        # Normal layout: harmonograf/tests/reference_agents/presentation_agent/agent.py
+        # climbs three parents to harmonograf root and then into the submodule.
+        here.parents[3]
+        / "third_party"
+        / "goldfive"
+        / "examples"
+        / "presentation_agent"
+        / "agent.py",
+    ]
+    # Also honour an explicit override so a dev who clones goldfive
+    # outside the submodule can still drive this tree.
+    override = os.environ.get("GOLDFIVE_PRESENTATION_AGENT_PATH")
+    if override:
+        candidates.insert(0, Path(override).expanduser().resolve())
+    for candidate in candidates:
+        if candidate.is_file():
+            spec = importlib.util.spec_from_file_location(
+                "_goldfive_presentation", candidate
+            )
+            if spec is None or spec.loader is None:
+                continue
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod
+    raise ImportError(
+        "Could not locate goldfive's presentation_agent example. Tried: "
+        + ", ".join(str(c) for c in candidates)
+    )
 
 
-write_webpage_tool = FunctionTool(write_webpage)
-read_presentation_files_tool = FunctionTool(read_presentation_files)
-patch_file_tool = FunctionTool(patch_file)
+_goldfive_presentation = _load_goldfive_presentation_module()
 
+# Re-export the shared tree + tools so callers that historically imported
+# these symbols from this module keep working unchanged.
+_build_agent_tree = _goldfive_presentation._build_agent_tree
+write_webpage = _goldfive_presentation.write_webpage
+read_presentation_files = _goldfive_presentation.read_presentation_files
+patch_file = _goldfive_presentation.patch_file
+write_webpage_tool = _goldfive_presentation.write_webpage_tool
+read_presentation_files_tool = _goldfive_presentation.read_presentation_files_tool
+patch_file_tool = _goldfive_presentation.patch_file_tool
 
 MODEL_NAME = os.environ.get("USER_MODEL_NAME", "gemini-2.5-flash")
 
-
-# ---------------------------------------------------------------------------
-# Agents
-# ---------------------------------------------------------------------------
-
-
-def _build_agent_tree(model: Any) -> Agent:
-    research_agent = Agent(
-        name="research_agent",
-        model=model,
-        instruction=(
-            "You are a researcher. Your goal is to gather information about "
-            "the topic the user provides.\nThink step-by-step and provide a "
-            "comprehensive synthesis of high-quality bullet points and facts "
-            "that can be used to generate a presentation slideshow."
-        ),
-        description=(
-            "An agent capable of deeply reasoning and synthesizing a given "
-            "topic for presentation notes."
-        ),
-        tools=[],
-    )
-
-    web_developer_agent = Agent(
-        name="web_developer_agent",
-        model=model,
-        instruction=(
-            "You are an expert Frontend Web Developer. Your goal is to take "
-            "research on a topic and generate a stunning, interactive, "
-            "single-page presentation slideshow.\nGenerate beautiful semantic "
-            "HTML structure, elegant CSS with modern design trends, "
-            "animations, and transitions, and JavaScript for slideshow "
-            "navigation (next/prev slides).\nThe HTML MUST include "
-            '`<link rel="stylesheet" href="styles.css">` and '
-            '`<script src="script.js"></script>` so the files are connected '
-            "properly.\nRemember to output the absolute final HTML, CSS, and "
-            "JS using the `write_webpage` tool! Do not just print the code "
-            "out, you must invoke the tool once everything is ready."
-        ),
-        description=(
-            "An expert frontend developer agent that generates interactive "
-            "HTML, CSS, and JS slideshow presentations and saves them to disk."
-        ),
-        tools=[write_webpage_tool],
-    )
-
-    reviewer_agent = Agent(
-        name="reviewer_agent",
-        model=model,
-        instruction=(
-            "You are a senior frontend code reviewer. You will be given the "
-            "topic of a presentation that ``web_developer_agent`` just "
-            "generated. Call the ``read_presentation_files`` tool with the "
-            "topic to fetch the generated HTML, CSS, and JS, then produce a "
-            "structured critique as a list of issues. Each issue must "
-            "include a short description and a severity of 'critical', "
-            "'major', or 'minor'. If there are no issues, return an empty "
-            "list and say so explicitly so the coordinator knows to skip "
-            "debugging."
-        ),
-        description=(
-            "A reviewer agent that reads the generated presentation files "
-            "and produces a structured critique of issues and their severity."
-        ),
-        tools=[read_presentation_files_tool],
-    )
-
-    debugger_agent = Agent(
-        name="debugger_agent",
-        model=model,
-        instruction=(
-            "You are a debugging agent. You are invoked when "
-            "``write_webpage`` failed or when ``reviewer_agent`` flagged "
-            "critical issues in the generated presentation. Read the issues "
-            "and their file paths, then call the ``patch_file`` tool with "
-            "the full corrected content of each file that needs to change. "
-            "Report which files you patched when you are done."
-        ),
-        description=(
-            "A debugger agent that patches generated presentation files in "
-            "place to resolve critical issues flagged by the reviewer or by "
-            "a failing write_webpage call."
-        ),
-        tools=[patch_file_tool],
-    )
-
-    return Agent(
-        name="coordinator_agent",
-        model=model,
-        instruction=(
-            "You are the Coordinator Agent. Your task is to work with the "
-            "user to pick a topic for an interactive slideshow "
-            "presentation.\nFirst, get a topic from the user.\nSecond, "
-            "transfer control to the 'research_agent' to gather "
-            "comprehensive context and facts about the topic. Make sure to "
-            "provide it with the topic!\nThird, after researching, transfer "
-            "control to the 'web_developer_agent' and provide it with all "
-            "the researched materials. Instruct it to generate and save the "
-            "presentation codebase.\nFourth, transfer control to the "
-            "'reviewer_agent' with the topic so it can read the generated "
-            "files and produce a structured critique.\nFifth, if "
-            "``write_webpage`` failed or the reviewer reported any critical "
-            "issues, transfer control to the 'debugger_agent' with the "
-            "reviewer's critique and have it patch the affected files. Skip "
-            "this step when the reviewer reports no critical issues.\n"
-            "Finally, report back to the user when the task is complete.\n"
-            "Flow: research → web_developer → reviewer → (if critical "
-            "issues) debugger → report."
-        ),
-        description=(
-            "The main coordinator agent that drives the overall process of "
-            "creating an interactive slideshow generation."
-        ),
-        tools=[
-            AgentTool(research_agent),
-            AgentTool(web_developer_agent),
-            AgentTool(reviewer_agent),
-            AgentTool(debugger_agent),
-        ],
-    )
-
-
+# Reconstruct the tree with the harmonograf-preferred model so runs that
+# don't set ``USER_MODEL_NAME`` still default to ``gemini-2.5-flash``.
+# Goldfive's own ``root_agent`` is built with ``openai/gpt-4o-mini`` at
+# import time; we rebuild rather than re-export to keep the historical
+# behaviour.
 root_agent = _build_agent_tree(MODEL_NAME)
 
 
 # ---------------------------------------------------------------------------
-# Harmonograf instrumentation — lazy ``app`` export
+# Harmonograf instrumentation — lazy ``app`` export. Observation mode only:
+# no ``goldfive.wrap`` here. The orchestrated sibling does the wrapping.
 # ---------------------------------------------------------------------------
 
 
@@ -280,7 +156,7 @@ def _get_or_create_client() -> Optional[Any]:
 
 
 def _build_app() -> Any:
-    """Construct the ADK ``App`` wrapping ``root_agent``.
+    """Construct the ADK ``App`` wrapping ``root_agent`` (observation mode).
 
     Installs :class:`HarmonografTelemetryPlugin` when harmonograf_client
     is importable so ``adk web`` / ``adk run`` emit per-span telemetry.
@@ -317,197 +193,6 @@ def __getattr__(name: str) -> Any:
             _APP = _build_app()
         return _APP
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-# ---------------------------------------------------------------------------
-# goldfive Runner wiring — mirrors ``goldfive/examples/adk_presentation``
-# ---------------------------------------------------------------------------
-
-
-def _mock_planner_call_llm(topic: str) -> Callable[[str, str, str], Any]:
-    """Return an async ``call_llm`` that produces a canned plan JSON.
-
-    Matches ``goldfive.LLMPlanner``'s ``(system_prompt, user_prompt,
-    model) -> str`` signature. Emits one task per specialist subagent
-    so the executor walks ``TaskStarted`` / ``TaskCompleted`` for each.
-    """
-
-    plan_json = {
-        "summary": f"Build a slideshow presentation on '{topic}'.",
-        "tasks": [
-            {
-                "id": "research",
-                "title": "Gather research bullet points on the topic",
-                "description": "Summarise key facts about the topic.",
-                "assignee_agent_id": "research_agent",
-            },
-            {
-                "id": "build",
-                "title": "Generate HTML/CSS/JS slideshow",
-                "description": "Produce the presentation files and save them.",
-                "assignee_agent_id": "web_developer_agent",
-            },
-            {
-                "id": "review",
-                "title": "Review the generated presentation",
-                "description": "Critique the generated slideshow for issues.",
-                "assignee_agent_id": "reviewer_agent",
-            },
-            {
-                "id": "debug",
-                "title": "Patch any critical issues the reviewer flagged",
-                "description": "Apply fixes to the presentation files.",
-                "assignee_agent_id": "debugger_agent",
-            },
-        ],
-        "edges": [
-            {"from_task_id": "research", "to_task_id": "build"},
-            {"from_task_id": "build", "to_task_id": "review"},
-            {"from_task_id": "review", "to_task_id": "debug"},
-        ],
-    }
-
-    async def _call(system: str, prompt: str, model: str) -> str:
-        return json.dumps(plan_json)
-
-    return _call
-
-
-def _mock_goal_call_llm(topic: str) -> Callable[[str, str, str], Any]:
-    """Return an async ``call_llm`` that produces a single canned goal."""
-
-    goals_json = {
-        "goals": [
-            {
-                "id": "g1",
-                "summary": f"Produce an interactive slideshow on '{topic}'.",
-            }
-        ]
-    }
-
-    async def _call(system: str, prompt: str, model: str) -> str:
-        return json.dumps(goals_json)
-
-    return _call
-
-
-def _make_mock_adk_model() -> Any:
-    """Return a BaseLlm that short-circuits every ADK model call.
-
-    Borrowed from goldfive's adk_presentation example. Each subagent
-    produces a deterministic reply so the executor's auto-complete
-    marks each task COMPLETED on a clean adapter return.
-    """
-    from google.adk.models.base_llm import BaseLlm
-    from google.adk.models.llm_request import LlmRequest
-    from google.adk.models.llm_response import LlmResponse
-    from google.genai import types as genai_types
-
-    class _MockLlm(BaseLlm):
-        @classmethod
-        def supported_models(cls) -> list[str]:
-            return [r"mock/.*"]
-
-        async def generate_content_async(
-            self, llm_request: LlmRequest, stream: bool = False
-        ) -> AsyncGenerator[LlmResponse, None]:
-            text = (
-                f"[mock:{self.model}] acknowledged task and deferred real "
-                "work to a production run."
-            )
-            yield LlmResponse(
-                content=genai_types.Content(
-                    role="model",
-                    parts=[genai_types.Part(text=text)],
-                ),
-                partial=False,
-                turn_complete=True,
-            )
-
-    return _MockLlm(model="mock/presentation-agent")
-
-
-def build_goldfive_runner(
-    *,
-    topic: str = "the history of the espresso machine",
-    mock: bool = True,
-    client: Optional[Any] = None,
-    extra_sinks: Optional[list[Any]] = None,
-) -> tuple[Any, Any, Optional[Any], Optional[Any]]:
-    """Assemble a :class:`goldfive.Runner` driving the coordinator tree.
-
-    Returns ``(runner, memory_sink, client, harmonograf_sink)``. The
-    harmonograf ``client`` + ``sink`` are ``None`` when
-    ``HARMONOGRAF_SERVER`` is unset and no explicit ``client`` is
-    passed; otherwise a :class:`HarmonografSink` is attached.
-
-    When ``mock=True`` every network call — ADK model, planner, goal
-    deriver — is short-circuited with canned output so the run
-    completes offline. This is the integration-oracle path used by
-    ``tests/e2e/test_presentation_agent.py``.
-    """
-    import goldfive
-    from goldfive import (
-        InMemorySink,
-        LLMGoalDeriver,
-        LLMPlanner,
-        Runner,
-        SequentialExecutor,
-    )
-    from goldfive.adapters.adk import ADKAdapter
-
-    if mock:
-        tree = _build_agent_tree(_make_mock_adk_model())
-        planner_call_llm = _mock_planner_call_llm(topic)
-        goal_call_llm = _mock_goal_call_llm(topic)
-        planner_model = "mock/planner"
-        goal_model = "mock/goal-deriver"
-    else:
-        tree = _build_agent_tree(MODEL_NAME)
-        raise SystemExit(
-            "non-mock mode not wired here; use goldfive/examples/adk_presentation "
-            "for a real OpenAI-backed run"
-        )
-
-    adapter = ADKAdapter(tree)
-
-    sinks: list[Any] = []
-    memory_sink = InMemorySink()
-    sinks.append(memory_sink)
-
-    explicit_client = client
-    if explicit_client is None:
-        explicit_client = _get_or_create_client()
-
-    harmonograf_sink = None
-    if explicit_client is not None:
-        try:
-            from harmonograf_client import HarmonografSink
-
-            harmonograf_sink = HarmonografSink(explicit_client)
-            sinks.append(harmonograf_sink)
-        except Exception as e:  # noqa: BLE001
-            log.warning("HarmonografSink unavailable (%s)", e)
-
-    try:
-        logging_sink = goldfive.sinks.LoggingSink()
-    except Exception:  # noqa: BLE001 — proto extra may be absent
-        logging_sink = None
-    if logging_sink is not None:
-        sinks.append(logging_sink)
-
-    if extra_sinks:
-        sinks.extend(extra_sinks)
-
-    runner = Runner(
-        agent=adapter,
-        planner=LLMPlanner(call_llm=planner_call_llm, model=planner_model),
-        executor=SequentialExecutor(max_plan_reinvocations=8),
-        goal_deriver=LLMGoalDeriver(call_llm=goal_call_llm, model=goal_model),
-        sinks=sinks,
-        max_plan_reinvocations=8,
-    )
-    return runner, memory_sink, explicit_client, harmonograf_sink
 
 
 def _reset_for_testing() -> None:

--- a/tests/reference_agents/presentation_agent_orchestrated/README.md
+++ b/tests/reference_agents/presentation_agent_orchestrated/README.md
@@ -1,0 +1,49 @@
+# presentation_agent_orchestrated
+
+Orchestration-mode sibling of `tests/reference_agents/presentation_agent/`.
+Both packages share the same coordinator + research + web_developer +
+reviewer + debugger tree (loaded by absolute file path from
+`third_party/goldfive/examples/presentation_agent/agent.py`); the only
+intentional difference is that this module wraps the tree with
+`goldfive.wrap(...)` before handing it to `App()`.
+
+## What orchestration mode adds
+
+| Layer | Observation (`presentation_agent`) | Orchestration (`presentation_agent_orchestrated`) |
+|---|---|---|
+| Routing | Coordinator LLM picks the next sub-agent via its instruction text. | Goldfive derives a goal, plans the specialists, and dispatches them in order. |
+| Plan | None — the LLM's transcript *is* the plan. | Explicit `TaskPlan` with `research → build → review → debug`. |
+| Drift | Not detected; the coordinator just keeps generating. | `TaskCompleted` fires per sub-agent; adapter-return mismatches trigger plan revision. |
+| Steering | Transcript-level only. | Goldfive's steering + HITL seams surface into harmonograf, so PAUSE / STEER / CANCEL take effect mid-run. |
+
+If you want to see the full goldfive drift / refine / user-actor
+behaviour end-to-end in `adk web`, load this package. Observation mode
+only emits per-span telemetry — the interesting orchestration events
+(plan submission, task dispatch, drift) never fire because nothing is
+doing the orchestrating.
+
+## How `adk web` picks between the two
+
+`make demo` / `make demo-presentation` stage **both** packages under
+`.demo-agents/` and point `adk web` at that directory. ADK's picker
+then lists both by name:
+
+* `presentation_agent` — observation
+* `presentation_agent_orchestrated` — orchestration (this module)
+
+Pick whichever you want to drive from the ADK UI; the harmonograf tab
+receives the appropriate telemetry regardless of which one is running.
+
+## Env vars
+
+* `OPENAI_API_KEY` — present → live mode (`openai` SDK behind
+  `LLMPlanner` / `LLMGoalDeriver`). Absent → mock mode so the `App`
+  builds offline with a canned plan.
+* `USER_MODEL_NAME` — ADK sub-agent model string (default
+  `gemini-2.5-flash`).
+* `GOLDFIVE_EXAMPLE_TOPIC` — default topic for the mock planner
+  (default `waffles`).
+* `GOLDFIVE_EXAMPLE_PLANNER_MODEL` — OpenAI model for the planner /
+  goal deriver in live mode (default `gpt-4o-mini`).
+* `HARMONOGRAF_SERVER` — `host:port` for the harmonograf server. When
+  `harmonograf_client` is importable a telemetry plugin is attached.

--- a/tests/reference_agents/presentation_agent_orchestrated/__init__.py
+++ b/tests/reference_agents/presentation_agent_orchestrated/__init__.py
@@ -1,0 +1,1 @@
+from . import agent

--- a/tests/reference_agents/presentation_agent_orchestrated/agent.py
+++ b/tests/reference_agents/presentation_agent_orchestrated/agent.py
@@ -1,0 +1,314 @@
+"""ADK multi-agent presentation demo — orchestration mode.
+
+This is the sibling of
+``tests/reference_agents/presentation_agent/agent.py``. Both packages
+share the same coordinator + research + web_developer + reviewer +
+debugger tree (loaded by absolute file path from
+``third_party/goldfive/examples/presentation_agent/agent.py``), so the
+only intentional behavioural difference is the goldfive wrapping.
+
+* **Observation mode** (``presentation_agent``) — plain ADK; the
+  coordinator routes via instruction text. Harmonograf passively
+  observes via :class:`HarmonografTelemetryPlugin`.
+* **Orchestration mode** (this module) — the tree is handed to
+  :func:`goldfive.wrap` before ``App()`` sees it. Goldfive derives a
+  goal, plans the specialists, dispatches them, fires drift when the
+  adapter return doesn't match, and surfaces steering / HITL seams
+  into harmonograf. This is where the full goldfive behaviour lands in
+  ``adk web``.
+
+Planner / goal deriver selection mirrors goldfive's own
+``examples/presentation_agent/agent.py`` live-mode branch:
+
+* ``OPENAI_API_KEY`` set → live mode, ``openai`` SDK behind
+  :class:`goldfive.LLMPlanner` / :class:`goldfive.LLMGoalDeriver`.
+* ``OPENAI_API_KEY`` unset → mock mode, so ``adk web`` loads offline.
+  The mock planner emits one task per specialist so the full drift /
+  dispatch stream still fires end-to-end.
+"""
+
+from __future__ import annotations
+
+import atexit
+import importlib.util
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared tree + mock planner / goal deriver / _MockLlm loaded from
+# goldfive's example by absolute file path. Same strategy as the sibling
+# observation-mode module — see that file for the rationale.
+# ---------------------------------------------------------------------------
+
+
+def _load_goldfive_presentation_module() -> Any:
+    here = Path(__file__).resolve()
+    candidates = [
+        here.parents[3]
+        / "third_party"
+        / "goldfive"
+        / "examples"
+        / "presentation_agent"
+        / "agent.py",
+    ]
+    override = os.environ.get("GOLDFIVE_PRESENTATION_AGENT_PATH")
+    if override:
+        candidates.insert(0, Path(override).expanduser().resolve())
+    for candidate in candidates:
+        if candidate.is_file():
+            spec = importlib.util.spec_from_file_location(
+                "_goldfive_presentation_orchestrated", candidate
+            )
+            if spec is None or spec.loader is None:
+                continue
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod
+    raise ImportError(
+        "Could not locate goldfive's presentation_agent example. Tried: "
+        + ", ".join(str(c) for c in candidates)
+    )
+
+
+_goldfive_presentation = _load_goldfive_presentation_module()
+
+_build_agent_tree = _goldfive_presentation._build_agent_tree
+_mock_planner_call_llm = _goldfive_presentation._mock_planner_call_llm
+_mock_goal_call_llm = _goldfive_presentation._mock_goal_call_llm
+_openai_call_llm = _goldfive_presentation._openai_call_llm
+_MockLlm = _goldfive_presentation._MockLlm
+
+MODEL_NAME = os.environ.get("USER_MODEL_NAME", "gemini-2.5-flash")
+
+# Build the plain ADK tree so ``root_agent`` is available pre-wrap for
+# tests that want to inspect the coordinator + sub-agents directly.
+root_agent = _build_agent_tree(MODEL_NAME)
+
+
+# ---------------------------------------------------------------------------
+# Harmonograf telemetry — shared Client across the lazy app builder and
+# any future programmatic drivers. Same shape as the observation-mode
+# sibling so the two can coexist under one harmonograf server.
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_SERVER = "127.0.0.1:7531"
+
+_APP: Optional[Any] = None
+_CLIENT: Optional[Any] = None
+_ATEXIT_REGISTERED: bool = False
+
+
+def _shutdown_client() -> None:
+    global _CLIENT
+    if _CLIENT is None:
+        return
+    try:
+        _CLIENT.shutdown(flush_timeout=5.0)
+    except Exception as e:  # noqa: BLE001 — atexit must never raise
+        log.debug("harmonograf client shutdown raised: %s", e)
+    _CLIENT = None
+
+
+def _get_or_create_client() -> Optional[Any]:
+    global _CLIENT, _ATEXIT_REGISTERED
+    if _CLIENT is not None:
+        return _CLIENT
+    try:
+        from harmonograf_client import Client
+    except Exception as e:  # noqa: BLE001
+        log.warning("harmonograf_client unavailable (%s); running without telemetry", e)
+        return None
+    server_addr = os.environ.get("HARMONOGRAF_SERVER", _DEFAULT_SERVER)
+    _CLIENT = Client(
+        name="presentation-orchestrated",
+        server_addr=server_addr,
+        framework="ADK",
+        capabilities=["HUMAN_IN_LOOP", "STEERING"],
+    )
+    if not _ATEXIT_REGISTERED:
+        atexit.register(_shutdown_client)
+        _ATEXIT_REGISTERED = True
+    log.info(
+        "harmonograf: presentation_agent_orchestrated client → %s (agent_id=%s)",
+        server_addr,
+        _CLIENT.agent_id,
+    )
+    return _CLIENT
+
+
+# ---------------------------------------------------------------------------
+# ``adk web`` ``App`` export — root agent is ``goldfive.wrap(tree, ...)``.
+# Lazy so importing the module offline is side-effect free.
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> Any:
+    """Construct the ``App`` whose root agent is ``goldfive.wrap(...)``.
+
+    Mirrors goldfive's own ``examples/presentation_agent`` planner /
+    goal-deriver selection: live when ``OPENAI_API_KEY`` is set, mock
+    otherwise so ``adk web`` can load offline.
+    """
+    import goldfive
+    from goldfive import LLMGoalDeriver, LLMPlanner
+    from google.adk.apps.app import App
+
+    live = bool(os.environ.get("OPENAI_API_KEY"))
+    topic = os.environ.get("GOLDFIVE_EXAMPLE_TOPIC", "waffles")
+
+    if live:
+        call_llm = _openai_call_llm()
+        planner_model = os.environ.get(
+            "GOLDFIVE_EXAMPLE_PLANNER_MODEL", "gpt-4o-mini"
+        )
+        tree = _build_agent_tree(MODEL_NAME)
+    else:
+        log.info(
+            "presentation_agent_orchestrated: OPENAI_API_KEY unset; building "
+            "App in mock mode so `adk web` can load offline."
+        )
+        call_llm = _mock_planner_call_llm(topic)
+        planner_model = "mock/planner"
+        tree = _build_agent_tree(_MockLlm(model="mock/presentation-agent"))
+
+    planner = LLMPlanner(call_llm=call_llm, model=planner_model)
+    goal_deriver = LLMGoalDeriver(call_llm=call_llm, model=planner_model)
+
+    wrapped = goldfive.wrap(tree, planner=planner, goal_deriver=goal_deriver)
+
+    plugins: list[Any] = []
+    client = _get_or_create_client()
+    if client is not None:
+        try:
+            from harmonograf_client import HarmonografTelemetryPlugin
+        except Exception as e:  # noqa: BLE001
+            log.warning(
+                "HarmonografTelemetryPlugin unavailable (%s); running without spans",
+                e,
+            )
+        else:
+            plugins.append(HarmonografTelemetryPlugin(client))
+
+    return App(
+        name="presentation_agent_orchestrated",
+        root_agent=wrapped,
+        plugins=plugins,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    """PEP 562 lazy attribute — build ``app`` on first access."""
+    global _APP
+    if name == "app":
+        if _APP is None:
+            _APP = _build_app()
+        return _APP
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# ---------------------------------------------------------------------------
+# Programmatic runner — the old ``build_goldfive_runner`` helper, moved
+# here so the observation-mode module stays strictly about observation.
+# Mirrors ``goldfive/examples/adk_presentation/agent.py`` so the demo
+# runs offline when needed. Driven by ``tests/e2e/test_presentation_agent.py``.
+# ---------------------------------------------------------------------------
+
+
+def build_goldfive_runner(
+    *,
+    topic: str = "the history of the espresso machine",
+    mock: bool = True,
+    client: Optional[Any] = None,
+    extra_sinks: Optional[list[Any]] = None,
+) -> tuple[Any, Any, Optional[Any], Optional[Any]]:
+    """Assemble a :class:`goldfive.Runner` driving the coordinator tree.
+
+    Returns ``(runner, memory_sink, client, harmonograf_sink)``. The
+    harmonograf ``client`` + ``sink`` are ``None`` when
+    ``HARMONOGRAF_SERVER`` is unset and no explicit ``client`` is
+    passed; otherwise a :class:`HarmonografSink` is attached.
+
+    When ``mock=True`` every network call — ADK model, planner, goal
+    deriver — is short-circuited with canned output so the run
+    completes offline.
+    """
+    import goldfive
+    from goldfive import (
+        InMemorySink,
+        LLMGoalDeriver,
+        LLMPlanner,
+        Runner,
+        SequentialExecutor,
+    )
+    from goldfive.adapters.adk import ADKAdapter
+
+    if mock:
+        tree = _build_agent_tree(_MockLlm(model="mock/presentation-agent"))
+        planner_call_llm = _mock_planner_call_llm(topic)
+        goal_call_llm = _mock_goal_call_llm(topic)
+        planner_model = "mock/planner"
+        goal_model = "mock/goal-deriver"
+    else:
+        tree = _build_agent_tree(MODEL_NAME)
+        raise SystemExit(
+            "non-mock mode not wired here; use goldfive/examples/presentation_agent "
+            "for a real OpenAI-backed run"
+        )
+
+    adapter = ADKAdapter(tree)
+
+    sinks: list[Any] = []
+    memory_sink = InMemorySink()
+    sinks.append(memory_sink)
+
+    explicit_client = client
+    if explicit_client is None:
+        explicit_client = _get_or_create_client()
+
+    harmonograf_sink = None
+    if explicit_client is not None:
+        try:
+            from harmonograf_client import HarmonografSink
+
+            harmonograf_sink = HarmonografSink(explicit_client)
+            sinks.append(harmonograf_sink)
+        except Exception as e:  # noqa: BLE001
+            log.warning("HarmonografSink unavailable (%s)", e)
+
+    try:
+        logging_sink = goldfive.sinks.LoggingSink()
+    except Exception:  # noqa: BLE001 — proto extra may be absent
+        logging_sink = None
+    if logging_sink is not None:
+        sinks.append(logging_sink)
+
+    if extra_sinks:
+        sinks.extend(extra_sinks)
+
+    runner = Runner(
+        agent=adapter,
+        planner=LLMPlanner(call_llm=planner_call_llm, model=planner_model),
+        executor=SequentialExecutor(max_task_invocations=8),
+        goal_deriver=LLMGoalDeriver(call_llm=goal_call_llm, model=goal_model),
+        sinks=sinks,
+        max_task_invocations=8,
+    )
+    return runner, memory_sink, explicit_client, harmonograf_sink
+
+
+def _reset_for_testing() -> None:
+    """Drop the cached ``app`` and ``Client``. Test-only hook."""
+    global _APP, _CLIENT
+    if _CLIENT is not None:
+        try:
+            _CLIENT.shutdown(flush_timeout=1.0)
+        except Exception:
+            pass
+    _APP = None
+    _CLIENT = None


### PR DESCRIPTION
## Summary

- Bumps the goldfive submodule from `8ecc90f` to `3d964b6` (the merged PR #119 that canonicalised `examples/presentation_agent/` — coordinator + research + web_developer + reviewer + debugger with real `write_webpage` / `read_presentation_files` / `patch_file` tools).
- Adds sibling package `tests/reference_agents/presentation_agent_orchestrated/` that loads the **same** tree from goldfive's example and wraps it with `goldfive.wrap(...)` before `App()` sees it. `adk web`'s picker now lists both observation and orchestration variants side by side — no env-var toggle.
- Shrinks `tests/reference_agents/presentation_agent/agent.py` to just the observation-mode wiring: the tree + tools are imported by absolute file path from goldfive's example (so the two stay byte-identical), and `build_goldfive_runner` moves to the orchestrated sibling where orchestration actually lives.
- Surgical doc updates everywhere the observation variant is mentioned (quickstart, demo-wont-start runbook, tasks-and-plans callout, goldfive-integration, dev-guide/testing, README).

## Test plan

- [x] `uv run pytest tests/e2e/test_presentation_agent.py -x -q` — 6/6 pass (2 observation tests + 1 orchestrated-app build + 3 runner end-to-end tests).
- [x] `make server-test` — 254 pass, 1 skipped (unchanged).
- [x] `make client-test` — 161 pass (unchanged).
- [x] `make e2e` — 7 pass, 3 skipped (unchanged; skips are the real-LLM paths).
- [x] `make .demo-agents-stage` — stages both passthrough packages; manual `import presentation_agent.agent` / `import presentation_agent_orchestrated.agent` from `.demo-agents/` both build their `app` offline with the expected root-agent types (`LlmAgent` vs `GoldfiveADKAgent`).
- [ ] `make demo` smoke (manual: pick each agent in the `adk web` picker and drive a waffles prompt, confirm timeline populates for both modes with / without the goldfive plan + drift events).