### PR TITLE
Stamp ADK session_id on telemetry spans (fix session-id collapse)

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -62,6 +62,31 @@ def _safe_attr(obj: Any, name: str, default: Any = None) -> Any:
         return default
 
 
+def _adk_session_id(ctx: Any) -> str:
+    """Extract the ADK session id from any ADK callback context.
+
+    ADK's ``InvocationContext``, ``CallbackContext``, and ``ToolContext``
+    all expose a ``session`` attribute that resolves to the
+    ``sessions.Session`` row carrying a stable per-ADK-session ``id``.
+    Without stamping this on every harmonograf span, a long-lived
+    module-level :class:`Client` (the usual presentation_agent pattern)
+    collapses every ADK session from the same Python process into
+    whatever ``sess_<date>_<nnnn>`` the server generated on first
+    Hello — see the issue description for the full pathology.
+
+    Returns the session id as a ``str``, or ``""`` when the context is
+    malformed or ADK is running without a session service. Empty
+    strings cause :class:`Client` to fall back to its default
+    ``session_id`` — the legacy pre-fix behaviour — which is the right
+    failure mode when the context shape is unexpected.
+    """
+    session = _safe_attr(ctx, "session", None)
+    if session is None:
+        return ""
+    sid = _safe_attr(session, "id", "") or ""
+    return str(sid)
+
+
 def _serialize_args(args: Any) -> bytes | None:
     if args is None:
         return None
@@ -228,6 +253,7 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             kind=SpanKind.INVOCATION,
             name=name,
             attributes={"adk.invocation_id": inv_id} if inv_id else None,
+            session_id=_adk_session_id(invocation_context),
         )
         if inv_id:
             self._invocation_spans[inv_id] = sid
@@ -294,6 +320,7 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             kind=SpanKind.LLM_CALL,
             name=model or "llm_call",
             attributes={"llm.model": model} if model else None,
+            session_id=_adk_session_id(callback_context),
         )
         key = self._model_span_key(callback_context)
         self._model_spans.setdefault(key, deque()).append(_ModelSpanSlot(span_id=sid))
@@ -379,6 +406,7 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             name=tool_name,
             payload=payload,
             payload_role="input",
+            session_id=_adk_session_id(tool_context),
         )
         self._tool_spans[id(tool_context)] = sid
 

--- a/client/tests/test_telemetry_plugin_session_id.py
+++ b/client/tests/test_telemetry_plugin_session_id.py
@@ -1,0 +1,221 @@
+"""Regression tests for per-span ADK ``session_id`` stamping.
+
+Before the fix, :class:`HarmonografTelemetryPlugin` emitted every span
+with an empty ``session_id`` field on the wire, causing the server to
+fall back to the stream's default session (assigned once on first
+``Hello``). Every ADK session sharing a process-level
+:class:`harmonograf_client.Client` therefore collapsed into one
+harmonograf session (``sess_<date>_<nnnn>``), making the Gantt /
+timeline unusable for long-lived presentation_agent-style processes.
+
+The fix reads the ADK ``session.id`` from the
+``invocation_context`` / ``callback_context`` / ``tool_context`` and
+passes it through :meth:`Client.emit_span_start`. These tests exercise
+each of the five callbacks and assert the stamped ``session_id``
+survives into the protobuf envelope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from harmonograf_client.buffer import EnvelopeKind
+from harmonograf_client.client import Client
+from harmonograf_client.telemetry_plugin import HarmonografTelemetryPlugin
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+# ---------------------------------------------------------------------------
+# ADK-shaped stand-ins
+# ---------------------------------------------------------------------------
+
+
+class _Session:
+    def __init__(self, sid: str) -> None:
+        self.id = sid
+
+
+class _Agent:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _InvocationContext:
+    """Mirrors :class:`google.adk.agents.invocation_context.InvocationContext`
+    just enough for the plugin's ``_safe_attr`` accessors.
+    """
+
+    def __init__(self, invocation_id: str, session_id: str) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id)
+        self.agent = _Agent("root-agent")
+
+
+class _CallbackContext:
+    """ADK unifies CallbackContext / ToolContext / Context under a single
+    type exposing ``invocation_id`` and ``session`` on the surface. The
+    fake mirrors that (the plugin only ever touches those two fields).
+    """
+
+    def __init__(self, invocation_id: str, session_id: str) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id)
+
+
+class _Tool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _LlmRequest:
+    def __init__(self, model: str = "gpt-test") -> None:
+        self.model = model
+
+
+class _LlmResponse:
+    def __init__(self) -> None:
+        self.partial = False
+        self.error_message = None
+
+
+ADK_SESSION = "adk-sess-abc123"
+OTHER_SESSION = "adk-sess-def456"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    # Seed with a DIFFERENT default session so we can prove the
+    # per-span override actually lands (instead of the wire simply
+    # reflecting the transport default).
+    return Client(
+        name="session-id-test",
+        agent_id="agent-X",
+        session_id="stream-default-session",
+        buffer_size=64,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def plugin(client: Client) -> HarmonografTelemetryPlugin:
+    return HarmonografTelemetryPlugin(client)
+
+
+def _span_session_ids(client: Client) -> list[str]:
+    ids: list[str] = []
+    for env in client._events.drain():
+        # Only SPAN_START envelopes carry a full Span message; SPAN_END
+        # and SPAN_UPDATE only reference the span by id, so session_id
+        # only needs to ride on SPAN_START.
+        if env.kind is EnvelopeKind.SPAN_START:
+            ids.append(env.payload.span.session_id)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_before_run_stamps_session_id_from_invocation_context(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    ctx = _InvocationContext(invocation_id="inv-1", session_id=ADK_SESSION)
+    await plugin.before_run_callback(invocation_context=ctx)
+    assert _span_session_ids(client) == [ADK_SESSION]
+
+
+@pytest.mark.asyncio
+async def test_before_model_stamps_session_id_from_callback_context(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    cb = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
+    await plugin.before_model_callback(callback_context=cb, llm_request=_LlmRequest())
+    assert _span_session_ids(client) == [ADK_SESSION]
+
+
+@pytest.mark.asyncio
+async def test_before_tool_stamps_session_id_from_tool_context(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    tc = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
+    await plugin.before_tool_callback(
+        tool=_Tool("search"), tool_args={"q": "hi"}, tool_context=tc
+    )
+    assert _span_session_ids(client) == [ADK_SESSION]
+
+
+@pytest.mark.asyncio
+async def test_full_invocation_spans_all_carry_same_adk_session_id(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """End-to-end: before_run + before_model + before_tool on the same
+    ADK session should yield three spans all stamped with the ADK
+    session id — the exact regression that motivated the fix.
+    """
+    ic = _InvocationContext(invocation_id="inv-1", session_id=ADK_SESSION)
+    cb = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
+    tc = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
+
+    await plugin.before_run_callback(invocation_context=ic)
+    await plugin.before_model_callback(callback_context=cb, llm_request=_LlmRequest())
+    await plugin.before_tool_callback(
+        tool=_Tool("fetch"), tool_args=None, tool_context=tc
+    )
+
+    sids = _span_session_ids(client)
+    assert len(sids) == 3
+    assert all(sid == ADK_SESSION for sid in sids)
+
+
+@pytest.mark.asyncio
+async def test_two_adk_sessions_share_one_process_and_stay_distinct(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """The motivating bug: a module-level Client shared across two ADK
+    sessions must surface both sessions distinctly on the wire, not
+    collapse them into the transport's default.
+    """
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext("inv-A", ADK_SESSION)
+    )
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext("inv-B", OTHER_SESSION)
+    )
+    assert _span_session_ids(client) == [ADK_SESSION, OTHER_SESSION]
+
+
+@pytest.mark.asyncio
+async def test_missing_session_falls_back_to_transport_default(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """If ADK runs without a session service (unit-test harnesses,
+    offline replays), ``_adk_session_id`` returns ``""`` and the
+    Client falls back to its default session_id — the pre-fix
+    behaviour. This matters so we don't break agents whose tests
+    stub out the context shape.
+    """
+
+    class _Bare:
+        invocation_id = "inv-bare"
+        agent = _Agent("root")
+        session = None
+
+    await plugin.before_run_callback(invocation_context=_Bare())
+    # emit_span_start resolves `session_id=""` to the Client's own
+    # default, preserving legacy behavior.
+    assert _span_session_ids(client) == ["stream-default-session"]


### PR DESCRIPTION
## Summary
- Module-level `harmonograf_client.Client` (the presentation_agent pattern) collapses every ADK session sharing one Python process into a single harmonograf `sess_<date>_<nnnn>` because the telemetry plugin never read `invocation_context.session.id` or passed it through to `Client.emit_span_start`.
- Fix: add `_adk_session_id(ctx)` helper and plumb per-callback ADK session ids through `before_run_callback`, `before_model_callback`, and `before_tool_callback`. Server already honors `pb_span.session_id` overrides and auto-registers new routes via `_ensure_route` — no server-side change needed.
- Defensive: `_adk_session_id` follows the `_safe_attr` pattern already in the file; empty strings fall back to the transport default, preserving legacy behaviour for offline harnesses.

## Test plan
- [x] `make client-test` is green (167 passed, 6 new).
- [x] New `client/tests/test_telemetry_plugin_session_id.py` covers: before_run / before_model / before_tool stamping; full-invocation all-spans-tagged; two interleaved ADK sessions staying distinct on one Client; missing-session fall-through.
- [ ] Manual: rerun a multi-session `adk web` demo with two conversations in the presentation_agent picker and confirm the timeline renders two harmonograf sessions (one per ADK session), not one collapsed view.