### PR TITLE
Wire DelegationObserved → cross-agent delegation edges on Gantt

### DIFF
--- a/docs/design/10-frontend-architecture.md
+++ b/docs/design/10-frontend-architecture.md
@@ -176,7 +176,19 @@ The net effect is that actor rows require no special-casing in the views. The Ga
 
 **Trajectory view.** [`components/shell/views/TrajectoryView.tsx`](file:///home/sunil/git/harmonograf/frontend/src/components/shell/views/TrajectoryView.tsx) is the primary plan-review surface and consumes the same drift records. Its `buildViewModel()` merges all plans for the session by `createdAtMs` (not by plan id — goldfive planners often mint fresh ids on each refine) and bins drifts into the rev that was live when each drift was observed. The ribbon then renders pivots (severity-colored `↻`) at rev boundaries and drift markers (stars for user-authored, circles for goldfive-authored) on each segment.
 
-## 8. Conclusions
+## 8. Delegation Edges
+
+goldfive `2986775+` emits a `DelegationObserved` event every time a
+coordinator agent calls `AgentTool(sub_agent)` — i.e. the registry
+dispatcher sees a registered-agent-to-registered-agent tool invocation
+and fans out an explicit cross-agent edge. The telemetry plugin's
+generic `TOOL_CALL` span on the coordinator row is insufficient to
+reconstruct this relationship (it does not name the sub-agent as a
+recognizable row), so harmonograf consumes the event directly.
+
+The [`goldfiveEvent.ts`](file:///home/sunil/git/harmonograf/frontend/src/rpc/goldfiveEvent.ts) dispatcher appends each payload to a new `SessionStore.delegations` registry ([`DelegationRegistry` in `gantt/index.ts`](file:///home/sunil/git/harmonograf/frontend/src/gantt/index.ts)) whose shape intentionally mirrors `DriftRegistry` — `append()` / `list()` / `clear()` / `subscribe()`. The Gantt renderer's `drawDelegations()` pass walks the registry per blocks-redraw and paints a dashed 30%-opacity bezier (goldfive-cyan) from the `fromAgent` row-center to the `toAgent` row-center at the observed time. The Trajectory DAG surfaces a faint "↪↪ delegated to: X" annotation under the task card. The companion `agentInvocationStarted` / `agentInvocationCompleted` events remain no-ops because `HarmonografTelemetryPlugin` already materializes them as per-agent `INVOCATION` spans.
+
+## 9. Conclusions
 
 The Harmonograf frontend minimizes React render cycles, adopting an ECS-like game-engine loop for data rendering via HTML5 Canvas. By securely interleaving DOM elements exclusively for native text/form inputs, the topology maintains flawless 60 FPS frame rates processing potentially millions of unstructured telemetry events visually correctly.
 

--- a/docs/user-guide/gantt-view.md
+++ b/docs/user-guide/gantt-view.md
@@ -106,6 +106,22 @@ the trailing edge, one per `streaming_tick` the client reported.
 TRANSFER and its invoked child on another agent row. Arrowhead at the target.
 These edges are the visual signature of a delegation.
 
+### Delegation edges
+
+When a coordinator agent calls `AgentTool(sub_agent)`, goldfive observes
+the tool call on its registry-dispatch side and emits a
+`DelegationObserved` event. Harmonograf paints an extra edge for each
+such event — dashed, 30% opacity, colored with the goldfive actor cyan
+(`#80deea`) — running from the coordinator's row to the sub-agent's row
+at the moment of delegation. A small `↪↪` glyph sits at the midpoint.
+
+These edges sit alongside the regular TRANSFER arrows above: a TRANSFER
+arrow means "the framework recorded a handoff span"; a delegation edge
+means "goldfive's registry saw a registered agent call another
+registered agent as a tool." The generic TOOL_CALL span the telemetry
+plugin emits on the coordinator's row is not enough to reconstruct this
+cross-row relationship, so goldfive fills it in.
+
 ## Navigating — pan, zoom, and selection
 
 ### Mouse

--- a/frontend/src/__tests__/gantt/delegations.test.ts
+++ b/frontend/src/__tests__/gantt/delegations.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DelegationRegistry, SessionStore } from '../../gantt/index';
+
+describe('DelegationRegistry', () => {
+  it('starts empty', () => {
+    const reg = new DelegationRegistry();
+    expect(reg.list()).toHaveLength(0);
+  });
+
+  it('append assigns monotonic seq starting at 0', () => {
+    const reg = new DelegationRegistry();
+    reg.append({
+      fromAgentId: 'coord',
+      toAgentId: 'sub_a',
+      taskId: 't-1',
+      invocationId: 'inv-1',
+      observedAtMs: 1000,
+    });
+    reg.append({
+      fromAgentId: 'coord',
+      toAgentId: 'sub_b',
+      taskId: 't-2',
+      invocationId: 'inv-2',
+      observedAtMs: 2000,
+    });
+    const list = reg.list();
+    expect(list).toHaveLength(2);
+    expect(list[0].seq).toBe(0);
+    expect(list[1].seq).toBe(1);
+    expect(list[0].toAgentId).toBe('sub_a');
+    expect(list[1].toAgentId).toBe('sub_b');
+  });
+
+  it('append fires subscribers exactly once per entry', () => {
+    const reg = new DelegationRegistry();
+    const fn = vi.fn();
+    reg.subscribe(fn);
+    reg.append({
+      fromAgentId: 'a',
+      toAgentId: 'b',
+      taskId: '',
+      invocationId: 'inv',
+      observedAtMs: 0,
+    });
+    reg.append({
+      fromAgentId: 'a',
+      toAgentId: 'c',
+      taskId: '',
+      invocationId: 'inv2',
+      observedAtMs: 10,
+    });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('unsubscribe stops further emissions', () => {
+    const reg = new DelegationRegistry();
+    const fn = vi.fn();
+    const un = reg.subscribe(fn);
+    reg.append({
+      fromAgentId: 'a',
+      toAgentId: 'b',
+      taskId: '',
+      invocationId: 'inv',
+      observedAtMs: 0,
+    });
+    un();
+    reg.append({
+      fromAgentId: 'a',
+      toAgentId: 'c',
+      taskId: '',
+      invocationId: 'inv2',
+      observedAtMs: 10,
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('clear resets list, seq, and emits', () => {
+    const reg = new DelegationRegistry();
+    reg.append({
+      fromAgentId: 'a',
+      toAgentId: 'b',
+      taskId: '',
+      invocationId: 'inv',
+      observedAtMs: 0,
+    });
+    const fn = vi.fn();
+    reg.subscribe(fn);
+    reg.clear();
+    expect(reg.list()).toHaveLength(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Seq restarts at 0 after clear.
+    reg.append({
+      fromAgentId: 'a',
+      toAgentId: 'b',
+      taskId: '',
+      invocationId: 'inv2',
+      observedAtMs: 5,
+    });
+    expect(reg.list()[0].seq).toBe(0);
+  });
+
+  it('clear on empty registry is a no-op (does not emit)', () => {
+    const reg = new DelegationRegistry();
+    const fn = vi.fn();
+    reg.subscribe(fn);
+    reg.clear();
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe('SessionStore.delegations integration', () => {
+  it('SessionStore exposes an empty DelegationRegistry', () => {
+    const store = new SessionStore();
+    expect(store.delegations).toBeInstanceOf(DelegationRegistry);
+    expect(store.delegations.list()).toHaveLength(0);
+  });
+
+  it('SessionStore.clear wipes delegations', () => {
+    const store = new SessionStore();
+    store.delegations.append({
+      fromAgentId: 'coord',
+      toAgentId: 'sub',
+      taskId: 't-1',
+      invocationId: 'inv-1',
+      observedAtMs: 100,
+    });
+    expect(store.delegations.list()).toHaveLength(1);
+    store.clear();
+    expect(store.delegations.list()).toHaveLength(0);
+  });
+});

--- a/frontend/src/__tests__/rpc/goldfiveEvent.test.ts
+++ b/frontend/src/__tests__/rpc/goldfiveEvent.test.ts
@@ -16,7 +16,11 @@ import {
   ApprovalRequestedSchema,
   ApprovalGrantedSchema,
   ApprovalRejectedSchema,
+  AgentInvocationStartedSchema,
+  AgentInvocationCompletedSchema,
+  DelegationObservedSchema,
 } from '../../pb/goldfive/v1/events_pb';
+import { TimestampSchema } from '@bufbuild/protobuf/wkt';
 import {
   PlanSchema,
   TaskSchema,
@@ -389,6 +393,127 @@ describe('applyGoldfiveEvent', () => {
       const [entry] = useApprovalsStore.getState().list('sess-x');
       // makePbTask sets assigneeAgentId = 'agent-a'.
       expect(entry.agentId).toBe('agent-a');
+    });
+  });
+
+  describe('registry-dispatch events (goldfive 2986775+)', () => {
+    it('delegationObserved appends a DelegationRecord with wire fields mapped through', () => {
+      const store = new SessionStore();
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-del',
+          runId: 'run-1',
+          sequence: 1n,
+          // emittedAt = 5000ms wall-clock. With sessionStartMs=2000, the
+          // recorded observedAtMs should land at 3000.
+          emittedAt: create(TimestampSchema, {
+            seconds: 5n,
+            nanos: 0,
+          }),
+          payload: {
+            case: 'delegationObserved',
+            value: create(DelegationObservedSchema, {
+              fromAgent: 'coordinator',
+              toAgent: 'researcher',
+              taskId: 't-42',
+              invocationId: 'inv-7',
+            }),
+          },
+        }),
+        store,
+        2000,
+      );
+
+      const list = store.delegations.list();
+      expect(list).toHaveLength(1);
+      expect(list[0]).toMatchObject({
+        seq: 0,
+        fromAgentId: 'coordinator',
+        toAgentId: 'researcher',
+        taskId: 't-42',
+        invocationId: 'inv-7',
+        observedAtMs: 3000,
+      });
+    });
+
+    it('delegationObserved without emittedAt records observedAtMs=0', () => {
+      const store = new SessionStore();
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-del2',
+          runId: 'run-1',
+          sequence: 0n,
+          payload: {
+            case: 'delegationObserved',
+            value: create(DelegationObservedSchema, {
+              fromAgent: 'a',
+              toAgent: 'b',
+              taskId: '',
+              invocationId: 'inv',
+            }),
+          },
+        }),
+        store,
+        0,
+      );
+      expect(store.delegations.list()[0].observedAtMs).toBe(0);
+    });
+
+    it('agentInvocationStarted is a no-op (telemetry plugin already emits INVOCATION spans)', () => {
+      const store = new SessionStore();
+      expect(() =>
+        applyGoldfiveEvent(
+          create(EventSchema, {
+            eventId: 'ev-ais',
+            runId: 'run-1',
+            sequence: 0n,
+            payload: {
+              case: 'agentInvocationStarted',
+              value: create(AgentInvocationStartedSchema, {
+                agentName: 'coordinator',
+                taskId: 't-1',
+                invocationId: 'inv-1',
+                parentInvocationId: '',
+              }),
+            },
+          }),
+          store,
+          0,
+        ),
+      ).not.toThrow();
+      // Should not have leaked into any store.
+      expect(store.delegations.list()).toHaveLength(0);
+      expect(store.spans.size).toBe(0);
+      expect(store.agents.size).toBe(0);
+      expect(store.tasks.size).toBe(0);
+    });
+
+    it('agentInvocationCompleted is a no-op', () => {
+      const store = new SessionStore();
+      expect(() =>
+        applyGoldfiveEvent(
+          create(EventSchema, {
+            eventId: 'ev-aic',
+            runId: 'run-1',
+            sequence: 0n,
+            payload: {
+              case: 'agentInvocationCompleted',
+              value: create(AgentInvocationCompletedSchema, {
+                agentName: 'coordinator',
+                taskId: 't-1',
+                invocationId: 'inv-1',
+                summary: 'ok',
+              }),
+            },
+          }),
+          store,
+          0,
+        ),
+      ).not.toThrow();
+      expect(store.delegations.list()).toHaveLength(0);
+      expect(store.spans.size).toBe(0);
+      expect(store.agents.size).toBe(0);
+      expect(store.tasks.size).toBe(0);
     });
   });
 

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -3,7 +3,11 @@ import { useEffect, useState } from 'react';
 import { useUiStore } from '../../../state/uiStore';
 import { useSessionWatch } from '../../../rpc/hooks';
 import type { Task, TaskEdge, TaskPlan, TaskStatus } from '../../../gantt/types';
-import type { DriftRecord, SessionStore } from '../../../gantt/index';
+import type {
+  DelegationRecord,
+  DriftRecord,
+  SessionStore,
+} from '../../../gantt/index';
 
 // ── Palette ────────────────────────────────────────────────────────────────
 // Aligned with GanttView's status palette so a task's status reads the same
@@ -39,6 +43,7 @@ interface TrajectoryViewModel {
   revs: TaskPlan[];
   driftsByRev: DriftRecord[][];
   allDrifts: DriftRecord[];
+  allDelegations: DelegationRecord[];
 }
 
 function buildViewModel(store: SessionStore | null): TrajectoryViewModel {
@@ -47,6 +52,7 @@ function buildViewModel(store: SessionStore | null): TrajectoryViewModel {
     revs: [],
     driftsByRev: [],
     allDrifts: [],
+    allDelegations: [],
   };
   if (!store) return empty;
   const plans = store.tasks.listPlans();
@@ -81,7 +87,14 @@ function buildViewModel(store: SessionStore | null): TrajectoryViewModel {
     }
     driftsByRev[idx].push(d);
   }
-  return { planId: primaryId, revs: combined, driftsByRev, allDrifts: drifts };
+  const delegations = [...store.delegations.list()];
+  return {
+    planId: primaryId,
+    revs: combined,
+    driftsByRev,
+    allDrifts: drifts,
+    allDelegations: delegations,
+  };
 }
 
 // ── DAG layout ─────────────────────────────────────────────────────────────
@@ -253,10 +266,12 @@ export function TrajectoryView() {
     const un1 = store.tasks.subscribe(() => setTick((n) => n + 1));
     const un2 = store.drifts.subscribe(() => setTick((n) => n + 1));
     const un3 = store.spans.subscribe(() => setTick((n) => n + 1));
+    const un4 = store.delegations.subscribe(() => setTick((n) => n + 1));
     return () => {
       un1();
       un2();
       un3();
+      un4();
     };
   }, [store]);
 
@@ -373,6 +388,7 @@ export function TrajectoryView() {
                 marks={marks}
                 compareRev={compareRev}
                 driftsOnRev={vm.driftsByRev[revIdx] ?? []}
+                delegations={vm.allDelegations}
                 selection={selection}
                 onSelectTask={(taskId) => {
                   if (!currentRev) return;
@@ -479,6 +495,7 @@ interface DagProps {
   marks: DiffMarks | null;
   compareRev: TaskPlan | null;
   driftsOnRev: DriftRecord[];
+  delegations: DelegationRecord[];
   selection: Selection;
   onSelectTask: (taskId: string) => void;
 }
@@ -496,10 +513,36 @@ function buildDriftsByTaskId(
   return m;
 }
 
+// Bucket delegations by the taskId the coordinator was bound to at the
+// moment of delegation. The DAG renders a faint "delegated to: X" line
+// under each task card that had at least one delegation observed during
+// its execution.
+function buildDelegationsByTaskId(
+  delegations: DelegationRecord[],
+): Map<string, DelegationRecord[]> {
+  const m = new Map<string, DelegationRecord[]>();
+  for (const d of delegations) {
+    if (!d.taskId) continue;
+    const arr = m.get(d.taskId) ?? [];
+    arr.push(d);
+    m.set(d.taskId, arr);
+  }
+  return m;
+}
+
 function DagPane(props: DagProps) {
-  const { plan, marks, compareRev, driftsOnRev, selection, onSelectTask } = props;
+  const {
+    plan,
+    marks,
+    compareRev,
+    driftsOnRev,
+    delegations,
+    selection,
+    onSelectTask,
+  } = props;
   const layout = plan ? layoutDag(plan) : null;
   const driftsByTaskId = buildDriftsByTaskId(driftsOnRev);
+  const delegationsByTaskId = buildDelegationsByTaskId(delegations);
 
   if (!plan || !layout) {
     return <div className="hg-traj__dag hg-traj__dag--empty">No plan to render.</div>;
@@ -569,6 +612,7 @@ function DagPane(props: DagProps) {
             const isAdded = marks?.added.has(t.id) ?? false;
             const isMod = marks?.modified.has(t.id) ?? false;
             const drifts = driftsByTaskId.get(t.id) ?? [];
+            const taskDelegations = delegationsByTaskId.get(t.id) ?? [];
             // Highest-severity drift drives the pill color (critical > warn > info).
             let worst = '';
             for (const d of drifts) {
@@ -632,6 +676,20 @@ function DagPane(props: DagProps) {
                       {drifts.length}
                     </text>
                   </g>
+                )}
+                {taskDelegations.length > 0 && (
+                  <text
+                    className="hg-traj__node-delegation"
+                    x={16}
+                    y={n.h - 6}
+                    fontSize={10}
+                    data-testid={`task-delegation-${t.id}`}
+                  >
+                    {`↪↪ delegated to: ${truncate(
+                      taskDelegations[0].toAgentId,
+                      14,
+                    )}${taskDelegations.length > 1 ? ` +${taskDelegations.length - 1}` : ''}`}
+                  </text>
                 )}
               </g>
             );

--- a/frontend/src/components/shell/views/views.css
+++ b/frontend/src/components/shell/views/views.css
@@ -470,6 +470,16 @@ a.hg-settings__value:hover {
   font-weight: 600;
 }
 
+/* Delegation annotation: faint cyan line under the task card. Driven by
+ * goldfive DelegationObserved events — see frontend/src/gantt/index.ts
+ * DelegationRegistry. */
+.hg-traj__node-delegation {
+  fill: #80deea;
+  font-size: 10px;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
 .hg-traj__removed {
   flex: 0 0 180px;
   background: var(--md-sys-color-surface-container, #1b1f29);

--- a/frontend/src/gantt/index.ts
+++ b/frontend/src/gantt/index.ts
@@ -557,6 +557,56 @@ export class DriftRegistry {
   }
 }
 
+// A captured goldfive DelegationObserved event. Emitted when a coordinator
+// agent invokes `AgentTool(sub_agent)` — goldfive observes the tool call on
+// its registry-dispatch side and fans out a DelegationObserved event so
+// sinks can render an explicit from→to edge that the telemetry plugin's
+// generic TOOL_CALL span on the coordinator row would otherwise leave
+// implicit.
+export interface DelegationRecord {
+  seq: number;             // monotonic across the session, assigned on arrival
+  fromAgentId: string;     // coordinator (the observer-side "from")
+  toAgentId: string;       // sub-agent the coordinator delegated to
+  taskId: string;          // empty when the host agent has no bound task
+  invocationId: string;    // ADK invocation id for the delegation
+  observedAtMs: number;    // session-relative
+}
+
+// Delegation registry — in-memory list of DelegationObserved events received
+// during the session. Shape mirrors DriftRegistry so consumers can subscribe
+// without special-casing and the Gantt's delegation-edge render pass can
+// walk a single array per frame.
+export class DelegationRegistry {
+  private delegations: DelegationRecord[] = [];
+  private listeners = new Set<() => void>();
+  private nextSeq = 0;
+
+  list(): readonly DelegationRecord[] {
+    return this.delegations;
+  }
+
+  append(d: Omit<DelegationRecord, 'seq'>): void {
+    this.delegations.push({ ...d, seq: this.nextSeq++ });
+    this.emit();
+  }
+
+  clear(): void {
+    if (this.delegations.length === 0) return;
+    this.delegations = [];
+    this.nextSeq = 0;
+    this.emit();
+  }
+
+  subscribe(fn: () => void): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+
+  private emit(): void {
+    for (const fn of this.listeners) fn();
+  }
+}
+
 // A Session couples an AgentRegistry, a SpanIndex, and a TaskRegistry. The
 // renderer and chrome read directly from all three.
 export class SessionStore {
@@ -564,6 +614,7 @@ export class SessionStore {
   readonly spans = new SpanIndex();
   readonly tasks = new TaskRegistry();
   readonly drifts = new DriftRegistry();
+  readonly delegations = new DelegationRegistry();
   readonly contextSeries = new ContextSeriesRegistry();
 
   // Scan the span index for TOOL_CALL spans whose name is one of the
@@ -696,6 +747,7 @@ export class SessionStore {
     this.spans.clear();
     this.tasks.clear();
     this.drifts.clear();
+    this.delegations.clear();
     this.contextSeries.clear();
     this.nowMs = 0;
   }

--- a/frontend/src/gantt/renderer.ts
+++ b/frontend/src/gantt/renderer.ts
@@ -13,7 +13,7 @@
 // canvases to a Renderer instance; the instance subscribes to the SessionStore
 // and schedules redraws via requestAnimationFrame.
 
-import { colorForAgent } from '../theme/agentColors';
+import { colorForAgent, GOLDFIVE_ACTOR_ID } from '../theme/agentColors';
 import type { TaskPlanMode } from '../state/uiStore';
 import { bucketKey, cssVar, refreshThemeCache, resolveStyle } from './colors';
 import {
@@ -207,6 +207,10 @@ export class GanttRenderer {
       this.store.contextSeries.subscribe(() => {
         // A new context-window sample always redraws blocks (band geometry
         // + header chip both live in the blocks pass).
+        this.blocksDirty = true;
+      }),
+      this.store.delegations.subscribe(() => {
+        // Delegation edges are painted inside the blocks pass.
         this.blocksDirty = true;
       }),
     );
@@ -924,6 +928,12 @@ export class GanttRenderer {
     // data area so curves never bleed into the gutter or axis.
     this.drawLinks(ctx);
 
+    // Delegation edges: coordinator→sub_agent curves fed by goldfive
+    // DelegationObserved events (see SessionStore.delegations). Distinct
+    // style from LINK_INVOKED — goldfive is the observer, so color + glyph
+    // borrow from the synthetic goldfive actor.
+    this.drawDelegations(ctx);
+
     ctx.restore();
     // Expose last-draw count for stress tooling.
     this.lastDrawnCount = visibleCount;
@@ -1025,6 +1035,97 @@ export class GanttRenderer {
       drawEdgePath(ctx, e.x1, e.y1, e.x2, e.y2);
       ctx.stroke();
       drawArrowhead(ctx, e.x2, e.y2, e.x1, e.y1, e.color);
+    }
+    ctx.restore();
+  }
+
+  // --- Delegation edges -------------------------------------------------
+  //
+  // One curve per goldfive DelegationRecord — from the fromAgentId row to
+  // the toAgentId row at the observed time. Unlike LINK_INVOKED edges,
+  // both anchors share the same t (delegation is instantaneous from the
+  // observer's POV), so the renderer lands them at each row's center
+  // rather than on a specific span bar. Dashed stroke + distinctive
+  // midpoint glyph keep them readable against the denser TRANSFER edges
+  // the plugin span path produces.
+  private drawDelegations(ctx: CanvasRenderingContext2D): void {
+    const delegations = this.store.delegations.list();
+    if (delegations.length === 0) return;
+    const vs = viewportStart(this.viewport);
+    const ve = this.viewport.endMs;
+    const w = this.widthCss;
+    const agents = this.store.agents.list;
+    if (agents.length === 0) return;
+
+    // Row-center lookup — delegation anchors are row-centered rather than
+    // lane-specific because there's no originating span bar to point at.
+    const rowCenterY = new Map<string, number>();
+    let y = TOP_MARGIN_PX;
+    for (const agent of agents) {
+      const rowH = this.rowHeight(agent.id);
+      rowCenterY.set(agent.id, y + rowH / 2);
+      y += rowH;
+    }
+
+    const dataLeft = GUTTER_WIDTH_PX + 10;
+    const dataRight = w;
+    // goldfive observed the delegation — color matches the synthetic
+    // goldfive actor row so the attribution reads the same everywhere.
+    const color = colorForAgent(GOLDFIVE_ACTOR_ID);
+
+    ctx.save();
+    ctx.lineWidth = 1.25;
+    ctx.globalAlpha = 0.3;
+    ctx.setLineDash([4, 3]);
+    ctx.strokeStyle = color;
+    let drew = 0;
+    for (const d of delegations) {
+      // Cull to the visible time window (with a small pad for endpoints
+      // sitting just off-edge). Consistent with drawLinks' margin approach.
+      const margin = this.viewport.windowMs * 0.5;
+      if (d.observedAtMs < vs - margin || d.observedAtMs > ve + margin) {
+        continue;
+      }
+      const srcY = rowCenterY.get(d.fromAgentId);
+      const tgtY = rowCenterY.get(d.toAgentId);
+      if (srcY === undefined || tgtY === undefined) continue;
+      const x = msToPx(this.viewport, w, d.observedAtMs);
+      if (x < dataLeft || x > dataRight) continue;
+      // Same-time, different-row edge: draw a shallow curve so the path
+      // doesn't collapse into a zero-width vertical line. Offset the
+      // control points horizontally by a fixed nudge.
+      const curveOffset = 24;
+      ctx.beginPath();
+      ctx.moveTo(x, srcY);
+      ctx.bezierCurveTo(
+        x + curveOffset, srcY,
+        x + curveOffset, tgtY,
+        x, tgtY,
+      );
+      ctx.stroke();
+      drew++;
+    }
+
+    // Midpoint glyph pass — unsharp without lineDash so the symbol reads
+    // as a single solid mark instead of picking up the dash pattern.
+    if (drew > 0) {
+      ctx.setLineDash([]);
+      ctx.globalAlpha = 0.6;
+      ctx.fillStyle = color;
+      ctx.font = '10px system-ui, sans-serif';
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      for (const d of delegations) {
+        const srcY = rowCenterY.get(d.fromAgentId);
+        const tgtY = rowCenterY.get(d.toAgentId);
+        if (srcY === undefined || tgtY === undefined) continue;
+        const x = msToPx(this.viewport, w, d.observedAtMs);
+        if (x < dataLeft || x > dataRight) continue;
+        // Midpoint of a bezier with equal-x endpoints and offset control
+        // points collapses to (x + 3/4 * offset, (srcY+tgtY)/2). Hand-fit
+        // so the glyph clears the curve's crest.
+        ctx.fillText('↪↪', x + 4, (srcY + tgtY) / 2);
+      }
     }
     ctx.restore();
   }

--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -295,15 +295,32 @@ export function applyGoldfiveEvent(
     case 'conversationStarted':
     case 'conversationEnded':
       return;
-    // goldfive 2986775+ registry-dispatch events. Deliberately no-op for
-    // now: the existing HarmonografTelemetryPlugin already emits per-agent
-    // invocation spans, so the Gantt / Trajectory don't need these.
-    // A follow-up can wire agentInvocationStarted/Completed → span
-    // enrichment and delegationObserved → Gantt edges if the observability
-    // plugin path turns out to miss something.
+    // goldfive 2986775+ registry-dispatch events. agentInvocationStarted /
+    // agentInvocationCompleted remain deliberate no-ops: the existing
+    // HarmonografTelemetryPlugin already emits per-agent INVOCATION spans,
+    // so Gantt / Trajectory see those invocations without duplication.
     case 'agentInvocationStarted':
     case 'agentInvocationCompleted':
-    case 'delegationObserved':
       return;
+    case 'delegationObserved': {
+      // DelegationObserved carries the coordinator→sub_agent edge that the
+      // telemetry plugin only records as a generic TOOL_CALL span on the
+      // coordinator row. Feed the registry; the Gantt renderer's delegation
+      // edge pass synthesizes a cross-agent curve from each record.
+      const d = payload.value;
+      const observedMs = event.emittedAt
+        ? Number(event.emittedAt.seconds) * 1000 +
+          Math.floor(event.emittedAt.nanos / 1_000_000) -
+          sessionStartMs
+        : 0;
+      store.delegations.append({
+        fromAgentId: d.fromAgent,
+        toAgentId: d.toAgent,
+        taskId: d.taskId,
+        invocationId: d.invocationId,
+        observedAtMs: observedMs,
+      });
+      return;
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Wire goldfive's new `DelegationObserved` event into the frontend. `agentInvocationStarted` / `agentInvocationCompleted` remain no-ops because `HarmonografTelemetryPlugin` already emits an `INVOCATION` span per agent invocation; the delegation event, by contrast, carries information the telemetry plugin's generic `TOOL_CALL` span cannot (specifically, which agent row is on the receiving end), so it drives a new render pass.
- New `DelegationRegistry` on `SessionStore` (shape mirrors `DriftRegistry`): `append()` / `list()` / `clear()` / `subscribe()`. Wired into `SessionStore.clear()`.
- Dispatch in `rpc/goldfiveEvent.ts` appends one `DelegationRecord` per event, computing `observedAtMs` from `event.emittedAt` - `sessionStartMs` (same pattern as `driftDetected`).
- Gantt renderer adds `drawDelegations()` — dashed, 30% opacity bezier in goldfive-actor cyan (`#80deea`) from the `fromAgent` row-center to the `toAgent` row-center at `observedAtMs`, with a `↪↪` midpoint glyph. Subscribes the renderer's `blocksDirty` flag to the new registry so edges repaint on arrival.
- Trajectory DAG annotates task cards that saw at least one delegation with a faint "↪↪ delegated to: X" line under the title.
- Docs: `docs/user-guide/gantt-view.md` gets a short "Delegation edges" subsection under Cross-agent edges. `docs/design/10-frontend-architecture.md` gets a new §8 describing the registry + render path.

## Test plan

- [x] `pnpm test` — 205 passing (12 new: 8 in `gantt/delegations.test.ts` for the registry itself, 4 in `rpc/goldfiveEvent.test.ts` covering `delegationObserved` dispatch semantics plus the two no-op cases).
- [x] `pnpm lint` — clean.
- [x] `pnpm exec tsc -b` — clean (no `typecheck` script, but `build` runs tsc).
- [x] `make test` — server (254 + 1 skipped), client (167), frontend build + lint all green.
- [ ] Visual verification against a live orchestrator session — coordinator-to-sub_agent edges render as intended during next smoke test.

## Notes

- `agentInvocationStarted/Completed` remain deliberate no-ops; the in-code comment has been updated to reflect the rationale (redundant with the telemetry plugin's INVOCATION spans).
- No changes to server, client, or `uv.lock`. Frontend + docs only.