### PR TITLE
Delegation edges: hover tooltip + click hit-testing

### DIFF
--- a/frontend/src/__tests__/components/DelegationTooltip.test.tsx
+++ b/frontend/src/__tests__/components/DelegationTooltip.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DelegationTooltip } from '../../components/DelegationTooltip/DelegationTooltip';
+import type { DelegationRecord } from '../../gantt/index';
+
+function mkRecord(overrides: Partial<DelegationRecord> = {}): DelegationRecord {
+  return {
+    seq: 0,
+    fromAgentId: 'coordinator_agent',
+    toAgentId: 'research_agent',
+    taskId: 't-research-weather-bologna',
+    invocationId: 'inv-abc12345-def67890-0000',
+    observedAtMs: 185_000, // 3:05
+    ...overrides,
+  };
+}
+
+describe('DelegationTooltip', () => {
+  it('renders header + all four lines with labelled fields', () => {
+    render(
+      <DelegationTooltip
+        hover={{ record: mkRecord(), x: 100, y: 100 }}
+        resolveAgentLabel={(id) => id}
+      />,
+    );
+    const tip = screen.getByTestId('delegation-tooltip');
+    expect(tip).toHaveTextContent('Delegation observed');
+    expect(screen.getByTestId('delegation-tooltip-agents')).toHaveTextContent(
+      'From: coordinator_agent → research_agent',
+    );
+    expect(screen.getByTestId('delegation-tooltip-task')).toHaveTextContent(
+      'Task: t-research-weather-bologna',
+    );
+    expect(
+      screen.getByTestId('delegation-tooltip-invocation'),
+    ).toHaveTextContent('Invocation: abc12345…');
+    expect(screen.getByTestId('delegation-tooltip-observed')).toHaveTextContent(
+      'Observed: 3:05',
+    );
+  });
+
+  it('applies resolveAgentLabel to synthetic actor ids', () => {
+    const resolveAgentLabel = (id: string): string => {
+      if (id === '__goldfive__') return 'goldfive';
+      if (id === 'coord_X') return 'Coordinator X';
+      return id;
+    };
+    render(
+      <DelegationTooltip
+        hover={{
+          record: mkRecord({ fromAgentId: 'coord_X', toAgentId: '__goldfive__' }),
+          x: 0,
+          y: 0,
+        }}
+        resolveAgentLabel={resolveAgentLabel}
+      />,
+    );
+    expect(screen.getByTestId('delegation-tooltip-agents')).toHaveTextContent(
+      'From: Coordinator X → goldfive',
+    );
+  });
+
+  it('omits the Task line when the record has no taskId', () => {
+    render(
+      <DelegationTooltip
+        hover={{ record: mkRecord({ taskId: '' }), x: 0, y: 0 }}
+        resolveAgentLabel={(id) => id}
+      />,
+    );
+    expect(screen.queryByTestId('delegation-tooltip-task')).toBeNull();
+  });
+
+  it('renders the full invocation tail when it is already short', () => {
+    render(
+      <DelegationTooltip
+        hover={{
+          record: mkRecord({ invocationId: 'inv-xy42' }),
+          x: 0,
+          y: 0,
+        }}
+        resolveAgentLabel={(id) => id}
+      />,
+    );
+    expect(
+      screen.getByTestId('delegation-tooltip-invocation'),
+    ).toHaveTextContent('Invocation: xy42');
+  });
+
+  it('anchors the tooltip near the pointer via inline left/top styles', () => {
+    render(
+      <DelegationTooltip
+        hover={{ record: mkRecord(), x: 250, y: 400 }}
+        resolveAgentLabel={(id) => id}
+      />,
+    );
+    const tip = screen.getByTestId('delegation-tooltip');
+    expect(tip.style.left).toBe('262px'); // 250 + 12 offset
+    expect(Number(tip.style.top.replace('px', ''))).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/frontend/src/__tests__/gantt/delegationHitTest.test.ts
+++ b/frontend/src/__tests__/gantt/delegationHitTest.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SessionStore } from '../../gantt/index';
+import type { DelegationRecord } from '../../gantt/index';
+import { GanttRenderer } from '../../gantt/renderer';
+
+// The hit-test depends only on DelegationEdgeLayout geometry + pointer
+// coordinates. We don't exercise the full draw pipeline (jsdom has no
+// canvas 2D context); instead, we seed known layouts via the renderer's
+// _seedDelegationLayoutsForTesting shim and assert the hit-test returns
+// the expected record for points-near-bezier and null for far points.
+//
+// Geometry under test — bezier P0..P3 matching drawDelegations():
+//   P0 = (x, srcY)
+//   P1 = (x + off, srcY)
+//   P2 = (x + off, tgtY)
+//   P3 = (x, tgtY)
+// For (x=500, srcY=100, tgtY=200, off=24), the midpoint of the curve
+// evaluates to roughly (518, 150). Points within ~6px of any sampled
+// segment should hit; points far from the curve should miss.
+
+function mkRecord(
+  seq: number,
+  overrides: Partial<DelegationRecord> = {},
+): DelegationRecord {
+  return {
+    seq,
+    fromAgentId: 'coord',
+    toAgentId: `sub_${seq}`,
+    taskId: `t-${seq}`,
+    invocationId: `inv-${seq}`,
+    observedAtMs: 1000 * (seq + 1),
+    ...overrides,
+  };
+}
+
+function mkRenderer(): GanttRenderer {
+  return new GanttRenderer(new SessionStore());
+}
+
+describe('GanttRenderer.hitTestDelegation', () => {
+  it('returns null when no delegation layouts are cached', () => {
+    const r = mkRenderer();
+    expect(r.hitTestDelegation(500, 150)).toBeNull();
+  });
+
+  it('hits a point lying on the curve midpoint', () => {
+    const r = mkRenderer();
+    const rec = mkRecord(0);
+    r._seedDelegationLayoutsForTesting([
+      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+    ]);
+    // Midpoint of the bezier is at (x + 3/4 * off, (srcY+tgtY)/2) = (518, 150).
+    expect(r.hitTestDelegation(518, 150)).toBe(rec);
+  });
+
+  it('hits a point near an endpoint', () => {
+    const r = mkRenderer();
+    const rec = mkRecord(0);
+    r._seedDelegationLayoutsForTesting([
+      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+    ]);
+    // A tolerance of 6px means (501, 101) sits on the source-anchor region.
+    expect(r.hitTestDelegation(501, 101)).toBe(rec);
+    expect(r.hitTestDelegation(501, 199)).toBe(rec);
+  });
+
+  it('misses when the pointer is far from every curve', () => {
+    const r = mkRenderer();
+    const rec = mkRecord(0);
+    r._seedDelegationLayoutsForTesting([
+      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+    ]);
+    // Point well outside the bezier's bounding bump.
+    expect(r.hitTestDelegation(100, 100)).toBeNull();
+    // Same-y as the source but off to the right of the curve's rightmost x.
+    expect(r.hitTestDelegation(600, 100)).toBeNull();
+  });
+
+  it('returns the most recent record when multiple curves overlap', () => {
+    const r = mkRenderer();
+    const older = mkRecord(0);
+    const newer = mkRecord(1);
+    // Two edges sharing the same geometry — the back-to-front walk in
+    // hitTestDelegation must return the `newer` one since it was appended
+    // later in the Registry's array.
+    r._seedDelegationLayoutsForTesting([
+      { seq: older.seq, record: older, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: newer.seq, record: newer, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+    ]);
+    expect(r.hitTestDelegation(518, 150)).toBe(newer);
+  });
+
+  it('bbox-rejects points outside the curve envelope without sampling', () => {
+    const r = mkRenderer();
+    const rec = mkRecord(0);
+    r._seedDelegationLayoutsForTesting([
+      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+    ]);
+    // x > x + off + tol (≈ 530): out of bbox.
+    expect(r.hitTestDelegation(540, 150)).toBeNull();
+    // y < srcY - tol (≈ 94): out of bbox.
+    expect(r.hitTestDelegation(510, 50)).toBeNull();
+  });
+
+  it('picks the correct record when two edges are near each other', () => {
+    const r = mkRenderer();
+    const a = mkRecord(0);
+    const b = mkRecord(1);
+    r._seedDelegationLayoutsForTesting([
+      { seq: a.seq, record: a, x: 200, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: b.seq, record: b, x: 400, srcY: 300, tgtY: 400, curveOffset: 24 },
+    ]);
+    expect(r.hitTestDelegation(218, 150)).toBe(a);
+    expect(r.hitTestDelegation(418, 350)).toBe(b);
+    // Midway between the two edges — far from both curves.
+    expect(r.hitTestDelegation(300, 250)).toBeNull();
+  });
+});
+
+describe('GanttRenderer delegation hover/click callbacks', () => {
+  it('emits onDelegationClick when a click lands on a cached edge', () => {
+    const store = new SessionStore();
+    const onDelegationClick = vi.fn();
+    const r = new GanttRenderer(store, { onDelegationClick });
+    const rec = mkRecord(0);
+    r._seedDelegationLayoutsForTesting([
+      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+    ]);
+    r.handleClick(518, 150);
+    expect(onDelegationClick).toHaveBeenCalledTimes(1);
+    expect(onDelegationClick.mock.calls[0][0]).toBe(rec);
+  });
+
+  it('emits onDelegationHoverChange when a pointer moves onto + off an edge', () => {
+    const store = new SessionStore();
+    const onDelegationHoverChange = vi.fn();
+    const r = new GanttRenderer(store, { onDelegationHoverChange });
+    const rec = mkRecord(0);
+    r._seedDelegationLayoutsForTesting([
+      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+    ]);
+    r.handlePointerMove(518, 150);
+    r.handlePointerMove(100, 100);
+    const calls = onDelegationHoverChange.mock.calls;
+    // First call: hover on; record is the injected one.
+    expect(calls[0][0]?.record).toBe(rec);
+    // Final call: hover cleared → null.
+    expect(calls[calls.length - 1][0]).toBeNull();
+  });
+
+  it('does not fire onDelegationClick for clicks off every edge', () => {
+    const store = new SessionStore();
+    const onDelegationClick = vi.fn();
+    const r = new GanttRenderer(store, { onDelegationClick });
+    const rec = mkRecord(0);
+    r._seedDelegationLayoutsForTesting([
+      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+    ]);
+    r.handleClick(100, 100);
+    expect(onDelegationClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/DelegationTooltip/DelegationTooltip.tsx
+++ b/frontend/src/components/DelegationTooltip/DelegationTooltip.tsx
@@ -1,0 +1,86 @@
+import type { DelegationHoverState } from '../../gantt/renderer';
+
+// Small tooltip anchored to the pointer when the user hovers a dashed
+// delegation-edge bezier on the Gantt. Matches the span-hover tooltip
+// visually (same surface-container-highest background, padding, radius,
+// font) so the two chrome elements read as a coherent hover family.
+//
+// Kept as a standalone component so it can be rendered headlessly in unit
+// tests without needing a full GanttCanvas + renderer instance.
+
+interface Props {
+  hover: DelegationHoverState;
+  // Agents are keyed by id on the session; the Gantt shell resolves
+  // display labels (user/goldfive/agent.name/agentId fallback) so the
+  // tooltip itself stays display-agnostic. Pass a resolver instead of
+  // threading the whole SessionStore through.
+  resolveAgentLabel: (agentId: string) => string;
+}
+
+function fmtTime(ms: number): string {
+  // Match the m:ss formatter used by ActivityView / GraphView so every
+  // session-relative timestamp in chrome reads the same way.
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${m}:${r.toString().padStart(2, '0')}`;
+}
+
+function shortInvocation(id: string): string {
+  // ADK invocation ids look like `inv-<uuid>`; the first ~8 chars of the
+  // tail are enough to distinguish invocations within one session without
+  // bloating the tooltip width.
+  if (!id) return '(none)';
+  const tail = id.startsWith('inv-') ? id.slice(4) : id;
+  if (tail.length <= 8) return tail;
+  return `${tail.slice(0, 8)}…`;
+}
+
+export function DelegationTooltip({ hover, resolveAgentLabel }: Props) {
+  const { record, x, y } = hover;
+  const from = resolveAgentLabel(record.fromAgentId);
+  const to = resolveAgentLabel(record.toAgentId);
+  return (
+    <div
+      role="tooltip"
+      data-testid="delegation-tooltip"
+      style={{
+        position: 'absolute',
+        left: Math.min(x + 12, 9999),
+        top: Math.max(0, y - 74),
+        background: 'var(--md-sys-color-surface-container-highest, #31333c)',
+        color: 'var(--md-sys-color-on-surface, #e2e2e9)',
+        padding: '6px 10px',
+        borderRadius: 6,
+        pointerEvents: 'none',
+        fontSize: 12,
+        fontFamily: 'system-ui, sans-serif',
+        boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+        zIndex: 10,
+        maxWidth: 360,
+      }}
+    >
+      <div style={{ fontWeight: 600 }}>Delegation observed</div>
+      <div style={{ opacity: 0.85 }} data-testid="delegation-tooltip-agents">
+        From: {from} → {to}
+      </div>
+      {record.taskId && (
+        <div
+          style={{ opacity: 0.8, fontFamily: 'monospace', fontSize: 11 }}
+          data-testid="delegation-tooltip-task"
+        >
+          Task: {record.taskId}
+        </div>
+      )}
+      <div
+        style={{ opacity: 0.8, fontFamily: 'monospace', fontSize: 11 }}
+        data-testid="delegation-tooltip-invocation"
+      >
+        Invocation: {shortInvocation(record.invocationId)}
+      </div>
+      <div style={{ opacity: 0.7 }} data-testid="delegation-tooltip-observed">
+        Observed: {fmtTime(record.observedAtMs)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -685,6 +685,24 @@ function DagPane(props: DagProps) {
                     fontSize={10}
                     data-testid={`task-delegation-${t.id}`}
                   >
+                    {/* Native SVG tooltip — mirrors the Gantt delegation
+                     * tooltip's fields. Trajectory has no existing nav
+                     * pattern into the Gantt so we deliberately don't
+                     * synthesize one here; hover + readable summary is
+                     * the lightweight equivalent. */}
+                    <title>
+                      {`Delegation observed\nFrom: ${
+                        taskDelegations[0].fromAgentId
+                      } → ${taskDelegations[0].toAgentId}\nTask: ${
+                        taskDelegations[0].taskId || '(none)'
+                      }\nInvocation: ${
+                        taskDelegations[0].invocationId || '(none)'
+                      }${
+                        taskDelegations.length > 1
+                          ? `\n+${taskDelegations.length - 1} more`
+                          : ''
+                      }`}
+                    </title>
                     {`↪↪ delegated to: ${truncate(
                       taskDelegations[0].toAgentId,
                       14,

--- a/frontend/src/components/shell/views/views.css
+++ b/frontend/src/components/shell/views/views.css
@@ -472,12 +472,18 @@ a.hg-settings__value:hover {
 
 /* Delegation annotation: faint cyan line under the task card. Driven by
  * goldfive DelegationObserved events — see frontend/src/gantt/index.ts
- * DelegationRegistry. */
+ * DelegationRegistry. The inner <title> element gives the text a native
+ * browser tooltip on hover; we re-enable pointer-events just for that. */
 .hg-traj__node-delegation {
   fill: #80deea;
   font-size: 10px;
   opacity: 0.7;
-  pointer-events: none;
+  pointer-events: auto;
+  cursor: help;
+  transition: opacity 120ms ease-out;
+}
+.hg-traj__node-delegation:hover {
+  opacity: 1;
 }
 
 .hg-traj__removed {

--- a/frontend/src/gantt/GanttCanvas.tsx
+++ b/frontend/src/gantt/GanttCanvas.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { GanttRenderer, type HoverState } from './renderer';
+import { GanttRenderer, type DelegationHoverState, type HoverState } from './renderer';
 import type { SessionStore } from './index';
 import type { ContextWindowSample } from './types';
 import { formatTokens } from './contextOverlay';
@@ -7,6 +7,8 @@ import { useThemeStore } from '../theme/store';
 import { useUiStore } from '../state/uiStore';
 import { SpanContextMenu, type ContextMenuState } from '../components/Interaction/SpanContextMenu';
 import { usePopoverStore } from '../state/popoverStore';
+import { DelegationTooltip } from '../components/DelegationTooltip/DelegationTooltip';
+import { actorDisplayLabel } from '../theme/agentColors';
 
 interface ContextHover {
   agentId: string;
@@ -46,6 +48,7 @@ export function GanttCanvas({ store, height, renderOverlay }: Props) {
   const overlayRef = useRef<HTMLCanvasElement | null>(null);
 
   const [hover, setHover] = useState<HoverState | null>(null);
+  const [delegHover, setDelegHover] = useState<DelegationHoverState | null>(null);
   const [ctxHover, setCtxHover] = useState<ContextHover | null>(null);
   const [liveBroken, setLiveBroken] = useState(false);
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
@@ -98,6 +101,31 @@ export function GanttCanvas({ store, height, renderOverlay }: Props) {
           if (prev?.spanId === h?.spanId) return prev;
           return h;
         }),
+        onDelegationHoverChange: (h) =>
+          setDelegHover((prev) => {
+            // Fast path: same edge + negligible pointer motion → bail to
+            // avoid a React re-render per mouse event.
+            if (!prev && !h) return prev;
+            if (prev && h && prev.record.seq === h.record.seq) {
+              if (Math.abs(prev.x - h.x) < 2 && Math.abs(prev.y - h.y) < 2) {
+                return prev;
+              }
+            }
+            return h;
+          }),
+        onDelegationClick: (rec) => {
+          // Focus the to-agent row so the reader's eye snaps to where the
+          // delegated work lands. setFocusedAgent drives row expansion in
+          // the renderer via setActiveRenderer; no manual scroll needed
+          // because focused rows are tall enough to stand out within the
+          // existing viewport.
+          const ui = useUiStore.getState();
+          ui.setFocusedAgent(rec.toAgentId);
+          // Push through the active renderer so the canvas immediately
+          // reflects the focus (the renderer subscribes to nothing in
+          // uiStore; setFocusedAgent on renderer is an imperative call).
+          ui.activeRenderer?.focusAgent(rec.toAgentId);
+        },
         onGutterAgentClick: (agentId) => {
           useUiStore.getState().toggleAgentHidden(agentId);
         },
@@ -209,6 +237,15 @@ export function GanttCanvas({ store, height, renderOverlay }: Props) {
     const px = e.clientX - r.left;
     const py = e.clientY - r.top;
     renderer.handlePointerMove(px, py);
+    // Cursor: pointer when over anything clickable (span or delegation
+    // edge). Matches the implicit behavior spans already got through the
+    // overlay hover stroke.
+    const el = e.currentTarget;
+    if (renderer.spanAt(px, py) || renderer.delegationAt(px, py)) {
+      if (el.style.cursor !== 'pointer') el.style.cursor = 'pointer';
+    } else if (el.style.cursor === 'pointer') {
+      el.style.cursor = '';
+    }
     // Only resolve the context-window hover when the pointer is NOT over a
     // span rect — spans own the foreground tooltip, the band is background.
     if (contextOverlayVisible && !renderer.spanAt(px, py)) {
@@ -228,10 +265,12 @@ export function GanttCanvas({ store, height, renderOverlay }: Props) {
       setCtxHover(null);
     }
   };
-  const onLeave = () => {
+  const onLeave = (e: React.MouseEvent<HTMLDivElement>) => {
     renderer.handlePointerLeave();
     setHover(null);
+    setDelegHover(null);
     setCtxHover(null);
+    e.currentTarget.style.cursor = '';
   };
   const onContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -245,6 +284,12 @@ export function GanttCanvas({ store, height, renderOverlay }: Props) {
   };
 
   const span = hover ? store.spans.get(hover.spanId) : undefined;
+
+  const resolveDelegationAgentLabel = (agentId: string): string => {
+    const synthetic = actorDisplayLabel(agentId);
+    if (synthetic) return synthetic;
+    return store.agents.get(agentId)?.name ?? agentId;
+  };
 
   return (
     <div
@@ -323,6 +368,12 @@ export function GanttCanvas({ store, height, renderOverlay }: Props) {
             )}
           </div>
         </div>
+      )}
+      {delegHover && !hover && (
+        <DelegationTooltip
+          hover={delegHover}
+          resolveAgentLabel={resolveDelegationAgentLabel}
+        />
       )}
       {liveBroken && !store.nowMs ? null : liveBroken && (
         <button

--- a/frontend/src/gantt/renderer.ts
+++ b/frontend/src/gantt/renderer.ts
@@ -21,7 +21,7 @@ import {
   contextColorForRatio,
   contextRatio,
 } from './contextOverlay';
-import type { SessionStore } from './index';
+import type { DelegationRecord, SessionStore } from './index';
 import type { SpanIndex, DirtyRect } from './spatialIndex';
 import type { Agent, ContextWindowSample, Span, SpanKind, Task, TaskStatus } from './types';
 import {
@@ -52,6 +52,19 @@ export interface RendererCallbacks {
   // Fired when the user clicks inside the agent gutter on a specific agent
   // row. Used by the DOM layer to toggle agent row visibility.
   onGutterAgentClick?: (agentId: string) => void;
+  // Fired when the hovered delegation edge changes (null when the pointer
+  // moves off every edge). The DOM layer renders a tooltip from this state.
+  onDelegationHoverChange?: (hover: DelegationHoverState | null) => void;
+  // Fired when the user clicks a delegation edge (no span under the pointer).
+  // The DOM layer focuses the to-agent row and can emit a toast.
+  onDelegationClick?: (record: DelegationRecord) => void;
+}
+
+export interface DelegationHoverState {
+  record: DelegationRecord;
+  // Tooltip anchor in CSS pixels, relative to the canvas container.
+  x: number;
+  y: number;
 }
 
 // Collapsed height used for hidden agents — tall enough to stay clickable and
@@ -77,6 +90,22 @@ interface EdgeLayout {
   x2: number;
   y2: number;
   color: string;
+}
+
+// Cached layout for a single DelegationRecord edge, rebuilt each blocks
+// redraw. Persisted so the hit-test pass and the overlay pulse highlight
+// share one source of truth with the primary draw call and the bezier is
+// never sampled against stale control points.
+interface DelegationEdgeLayout {
+  seq: number;
+  record: DelegationRecord;
+  // Both endpoints sit at the same x (delegation is instantaneous), so we
+  // only store one x value and the two y anchors + the horizontal curve
+  // offset — the bezier is fully determined by these.
+  x: number;
+  srcY: number;
+  tgtY: number;
+  curveOffset: number;
 }
 
 interface FrameMetrics {
@@ -125,6 +154,19 @@ export class GanttRenderer {
   private hoveredSpanId: string | null = null;
   private edges: EdgeLayout[] = [];
   private hoveredEdgeIdx: number | null = null;
+
+  // Delegation-edge layouts cached by drawDelegations. Lookup keyed by seq
+  // so the hit-test can return the DelegationRecord directly and the overlay
+  // pulse pass can find the bezier geometry for the currently-pulsing edge
+  // without recomputing row positions.
+  private delegationEdges: DelegationEdgeLayout[] = [];
+  private hoveredDelegationSeq: number | null = null;
+  // When a delegation is clicked, its seq goes here and `pulseUntilMs`
+  // holds the wall-clock deadline; the overlay pass draws a bright stroke
+  // while inside the window and schedules another frame so the stroke
+  // fades on its own.
+  private pulsingDelegationSeq: number | null = null;
+  private pulseUntilMs = 0;
 
   // Dirty flags per layer.
   private bgDirty = true;
@@ -292,9 +334,27 @@ export class GanttRenderer {
       return;
     }
     const hit = this.hitTest(x, y);
-    this.selectedSpanId = hit;
+    if (hit) {
+      this.selectedSpanId = hit;
+      this.overlayDirty = true;
+      this.cb.onSelect?.(hit, x, y);
+      return;
+    }
+    // Spans win over delegation edges; only test the latter when no span
+    // sits under the pointer. This mirrors the hover precedence below.
+    const deleg = this.hitTestDelegation(x, y);
+    if (deleg) {
+      // Brief highlight on the clicked edge — pulse for ~500ms.
+      this.pulsingDelegationSeq = deleg.seq;
+      this.pulseUntilMs = performance.now() + 500;
+      this.overlayDirty = true;
+      this.cb.onDelegationClick?.(deleg);
+      return;
+    }
+    // Nothing under the pointer: clear span selection.
+    this.selectedSpanId = null;
     this.overlayDirty = true;
-    this.cb.onSelect?.(hit, x, y);
+    this.cb.onSelect?.(null, x, y);
   }
 
   private agentAtY(py: number): string | null {
@@ -333,6 +393,25 @@ export class GanttRenderer {
       this.hoveredEdgeIdx = edgeIdx;
       this.overlayDirty = true;
     }
+    // Delegation-edge hover: only when neither a span nor a LINK_INVOKED
+    // edge is under the cursor. The delegation hit-test is cheap (16
+    // samples × ≤ N delegations) so we can run it every move without
+    // throttling.
+    const delegHit =
+      hit || edgeIdx !== null ? null : this.hitTestDelegation(x, y);
+    const nextSeq = delegHit?.seq ?? null;
+    if (nextSeq !== this.hoveredDelegationSeq) {
+      this.hoveredDelegationSeq = nextSeq;
+      this.overlayDirty = true;
+      this.cb.onDelegationHoverChange?.(
+        delegHit ? { record: delegHit, x, y } : null,
+      );
+    } else if (delegHit) {
+      // Seq unchanged but pointer moved — update anchor so the DOM tooltip
+      // tracks the cursor. Omit the overlay-dirty flag; anchor-only updates
+      // don't change the canvas.
+      this.cb.onDelegationHoverChange?.({ record: delegHit, x, y });
+    }
   }
 
   handlePointerLeave(): void {
@@ -345,6 +424,22 @@ export class GanttRenderer {
       this.hoveredEdgeIdx = null;
       this.overlayDirty = true;
     }
+    if (this.hoveredDelegationSeq !== null) {
+      this.hoveredDelegationSeq = null;
+      this.overlayDirty = true;
+      this.cb.onDelegationHoverChange?.(null);
+    }
+  }
+
+  // DOM layer asks whether a pointer coordinate sits on a delegation edge so
+  // it can drive the cursor: the canvas CSS cursor swaps to pointer when
+  // over a delegation, same as for span rects.
+  delegationAt(x: number, y: number): DelegationRecord | null {
+    // Respect the same precedence as the hover path — spans and
+    // LINK_INVOKED edges win.
+    if (this.hitTest(x, y)) return null;
+    if (this.edgeHitTest(x, y) !== null) return null;
+    return this.hitTestDelegation(x, y);
   }
 
   panBy(fraction: number): void {
@@ -1049,6 +1144,9 @@ export class GanttRenderer {
   // midpoint glyph keep them readable against the denser TRANSFER edges
   // the plugin span path produces.
   private drawDelegations(ctx: CanvasRenderingContext2D): void {
+    // Rebuild the layout cache each pass — viewport changes, row-focus
+    // toggles, and agent-hide state all move delegation anchors around.
+    this.delegationEdges = [];
     const delegations = this.store.delegations.list();
     if (delegations.length === 0) return;
     const vs = viewportStart(this.viewport);
@@ -1072,13 +1170,8 @@ export class GanttRenderer {
     // goldfive observed the delegation — color matches the synthetic
     // goldfive actor row so the attribution reads the same everywhere.
     const color = colorForAgent(GOLDFIVE_ACTOR_ID);
+    const curveOffset = 24;
 
-    ctx.save();
-    ctx.lineWidth = 1.25;
-    ctx.globalAlpha = 0.3;
-    ctx.setLineDash([4, 3]);
-    ctx.strokeStyle = color;
-    let drew = 0;
     for (const d of delegations) {
       // Cull to the visible time window (with a small pad for endpoints
       // sitting just off-edge). Consistent with drawLinks' margin approach.
@@ -1091,43 +1184,129 @@ export class GanttRenderer {
       if (srcY === undefined || tgtY === undefined) continue;
       const x = msToPx(this.viewport, w, d.observedAtMs);
       if (x < dataLeft || x > dataRight) continue;
+      this.delegationEdges.push({
+        seq: d.seq,
+        record: d,
+        x,
+        srcY,
+        tgtY,
+        curveOffset,
+      });
+    }
+
+    if (this.delegationEdges.length === 0) return;
+
+    ctx.save();
+    ctx.lineWidth = 1.25;
+    ctx.globalAlpha = 0.3;
+    ctx.setLineDash([4, 3]);
+    ctx.strokeStyle = color;
+    for (const e of this.delegationEdges) {
       // Same-time, different-row edge: draw a shallow curve so the path
       // doesn't collapse into a zero-width vertical line. Offset the
       // control points horizontally by a fixed nudge.
-      const curveOffset = 24;
       ctx.beginPath();
-      ctx.moveTo(x, srcY);
+      ctx.moveTo(e.x, e.srcY);
       ctx.bezierCurveTo(
-        x + curveOffset, srcY,
-        x + curveOffset, tgtY,
-        x, tgtY,
+        e.x + e.curveOffset, e.srcY,
+        e.x + e.curveOffset, e.tgtY,
+        e.x, e.tgtY,
       );
       ctx.stroke();
-      drew++;
     }
 
     // Midpoint glyph pass — unsharp without lineDash so the symbol reads
     // as a single solid mark instead of picking up the dash pattern.
-    if (drew > 0) {
-      ctx.setLineDash([]);
-      ctx.globalAlpha = 0.6;
-      ctx.fillStyle = color;
-      ctx.font = '10px system-ui, sans-serif';
-      ctx.textAlign = 'left';
-      ctx.textBaseline = 'middle';
-      for (const d of delegations) {
-        const srcY = rowCenterY.get(d.fromAgentId);
-        const tgtY = rowCenterY.get(d.toAgentId);
-        if (srcY === undefined || tgtY === undefined) continue;
-        const x = msToPx(this.viewport, w, d.observedAtMs);
-        if (x < dataLeft || x > dataRight) continue;
-        // Midpoint of a bezier with equal-x endpoints and offset control
-        // points collapses to (x + 3/4 * offset, (srcY+tgtY)/2). Hand-fit
-        // so the glyph clears the curve's crest.
-        ctx.fillText('↪↪', x + 4, (srcY + tgtY) / 2);
-      }
+    ctx.setLineDash([]);
+    ctx.globalAlpha = 0.6;
+    ctx.fillStyle = color;
+    ctx.font = '10px system-ui, sans-serif';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    for (const e of this.delegationEdges) {
+      // Midpoint of a bezier with equal-x endpoints and offset control
+      // points collapses to (x + 3/4 * offset, (srcY+tgtY)/2). Hand-fit
+      // so the glyph clears the curve's crest.
+      ctx.fillText('↪↪', e.x + 4, (e.srcY + e.tgtY) / 2);
     }
     ctx.restore();
+  }
+
+  // --- Delegation edge hit-testing / hover / click ---------------------
+  //
+  // Public for the __tests__ suite — the DOM path uses
+  // handlePointerMove / handleClick, which route to this internally.
+  //
+  // Samples the bezier at a coarse step and does a per-segment point-to-line
+  // distance check. The curve geometry is fully captured by the cached
+  // DelegationEdgeLayout entries so this never touches the SessionStore.
+  hitTestDelegation(px: number, py: number): DelegationRecord | null {
+    const edges = this.delegationEdges;
+    if (edges.length === 0) return null;
+    const tol = 6; // CSS px — slightly looser than LINK_INVOKED (5) since
+    //              the delegation curve is thinner (lineWidth 1.25 and
+    //              30% alpha) and harder to target precisely.
+    const samples = 16;
+    // Walk back-to-front so the latest delegation wins when curves overlap.
+    for (let i = edges.length - 1; i >= 0; i--) {
+      const e = edges[i];
+      // Quick bbox reject. The curve hugs x..x+curveOffset in the x-axis;
+      // y is bounded by the two anchors, padded for rounding.
+      const minX = e.x - tol;
+      const maxX = e.x + e.curveOffset + tol;
+      const minY = Math.min(e.srcY, e.tgtY) - tol;
+      const maxY = Math.max(e.srcY, e.tgtY) + tol;
+      if (px < minX || px > maxX || py < minY || py > maxY) continue;
+      // Bezier coefficients for the curve drawn in drawDelegations:
+      //   P0 = (x, srcY)
+      //   P1 = (x + off, srcY)
+      //   P2 = (x + off, tgtY)
+      //   P3 = (x, tgtY)
+      const x0 = e.x;
+      const y0 = e.srcY;
+      const x1 = e.x + e.curveOffset;
+      const y1 = e.srcY;
+      const x2 = e.x + e.curveOffset;
+      const y2 = e.tgtY;
+      const x3 = e.x;
+      const y3 = e.tgtY;
+      let prevX = x0;
+      let prevY = y0;
+      for (let j = 1; j <= samples; j++) {
+        const t = j / samples;
+        const mt = 1 - t;
+        const sx =
+          mt * mt * mt * x0 +
+          3 * mt * mt * t * x1 +
+          3 * mt * t * t * x2 +
+          t * t * t * x3;
+        const sy =
+          mt * mt * mt * y0 +
+          3 * mt * mt * t * y1 +
+          3 * mt * t * t * y2 +
+          t * t * t * y3;
+        if (pointSegmentDist(px, py, prevX, prevY, sx, sy) <= tol) {
+          return e.record;
+        }
+        prevX = sx;
+        prevY = sy;
+      }
+    }
+    return null;
+  }
+
+  // Test-only accessor so unit tests can assert the cached layout without
+  // poking into private state. The array is rebuilt each blocks redraw.
+  _delegationLayoutsForTesting(): readonly DelegationEdgeLayout[] {
+    return this.delegationEdges;
+  }
+
+  // Test-only seed path. drawBlocks populates delegationEdges as a side
+  // effect of drawing — and drawing can't run under jsdom since the
+  // canvas 2D context is a stub. Tests inject known geometry directly
+  // through this shim so hitTestDelegation can be exercised in isolation.
+  _seedDelegationLayoutsForTesting(edges: DelegationEdgeLayout[]): void {
+    this.delegationEdges = edges;
   }
 
   // --- Context-window overlay -------------------------------------------
@@ -1607,6 +1786,73 @@ export class GanttRenderer {
         ctx.lineWidth = 2;
         ctx.strokeRect(rect.x - 1, rect.y - 1, rect.w + 2, rect.h + 2);
       }
+    }
+
+    // Delegation-edge hover / pulse highlight. Two states:
+    //   - hover: bright dashed stroke matching the canonical delegation
+    //     color so the cursor can rest on the edge and read clearly.
+    //   - pulse: 500ms solid stroke after a click; fades to 0 at deadline.
+    // The pulse is self-scheduling — as long as `performance.now() <
+    // pulseUntilMs` we keep the overlay dirty so the frame loop repaints.
+    const nowMs = performance.now();
+    const pulseActive =
+      this.pulsingDelegationSeq !== null && nowMs < this.pulseUntilMs;
+    if (pulseActive || this.hoveredDelegationSeq !== null) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(GUTTER_WIDTH_PX, TOP_MARGIN_PX, w - GUTTER_WIDTH_PX, h - TOP_MARGIN_PX);
+      ctx.clip();
+      const color = cssVar('--md-sys-color-primary') || '#a8c8ff';
+      // Hover first, so a pulse on the currently-hovered edge overwrites
+      // it with the brighter solid stroke.
+      if (this.hoveredDelegationSeq !== null) {
+        const e = this.delegationEdges.find(
+          (d) => d.seq === this.hoveredDelegationSeq,
+        );
+        if (e) {
+          ctx.strokeStyle = color;
+          ctx.globalAlpha = 0.85;
+          ctx.lineWidth = 2;
+          ctx.setLineDash([4, 3]);
+          ctx.beginPath();
+          ctx.moveTo(e.x, e.srcY);
+          ctx.bezierCurveTo(
+            e.x + e.curveOffset, e.srcY,
+            e.x + e.curveOffset, e.tgtY,
+            e.x, e.tgtY,
+          );
+          ctx.stroke();
+        }
+      }
+      if (pulseActive) {
+        const e = this.delegationEdges.find(
+          (d) => d.seq === this.pulsingDelegationSeq,
+        );
+        if (e) {
+          const remaining = Math.max(0, this.pulseUntilMs - nowMs);
+          const fade = remaining / 500; // 1 → 0 across 500ms.
+          ctx.strokeStyle = color;
+          ctx.globalAlpha = 0.3 + 0.7 * fade;
+          ctx.lineWidth = 2.5 + 2 * fade;
+          ctx.setLineDash([]);
+          ctx.beginPath();
+          ctx.moveTo(e.x, e.srcY);
+          ctx.bezierCurveTo(
+            e.x + e.curveOffset, e.srcY,
+            e.x + e.curveOffset, e.tgtY,
+            e.x, e.tgtY,
+          );
+          ctx.stroke();
+        }
+        // Keep asking for more frames until the deadline passes so the
+        // pulse runs to completion regardless of user interaction.
+        this.overlayDirty = true;
+      } else if (this.pulsingDelegationSeq !== null) {
+        // Expired — drop state so the overlay doesn't keep marking itself
+        // dirty forever.
+        this.pulsingDelegationSeq = null;
+      }
+      ctx.restore();
     }
 
     // Edge hover highlight: brighten the curve + both endpoint rectangles so


### PR DESCRIPTION
## Summary

- Close the interactivity gap PR #50 left for dashed cyan delegation edges: the bezier now hit-tests under the pointer, hovers render a tooltip, and clicks focus the to-agent row and pulse the edge for ~500ms.
- The Trajectory DAG's `↪↪ delegated to: X` annotation gains a native SVG tooltip + cursor:help hover, matching the Gantt tooltip fields without inventing a new Trajectory → Gantt nav pattern.

## Scope

- Renderer caches `DelegationEdgeLayout` geometry in `drawDelegations()` so hit-test, overlay hover, and pulse repaint share one source of truth with the primary draw call (no re-sampling against stale control points).
- `hitTestDelegation(x, y)` samples the cubic at 16 points with a 6px tolerance; hover precedence is `span > link-invoked edge > delegation edge`, consistent with the existing `edgeHitTest` guard.
- New `DelegationTooltip` component renders the hover body (`From → To`, `Task`, shortened `Invocation`, `Observed`), styled to match the existing span-hover tooltip (same surface-container-highest background, radius, padding, font).
- Click on a delegation edge calls `uiStore.setFocusedAgent(toAgentId)` + `renderer.focusAgent(...)` and triggers a self-scheduling 500ms pulse in the overlay pass.
- Trajectory DAG: the existing `.hg-traj__node-delegation` text now has pointer-events enabled, a `cursor:help`, a hover-to-full-opacity transition, and an inline `<title>` with the same fields as the Gantt tooltip.

## Test plan

- [x] `cd frontend && npx vitest run` — 220 passing (+15 new across `delegationHitTest.test.ts` and `DelegationTooltip.test.tsx`): hit-test geometry (midpoint, endpoints, far misses, bbox reject, overlap precedence, multi-edge disambiguation), callback emission (`onDelegationClick`, `onDelegationHoverChange`, click-on-empty area), and tooltip DOM (header, labelled fields, resolveAgentLabel for synthetic actors, omitted empty task, short-invocation fallback, pointer-anchor styling).
- [x] `npx tsc -b` clean.
- [x] `npx eslint .` clean.
- [ ] **End-to-end browser-use validation deferred** due to a pre-existing server-side gap outside this PR's scope. See below.

## Notes on browser-use validation

Attempted the Option C path from the task brief: a standalone Python driver (`/tmp/delegation_validator.py`) boots the harmonograf server + vite, connects two `harmonograf_client.Client`s in one session (coordinator + research), emits a `TOOL_CALL` span + `LLM_CALL` span, then publishes two `goldfive.v1.Event` messages with `delegation_observed` payloads via `Client.emit_goldfive_event`.

**Outcome:** the client ships the events and the server accepts them on the ingest stream, but no delegation edges render in the UI. Root cause: `server/harmonograf_server/ingest.py::_handle_goldfive_event` dispatches `plan_submitted`, `task_started`, `drift_detected`, etc. but has no case for `delegation_observed` (nor `agent_invocation_started` / `agent_invocation_completed`). Unknown payload variants fall through to `else: logger.debug("ignoring unknown goldfive event payload kind=%s", kind)` and never publish to the frontend bus, so `WatchSession` subscribers never see them.

This is a pre-existing server gap, not something introduced by PR #50 or this PR — the frontend `applyGoldfiveEvent` handler for `delegationObserved` is already wired and covered by `src/__tests__/rpc/goldfiveEvent.test.ts`. Per the task-brief constraint ("Frontend-only + possibly docs. Do NOT touch server/ or client/"), I documented the gap here rather than fixing it. Unit-level coverage (`delegationHitTest.test.ts` exercises `handlePointerMove` / `handleClick` with seeded layouts; `DelegationTooltip.test.tsx` exercises the DOM) replaces what browser-use would have asserted.

Follow-up: add the missing server cases + bus fan-out (single ~40 LoC diff in `server/harmonograf_server/ingest.py`); once that ships, the browser-use flow in `/tmp/delegation_validator.py` should light up the edges, tooltip, and click focus end-to-end without frontend changes.

## Files touched

- Code: `frontend/src/gantt/renderer.ts`, `frontend/src/gantt/GanttCanvas.tsx`, `frontend/src/components/DelegationTooltip/DelegationTooltip.tsx` (new), `frontend/src/components/shell/views/TrajectoryView.tsx`, `frontend/src/components/shell/views/views.css`.
- Tests: `frontend/src/__tests__/gantt/delegationHitTest.test.ts` (new, 10 tests), `frontend/src/__tests__/components/DelegationTooltip.test.tsx` (new, 5 tests).