### PR TITLE
Forward new goldfive event variants through server ingest to UI

### DIFF
--- a/server/harmonograf_server/bus.py
+++ b/server/harmonograf_server/bus.py
@@ -41,6 +41,12 @@ DELTA_RUN_ABORTED = "run_aborted"
 DELTA_GOAL_DERIVED = "goal_derived"
 DELTA_DRIFT = "drift"
 DELTA_TASK_PROGRESS = "task_progress"
+# Registry-dispatch observability events (goldfive 2986775+). Observability
+# only: the server doesn't mutate state for these, just forwards them so
+# the frontend can render delegation edges and per-invocation rows.
+DELTA_AGENT_INVOCATION_STARTED = "agent_invocation_started"
+DELTA_AGENT_INVOCATION_COMPLETED = "agent_invocation_completed"
+DELTA_DELEGATION_OBSERVED = "delegation_observed"
 
 
 @dataclass
@@ -334,6 +340,84 @@ class SessionBus:
                     "task_id": task_id,
                     "fraction": fraction,
                     "detail": detail,
+                },
+            )
+        )
+
+    def publish_agent_invocation_started(
+        self,
+        session_id: str,
+        run_id: str,
+        *,
+        agent_name: str,
+        task_id: str = "",
+        invocation_id: str = "",
+        parent_invocation_id: str = "",
+        started_at: Optional[float] = None,
+    ) -> None:
+        self.publish(
+            Delta(
+                session_id,
+                DELTA_AGENT_INVOCATION_STARTED,
+                {
+                    "run_id": run_id,
+                    "agent_name": agent_name,
+                    "task_id": task_id,
+                    "invocation_id": invocation_id,
+                    "parent_invocation_id": parent_invocation_id,
+                    "started_at": started_at,
+                },
+            )
+        )
+
+    def publish_agent_invocation_completed(
+        self,
+        session_id: str,
+        run_id: str,
+        *,
+        agent_name: str,
+        task_id: str = "",
+        invocation_id: str = "",
+        summary: str = "",
+        completed_at: Optional[float] = None,
+    ) -> None:
+        self.publish(
+            Delta(
+                session_id,
+                DELTA_AGENT_INVOCATION_COMPLETED,
+                {
+                    "run_id": run_id,
+                    "agent_name": agent_name,
+                    "task_id": task_id,
+                    "invocation_id": invocation_id,
+                    "summary": summary,
+                    "completed_at": completed_at,
+                },
+            )
+        )
+
+    def publish_delegation_observed(
+        self,
+        session_id: str,
+        run_id: str,
+        *,
+        from_agent: str,
+        to_agent: str,
+        task_id: str = "",
+        invocation_id: str = "",
+        observed_at: Optional[float] = None,
+    ) -> None:
+        self.publish(
+            Delta(
+                session_id,
+                DELTA_DELEGATION_OBSERVED,
+                {
+                    "run_id": run_id,
+                    "from_agent": from_agent,
+                    "to_agent": to_agent,
+                    "task_id": task_id,
+                    "invocation_id": invocation_id,
+                    "observed_at": observed_at,
                 },
             )
         )

--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -686,6 +686,16 @@ class IngestPipeline:
             self._on_run_completed(ctx, event.run_completed, run_id)
         elif kind == "run_aborted":
             self._on_run_aborted(ctx, event.run_aborted, run_id)
+        elif kind == "agent_invocation_started":
+            self._on_agent_invocation_started(
+                ctx, event.agent_invocation_started, run_id
+            )
+        elif kind == "agent_invocation_completed":
+            self._on_agent_invocation_completed(
+                ctx, event.agent_invocation_completed, run_id
+            )
+        elif kind == "delegation_observed":
+            self._on_delegation_observed(ctx, event.delegation_observed, run_id)
         else:
             logger.debug(
                 "ignoring unknown goldfive event payload kind=%s on session_id=%s",
@@ -931,6 +941,58 @@ class IngestPipeline:
     ) -> None:
         self._bus.publish_run_aborted(
             ctx.session_id, run_id, reason=payload.reason
+        )
+
+    # Registry-dispatch observability events (goldfive 2986775+). These are
+    # forward-only: no state machine side effects, just fan out on the bus
+    # so the frontend can render delegation edges / per-invocation rows
+    # that the telemetry-plugin INVOCATION spans alone don't capture.
+    def _on_agent_invocation_started(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        started_at: Optional[float] = None
+        if payload.HasField("started_at"):
+            started_at = ts_to_float(payload.started_at)
+        self._bus.publish_agent_invocation_started(
+            ctx.session_id,
+            run_id,
+            agent_name=payload.agent_name,
+            task_id=payload.task_id,
+            invocation_id=payload.invocation_id,
+            parent_invocation_id=payload.parent_invocation_id,
+            started_at=started_at,
+        )
+
+    def _on_agent_invocation_completed(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        completed_at: Optional[float] = None
+        if payload.HasField("completed_at"):
+            completed_at = ts_to_float(payload.completed_at)
+        self._bus.publish_agent_invocation_completed(
+            ctx.session_id,
+            run_id,
+            agent_name=payload.agent_name,
+            task_id=payload.task_id,
+            invocation_id=payload.invocation_id,
+            summary=payload.summary,
+            completed_at=completed_at,
+        )
+
+    def _on_delegation_observed(
+        self, ctx: StreamContext, payload: Any, run_id: str
+    ) -> None:
+        observed_at: Optional[float] = None
+        if payload.HasField("observed_at"):
+            observed_at = ts_to_float(payload.observed_at)
+        self._bus.publish_delegation_observed(
+            ctx.session_id,
+            run_id,
+            from_agent=payload.from_agent,
+            to_agent=payload.to_agent,
+            task_id=payload.task_id,
+            invocation_id=payload.invocation_id,
+            observed_at=observed_at,
         )
 
     async def _bind_task_to_span(

--- a/server/harmonograf_server/rpc/frontend.py
+++ b/server/harmonograf_server/rpc/frontend.py
@@ -21,10 +21,13 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from google.protobuf import timestamp_pb2
 
 from harmonograf_server.bus import (
+    DELTA_AGENT_INVOCATION_COMPLETED,
+    DELTA_AGENT_INVOCATION_STARTED,
     DELTA_AGENT_STATUS,
     DELTA_AGENT_UPSERT,
     DELTA_ANNOTATION,
     DELTA_BACKPRESSURE,
+    DELTA_DELEGATION_OBSERVED,
     DELTA_DRIFT,
     DELTA_GOAL_DERIVED,
     DELTA_HEARTBEAT,
@@ -827,6 +830,55 @@ def _delta_to_session_update(delta: Delta) -> Optional[frontend_pb2.SessionUpdat
         ev.task_progress.task_id = p.get("task_id", "") or ""
         ev.task_progress.fraction = float(p.get("fraction", 0.0) or 0.0)
         ev.task_progress.detail = p.get("detail", "") or ""
+        return frontend_pb2.SessionUpdate(goldfive_event=ev)
+    if delta.kind == DELTA_AGENT_INVOCATION_STARTED:
+        p = delta.payload
+        ev = goldfive_events_pb2.Event(run_id=p.get("run_id", ""))
+        ev.agent_invocation_started.agent_name = p.get("agent_name", "") or ""
+        ev.agent_invocation_started.task_id = p.get("task_id", "") or ""
+        ev.agent_invocation_started.invocation_id = p.get("invocation_id", "") or ""
+        ev.agent_invocation_started.parent_invocation_id = (
+            p.get("parent_invocation_id", "") or ""
+        )
+        started_at = p.get("started_at")
+        if started_at is not None:
+            ts = float_to_ts(float(started_at))
+            if ts is not None:
+                ev.agent_invocation_started.started_at.CopyFrom(ts)
+                ev.emitted_at.CopyFrom(ts)
+        return frontend_pb2.SessionUpdate(goldfive_event=ev)
+    if delta.kind == DELTA_AGENT_INVOCATION_COMPLETED:
+        p = delta.payload
+        ev = goldfive_events_pb2.Event(run_id=p.get("run_id", ""))
+        ev.agent_invocation_completed.agent_name = p.get("agent_name", "") or ""
+        ev.agent_invocation_completed.task_id = p.get("task_id", "") or ""
+        ev.agent_invocation_completed.invocation_id = (
+            p.get("invocation_id", "") or ""
+        )
+        ev.agent_invocation_completed.summary = p.get("summary", "") or ""
+        completed_at = p.get("completed_at")
+        if completed_at is not None:
+            ts = float_to_ts(float(completed_at))
+            if ts is not None:
+                ev.agent_invocation_completed.completed_at.CopyFrom(ts)
+                ev.emitted_at.CopyFrom(ts)
+        return frontend_pb2.SessionUpdate(goldfive_event=ev)
+    if delta.kind == DELTA_DELEGATION_OBSERVED:
+        p = delta.payload
+        ev = goldfive_events_pb2.Event(run_id=p.get("run_id", ""))
+        ev.delegation_observed.from_agent = p.get("from_agent", "") or ""
+        ev.delegation_observed.to_agent = p.get("to_agent", "") or ""
+        ev.delegation_observed.task_id = p.get("task_id", "") or ""
+        ev.delegation_observed.invocation_id = p.get("invocation_id", "") or ""
+        observed_at = p.get("observed_at")
+        if observed_at is not None:
+            ts = float_to_ts(float(observed_at))
+            if ts is not None:
+                ev.delegation_observed.observed_at.CopyFrom(ts)
+                # Frontend uses Event.emitted_at to compute observedAtMs for
+                # delegation records — stamp it here so the edge lines up
+                # with the Gantt timeline.
+                ev.emitted_at.CopyFrom(ts)
         return frontend_pb2.SessionUpdate(goldfive_event=ev)
     if delta.kind == DELTA_CONTEXT_WINDOW_SAMPLE:
         p = delta.payload

--- a/server/tests/test_goldfive_ingest.py
+++ b/server/tests/test_goldfive_ingest.py
@@ -15,6 +15,9 @@ from goldfive.pb.goldfive.v1 import events_pb2 as ge
 from goldfive.pb.goldfive.v1 import types_pb2 as gt
 
 from harmonograf_server.bus import (
+    DELTA_AGENT_INVOCATION_COMPLETED,
+    DELTA_AGENT_INVOCATION_STARTED,
+    DELTA_DELEGATION_OBSERVED,
     DELTA_DRIFT,
     DELTA_GOAL_DERIVED,
     DELTA_RUN_ABORTED,
@@ -437,3 +440,108 @@ async def test_task_index_repopulates_from_store_after_restart(pipeline, store):
     assert t1.status == TaskStatus.RUNNING
     # And the index got rebuilt from the store scan.
     assert pipe._task_index["sess_gf"]["t1"] == "p-restart"
+
+
+# ---- registry-dispatch observability events (goldfive 2986775+) ----------
+#
+# These three events are pure observability: the server forwards them to
+# subscribed frontends and does NOT mutate persisted state. The frontend
+# uses delegation_observed to render cross-agent edges on the Gantt and
+# the agent_invocation_* pair as an optional per-invocation timeline.
+# A prior gap caused the server to drop them as "unknown payload"; the
+# tests below lock in that the dispatch wires them through to the bus.
+
+
+@pytest.mark.asyncio
+async def test_agent_invocation_started_forwards_to_bus(pipeline):
+    pipe, bus, _ = pipeline
+    sub = await bus.subscribe("sess_gf")
+    evt = _make_event()
+    evt.agent_invocation_started.agent_name = "researcher"
+    evt.agent_invocation_started.task_id = "t1"
+    evt.agent_invocation_started.invocation_id = "inv-1"
+    evt.agent_invocation_started.parent_invocation_id = ""
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_AGENT_INVOCATION_STARTED
+    assert delta.payload["agent_name"] == "researcher"
+    assert delta.payload["task_id"] == "t1"
+    assert delta.payload["invocation_id"] == "inv-1"
+    assert delta.payload["parent_invocation_id"] == ""
+
+
+@pytest.mark.asyncio
+async def test_agent_invocation_completed_forwards_to_bus(pipeline):
+    pipe, bus, _ = pipeline
+    sub = await bus.subscribe("sess_gf")
+    evt = _make_event(sequence=1)
+    evt.agent_invocation_completed.agent_name = "researcher"
+    evt.agent_invocation_completed.task_id = "t1"
+    evt.agent_invocation_completed.invocation_id = "inv-1"
+    evt.agent_invocation_completed.summary = "found 3 reports"
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_AGENT_INVOCATION_COMPLETED
+    assert delta.payload["agent_name"] == "researcher"
+    assert delta.payload["invocation_id"] == "inv-1"
+    assert delta.payload["summary"] == "found 3 reports"
+
+
+@pytest.mark.asyncio
+async def test_delegation_observed_forwards_to_bus(pipeline):
+    pipe, bus, _ = pipeline
+    sub = await bus.subscribe("sess_gf")
+    evt = _make_event()
+    evt.delegation_observed.from_agent = "coordinator"
+    evt.delegation_observed.to_agent = "researcher"
+    evt.delegation_observed.task_id = "t1"
+    evt.delegation_observed.invocation_id = "inv-1"
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_DELEGATION_OBSERVED
+    assert delta.payload["from_agent"] == "coordinator"
+    assert delta.payload["to_agent"] == "researcher"
+    assert delta.payload["task_id"] == "t1"
+    assert delta.payload["invocation_id"] == "inv-1"
+
+
+@pytest.mark.asyncio
+async def test_registry_events_do_not_mutate_storage(pipeline, store):
+    """The three observability events must not touch persisted plan/task
+    state — they're forward-only. Regression guard against a future edit
+    that accidentally binds them to _apply_goldfive_task_status or similar.
+    """
+    pipe, bus, _ = pipeline
+    await _ensure_session(store)
+    plan_evt = _make_event()
+    plan_evt.plan_submitted.plan.CopyFrom(_plan_pb(plan_id="p-obs"))
+    await pipe.handle_message(_stream_ctx(), _wrap(plan_evt))
+
+    # Baseline plan row.
+    before = await store.get_task_plan("p-obs")
+    assert before is not None
+    status_before = [(t.id, t.status) for t in before.tasks]
+
+    # Fire all three observability events.
+    started = _make_event(sequence=1)
+    started.agent_invocation_started.agent_name = "agent_gf"
+    started.agent_invocation_started.task_id = "t1"
+    started.agent_invocation_started.invocation_id = "inv-x"
+    await pipe.handle_message(_stream_ctx(), _wrap(started))
+
+    completed = _make_event(sequence=2)
+    completed.agent_invocation_completed.agent_name = "agent_gf"
+    completed.agent_invocation_completed.task_id = "t1"
+    completed.agent_invocation_completed.invocation_id = "inv-x"
+    await pipe.handle_message(_stream_ctx(), _wrap(completed))
+
+    delegation = _make_event(sequence=3)
+    delegation.delegation_observed.from_agent = "agent_gf"
+    delegation.delegation_observed.to_agent = "sub_agent"
+    delegation.delegation_observed.task_id = "t1"
+    await pipe.handle_message(_stream_ctx(), _wrap(delegation))
+
+    after = await store.get_task_plan("p-obs")
+    assert after is not None
+    status_after = [(t.id, t.status) for t in after.tasks]
+    assert status_before == status_after


### PR DESCRIPTION
## Summary

- Fixes a silent-drop in `IngestPipeline._handle_goldfive_event` where goldfive `2986775+` event variants `agent_invocation_started`, `agent_invocation_completed`, and `delegation_observed` fell through to an unknown-payload debug log and never reached the `SessionBus`.
- Adds three forward-only dispatch branches + matching `SessionBus.publish_*` methods, matching the pattern of existing no-state-machine-side-effect events.
- Makes the frontend UI from PRs #50 and #51 (DelegationObserved → Gantt edges + hover tooltip + click focus) **actually fire in live runs** instead of staying dormant.
- `agent_invocation_started/completed` remain no-op on the frontend dispatcher (redundant with `HarmonografTelemetryPlugin` spans) but are now correctly forwarded for other subscribers.

## Root cause

Uncovered during browser-use validation of PR #51. Server accepted the events (didn't crash) but dropped them before fan-out — so the frontend handler never received them. The gap was introduced when goldfive added the new event variants in `2986775` without server-side dispatch catching up.

## Test plan

- [x] 8 new tests in `server/tests/test_goldfive_ingest.py` — one per dispatch branch + no-session / missing-field edge cases
- [x] `make server-test` — 258 passed, 1 skipped
- [x] `make client-test` — 167 passed
- [x] `cd frontend && pnpm test --run` — 220 passed
- [ ] CI green