### PR TITLE
Open per-ADK-session control subscription so steer routes to live ADK session (closes #53)

### DIFF
--- a/client/harmonograf_client/client.py
+++ b/client/harmonograf_client/client.py
@@ -311,6 +311,34 @@ class Client:
     def on_control(self, kind: str, callback: ControlCallback) -> None:
         self._transport.register_control_handler(kind.upper(), callback)
 
+    def register_session(self, adk_session_id: str) -> None:
+        """Open a per-ADK-session ``SubscribeControl`` stream.
+
+        The Client's home subscription (opened once at start, keyed on
+        the harmonograf-assigned session) is the baseline identity to
+        the server. ``register_session`` opens an *additional* control
+        stream whose ``session_id`` matches the ADK ``session.id`` you
+        pass in. The server's router prefers session-matching
+        subscriptions when routing STEER / INJECT_MESSAGE events
+        targeting ``(session_id, agent_id)``, so frontend steer
+        actions fired against the ADK session reach this Client's
+        bound steerer instead of returning ``delivery=FAILURE``.
+
+        Thread-safe and idempotent: re-registering the same session is
+        a no-op. Safe to call before the transport has connected — the
+        sub is recorded and opened on the next successful connect.
+        """
+        self._transport.open_session_subscription(adk_session_id)
+
+    def unregister_session(self, adk_session_id: str) -> None:
+        """Cancel a previously-registered per-ADK-session control stream."""
+        self._transport.close_session_subscription(adk_session_id)
+
+    @property
+    def registered_session_ids(self) -> tuple[str, ...]:
+        """ADK session ids currently subscribed. For tests and diagnostics."""
+        return self._transport.registered_session_ids
+
     def set_control_forward(self, fn: Optional[Callable[[Any], None]]) -> None:
         """Install a raw ``ControlEvent`` forwarder. ``None`` uninstalls.
 

--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -220,6 +220,13 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             # is never actually invoked in that case.
             pass
         self._client = client
+        # ADK session ids we've already asked the client to subscribe a
+        # per-session control stream for. Without this, a STEER fired
+        # against the ADK session from the frontend cannot find a
+        # matching subscription (the Client's home sub is keyed on a
+        # harmonograf-assigned session id, not the ADK one) and the
+        # PostAnnotation returns delivery=FAILURE. See issue #53.
+        self._registered_adk_sessions: set[str] = set()
         self._invocation_spans: dict[str, str] = {}
         # Model-call spans are keyed by ``invocation_id`` and tracked as
         # FIFO queues: ADK rebuilds the ``CallbackContext`` between
@@ -241,6 +248,26 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     def client(self) -> Client:
         return self._client
 
+    def _ensure_session_subscription(self, ctx: Any) -> str:
+        """Open a per-ADK-session control stream the first time we see ``ctx``.
+
+        Returns the ADK session id so the caller can pass it to
+        ``emit_span_start`` in the same expression. Returns ``""`` when
+        the context is running without a session service — matching the
+        pre-fix behaviour of :func:`_adk_session_id`.
+        """
+        sid = _adk_session_id(ctx)
+        if not sid:
+            return ""
+        if sid in self._registered_adk_sessions:
+            return sid
+        self._registered_adk_sessions.add(sid)
+        try:
+            self._client.register_session(sid)
+        except Exception:  # noqa: BLE001 -- observability must never crash ADK
+            log.exception("register_session failed for adk_session_id=%s", sid)
+        return sid
+
     # ------------------------------------------------------------------
     # Invocation lifecycle
     # ------------------------------------------------------------------
@@ -253,7 +280,7 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             kind=SpanKind.INVOCATION,
             name=name,
             attributes={"adk.invocation_id": inv_id} if inv_id else None,
-            session_id=_adk_session_id(invocation_context),
+            session_id=self._ensure_session_subscription(invocation_context),
         )
         if inv_id:
             self._invocation_spans[inv_id] = sid
@@ -320,7 +347,7 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             kind=SpanKind.LLM_CALL,
             name=model or "llm_call",
             attributes={"llm.model": model} if model else None,
-            session_id=_adk_session_id(callback_context),
+            session_id=self._ensure_session_subscription(callback_context),
         )
         key = self._model_span_key(callback_context)
         self._model_spans.setdefault(key, deque()).append(_ModelSpanSlot(span_id=sid))
@@ -406,7 +433,7 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             name=tool_name,
             payload=payload,
             payload_role="input",
-            session_id=_adk_session_id(tool_context),
+            session_id=self._ensure_session_subscription(tool_context),
         )
         self._tool_spans[id(tool_context)] = sid
 

--- a/client/harmonograf_client/transport.py
+++ b/client/harmonograf_client/transport.py
@@ -89,6 +89,24 @@ class ControlAckSpec:
     detail: str = ""
 
 
+@dataclasses.dataclass
+class _SessionSubscription:
+    """Bookkeeping for one per-ADK-session control subscription.
+
+    ``task`` is the asyncio task that owns the ``SubscribeControl`` RPC
+    for this session. ``stream_id`` is a freshly-minted id used on the
+    SubscribeControl request so the server can attribute this secondary
+    sub independently of the home subscription. ``cancelled`` is set
+    when :meth:`Transport.close_session_subscription` removes the entry
+    so the loop can skip restart on the next reconnect.
+    """
+
+    session_id: str
+    stream_id: str
+    task: Optional[asyncio.Task] = None
+    cancelled: bool = False
+
+
 class Transport:
     def __init__(
         self,
@@ -160,6 +178,21 @@ class Transport:
 
         self._assigned_session_id: str = session_id
         self._assigned_stream_id: str = ""
+
+        # Per-ADK-session secondary control subscriptions. Keyed by the ADK
+        # ``session.id`` — NOT the harmonograf-assigned home session. The
+        # home subscription (opened from ``_control_loop``) is always the
+        # baseline identity of this Client to the server; these additional
+        # subscriptions are additive and let STEER targets carrying an
+        # ADK ``session_id`` land on a sub whose ``session_id`` matches,
+        # which the router prefers over the home sub (see server-side
+        # ``ControlRouter.deliver``).
+        self._session_subs: dict[str, _SessionSubscription] = {}
+        self._session_subs_lock = threading.Lock()
+        # Snapshot of the currently-live stub so newly-registered
+        # subscriptions can bind without waiting for the next connect.
+        # Cleared on every ``_serve`` teardown; replayed after reconnect.
+        self._live_stub: Any = None
 
         # Reconnect hardening state.
         # _healthy is set when the current connection has produced at
@@ -459,6 +492,7 @@ class Transport:
         hello = self._build_hello(telemetry_pb2)
         send_queue: asyncio.Queue = asyncio.Queue()
         self._send_queue = send_queue
+        self._live_stub = stub
         await send_queue.put(telemetry_pb2.TelemetryUp(hello=hello))
 
         async def request_iter():
@@ -502,46 +536,67 @@ class Transport:
             recv_task.cancel()
             raise RuntimeError("no welcome from server")
 
-        control_task = asyncio.create_task(self._control_loop(stub, send_queue))
+        control_task = asyncio.create_task(
+            self._control_loop(
+                stub,
+                send_queue,
+                session_id=self._assigned_session_id,
+                stream_id=self._assigned_stream_id,
+            )
+        )
         send_task = asyncio.create_task(self._send_loop(send_queue))
 
-        done, pending = await asyncio.wait(
-            {recv_task, control_task, send_task},
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        # On clean shutdown — send_task exited because ``_stop`` was set —
-        # the send_loop has already drained the ring buffer and put Goodbye
-        # + EOF on the queue. gRPC is still yielding those items to the
-        # server; cancelling recv_task now would abort the bidi call and
-        # drop pending events in transit. Wait for the server to close
-        # its side (recv_task returns naturally) before tearing down.
-        if (
-            self._stop.is_set()
-            and send_task in done
-            and not send_task.cancelled()
-            and recv_task not in done
-        ):
-            try:
-                await asyncio.wait_for(
-                    asyncio.shield(recv_task), timeout=_SHUTDOWN_DRAIN_TIMEOUT_S
-                )
-            except (asyncio.TimeoutError, Exception):
-                pass
-        for t in pending:
-            t.cancel()
-        for t in pending:
-            try:
-                await t
-            except Exception:
-                pass
-        for t in done:
-            exc = t.exception()
-            if exc is not None and not isinstance(exc, asyncio.CancelledError):
-                # Clear send_queue so late bridge acks are not posted
-                # onto a stream that is already dead.
-                self._send_queue = None
-                raise exc
-        self._send_queue = None
+        # Replay any per-ADK-session subscriptions registered before or
+        # between connects so STEER targets carrying an ADK session id
+        # land on a sub whose session_id matches, which the server
+        # prefers over the home sub.
+        self._start_registered_session_subs(stub, send_queue)
+
+        try:
+            done, pending = await asyncio.wait(
+                {recv_task, control_task, send_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            # On clean shutdown — send_task exited because ``_stop`` was set —
+            # the send_loop has already drained the ring buffer and put Goodbye
+            # + EOF on the queue. gRPC is still yielding those items to the
+            # server; cancelling recv_task now would abort the bidi call and
+            # drop pending events in transit. Wait for the server to close
+            # its side (recv_task returns naturally) before tearing down.
+            if (
+                self._stop.is_set()
+                and send_task in done
+                and not send_task.cancelled()
+                and recv_task not in done
+            ):
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(recv_task), timeout=_SHUTDOWN_DRAIN_TIMEOUT_S
+                    )
+                except (asyncio.TimeoutError, Exception):
+                    pass
+            for t in pending:
+                t.cancel()
+            for t in pending:
+                try:
+                    await t
+                except Exception:
+                    pass
+            for t in done:
+                exc = t.exception()
+                if exc is not None and not isinstance(exc, asyncio.CancelledError):
+                    raise exc
+        finally:
+            # Always tear down per-session subscription tasks tied to this
+            # stub, even on exception — otherwise the task wraps a stale
+            # gRPC call and leaks across reconnect. The registered subs
+            # themselves stay in ``_session_subs`` so the next ``_serve``
+            # can re-bind them.
+            await self._cancel_session_sub_tasks()
+            # Clear send_queue so late bridge acks are not posted onto a
+            # stream that is already dead.
+            self._send_queue = None
+            self._live_stub = None
 
     # ------------------------------------------------------------------
     # Send loop
@@ -720,15 +775,32 @@ class Transport:
     # Control subscribe loop
     # ------------------------------------------------------------------
 
-    async def _control_loop(self, stub: Any, send_queue: asyncio.Queue) -> None:
+    async def _control_loop(
+        self,
+        stub: Any,
+        send_queue: asyncio.Queue,
+        *,
+        session_id: str,
+        stream_id: str,
+    ) -> None:
+        """Open one ``SubscribeControl`` stream and route its events.
+
+        Used for both the home subscription (called once from
+        :meth:`_serve`) and for each per-ADK-session subscription
+        registered via :meth:`open_session_subscription`. All subs share
+        the same ``_control_forward`` / ``_dispatch_control`` path so a
+        goldfive bridge receives events from any sub indistinguishably —
+        session scoping is achieved by the server's router preferring
+        session-matching subs over the home fallback.
+        """
         from goldfive.pb.goldfive.v1 import control_pb2 as gf_control_pb2
 
         from .pb import control_pb2, telemetry_pb2
 
         req = control_pb2.SubscribeControlRequest(
-            session_id=self._assigned_session_id,
+            session_id=session_id,
             agent_id=self._agent_id,
-            stream_id=self._assigned_stream_id,
+            stream_id=stream_id,
         )
         sub_kwargs = {}
         if self._auth_token:
@@ -752,7 +824,124 @@ class Transport:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            log.warning("control subscription ended: %s", e)
+            log.warning(
+                "control subscription ended session_id=%s: %s", session_id, e
+            )
+
+    # ------------------------------------------------------------------
+    # Per-ADK-session control subscriptions
+    # ------------------------------------------------------------------
+
+    def open_session_subscription(self, adk_session_id: str) -> None:
+        """Open an additional ``SubscribeControl`` stream keyed on ``adk_session_id``.
+
+        Thread-safe. Idempotent: calling twice with the same session_id
+        is a no-op. Safe to call before the transport has connected —
+        the subscription is recorded and opened automatically once the
+        loop reaches the control-loop phase of the next ``_serve`` call.
+        """
+        if not adk_session_id:
+            return
+        with self._session_subs_lock:
+            if adk_session_id in self._session_subs:
+                return
+            stream_id = f"{self._assigned_stream_id or 'str'}.{adk_session_id}"
+            sub = _SessionSubscription(
+                session_id=adk_session_id, stream_id=stream_id
+            )
+            self._session_subs[adk_session_id] = sub
+        loop = self._loop
+        stub = self._live_stub
+        sq = self._send_queue
+        if loop is None or stub is None or sq is None:
+            # Not currently connected. The sub is registered; it will be
+            # started on the next successful ``_serve``.
+            return
+        try:
+            loop.call_soon_threadsafe(
+                self._spawn_session_sub_task, stub, sq, sub
+            )
+        except RuntimeError:
+            # Loop is shutting down — next reconnect (if any) replays.
+            pass
+
+    def close_session_subscription(self, adk_session_id: str) -> None:
+        """Cancel and remove a previously-registered per-ADK-session sub.
+
+        Safe to call from any thread. A no-op if no matching sub exists.
+        """
+        if not adk_session_id:
+            return
+        with self._session_subs_lock:
+            sub = self._session_subs.pop(adk_session_id, None)
+        if sub is None:
+            return
+        sub.cancelled = True
+        task = sub.task
+        loop = self._loop
+        if task is not None and loop is not None:
+            try:
+                loop.call_soon_threadsafe(task.cancel)
+            except RuntimeError:
+                pass
+
+    @property
+    def registered_session_ids(self) -> tuple[str, ...]:
+        """Snapshot of currently-registered per-ADK-session ids.
+
+        Exposed for tests and observability; not part of the daily API.
+        """
+        with self._session_subs_lock:
+            return tuple(self._session_subs.keys())
+
+    def _start_registered_session_subs(
+        self, stub: Any, send_queue: asyncio.Queue
+    ) -> None:
+        """Called from :meth:`_serve` after the home control task is live.
+
+        Launches one ``_control_loop`` task per already-registered
+        per-ADK-session subscription so they are re-bound to the fresh
+        stub after every reconnect.
+        """
+        with self._session_subs_lock:
+            snapshot = list(self._session_subs.values())
+        for sub in snapshot:
+            if sub.cancelled:
+                continue
+            self._spawn_session_sub_task(stub, send_queue, sub)
+
+    def _spawn_session_sub_task(
+        self, stub: Any, send_queue: asyncio.Queue, sub: _SessionSubscription
+    ) -> None:
+        # Runs on the transport loop.
+        if sub.cancelled:
+            return
+        if sub.task is not None and not sub.task.done():
+            return
+        sub.task = asyncio.create_task(
+            self._control_loop(
+                stub,
+                send_queue,
+                session_id=sub.session_id,
+                stream_id=sub.stream_id,
+            )
+        )
+
+    async def _cancel_session_sub_tasks(self) -> None:
+        with self._session_subs_lock:
+            tasks = [
+                s.task for s in self._session_subs.values() if s.task is not None
+            ]
+            for s in self._session_subs.values():
+                s.task = None
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+        for t in tasks:
+            try:
+                await t
+            except Exception:
+                pass
 
     def _dispatch_control(self, event: Any, gf_control_pb2: Any) -> Any:
         kind_name = _control_kind_name(event.kind, gf_control_pb2)

--- a/client/tests/_fixtures.py
+++ b/client/tests/_fixtures.py
@@ -69,6 +69,13 @@ class FakeTransport:
         self.control_forward: Optional[Callable[[Any], None]] = None
         # (control_id, result, detail) tuples pushed via send_control_ack.
         self.sent_acks: list[tuple[str, str, str]] = []
+        # ADK session ids passed to open_session_subscription, in order,
+        # with duplicates suppressed by open_session_subscription itself.
+        # Tests assert against this to prove the client wires
+        # register_session through to the transport exactly once per
+        # distinct ADK session.
+        self.opened_sessions: list[str] = []
+        self.closed_sessions: list[str] = []
 
     # --- public surface Client depends on -----------------------------
 
@@ -95,6 +102,22 @@ class FakeTransport:
         self, control_id: str, result: str, detail: str = ""
     ) -> None:
         self.sent_acks.append((control_id, result, detail))
+
+    def open_session_subscription(self, adk_session_id: str) -> None:
+        # Mirror the real transport's idempotence contract so tests that
+        # drive the plugin through multiple spans see exactly one call
+        # per distinct session id.
+        if not adk_session_id or adk_session_id in self.opened_sessions:
+            return
+        self.opened_sessions.append(adk_session_id)
+
+    def close_session_subscription(self, adk_session_id: str) -> None:
+        if adk_session_id:
+            self.closed_sessions.append(adk_session_id)
+
+    @property
+    def registered_session_ids(self) -> tuple[str, ...]:
+        return tuple(self.opened_sessions)
 
     # Bridge tests simulate a ControlEvent arriving on the control stream
     # by calling this directly. Matches the real transport's call path —

--- a/client/tests/test_client_session_subscription.py
+++ b/client/tests/test_client_session_subscription.py
@@ -1,0 +1,86 @@
+"""Tests for per-ADK-session control subscriptions (harmonograf #53).
+
+The :class:`Client` opens exactly one control ``SubscribeControl`` RPC
+at startup (the "home" subscription) keyed on the harmonograf-assigned
+session id. ADK processes that share a single module-level Client
+across many live sessions need *additional* per-session subscriptions
+so a STEER targeting ``(ADK_session, agent_id)`` can be routed by the
+server to a sub whose ``session_id`` matches.
+
+These tests exercise the :meth:`Client.register_session` /
+:meth:`Client.unregister_session` surface against the
+:class:`FakeTransport` harness. Transport-level reconnect / task
+lifecycle for the per-session subscription is covered separately in
+``test_transport_session_subscriptions.py`` against the real
+:class:`Transport`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from harmonograf_client.client import Client
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+ADK_SESSION = "adk-sess-abc123"
+OTHER_SESSION = "adk-sess-def456"
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="session-sub-test",
+        agent_id="agent-X",
+        session_id="stream-default-session",
+        buffer_size=16,
+        _transport_factory=make_factory(made),
+    )
+
+
+def test_register_session_opens_new_control_stream(client: Client, made: list[FakeTransport]) -> None:
+    """The critical invariant: register_session must reach the transport
+    and (eventually) open an additional SubscribeControl stream."""
+    client.register_session(ADK_SESSION)
+    assert made[0].opened_sessions == [ADK_SESSION]
+    assert client.registered_session_ids == (ADK_SESSION,)
+
+
+def test_register_session_is_idempotent(client: Client, made: list[FakeTransport]) -> None:
+    """A plugin calling register_session on every span must not create
+    one subscription per span — the transport should see exactly one
+    SubscribeControl open per distinct ADK session id."""
+    client.register_session(ADK_SESSION)
+    client.register_session(ADK_SESSION)
+    client.register_session(ADK_SESSION)
+    assert made[0].opened_sessions == [ADK_SESSION]
+
+
+def test_register_session_empty_string_is_noop(client: Client, made: list[FakeTransport]) -> None:
+    """The plugin passes ``""`` when the ADK context has no session
+    service. That must not open a subscription (empty-session subs
+    could never match anything on the router anyway)."""
+    client.register_session("")
+    assert made[0].opened_sessions == []
+    assert client.registered_session_ids == ()
+
+
+def test_register_multiple_distinct_sessions(client: Client, made: list[FakeTransport]) -> None:
+    """Distinct ADK sessions in the same process each get their own
+    subscription — the whole motivation for the fix."""
+    client.register_session(ADK_SESSION)
+    client.register_session(OTHER_SESSION)
+    assert made[0].opened_sessions == [ADK_SESSION, OTHER_SESSION]
+    assert set(client.registered_session_ids) == {ADK_SESSION, OTHER_SESSION}
+
+
+def test_unregister_session_removes_subscription(client: Client, made: list[FakeTransport]) -> None:
+    client.register_session(ADK_SESSION)
+    client.unregister_session(ADK_SESSION)
+    assert made[0].closed_sessions == [ADK_SESSION]

--- a/client/tests/test_telemetry_plugin_session_subscription.py
+++ b/client/tests/test_telemetry_plugin_session_subscription.py
@@ -1,0 +1,227 @@
+"""Tests that :class:`HarmonografTelemetryPlugin` auto-registers every
+ADK session it sees with the Client's control-subscription manager
+(harmonograf #53).
+
+Without this wiring the frontend STEER button is wired to the ADK
+session id, but the Client's home SubscribeControl stream is keyed on
+the harmonograf-assigned session — so the server's router finds no
+matching sub and returns ``delivery=FAILURE``. The plugin is the one
+place with visibility into the ADK session id on the hot path, so it
+owns the auto-registration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from harmonograf_client.client import Client
+from harmonograf_client.telemetry_plugin import HarmonografTelemetryPlugin
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+# ---------------------------------------------------------------------------
+# ADK-shaped stand-ins (mirror the fixtures in test_telemetry_plugin_session_id)
+# ---------------------------------------------------------------------------
+
+
+class _Session:
+    def __init__(self, sid: str) -> None:
+        self.id = sid
+
+
+class _Agent:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _InvocationContext:
+    def __init__(self, invocation_id: str, session_id: str) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id)
+        self.agent = _Agent("root-agent")
+
+
+class _CallbackContext:
+    def __init__(self, invocation_id: str, session_id: str) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id)
+
+
+class _Tool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _LlmRequest:
+    def __init__(self, model: str = "gpt-test") -> None:
+        self.model = model
+
+
+ADK_SESSION = "adk-sess-abc123"
+OTHER_SESSION = "adk-sess-def456"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="session-sub-plugin-test",
+        agent_id="agent-X",
+        session_id="stream-default-session",
+        buffer_size=16,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def plugin(client: Client) -> HarmonografTelemetryPlugin:
+    return HarmonografTelemetryPlugin(client)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plugin_registers_session_on_first_invocation_span(
+    plugin: HarmonografTelemetryPlugin,
+    client: Client,
+    made: list[FakeTransport],
+) -> None:
+    """``before_run_callback`` is the earliest ADK-visible hook that
+    carries the invocation_context, so the plugin must register the
+    session on that entry point at the latest."""
+    ctx = _InvocationContext(invocation_id="inv-1", session_id=ADK_SESSION)
+    await plugin.before_run_callback(invocation_context=ctx)
+    assert made[0].opened_sessions == [ADK_SESSION]
+
+
+@pytest.mark.asyncio
+async def test_plugin_registers_session_on_first_model_span(
+    plugin: HarmonografTelemetryPlugin,
+    client: Client,
+    made: list[FakeTransport],
+) -> None:
+    """Some flows take a before_model path before before_run (e.g. when
+    another plugin gates invocation). The session must still get
+    registered lazily on the first observed span."""
+    cb = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
+    await plugin.before_model_callback(callback_context=cb, llm_request=_LlmRequest())
+    assert made[0].opened_sessions == [ADK_SESSION]
+
+
+@pytest.mark.asyncio
+async def test_plugin_registers_session_on_first_tool_span(
+    plugin: HarmonografTelemetryPlugin,
+    client: Client,
+    made: list[FakeTransport],
+) -> None:
+    tc = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
+    await plugin.before_tool_callback(
+        tool=_Tool("search"), tool_args={"q": "hi"}, tool_context=tc
+    )
+    assert made[0].opened_sessions == [ADK_SESSION]
+
+
+@pytest.mark.asyncio
+async def test_plugin_does_not_re_register_same_session(
+    plugin: HarmonografTelemetryPlugin,
+    client: Client,
+    made: list[FakeTransport],
+) -> None:
+    """Many spans per ADK session — before_run, before_model, before_tool,
+    etc — must all collapse to a single register_session call to avoid
+    leaking one SubscribeControl RPC per span."""
+    ic = _InvocationContext(invocation_id="inv-1", session_id=ADK_SESSION)
+    cb = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
+    tc = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
+
+    await plugin.before_run_callback(invocation_context=ic)
+    await plugin.before_model_callback(callback_context=cb, llm_request=_LlmRequest())
+    await plugin.before_tool_callback(
+        tool=_Tool("fetch"), tool_args=None, tool_context=tc
+    )
+
+    assert made[0].opened_sessions == [ADK_SESSION]
+
+
+@pytest.mark.asyncio
+async def test_plugin_registers_each_distinct_session(
+    plugin: HarmonografTelemetryPlugin,
+    client: Client,
+    made: list[FakeTransport],
+) -> None:
+    """Two ADK sessions sharing one process-level Client must each get
+    their own SubscribeControl — the motivating scenario for the fix."""
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext("inv-A", ADK_SESSION)
+    )
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext("inv-B", OTHER_SESSION)
+    )
+    assert made[0].opened_sessions == [ADK_SESSION, OTHER_SESSION]
+
+
+@pytest.mark.asyncio
+async def test_plugin_skips_registration_when_session_missing(
+    plugin: HarmonografTelemetryPlugin,
+    client: Client,
+    made: list[FakeTransport],
+) -> None:
+    """A ctx without a session service (bare unit tests, offline replays)
+    must not attempt to open a useless empty-session subscription —
+    register_session would no-op anyway, but we assert the plugin also
+    skips tracking so a later real session still gets registered."""
+
+    class _Bare:
+        invocation_id = "inv-bare"
+        agent = _Agent("root")
+        session = None
+
+    await plugin.before_run_callback(invocation_context=_Bare())
+    assert made[0].opened_sessions == []
+
+    # Now a real session should still register.
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext("inv-real", ADK_SESSION)
+    )
+    assert made[0].opened_sessions == [ADK_SESSION]
+
+
+@pytest.mark.asyncio
+async def test_register_session_failure_does_not_crash_plugin(
+    plugin: HarmonografTelemetryPlugin,
+    client: Client,
+    made: list[FakeTransport],
+) -> None:
+    """Observability must never take down the ADK invocation. If the
+    transport bombs inside register_session, the span still emits."""
+
+    def _boom(_: Any) -> None:
+        raise RuntimeError("transport is on fire")
+
+    # Monkey-patch the FakeTransport's open method to raise — mimics
+    # a scenario where the underlying grpc layer has already torn down.
+    made[0].open_session_subscription = _boom  # type: ignore[assignment]
+
+    ctx = _InvocationContext(invocation_id="inv-1", session_id=ADK_SESSION)
+    # Must not raise.
+    await plugin.before_run_callback(invocation_context=ctx)
+    # The span still rode through to the events buffer.
+    from harmonograf_client.buffer import EnvelopeKind
+
+    starts = [e for e in client._events.drain() if e.kind is EnvelopeKind.SPAN_START]
+    assert len(starts) == 1

--- a/client/tests/test_transport_session_subscriptions.py
+++ b/client/tests/test_transport_session_subscriptions.py
@@ -1,0 +1,282 @@
+"""Integration tests for per-ADK-session control subscriptions.
+
+These tests drive the real :class:`Transport` (not :class:`FakeTransport`)
+against an in-process gRPC server to prove that
+:meth:`Client.register_session` actually opens a second SubscribeControl
+RPC and that the subscription is re-established after reconnect.
+
+The server fixture is a trimmed variant of the one in
+``test_transport_mock.py`` that remembers every ``SubscribeControlRequest``
+it received so tests can assert on session_id / stream_id / agent_id.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+import grpc
+import pytest
+
+from harmonograf_client import Client
+from harmonograf_client.pb import service_pb2_grpc, telemetry_pb2
+
+
+ADK_SESSION = "adk-session-integration-abc"
+OTHER_SESSION = "adk-session-integration-def"
+
+
+class _RecordingServicer(service_pb2_grpc.HarmonografServicer):
+    """Records every SubscribeControl request so tests can assert on them."""
+
+    def __init__(self) -> None:
+        self.subscribe_requests: list[Any] = []
+        self.subscribe_lock = threading.Lock()
+        self.welcome_sent = threading.Event()
+        self.stream_counter = 0
+        # Event that fires each time a distinct session_id is observed on
+        # a SubscribeControl request.
+        self.subscribed_session_ids: set[str] = set()
+
+    async def StreamTelemetry(self, request_iterator, context):
+        async for msg in request_iterator:
+            which = msg.WhichOneof("msg")
+            if which == "hello":
+                self.stream_counter += 1
+                session_id = msg.hello.session_id or "sess_srv_0001"
+                yield telemetry_pb2.TelemetryDown(
+                    welcome=telemetry_pb2.Welcome(
+                        accepted=True,
+                        assigned_session_id=session_id,
+                        assigned_stream_id=f"srv-stream-{self.stream_counter}",
+                    )
+                )
+                self.welcome_sent.set()
+            elif which == "goodbye":
+                return
+
+    async def SubscribeControl(self, request, context):
+        with self.subscribe_lock:
+            self.subscribe_requests.append(request)
+            self.subscribed_session_ids.add(request.session_id)
+        # Hold the stream open until the client tears it down; no events are
+        # pushed — these tests only care about subscribe REQUEST bookkeeping.
+        try:
+            while True:
+                await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            return
+
+    async def ListSessions(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        return
+
+    async def WatchSession(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        return
+
+    async def GetPayload(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        return
+
+    async def GetSpanTree(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        return
+
+    async def PostAnnotation(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        return
+
+    async def SendControl(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        return
+
+    async def DeleteSession(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        return
+
+    async def GetStats(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        return
+
+
+class _ServerHarness:
+    def __init__(self) -> None:
+        self.servicer = _RecordingServicer()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._server: grpc.aio.Server | None = None
+        self._thread: threading.Thread | None = None
+        self._ready = threading.Event()
+        self._stop_event: asyncio.Event | None = None
+        self.port: int = 0
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        self._ready.wait(timeout=5.0)
+
+    def _run(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        try:
+            self._loop.run_until_complete(self._serve())
+        except RuntimeError:
+            pass
+        finally:
+            try:
+                self._loop.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    async def _serve(self) -> None:
+        self._server = grpc.aio.server()
+        service_pb2_grpc.add_HarmonografServicer_to_server(self.servicer, self._server)
+        self.port = self._server.add_insecure_port("127.0.0.1:0")
+        await self._server.start()
+        self._ready.set()
+        self._stop_event = asyncio.Event()
+        await self._stop_event.wait()
+        try:
+            await self._server.stop(grace=0)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def stop(self) -> None:
+        if self._loop is None or self._stop_event is None:
+            return
+        try:
+            self._loop.call_soon_threadsafe(self._stop_event.set)
+        except Exception:  # noqa: BLE001
+            pass
+        if self._thread is not None:
+            self._thread.join(timeout=3.0)
+
+
+@pytest.fixture()
+def server():
+    h = _ServerHarness()
+    h.start()
+    yield h
+    h.stop()
+
+
+@pytest.fixture()
+def isolated_identity(tmp_path, monkeypatch):
+    monkeypatch.setenv("HARMONOGRAF_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def _wait(cond, timeout=3.0):
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        if cond():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_register_session_opens_second_subscribe_control_rpc(server, isolated_identity):
+    """End-to-end: registering an ADK session with the Client results in
+    a second SubscribeControl request hitting the server with the right
+    session_id. The home subscription also survives."""
+    client = Client(
+        name="real-transport-test",
+        server_addr=f"127.0.0.1:{server.port}",
+    )
+    try:
+        assert _wait(lambda: server.servicer.welcome_sent.is_set())
+        # Home subscription should have landed already.
+        assert _wait(lambda: len(server.servicer.subscribe_requests) >= 1, timeout=3.0)
+        home_req = server.servicer.subscribe_requests[0]
+        assert home_req.agent_id == client.agent_id
+        # Now register an ADK session; a second SubscribeControl should fire.
+        client.register_session(ADK_SESSION)
+        assert _wait(
+            lambda: ADK_SESSION in server.servicer.subscribed_session_ids, timeout=3.0
+        )
+        # And we still see the home session — the new sub is additive.
+        assert home_req.session_id in server.servicer.subscribed_session_ids
+    finally:
+        client.shutdown(flush_timeout=1.0)
+
+
+def test_register_session_is_idempotent_over_transport(server, isolated_identity):
+    """The transport suppresses duplicate SubscribeControl for the same
+    session_id — the plugin may call register_session on every span."""
+    client = Client(
+        name="real-transport-idem",
+        server_addr=f"127.0.0.1:{server.port}",
+    )
+    try:
+        assert _wait(lambda: server.servicer.welcome_sent.is_set())
+        client.register_session(ADK_SESSION)
+        client.register_session(ADK_SESSION)
+        client.register_session(ADK_SESSION)
+        # Let any stragglers land.
+        _wait(
+            lambda: sum(
+                1
+                for r in server.servicer.subscribe_requests
+                if r.session_id == ADK_SESSION
+            )
+            >= 1,
+            timeout=1.0,
+        )
+        # Exactly one SubscribeControl for ADK_SESSION.
+        count = sum(
+            1
+            for r in server.servicer.subscribe_requests
+            if r.session_id == ADK_SESSION
+        )
+        assert count == 1, f"expected 1 ADK_SESSION sub, got {count}"
+    finally:
+        client.shutdown(flush_timeout=1.0)
+
+
+def test_register_multiple_sessions_produces_multiple_subs(server, isolated_identity):
+    client = Client(
+        name="real-transport-multi",
+        server_addr=f"127.0.0.1:{server.port}",
+    )
+    try:
+        assert _wait(lambda: server.servicer.welcome_sent.is_set())
+        client.register_session(ADK_SESSION)
+        client.register_session(OTHER_SESSION)
+        assert _wait(
+            lambda: {ADK_SESSION, OTHER_SESSION}.issubset(
+                server.servicer.subscribed_session_ids
+            ),
+            timeout=3.0,
+        )
+    finally:
+        client.shutdown(flush_timeout=1.0)
+
+
+def test_register_session_before_connect_opens_after_welcome(isolated_identity, tmp_path):
+    """register_session may be called before the transport has its first
+    stub. The sub must open as soon as the connect+welcome completes."""
+    # Boot a fresh server harness so we can register BEFORE welcome.
+    h = _ServerHarness()
+    h.start()
+    try:
+        client = Client(
+            name="pre-connect",
+            server_addr=f"127.0.0.1:{h.port}",
+            autostart=False,
+        )
+        # Register BEFORE transport.start(). The sub is only recorded; no
+        # SubscribeControl RPC yet.
+        client.register_session(ADK_SESSION)
+        client._transport.start()
+        try:
+            assert _wait(lambda: h.servicer.welcome_sent.is_set(), timeout=3.0)
+            assert _wait(
+                lambda: ADK_SESSION in h.servicer.subscribed_session_ids,
+                timeout=3.0,
+            )
+        finally:
+            client.shutdown(flush_timeout=1.0)
+    finally:
+        h.stop()

--- a/server/harmonograf_server/control_router.py
+++ b/server/harmonograf_server/control_router.py
@@ -221,7 +221,26 @@ class ControlRouter:
             if aliased_id:
                 async with self._lock:
                     bucket = dict(self._subs.get(aliased_id, {}))
-        live_ids = [sid for sid, sub in bucket.items() if not sub.closed]
+        # Prefer subscriptions whose session_id matches the target when any
+        # such sub exists. A single Client process may open multiple
+        # SubscribeControl streams for the same agent_id — a home sub keyed
+        # on the harmonograf-assigned session plus one per live ADK session
+        # (see harmonograf #53). Fanning out to every sub would cause a
+        # goldfive bridge to see the same STEER twice; filtering to
+        # session-matching subs preserves the baseline while letting
+        # per-ADK-session steering land precisely on the ADK session that
+        # originated the request. Falls back to every live sub when no
+        # session-matching sub is present — that is the legacy path the
+        # home-only topology always took.
+        session_matched_ids = [
+            sid
+            for sid, sub in bucket.items()
+            if not sub.closed and session_id and sub.session_id == session_id
+        ]
+        if session_matched_ids:
+            live_ids = session_matched_ids
+        else:
+            live_ids = [sid for sid, sub in bucket.items() if not sub.closed]
         if not live_ids:
             return DeliveryOutcome(control_id=control_id, result=DeliveryResult.UNAVAILABLE)
 
@@ -289,14 +308,22 @@ class ControlRouter:
             if ack.HasField("acked_at")
             else time.time(),
         )
-        # If stream_id unknown, attribute it to any still-expected stream.
-        if not record.stream_id:
+        # If stream_id unknown or not in the expected set, attribute it
+        # to any still-expected stream. The ingest layer stamps acks with
+        # the telemetry stream_id (that's where ControlAck rides), which
+        # may differ from the SubscribeControl stream_id when the client
+        # opens multiple control subs on the same telemetry stream (the
+        # per-ADK-session case introduced by harmonograf #53). In that
+        # topology the ack is unambiguously for the one pending
+        # control_id we already filtered on, so picking the single
+        # expected stream is correct. When the agent actually has
+        # multiple concurrent telemetry streams we get one ack per
+        # stream and the caller-supplied stream_id still matches.
+        if not record.stream_id or record.stream_id not in pending.expected_stream_ids:
             if pending.expected_stream_ids:
                 record.stream_id = next(iter(pending.expected_stream_ids))
             else:
                 return
-        if record.stream_id not in pending.expected_stream_ids:
-            return
         pending.expected_stream_ids.discard(record.stream_id)
         pending.acks.append(record)
         self._maybe_resolve(pending)

--- a/server/tests/test_control_router_session_scoped.py
+++ b/server/tests/test_control_router_session_scoped.py
@@ -1,0 +1,209 @@
+"""Router-level tests for per-ADK-session scoped control delivery
+(harmonograf #53).
+
+A single Client may open multiple SubscribeControl streams for the same
+agent_id — a home sub keyed on the harmonograf-assigned session and one
+per live ADK session. The router must prefer the session-matching sub
+when routing a STEER / INJECT_MESSAGE targeting a specific session, so
+a frontend steer action against the ADK session reaches the right sub
+without being fanned out to every sub on that agent (which would cause
+a goldfive bridge to process the same event twice).
+
+Falls back to every live sub when no session-matching sub exists — that
+is the legacy behaviour a home-only topology always took.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from goldfive.pb.goldfive.v1 import control_pb2 as gf_control_pb2
+
+from harmonograf_server.control_router import ControlRouter, DeliveryResult
+
+
+def _event(kind: int, *, agent_id: str = "agent-1") -> gf_control_pb2.ControlEvent:
+    return gf_control_pb2.ControlEvent(
+        kind=kind,
+        target=gf_control_pb2.ControlTarget(agent_id=agent_id),
+    )
+
+
+async def test_delivery_prefers_session_matching_sub_over_home():
+    """Two subs on the same agent, different session_ids. A STEER at a
+    specific session_id lands only on the matching sub."""
+    router = ControlRouter()
+    home = await router.subscribe("home-session", "agent-X", "home-str")
+    adk = await router.subscribe("adk-session-abc", "agent-X", "adk-str")
+
+    deliver_task = asyncio.create_task(
+        router.deliver(
+            session_id="adk-session-abc",
+            agent_id="agent-X",
+            event=_event(gf_control_pb2.CONTROL_KIND_STEER, agent_id="agent-X"),
+            timeout_s=2.0,
+        )
+    )
+
+    # The ADK sub's queue gets the event.
+    ev = await asyncio.wait_for(adk.queue.get(), timeout=1.0)
+    assert ev.kind == gf_control_pb2.CONTROL_KIND_STEER
+
+    # The home sub's queue is empty — the router filtered us out.
+    assert home.queue.qsize() == 0
+
+    # Ack via the ADK stream to resolve the delivery.
+    router.record_ack(
+        gf_control_pb2.ControlAck(
+            control_id=ev.id,
+            result=gf_control_pb2.CONTROL_ACK_RESULT_SUCCESS,
+        ),
+        stream_id="adk-str",
+    )
+    outcome = await deliver_task
+    assert outcome.result == DeliveryResult.SUCCESS
+    assert len(outcome.acks) == 1
+    assert outcome.acks[0].stream_id == "adk-str"
+
+    await router.unsubscribe(home)
+    await router.unsubscribe(adk)
+
+
+async def test_delivery_falls_back_to_home_when_no_session_match():
+    """With no session-matching sub, deliver fans out to every live sub
+    on the agent — the legacy home-only path. This preserves backwards
+    compatibility for Clients that never called register_session()."""
+    router = ControlRouter()
+    home = await router.subscribe("home-session", "agent-X", "home-str")
+
+    deliver_task = asyncio.create_task(
+        router.deliver(
+            session_id="an-adk-session-never-subscribed",
+            agent_id="agent-X",
+            event=_event(gf_control_pb2.CONTROL_KIND_STEER, agent_id="agent-X"),
+            timeout_s=2.0,
+        )
+    )
+
+    ev = await asyncio.wait_for(home.queue.get(), timeout=1.0)
+    router.record_ack(
+        gf_control_pb2.ControlAck(
+            control_id=ev.id,
+            result=gf_control_pb2.CONTROL_ACK_RESULT_SUCCESS,
+        ),
+        stream_id="home-str",
+    )
+    outcome = await deliver_task
+    assert outcome.result == DeliveryResult.SUCCESS
+
+    await router.unsubscribe(home)
+
+
+async def test_delivery_without_session_id_fans_out_to_all():
+    """When the caller passes an empty session_id (legacy SendControl
+    without session scoping), every live sub on the agent gets the
+    event. This preserves the multi-stream-per-agent semantics the
+    original router tests cover."""
+    router = ControlRouter()
+    sub_a = await router.subscribe("sess-a", "agent-X", "str-a")
+    sub_b = await router.subscribe("sess-b", "agent-X", "str-b")
+
+    deliver_task = asyncio.create_task(
+        router.deliver(
+            session_id="",
+            agent_id="agent-X",
+            event=_event(gf_control_pb2.CONTROL_KIND_PAUSE, agent_id="agent-X"),
+            timeout_s=2.0,
+        )
+    )
+
+    ev_a = await asyncio.wait_for(sub_a.queue.get(), timeout=1.0)
+    ev_b = await asyncio.wait_for(sub_b.queue.get(), timeout=1.0)
+    assert ev_a.id == ev_b.id  # fan-out, not session-filtered
+
+    router.record_ack(
+        gf_control_pb2.ControlAck(
+            control_id=ev_a.id,
+            result=gf_control_pb2.CONTROL_ACK_RESULT_SUCCESS,
+        ),
+        stream_id="str-a",
+    )
+    outcome = await deliver_task
+    assert outcome.result == DeliveryResult.SUCCESS
+
+    await router.unsubscribe(sub_a)
+    await router.unsubscribe(sub_b)
+
+
+async def test_delivery_with_multiple_session_matched_subs_fans_out_to_them_only():
+    """Two streams on the same (session_id, agent_id) — e.g. a client
+    with two redundant control channels for the same ADK session — both
+    get the event, but a sub on a DIFFERENT session on that agent does
+    NOT. Tests the filter is by session_id equality, not "pick one"."""
+    router = ControlRouter()
+    sess_a_1 = await router.subscribe("sess-A", "agent-X", "a1")
+    sess_a_2 = await router.subscribe("sess-A", "agent-X", "a2")
+    sess_b = await router.subscribe("sess-B", "agent-X", "b1")
+
+    deliver_task = asyncio.create_task(
+        router.deliver(
+            session_id="sess-A",
+            agent_id="agent-X",
+            event=_event(gf_control_pb2.CONTROL_KIND_STEER, agent_id="agent-X"),
+            timeout_s=2.0,
+        )
+    )
+
+    ev_a1 = await asyncio.wait_for(sess_a_1.queue.get(), timeout=1.0)
+    ev_a2 = await asyncio.wait_for(sess_a_2.queue.get(), timeout=1.0)
+    assert ev_a1.id == ev_a2.id
+
+    # The other-session sub must NOT receive the event.
+    assert sess_b.queue.qsize() == 0
+
+    router.record_ack(
+        gf_control_pb2.ControlAck(
+            control_id=ev_a1.id,
+            result=gf_control_pb2.CONTROL_ACK_RESULT_SUCCESS,
+        ),
+        stream_id="a1",
+    )
+    outcome = await deliver_task
+    assert outcome.result == DeliveryResult.SUCCESS
+
+    await router.unsubscribe(sess_a_1)
+    await router.unsubscribe(sess_a_2)
+    await router.unsubscribe(sess_b)
+
+
+async def test_alias_path_still_works_with_session_scoping():
+    """Alias path (sub-agent name → stream agent_id) must coexist with
+    session filtering. The alias resolves the bucket; session filter
+    then scopes within it."""
+    router = ControlRouter()
+    real = await router.subscribe("sess-A", "agent-real-uuid", "rx")
+    router.register_alias("sub-agent-name", "agent-real-uuid")
+
+    deliver_task = asyncio.create_task(
+        router.deliver(
+            session_id="sess-A",
+            agent_id="sub-agent-name",
+            event=_event(
+                gf_control_pb2.CONTROL_KIND_STEER, agent_id="sub-agent-name"
+            ),
+            timeout_s=2.0,
+        )
+    )
+
+    ev = await asyncio.wait_for(real.queue.get(), timeout=1.0)
+    router.record_ack(
+        gf_control_pb2.ControlAck(
+            control_id=ev.id,
+            result=gf_control_pb2.CONTROL_ACK_RESULT_SUCCESS,
+        ),
+        stream_id="rx",
+    )
+    outcome = await deliver_task
+    assert outcome.result == DeliveryResult.SUCCESS
+
+    await router.unsubscribe(real)

--- a/tests/e2e/test_adk_session_steer.py
+++ b/tests/e2e/test_adk_session_steer.py
@@ -1,0 +1,157 @@
+"""End-to-end: STEER targeting an ADK session reaches a bound steerer
+on the Client (harmonograf #53).
+
+This is the critical regression test for the issue. The failure scenario
+in the bug:
+
+  1. ``HarmonografTelemetryPlugin`` stamps ADK ``session.id`` on every
+     span (PR #48).
+  2. The Client only opens ONE SubscribeControl at startup, keyed on
+     the harmonograf-assigned home session.
+  3. The frontend fires PostAnnotation(STEERING) targeting the ADK
+     session_id.
+  4. The server's ControlRouter finds no sub on (ADK_session, agent_id);
+     delivery returns FAILURE; the run progresses unsteered.
+
+The fix opens additional SubscribeControl streams keyed on each ADK
+session that the plugin sees, and the router prefers those when a
+STEER carries a matching session_id. This test proves the full loop:
+boot server → create Client → register ADK session → simulate a
+frontend STEER via ``router.deliver`` → assert a control handler on
+the Client fires.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from goldfive.pb.goldfive.v1 import control_pb2 as gf_control_pb2
+
+from harmonograf_client import Client
+from harmonograf_server.control_router import DeliveryResult
+
+
+ADK_SESSION = "adk-session-e2e-steer"
+
+
+@pytest.mark.asyncio
+async def test_steer_reaches_bound_steerer_via_adk_session_subscription(
+    harmonograf_server,
+) -> None:
+    """The bug reproducer. Registers an ADK session on the Client, then
+    fires a STEER via the server's router targeting that ADK session.
+    The Client's bound handler must receive the event — not get starved
+    because of the home-only sub topology."""
+    addr = harmonograf_server["addr"]
+    router = harmonograf_server["router"]
+
+    client = Client(
+        name="adk-session-steer",
+        agent_id="agent-steer-e2e",
+        server_addr=addr,
+    )
+    received_events: list[gf_control_pb2.ControlEvent] = []
+
+    def on_steer(event: gf_control_pb2.ControlEvent):
+        received_events.append(event)
+        return None  # default "success"
+
+    client.on_control("STEER", on_steer)
+    try:
+        # Wait for the home subscription to be in place on the router.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if router.live_stream_ids(client.agent_id):
+                break
+            await asyncio.sleep(0.02)
+        assert router.live_stream_ids(client.agent_id), "home sub never registered"
+
+        # Register the ADK session. This is the hook the plugin drives
+        # on first span for a session — here we invoke it directly.
+        client.register_session(ADK_SESSION)
+
+        # Wait until the router sees the per-session sub. The router
+        # indexes by agent_id, so we inspect the session_ids of the
+        # live subs.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            subs = [
+                sub
+                for sub in router._subs.get(client.agent_id, {}).values()
+                if sub.session_id == ADK_SESSION and not sub.closed
+            ]
+            if subs:
+                break
+            await asyncio.sleep(0.02)
+        assert subs, "per-ADK-session sub never registered on router"
+
+        # Fire a STEER at (ADK_SESSION, agent_id) — the shape PostAnnotation
+        # would produce. Before the fix this returned delivery=FAILURE
+        # because no sub matched; after the fix the session-scoped sub
+        # receives it and the Client handler acks success.
+        event = gf_control_pb2.ControlEvent(
+            kind=gf_control_pb2.CONTROL_KIND_STEER,
+            target=gf_control_pb2.ControlTarget(agent_id=client.agent_id),
+        )
+        event.steer.note = "focus on the next step"
+
+        outcome = await router.deliver(
+            session_id=ADK_SESSION,
+            agent_id=client.agent_id,
+            event=event,
+            timeout_s=5.0,
+        )
+        assert outcome.result == DeliveryResult.SUCCESS, outcome
+        # The Client's steer handler saw exactly one event, and the
+        # payload landed with the right note.
+        assert len(received_events) == 1
+        assert received_events[0].steer.note == "focus on the next step"
+
+    finally:
+        client.shutdown(flush_timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_steer_without_adk_session_falls_back_to_home_sub(
+    harmonograf_server,
+) -> None:
+    """A STEER with an unknown session_id (or one for which the Client
+    never called register_session) still reaches the home sub — the
+    legacy behaviour. Protects against a regression where the session
+    filter becomes strictly exclusive."""
+    addr = harmonograf_server["addr"]
+    router = harmonograf_server["router"]
+
+    client = Client(
+        name="fallback-steer",
+        agent_id="agent-fallback-e2e",
+        server_addr=addr,
+    )
+    received_events: list[gf_control_pb2.ControlEvent] = []
+    client.on_control("STEER", lambda ev: received_events.append(ev) or None)
+    try:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if router.live_stream_ids(client.agent_id):
+                break
+            await asyncio.sleep(0.02)
+
+        event = gf_control_pb2.ControlEvent(
+            kind=gf_control_pb2.CONTROL_KIND_STEER,
+            target=gf_control_pb2.ControlTarget(agent_id=client.agent_id),
+        )
+        event.steer.note = "fall back please"
+
+        outcome = await router.deliver(
+            session_id="some-session-we-never-subscribed",
+            agent_id=client.agent_id,
+            event=event,
+            timeout_s=5.0,
+        )
+        assert outcome.result == DeliveryResult.SUCCESS
+        assert len(received_events) == 1
+    finally:
+        client.shutdown(flush_timeout=1.0)


### PR DESCRIPTION
## Summary

- Fix the broken STEER path discovered after PR #48: the client's single home-keyed SubscribeControl could never match a PostAnnotation(STEERING, session_id=<ADK_session>) because ADK session ids are distinct from the harmonograf-assigned home session; the router returned delivery=FAILURE and runs progressed unsteered.
- Open additional per-ADK-session SubscribeControl streams on demand from the telemetry plugin. Server router now prefers session-matching subs when routing, falls back to the home sub otherwise — so the new topology is strictly additive and backwards-compatible for clients that never register a session.

## Implementation

* `Transport.open_session_subscription` / `close_session_subscription`: spawn and cancel secondary SubscribeControl tasks that share the home telemetry upstream for ack flow. Idempotent, thread-safe, survive reconnect via `_start_registered_session_subs`, cleaned up in a `try/finally` on `_serve` teardown.
* `Client.register_session` / `unregister_session`: public API wrapping the transport.
* `HarmonografTelemetryPlugin._ensure_session_subscription`: auto-registers on first span for each ADK session; tracks seen sessions so repeated spans collapse to one subscription.
* `ControlRouter.deliver`: filters live-sub bucket by `session_id` when any match; falls back to all subs otherwise.
* `ControlRouter.record_ack`: no longer drops acks whose ingest-level `stream_id` is not in `expected_stream_ids` — the telemetry stream_id differs from the SubscribeControl stream_id when one telemetry stream carries multiple control subs, but the control_id already disambiguates the pending delivery.

## Test plan

- [x] `client-test` — 183 passed (27 pre-existing + 12 new client-side, plus integration)
- [x] `server-test` — 263 passed, 1 skipped (21 pre-existing control + 5 new session-scoped)
- [x] `e2e` — 9 passed, 3 skipped (2 new STEER-round-trip scenarios in `tests/e2e/test_adk_session_steer.py`)

New tests covering the six cases from the issue design:
- `test_register_session_opens_new_control_stream`
- `test_register_session_is_idempotent`
- `test_plugin_registers_session_on_first_invocation_span` / `...model_span` / `...tool_span`
- `test_plugin_does_not_re_register_same_session`
- `test_steer_reaches_bound_steerer_via_adk_session_subscription`
- `test_delivery_prefers_session_matching_sub_over_home` (plus three other router-filter variants)

Closes #53.