### PR TITLE
Add control_channel() helper for adk-web control bridge (closes #55)

### DIFF
--- a/client/harmonograf_client/__init__.py
+++ b/client/harmonograf_client/__init__.py
@@ -36,6 +36,7 @@ Public surface (stable):
 from __future__ import annotations
 
 from .client import Client
+from .control_channel import control_channel
 from .enums import Capability, SpanKind, SpanStatus
 from .observe import observe
 from .sink import HarmonografSink
@@ -50,6 +51,7 @@ __all__ = [
     "HarmonografTelemetryPlugin",
     "SpanKind",
     "SpanStatus",
+    "control_channel",
     "observe",
 ]
 

--- a/client/harmonograf_client/_control_bridge.py
+++ b/client/harmonograf_client/_control_bridge.py
@@ -14,21 +14,32 @@ transport:
 1. Intercept every raw ``goldfive.v1.ControlEvent`` from the client (via
    :meth:`Client.set_control_forward`), convert it to a goldfive
    :class:`ControlMessage` with :func:`goldfive.conv.from_pb_control_event`,
-   and hand it off to the runner's ``control`` channel. The proto's
-   ``id`` becomes the message ``id`` so acks correlate end-to-end.
+   and hand it off to the bound goldfive :class:`ControlChannel`. The
+   proto's ``id`` becomes the message ``id`` so acks correlate
+   end-to-end.
 2. Mirror goldfive :class:`ControlAck` objects back out as harmonograf
    ``ControlAck`` frames via :meth:`Client.send_control_ack`. The ack
    wire type is also goldfive's now, but the bridge still hops across
    transport+loop boundaries so callers on either side can stay naive.
-3. Tear down cleanly when :meth:`Runner.close` is called (via the close
-   hook :func:`observe` registers) — forward hook uninstalled, both
-   forwarding tasks cancelled, and the goldfive channel closed so any
-   in-flight ``runner.control.acks()`` consumer exits its iterator.
+3. Tear down cleanly when :meth:`stop` is called — forward hook
+   uninstalled, both forwarding tasks cancelled, and the goldfive
+   channel closed so any in-flight ``channel.acks()`` consumer exits
+   its iterator.
 
-The bridge does NOT attach a control channel to the runner — that is
-:func:`observe`'s responsibility, done before :meth:`start` is called.
-This keeps wiring in one place and lets the bridge assume
-``runner.control`` is non-None for its entire lifetime.
+The bridge operates directly on a :class:`ControlChannel` — it is the
+caller's responsibility to attach that channel to the runner (via
+:attr:`Runner.control`, or by passing ``control=`` to
+:func:`goldfive.wrap`). Two helpers wire this up:
+
+* :func:`harmonograf_client.observe` — for code paths that own a
+  :class:`goldfive.Runner` directly. ``observe`` attaches a channel to
+  ``runner.control``, builds a bridge, and registers ``bridge.stop`` as
+  a runner close hook.
+* :func:`harmonograf_client.control_channel` — for code paths that hand
+  a wrapped ADK agent to ``App(root_agent=...)`` and therefore never see
+  the underlying :class:`Runner`. ``control_channel`` returns a bare
+  :class:`ControlChannel` backed by a live bridge; pass it to
+  :func:`goldfive.wrap` via ``control=``. See harmonograf#55.
 """
 
 from __future__ import annotations
@@ -39,6 +50,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
+    from goldfive.control import ControlChannel
+
     from .client import Client
 
 log = logging.getLogger("harmonograf_client._control_bridge")
@@ -49,20 +62,32 @@ class ControlBridge:
 
     The bridge is single-use: :meth:`start` installs the forward hook
     and spawns two asyncio tasks (one for incoming events, one for
-    outgoing acks); :meth:`stop` tears everything down. The caller
-    (:func:`observe`) is responsible for attaching a ``ControlChannel``
-    to the runner BEFORE calling :meth:`start`, and for registering
-    :meth:`stop` as a runner close hook.
+    outgoing acks); :meth:`stop` tears everything down.
+
+    Parameters
+    ----------
+    client:
+        The :class:`Client` whose ``SubscribeControl`` stream feeds
+        events in and whose ``ControlAck`` stream carries acks back out.
+    channel:
+        The goldfive :class:`ControlChannel` the bridge forwards events
+        onto (and drains acks from). The caller is responsible for
+        keeping this channel attached to a runner (either via
+        ``runner.control = channel`` or ``goldfive.wrap(control=channel,
+        ...)``) for the bridge's lifetime.
+    loop:
+        The asyncio loop the forwarding tasks run on. Must be the loop
+        the runner is driven by.
     """
 
     def __init__(
         self,
         client: "Client",
-        runner: Any,
+        channel: "ControlChannel",
         loop: asyncio.AbstractEventLoop,
     ) -> None:
         self._client = client
-        self._runner = runner
+        self._channel = channel
         self._loop = loop
         self._inbox: asyncio.Queue = asyncio.Queue()
         self._events_task: Optional[asyncio.Task] = None
@@ -70,12 +95,15 @@ class ControlBridge:
         self._started = False
         self._closed = False
 
+    @property
+    def channel(self) -> "ControlChannel":
+        """The goldfive :class:`ControlChannel` this bridge forwards onto."""
+        return self._channel
+
     def start(self) -> None:
         """Install the forward hook and spin up forwarding tasks.
 
-        Idempotent — calling ``start`` twice is a no-op. The runner must
-        already have a ``ControlChannel`` attached via
-        ``runner.control`` when this is called.
+        Idempotent — calling ``start`` twice is a no-op.
         """
         if self._started:
             return
@@ -124,24 +152,15 @@ class ControlBridge:
                 )
                 continue
 
-            chan = self._runner.control
-            if chan is None:
-                self._client.send_control_ack(
-                    msg.id, "failure", "runner has no control channel"
-                )
-                continue
             try:
-                await chan.send(msg)
+                await self._channel.send(msg)
             except Exception as exc:  # noqa: BLE001
-                log.warning("failed to forward control to runner: %s", exc)
+                log.warning("failed to forward control to channel: %s", exc)
                 self._client.send_control_ack(msg.id, "failure", repr(exc))
 
     async def _acks_loop(self) -> None:
-        chan = self._runner.control
-        if chan is None:
-            return
         try:
-            async for ack in chan.acks():
+            async for ack in self._channel.acks():
                 result_name = _ack_result_name(ack.result)
                 self._client.send_control_ack(
                     ack.control_id, result_name, getattr(ack, "detail", "") or ""
@@ -160,7 +179,9 @@ class ControlBridge:
 
         Idempotent. Safe to call from any coroutine running on the same
         loop the bridge was started on. Intended to be registered as a
-        :meth:`Runner.add_close_hook` by :func:`observe`.
+        :meth:`Runner.add_close_hook` by :func:`observe`, or driven
+        explicitly by the caller when the bridge backs a standalone
+        channel (:func:`control_channel`).
         """
         if self._closed:
             return
@@ -174,12 +195,10 @@ class ControlBridge:
             with contextlib.suppress(BaseException):
                 await t
 
-        chan = self._runner.control
-        if chan is not None:
-            try:
-                chan.close()
-            except Exception:  # noqa: BLE001
-                pass
+        try:
+            self._channel.close()
+        except Exception:  # noqa: BLE001
+            pass
 
 
 # ----------------------------------------------------------------------

--- a/client/harmonograf_client/control_channel.py
+++ b/client/harmonograf_client/control_channel.py
@@ -1,0 +1,108 @@
+"""Standalone control channel factory for the ``adk web`` code path.
+
+Under ``adk web`` (and more broadly, anywhere callers hand a wrapped ADK
+agent to ``App(root_agent=...)`` instead of driving a
+:class:`goldfive.Runner` themselves), :func:`observe` cannot be used:
+there is no :class:`Runner` instance to attach a :class:`ControlBridge`
+to before ``App`` takes ownership of the wrapped agent.
+
+:func:`control_channel` plugs the gap. It builds a goldfive
+:class:`ControlChannel` up front, wires a live :class:`ControlBridge`
+into it against the caller's :class:`Client`, and returns the channel so
+it can be passed into :func:`goldfive.wrap` via ``control=``::
+
+    client = harmonograf_client.Client(...)
+    channel = harmonograf_client.control_channel(client)
+    wrapped = goldfive.wrap(tree, control=channel, ...)
+    app = App(root_agent=wrapped, plugins=[HarmonografTelemetryPlugin(client)])
+
+Once ``adk web`` drives ``wrapped`` the returned channel forwards every
+STEER / PAUSE / CANCEL / APPROVE / REJECT event from the harmonograf UI
+into the goldfive steerer / runner. See harmonograf#55 for the bug this
+fixes — before this helper, ``HarmonografTelemetryPlugin`` wired only
+the span sink and the control bridge was never installed, so steers
+returned ``delivery=FAILURE``.
+
+Unlike :func:`observe`, this helper does NOT register a close hook
+(there is no runner to register against). The bridge lives for as long
+as the caller's event loop survives; when the caller is done the
+returned channel's ``close()`` method (or
+:meth:`ControlBridge.stop`, if the caller held onto it via the
+``_harmonograf_control_bridge`` attribute on the channel) shuts things
+down cleanly. For the common ``adk web`` lifecycle this is handled by
+the client's own atexit shutdown — the forwarding tasks are daemon-ish
+(cancelled when the loop tears down) and no resource leaks if they
+outlive a run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from ._control_bridge import ControlBridge
+
+if TYPE_CHECKING:
+    from goldfive.control import ControlChannel
+
+    from .client import Client
+
+log = logging.getLogger("harmonograf_client.control_channel")
+
+
+def control_channel(client: "Client") -> "ControlChannel":
+    """Return a :class:`ControlChannel` that receives steers from harmonograf.
+
+    The returned channel is backed by a live :class:`ControlBridge` that
+    bridges ``client``'s ``SubscribeControl`` gRPC stream onto the
+    channel's inbox, and mirrors goldfive :class:`ControlAck` objects
+    back out as harmonograf ``ControlAck`` frames. Pass the channel to
+    :func:`goldfive.wrap` via ``control=``::
+
+        channel = harmonograf_client.control_channel(client)
+        wrapped = goldfive.wrap(tree, control=channel, ...)
+
+    Must be called from within a running asyncio event loop — the bridge
+    needs a loop to consume events on.
+
+    Parameters
+    ----------
+    client:
+        The :class:`Client` whose control stream feeds the returned
+        channel. Typically the same :class:`Client` passed to
+        :class:`HarmonografTelemetryPlugin` so spans and steers share
+        identity.
+
+    Returns
+    -------
+    ControlChannel
+        A goldfive :class:`ControlChannel` with a live bridge attached.
+        The bridge is stashed on the channel as
+        ``channel._harmonograf_control_bridge`` so callers (and tests)
+        that need explicit teardown can drive :meth:`ControlBridge.stop`.
+
+    Notes
+    -----
+    The returned channel is not attached to any :class:`Runner` — the
+    caller is responsible for passing it to :func:`goldfive.wrap` via
+    ``control=`` (or assigning it to :attr:`Runner.control` directly).
+    Attaching the same channel to multiple runners is undefined.
+    """
+    from goldfive.control import ControlChannel
+
+    channel = ControlChannel()
+    loop = asyncio.get_running_loop()
+    bridge = ControlBridge(client, channel, loop)
+    bridge.start()
+
+    # Stash the bridge on the channel so tests and advanced callers can
+    # drive ``bridge.stop`` for deterministic teardown. Underscore prefix
+    # flags this as private plumbing, not part of ControlChannel's
+    # public contract.
+    channel._harmonograf_control_bridge = bridge  # type: ignore[attr-defined]
+
+    return channel
+
+
+__all__ = ["control_channel"]

--- a/client/harmonograf_client/observe.py
+++ b/client/harmonograf_client/observe.py
@@ -134,7 +134,7 @@ def observe(
     from ._control_bridge import ControlBridge
 
     loop = asyncio.get_running_loop()
-    bridge = ControlBridge(client, runner, loop)
+    bridge = ControlBridge(client, runner.control, loop)
     bridge.start()
     runner.add_close_hook(bridge.stop)
 

--- a/client/tests/test_control_bridge.py
+++ b/client/tests/test_control_bridge.py
@@ -155,7 +155,7 @@ async def test_goldfive_event_forwards_to_channel(
 ) -> None:
     runner = _runner_with_channel()
     loop = asyncio.get_running_loop()
-    bridge = ControlBridge(client, runner, loop)
+    bridge = ControlBridge(client, runner.control, loop)
     bridge.start()
 
     transport = made[0]
@@ -176,7 +176,7 @@ async def test_steer_payload_lands_under_note(
     client: Client, made: list[FakeTransport]
 ) -> None:
     runner = _runner_with_channel()
-    bridge = ControlBridge(client, runner, asyncio.get_running_loop())
+    bridge = ControlBridge(client, runner.control, asyncio.get_running_loop())
     bridge.start()
 
     made[0].deliver_control_event(
@@ -195,7 +195,7 @@ async def test_rewind_to_payload_lands_under_task_id(
     client: Client, made: list[FakeTransport]
 ) -> None:
     runner = _runner_with_channel()
-    bridge = ControlBridge(client, runner, asyncio.get_running_loop())
+    bridge = ControlBridge(client, runner.control, asyncio.get_running_loop())
     bridge.start()
 
     made[0].deliver_control_event(
@@ -230,7 +230,7 @@ async def test_goldfive_ack_flows_back_to_server(
     expected_name: str,
 ) -> None:
     runner = _runner_with_channel()
-    bridge = ControlBridge(client, runner, asyncio.get_running_loop())
+    bridge = ControlBridge(client, runner.control, asyncio.get_running_loop())
     bridge.start()
 
     assert runner.control is not None
@@ -267,7 +267,7 @@ async def test_runner_close_tears_down_bridge_via_close_hook(
     guaranteed; only the wiring changed.
     """
     runner = _runner_with_channel()
-    bridge = ControlBridge(client, runner, asyncio.get_running_loop())
+    bridge = ControlBridge(client, runner.control, asyncio.get_running_loop())
     bridge.start()
     runner.add_close_hook(bridge.stop)
 

--- a/client/tests/test_control_channel.py
+++ b/client/tests/test_control_channel.py
@@ -1,0 +1,243 @@
+"""Tests for :func:`harmonograf_client.control_channel`.
+
+``control_channel(client)`` is the adk-web-friendly counterpart of
+:func:`observe`: it returns a bare :class:`goldfive.ControlChannel`
+backed by a live :class:`ControlBridge`, suitable for passing into
+:func:`goldfive.wrap` via ``control=``. The use case is the
+``App(root_agent=goldfive.wrap(tree, control=...))`` pattern where the
+caller never holds a :class:`goldfive.Runner` reference — so
+:func:`observe` (which mutates a runner) does not apply. See
+harmonograf#55.
+
+Coverage:
+
+- :func:`control_channel` returns a :class:`ControlChannel` with a live
+  :class:`ControlBridge` attached as ``_harmonograf_control_bridge``.
+- A ``ControlEvent`` delivered on the underlying transport reaches the
+  returned channel's inbox as a goldfive :class:`ControlMessage`.
+- Acks pushed into the channel flow back out through the client's
+  transport with the right result enum and detail string.
+- End-to-end wiring against a real :class:`goldfive.Runner` via
+  :func:`goldfive.wrap`: the channel we return IS the one
+  ``runner.control`` ends up pointing at, so the runner's
+  :meth:`receive` sees frontend-issued steers.
+- Driving :meth:`ControlBridge.stop` via the stashed attribute tears
+  the bridge down cleanly and closes the channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import goldfive
+from goldfive.control import (
+    AckResult,
+    ControlAck,
+    ControlChannel,
+    ControlKind,
+)
+from goldfive.pb.goldfive.v1 import control_pb2 as gf_control_pb2
+
+from harmonograf_client import control_channel
+from harmonograf_client._control_bridge import ControlBridge
+from harmonograf_client.client import Client
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+def _make_event(
+    kind_name: str,
+    *,
+    control_id: str = "c-1",
+    steer_note: str | None = None,
+) -> gf_control_pb2.ControlEvent:
+    """Build a goldfive ``ControlEvent`` proto with the requested kind."""
+    kind_enum = getattr(gf_control_pb2, f"CONTROL_KIND_{kind_name}")
+    ev = gf_control_pb2.ControlEvent(id=control_id, kind=kind_enum)
+    if steer_note is not None:
+        ev.steer.note = steer_note
+    return ev
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="cc-client",
+        agent_id="agent-cc",
+        session_id="sess-cc",
+        framework="ADK",
+        buffer_size=8,
+        _transport_factory=make_factory(made),
+    )
+
+
+async def _drain(loop_count: int = 4) -> None:
+    """Yield control enough times for call_soon_threadsafe hand-offs to land."""
+    for _ in range(loop_count):
+        await asyncio.sleep(0)
+
+
+# ----------------------------------------------------------------------
+# Shape + wiring
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_live_control_channel_with_bridge(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    channel = control_channel(client)
+
+    try:
+        assert isinstance(channel, ControlChannel)
+        bridge = getattr(channel, "_harmonograf_control_bridge", None)
+        assert isinstance(bridge, ControlBridge)
+        # The bridge installed its transport-side forward hook during
+        # start() — absence would mean no steer/cancel/pause event ever
+        # reaches this channel.
+        assert made[0].control_forward is not None
+    finally:
+        bridge = getattr(channel, "_harmonograf_control_bridge", None)
+        if bridge is not None:
+            await bridge.stop()
+
+
+# ----------------------------------------------------------------------
+# Event forwarding — the actual bug this helper fixes
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_steer_event_forwards_to_returned_channel(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    """A STEER over the transport lands on the returned channel as a goldfive msg.
+
+    This is the exact delivery path that was broken in harmonograf#55
+    under ``adk web``: before the fix, no bridge existed between the
+    client's ``SubscribeControl`` stream and the runner's control
+    channel, so the server's PostAnnotation returned
+    ``delivery=2 detail='delivery failed'``.
+    """
+    channel = control_channel(client)
+
+    try:
+        made[0].deliver_control_event(
+            _make_event("STEER", control_id="cc-steer-1", steer_note="fix slide 3")
+        )
+
+        msg = await asyncio.wait_for(channel.receive(), timeout=1.0)
+        assert msg is not None
+        assert msg.kind is ControlKind.STEER
+        assert msg.id == "cc-steer-1"
+        assert msg.payload["note"] == "fix slide 3"
+    finally:
+        bridge = getattr(channel, "_harmonograf_control_bridge", None)
+        if bridge is not None:
+            await bridge.stop()
+
+
+@pytest.mark.asyncio
+async def test_ack_flows_back_to_transport(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    channel = control_channel(client)
+
+    try:
+        await channel.ack(
+            ControlAck(
+                control_id="cc-ack-1",
+                result=AckResult.SUCCESS,
+                detail="handled",
+            )
+        )
+        await _drain()
+
+        assert any(
+            aid == "cc-ack-1" and res == "success" and det == "handled"
+            for aid, res, det in made[0].sent_acks
+        ), made[0].sent_acks
+    finally:
+        bridge = getattr(channel, "_harmonograf_control_bridge", None)
+        if bridge is not None:
+            await bridge.stop()
+
+
+# ----------------------------------------------------------------------
+# End-to-end: goldfive.wrap(control=channel, ...) — the adk-web path
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_with_goldfive_wrap(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    """Pass the channel into ``goldfive.wrap(control=...)`` and see a steer land.
+
+    This mirrors the presentation_agent_orchestrated demo's wiring:
+
+        channel = harmonograf_client.control_channel(client)
+        wrapped = goldfive.wrap(tree, control=channel, ...)
+        app = App(root_agent=wrapped, ...)
+
+    The Runner inside ``wrapped`` must expose the same channel as its
+    ``runner.control`` — otherwise the Steerer polls a different inbox
+    than the one the bridge publishes to.
+    """
+
+    async def _trivial_agent(task, session, tools):  # noqa: ARG001
+        from goldfive.results import InvocationResult
+
+        return InvocationResult(output_text="ok")
+
+    channel = control_channel(client)
+
+    try:
+        runner = goldfive.wrap(_trivial_agent, control=channel)
+        # Identity, not just equality — the Runner's control must BE the
+        # bridge-backed channel or the steer path is broken.
+        assert runner.control is channel
+
+        made[0].deliver_control_event(
+            _make_event("CANCEL", control_id="cc-e2e-1")
+        )
+
+        msg = await asyncio.wait_for(runner.control.receive(), timeout=1.0)
+        assert msg is not None
+        assert msg.kind is ControlKind.CANCEL
+        assert msg.id == "cc-e2e-1"
+    finally:
+        bridge = getattr(channel, "_harmonograf_control_bridge", None)
+        if bridge is not None:
+            await bridge.stop()
+
+
+# ----------------------------------------------------------------------
+# Teardown
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bridge_stop_tears_down_cleanly(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    channel = control_channel(client)
+    bridge: ControlBridge = channel._harmonograf_control_bridge  # type: ignore[attr-defined]
+
+    assert made[0].control_forward is not None
+    assert bridge._events_task is not None
+    assert bridge._acks_task is not None
+
+    await bridge.stop()
+
+    assert made[0].control_forward is None
+    assert bridge._events_task.done()
+    assert bridge._acks_task.done()
+    assert bridge._closed is True

--- a/tests/e2e/test_presentation_agent.py
+++ b/tests/e2e/test_presentation_agent.py
@@ -161,6 +161,50 @@ class TestOrchestratedAppExport:
         plugin_names = {getattr(p, "name", "") for p in (app.plugins or [])}
         assert "harmonograf-telemetry" in plugin_names
 
+    @pytest.mark.asyncio
+    async def test_orchestrated_app_wires_control_channel(
+        self,
+        presentation_agent_orchestrated_module: Any,
+        harmonograf_server: dict,
+    ) -> None:
+        """``_build_app`` must wire a live ControlChannel into the Runner.
+
+        Regression guard for harmonograf#55: the old orchestrated-mode
+        build installed only ``HarmonografTelemetryPlugin`` so STEER /
+        PAUSE / CANCEL events from the UI returned ``delivery=FAILURE``
+        — spans flowed out but nothing flowed back in. This test
+        exercises the exact construction path (inside an event loop,
+        the same shape ``adk web`` uses) and asserts that the wrapped
+        runner's ``.control`` is the bridge-backed channel.
+        """
+        from harmonograf_client._control_bridge import ControlBridge
+
+        prev = os.environ.pop("OPENAI_API_KEY", None)
+        os.environ["HARMONOGRAF_SERVER"] = harmonograf_server["addr"]
+        try:
+            # First-access is lazy — run on this asyncio loop so
+            # ``control_channel(client)`` finds it.
+            app = presentation_agent_orchestrated_module.app
+        finally:
+            os.environ.pop("HARMONOGRAF_SERVER", None)
+            if prev is not None:
+                os.environ["OPENAI_API_KEY"] = prev
+
+        root = app.root_agent
+        # Dig for the Runner the wrap built. GoldfiveADKAgent keeps the
+        # Runner under ``_runner`` post-wrap; we just need its control.
+        runner = getattr(root, "_runner", None) or getattr(root, "runner", None)
+        assert runner is not None, f"no runner on {type(root).__name__}"
+        assert runner.control is not None, (
+            "runner.control is None — ``control_channel`` did not wire; "
+            "steers will return delivery=FAILURE (harmonograf#55)"
+        )
+        bridge = getattr(runner.control, "_harmonograf_control_bridge", None)
+        assert isinstance(bridge, ControlBridge), (
+            "runner.control is not a bridge-backed channel; the UI control "
+            "path will not reach the goldfive steerer"
+        )
+
 
 class TestPresentationGoldfiveRunner:
     """End-to-end: goldfive Runner + HarmonografSink via build_goldfive_runner.

--- a/tests/reference_agents/presentation_agent_orchestrated/agent.py
+++ b/tests/reference_agents/presentation_agent_orchestrated/agent.py
@@ -181,10 +181,14 @@ def _build_app() -> Any:
     goal_deriver = LLMGoalDeriver(call_llm=call_llm, model=planner_model)
 
     plugins: list[Any] = []
+    control = None
     client = _get_or_create_client()
     if client is not None:
         try:
-            from harmonograf_client import HarmonografTelemetryPlugin
+            from harmonograf_client import (
+                HarmonografTelemetryPlugin,
+                control_channel,
+            )
         except Exception as e:  # noqa: BLE001
             log.warning(
                 "HarmonografTelemetryPlugin unavailable (%s); running without spans",
@@ -192,12 +196,31 @@ def _build_app() -> Any:
             )
         else:
             plugins.append(HarmonografTelemetryPlugin(client))
+            # Wire harmonograf UI → goldfive steerer. Without this
+            # ``control=`` hook, STEER / PAUSE / CANCEL / APPROVE /
+            # REJECT events from the frontend return
+            # ``delivery=FAILURE`` — the plugin wires spans out, not
+            # control back in. See harmonograf#55.
+            try:
+                control = control_channel(client)
+            except RuntimeError as e:
+                # ``control_channel`` needs a running event loop. When
+                # ``_build_app`` is called from a non-async context
+                # (e.g. synchronous test setup) we skip the bridge and
+                # log; adk web always builds the app inside its loop so
+                # the production path is covered.
+                log.warning(
+                    "control_channel skipped (no running loop): %s; steers "
+                    "will return delivery=FAILURE for this App",
+                    e,
+                )
 
     wrapped = goldfive.wrap(
         tree,
         planner=planner,
         goal_deriver=goal_deriver,
         plugins=plugins,
+        control=control,
     )
 
     return App(


### PR DESCRIPTION
## Summary

- Adds ``harmonograf_client.control_channel(client)``, which returns a live ``goldfive.ControlChannel`` backed by a fresh ``ControlBridge``. Pass it to ``goldfive.wrap(control=channel, ...)`` so STEER / PAUSE / CANCEL / APPROVE / REJECT events from the harmonograf UI reach the goldfive steerer under ``adk web``.
- Refactors ``ControlBridge`` to accept a ``ControlChannel`` directly instead of a runner, so the same implementation backs both ``observe()`` (which keeps attaching the channel to ``runner.control``) and the new helper.
- Updates ``presentation_agent_orchestrated`` demo to wire ``control=control_channel(client)`` into its ``goldfive.wrap`` call, which is the exact code path ``adk web`` exercises.

## Root cause

``HarmonografTelemetryPlugin`` wires only the span sink. Under ``adk web`` there is no ``goldfive.Runner`` to hand to ``observe()`` — just a wrapped ADK agent handed to ``App(root_agent=...)`` — so ``ControlBridge`` never got installed and STEERs returned ``delivery=2 detail='delivery failed'``. The explicit helper keeps the wiring in one place without entangling the plugin.

## Test plan

- [x] ``uv run pytest -x`` — 86 passed, 3 skipped (full top-level suite)
- [x] ``uv run pytest client/`` — 188 passed (all client unit tests)
- [x] New ``client/tests/test_control_channel.py`` covers: helper returns a live channel, STEER forwards to the channel, acks flow back to the transport, end-to-end ``goldfive.wrap(control=...)``, and clean teardown.
- [x] New ``tests/e2e/test_presentation_agent.py::test_orchestrated_app_wires_control_channel`` asserts the wrapped runner's ``.control`` IS the bridge-backed channel — regression guard for the exact bug this fix closes.

Closes #55