### PR TITLE
Wire HarmonografSink into adk-web demo (closes #57)

### DIFF
--- a/client/harmonograf_client/__init__.py
+++ b/client/harmonograf_client/__init__.py
@@ -35,6 +35,7 @@ Public surface (stable):
 
 from __future__ import annotations
 
+from .adk_web import AdkWebObservability, adk_web_observability
 from .client import Client
 from .control_channel import control_channel
 from .enums import Capability, SpanKind, SpanStatus
@@ -44,6 +45,7 @@ from .telemetry_plugin import HarmonografTelemetryPlugin
 from .transport import ControlAckSpec
 
 __all__ = [
+    "AdkWebObservability",
     "Capability",
     "Client",
     "ControlAckSpec",
@@ -51,6 +53,7 @@ __all__ = [
     "HarmonografTelemetryPlugin",
     "SpanKind",
     "SpanStatus",
+    "adk_web_observability",
     "control_channel",
     "observe",
 ]

--- a/client/harmonograf_client/adk_web.py
+++ b/client/harmonograf_client/adk_web.py
@@ -1,0 +1,142 @@
+"""Convenience bundle for ``adk web`` observability wiring.
+
+Under ``adk web`` every orchestrated demo needs the same three
+hook-ups from a :class:`Client`:
+
+* :class:`HarmonografTelemetryPlugin` — ADK plugin that emits per-span
+  telemetry (the ``plugins=`` kwarg on :class:`App` and
+  :func:`goldfive.wrap`).
+* :class:`HarmonografSink` — goldfive :class:`EventSink` that ships
+  plan / task / drift events to harmonograf (the ``sinks=`` kwarg on
+  :func:`goldfive.wrap`). Without this, harmonograf's Trajectory view
+  shows "no plan yet" and the Task panel stays at "0 plans · 0 tasks"
+  even while goldfive fires the full event stream — see
+  harmonograf#57.
+* :func:`control_channel` — bridges the UI's STEER / PAUSE / CANCEL /
+  APPROVE / REJECT events back into goldfive's steerer (the
+  ``control=`` kwarg on :func:`goldfive.wrap`). Requires a running
+  event loop — see harmonograf#55 / harmonograf#56.
+
+Spelling these out one at a time is easy to get wrong: the demo in
+``tests/reference_agents/presentation_agent_orchestrated`` originally
+wired plugin + control but forgot the sink, exactly the shape of bug
+harmonograf#57 tracks. This helper bundles the three so every future
+``adk web`` caller gets all three by construction::
+
+    from harmonograf_client import adk_web_observability
+
+    bundle = adk_web_observability(client)
+    wrapped = goldfive.wrap(
+        tree,
+        planner=planner,
+        goal_deriver=goal_deriver,
+        plugins=[bundle.plugin],
+        sinks=[bundle.sink],
+        control=bundle.control,
+    )
+    app = App(root_agent=wrapped, plugins=[bundle.plugin])
+
+``control_channel`` needs a running event loop. The bundle helper
+mirrors the fallback the demo already handled: when no loop is
+running, ``bundle.control`` is ``None`` and a warning is logged. The
+plugin + sink are always populated — they do not depend on a loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from .control_channel import control_channel as _control_channel
+from .sink import HarmonografSink
+from .telemetry_plugin import HarmonografTelemetryPlugin
+
+if TYPE_CHECKING:
+    from goldfive.control import ControlChannel
+
+    from .client import Client
+
+log = logging.getLogger("harmonograf_client.adk_web")
+
+
+@dataclass(frozen=True)
+class AdkWebObservability:
+    """Bundle of the three ``adk web`` observability hook-ups.
+
+    Attributes
+    ----------
+    plugin:
+        :class:`HarmonografTelemetryPlugin` — pass to ``plugins=`` on
+        :class:`App` and :func:`goldfive.wrap`.
+    sink:
+        :class:`HarmonografSink` — pass to ``sinks=`` on
+        :func:`goldfive.wrap`. The missing piece that harmonograf#57
+        tracked.
+    control:
+        :class:`ControlChannel` or ``None``. ``None`` when
+        :func:`adk_web_observability` is called outside a running
+        event loop; a warning is logged in that case and the demo
+        should fall through to ``control=None`` on :func:`goldfive.wrap`
+        (steers will return ``delivery=FAILURE`` until the loop path
+        is taken — same fallback as the pre-bundle demo).
+    """
+
+    plugin: HarmonografTelemetryPlugin
+    sink: HarmonografSink
+    control: Optional["ControlChannel"]
+
+
+def adk_web_observability(client: "Client") -> AdkWebObservability:
+    """Return the three ``adk web`` observability hook-ups for ``client``.
+
+    Bundles :class:`HarmonografTelemetryPlugin`,
+    :class:`HarmonografSink`, and :func:`control_channel` so every
+    orchestrated demo wires all three at once. This is the shape the
+    ``presentation_agent_orchestrated`` demo uses — see that module for
+    an end-to-end example.
+
+    Parameters
+    ----------
+    client:
+        The :class:`Client` whose transport backs all three hook-ups.
+        Span frames (from the plugin), goldfive events (from the
+        sink), and control acks (from the channel bridge) share the
+        same ``agent_id`` and stream so harmonograf correlates them
+        into one run on the UI.
+
+    Returns
+    -------
+    AdkWebObservability
+        A frozen dataclass with ``plugin``, ``sink``, and ``control``.
+        ``control`` is ``None`` when no asyncio loop is running (the
+        only failure mode :func:`control_channel` raises on); the
+        plugin and sink are always populated.
+
+    Notes
+    -----
+    The caller owns ``client``'s lifecycle. The bundle does not
+    register an atexit hook or take ownership of shutdown — call
+    ``client.shutdown()`` when tearing down.
+    """
+    plugin = HarmonografTelemetryPlugin(client)
+    sink = HarmonografSink(client)
+    control: Optional["ControlChannel"]
+    try:
+        control = _control_channel(client)
+    except RuntimeError as e:
+        # ``control_channel`` raises when no asyncio loop is running
+        # (``asyncio.get_running_loop()``). Mirror the demo's existing
+        # fallback — log and return control=None so sink + plugin are
+        # still usable in synchronous contexts.
+        log.warning(
+            "adk_web_observability: control_channel skipped (no running "
+            "loop): %s; steers will return delivery=FAILURE until the "
+            "caller rebuilds the bundle inside an event loop",
+            e,
+        )
+        control = None
+    return AdkWebObservability(plugin=plugin, sink=sink, control=control)
+
+
+__all__ = ["AdkWebObservability", "adk_web_observability"]

--- a/client/tests/test_adk_web.py
+++ b/client/tests/test_adk_web.py
@@ -1,0 +1,140 @@
+"""Tests for :func:`harmonograf_client.adk_web_observability`.
+
+The bundle helper plugs the three-wiring shape every ``adk web`` caller
+needs: telemetry plugin (span stream), plan sink (goldfive event
+stream — the piece harmonograf#57 tracked), and control channel (UI →
+steerer, from harmonograf#55 / #56). Spelling them out one at a time
+is what let the presentation demo ship without the sink; the bundle
+closes that gap by construction.
+
+Coverage:
+
+- In an event loop the bundle populates all three fields with the
+  right types, and the control channel is live (bridge attached).
+- Outside an event loop the helper swallows the ``RuntimeError``
+  ``control_channel`` raises, sets ``control=None``, and still
+  returns plugin + sink — mirroring the demo's pre-bundle fallback.
+- The sink actually ships goldfive events to the client's transport,
+  so a caller passing ``bundle.sink`` into ``goldfive.wrap(sinks=...)``
+  gets plan / task / drift events on the wire (the harmonograf#57 fix).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from harmonograf_client import (
+    AdkWebObservability,
+    HarmonografSink,
+    HarmonografTelemetryPlugin,
+    adk_web_observability,
+)
+from harmonograf_client._control_bridge import ControlBridge
+from harmonograf_client.client import Client
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="adk-web-client",
+        agent_id="agent-adkweb",
+        session_id="sess-adkweb",
+        framework="ADK",
+        buffer_size=8,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.mark.asyncio
+async def test_bundle_populates_all_three_hookups(client: Client) -> None:
+    bundle = adk_web_observability(client)
+
+    try:
+        assert isinstance(bundle, AdkWebObservability)
+        assert isinstance(bundle.plugin, HarmonografTelemetryPlugin)
+        assert isinstance(bundle.sink, HarmonografSink)
+        # Plugin + sink share the same client so span frames, goldfive
+        # events, and control acks land on one agent_id in harmonograf.
+        assert bundle.sink.client is client
+        # ``control`` is live — has a bridge attached. This only works
+        # inside an event loop, which pytest-asyncio provides here.
+        assert bundle.control is not None
+        bridge = getattr(bundle.control, "_harmonograf_control_bridge", None)
+        assert isinstance(bridge, ControlBridge)
+    finally:
+        bridge = getattr(bundle.control, "_harmonograf_control_bridge", None)
+        if bridge is not None:
+            await bridge.stop()
+
+
+def test_bundle_without_running_loop_returns_control_none(
+    client: Client, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Outside an event loop ``control`` is ``None`` but the rest is live.
+
+    ``control_channel`` calls ``asyncio.get_running_loop()`` which
+    raises ``RuntimeError`` in a synchronous context. The bundle
+    helper must swallow that and log, not propagate — the demo's
+    ``_build_app`` relies on this so imports stay offline-safe.
+    """
+    caplog.set_level(logging.WARNING, logger="harmonograf_client.adk_web")
+
+    bundle = adk_web_observability(client)
+
+    assert isinstance(bundle, AdkWebObservability)
+    assert isinstance(bundle.plugin, HarmonografTelemetryPlugin)
+    assert isinstance(bundle.sink, HarmonografSink)
+    assert bundle.control is None
+    # A warning must be emitted so the demo's operator can spot the
+    # skipped bridge in the adk log.
+    assert any(
+        "control_channel skipped" in rec.message for rec in caplog.records
+    ), [rec.message for rec in caplog.records]
+
+
+@pytest.mark.asyncio
+async def test_sink_forwards_goldfive_events_to_client_buffer(
+    client: Client,
+) -> None:
+    """The bundle's sink must actually push goldfive events onto the client buffer.
+
+    This is the regression guard for harmonograf#57: before the fix,
+    the demo built a telemetry plugin + control channel but no sink,
+    so goldfive's ``plan_submitted`` / ``plan_revised`` /
+    ``drift_detected`` / ``task_*`` events ran through goldfive's
+    default ``LoggingSink`` only and never reached harmonograf's UI.
+    """
+    from goldfive.pb.goldfive.v1 import events_pb2 as ge
+
+    from harmonograf_client.buffer import EnvelopeKind
+
+    bundle = adk_web_observability(client)
+    try:
+        event = ge.Event()
+        event.event_id = "e-adkweb-1"
+        event.run_id = "run-adkweb-1"
+        event.sequence = 0
+        event.run_started.run_id = "run-adkweb-1"
+        event.run_started.goal_summary = "bundle demo"
+
+        await bundle.sink.emit(event)
+
+        envelopes = list(client._events.drain())
+        assert any(
+            env.kind is EnvelopeKind.GOLDFIVE_EVENT
+            and getattr(env.payload, "run_id", "") == "run-adkweb-1"
+            for env in envelopes
+        ), [(e.kind, e.payload) for e in envelopes]
+    finally:
+        bridge = getattr(bundle.control, "_harmonograf_control_bridge", None)
+        if bridge is not None:
+            await bridge.stop()

--- a/tests/e2e/test_presentation_agent.py
+++ b/tests/e2e/test_presentation_agent.py
@@ -205,6 +205,23 @@ class TestOrchestratedAppExport:
             "path will not reach the goldfive steerer"
         )
 
+        # Regression guard for harmonograf#57: a ``HarmonografSink``
+        # must appear among the runner's sinks so goldfive's
+        # ``plan_submitted`` / ``plan_revised`` / ``drift_detected`` /
+        # ``task_*`` events reach harmonograf. Before the fix the demo
+        # only wired the telemetry plugin + control channel; the
+        # goldfive event bus ran through ``LoggingSink`` only and the
+        # UI's Trajectory view stayed at "no plan yet" for the whole
+        # run even while goldfive fired the full event stream.
+        from harmonograf_client import HarmonografSink
+
+        sinks = list(getattr(runner, "sinks", None) or [])
+        assert any(isinstance(s, HarmonografSink) for s in sinks), (
+            "no HarmonografSink on runner.sinks — goldfive plan / task "
+            "events will not reach harmonograf (harmonograf#57). "
+            f"sinks={[type(s).__name__ for s in sinks]}"
+        )
+
 
 class TestPresentationGoldfiveRunner:
     """End-to-end: goldfive Runner + HarmonografSink via build_goldfive_runner.

--- a/tests/reference_agents/presentation_agent_orchestrated/agent.py
+++ b/tests/reference_agents/presentation_agent_orchestrated/agent.py
@@ -181,45 +181,41 @@ def _build_app() -> Any:
     goal_deriver = LLMGoalDeriver(call_llm=call_llm, model=planner_model)
 
     plugins: list[Any] = []
+    sinks: list[Any] = []
     control = None
     client = _get_or_create_client()
     if client is not None:
         try:
-            from harmonograf_client import (
-                HarmonografTelemetryPlugin,
-                control_channel,
-            )
+            from harmonograf_client import adk_web_observability
         except Exception as e:  # noqa: BLE001
             log.warning(
-                "HarmonografTelemetryPlugin unavailable (%s); running without spans",
+                "harmonograf_client.adk_web_observability unavailable (%s); "
+                "running without spans / plan sink / control",
                 e,
             )
         else:
-            plugins.append(HarmonografTelemetryPlugin(client))
-            # Wire harmonograf UI → goldfive steerer. Without this
-            # ``control=`` hook, STEER / PAUSE / CANCEL / APPROVE /
-            # REJECT events from the frontend return
-            # ``delivery=FAILURE`` — the plugin wires spans out, not
-            # control back in. See harmonograf#55.
-            try:
-                control = control_channel(client)
-            except RuntimeError as e:
-                # ``control_channel`` needs a running event loop. When
-                # ``_build_app`` is called from a non-async context
-                # (e.g. synchronous test setup) we skip the bridge and
-                # log; adk web always builds the app inside its loop so
-                # the production path is covered.
-                log.warning(
-                    "control_channel skipped (no running loop): %s; steers "
-                    "will return delivery=FAILURE for this App",
-                    e,
-                )
+            # ``adk_web_observability`` bundles the three hook-ups the
+            # ``adk web`` path needs: telemetry plugin (spans), plan
+            # sink (goldfive plan / task / drift events — the missing
+            # piece from harmonograf#57), and control channel (STEER /
+            # PAUSE / CANCEL from the UI — harmonograf#55).
+            #
+            # ``control`` is ``None`` when ``_build_app`` runs outside
+            # an asyncio loop (synchronous test setup); adk web always
+            # builds the app inside its loop so the production path is
+            # covered. A warning is logged inside the helper in that
+            # case.
+            bundle = adk_web_observability(client)
+            plugins.append(bundle.plugin)
+            sinks.append(bundle.sink)
+            control = bundle.control
 
     wrapped = goldfive.wrap(
         tree,
         planner=planner,
         goal_deriver=goal_deriver,
         plugins=plugins,
+        sinks=sinks or None,
         control=control,
     )
 


### PR DESCRIPTION
## Summary

- Attach a ``HarmonografSink`` to ``goldfive.wrap(sinks=...)`` in ``_build_app`` so plan / task / drift events reach harmonograf. Before this fix the adk-web orchestrated demo wired only the telemetry plugin (spans) + control channel (steering); goldfive's default was ``[LoggingSink()]`` and the UI's Trajectory view stayed at "no plan yet" for the entire run.
- Add ``harmonograf_client.adk_web_observability(client)`` — a bundle helper returning a frozen ``AdkWebObservability`` dataclass with ``(plugin, sink, control)``. Every future adk-web caller gets all three hook-ups at once instead of having to remember each one. ``control_channel``'s "needs a running event loop" behavior is preserved: outside a loop the bundle sets ``control=None`` and logs, matching the demo's prior fallback.
- Extend the harmonograf#56 regression test to also assert a ``HarmonografSink`` appears on ``runner.sinks``.

Closes #57.

## Test plan

- [x] ``uv run pytest client/tests/test_adk_web.py -v`` — 3 new unit tests pass (bundle populates all three, loop-missing fallback, sink forwards events).
- [x] ``uv run pytest tests/e2e/test_presentation_agent.py -v`` — 7 pass; the updated regression test now asserts HarmonografSink is on the wrapped runner.
- [x] ``uv run pytest -x`` (top-level + client + server) — 86 / 191 / 263 pass, 3 + 0 + 1 skipped, no new failures.
- [ ] adk-web smoke: open the orchestrated demo, confirm the Trajectory + Task panels populate alongside the span Gantt.