### PR TITLE
Route goldfive events by per-event session_id (closes #63)

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -244,22 +244,46 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     def _stamp_session_id(self, ctx: Any) -> str:
         """Return the harmonograf session id to stamp on a span.
 
-        Returns the Client's home session (``self._client.session_id`` —
-        the Hello session assigned at connect) rather than the per-ctx
-        ADK session id. Under ADK's ``AgentTool`` delegation, each
-        sub-Runner has its own ``InMemorySessionService`` and mints its
-        own ADK session_id per invocation — stamping those directly
-        scatters spans across N sessions per adk-web run while goldfive
-        events (riding the Hello stream) land on the home session. By
-        rolling spans onto the home session too, every adk-web run
-        produces one coherent harmonograf session. The specific
-        sub-Runner ADK session is preserved as a span attribute by
-        callers for debugging.
+        Prefers the per-callback ADK session id (``ctx.session.id``) so
+        each span lands on the session its invocation actually belongs
+        to. Falls back to the Client's home / Hello session when ADK
+        runs without a session service (unit-test harnesses, offline
+        replays, or a ctx whose ``session`` is ``None``).
 
-        Returns ``""`` when the client has no session assigned yet,
-        which causes :class:`Client` to fall back to its default
-        ``session_id`` — matching the legacy pre-issue behaviour.
+        History: harmonograf#61 previously returned
+        ``self._client.session_id`` unconditionally to work around a
+        fan-out problem — goldfive events (which ride the transport's
+        Hello stream) landed on the home session while spans landed on
+        per-ctx ADK sessions, so the UI saw "N+1 sessions per adk-web
+        run". goldfive#155 / PR #157 added ``Event.session_id`` to the
+        wire envelope and harmonograf#63 flipped server-side routing to
+        honor it, which puts goldfive events back on the ADK session
+        where their spans live. With that plumbing in place the simpler
+        ``ctx.session.id`` contract is correct again — and the ADK
+        session id already surfaces as a span attribute
+        (``adk.session_id``) from harmonograf#62 for forensic lookups.
+
+        AgentTool sub-Runner caveat: ADK's :class:`AgentTool` spawns
+        sub-Runners that mint their own ``InMemorySessionService`` and
+        per-invocation session_id, so spans emitted inside a sub-Runner
+        land on the sub-Runner's session rather than the outer adk-web
+        session. ADK's :class:`InvocationContext` exposes no parent /
+        root traversal, so there is no clean way for the plugin to walk
+        to the outer session from inside an AgentTool callback.
+        goldfive#155 stamps the sub-Runner session on its own events
+        (same session the spans target), so each sub-Runner-worth of
+        telemetry remains internally coherent. Cross-sub-Runner rollup
+        is now a UI concern (group by ``adk.root_session_id`` or
+        similar) rather than something the client papers over by
+        collapsing every session onto one Hello id.
+
+        Returns ``""`` only when neither the ctx nor the client carry a
+        session id — the plugin's pre-connect degraded path — matching
+        the pre-#61 behaviour.
         """
+        adk_sid = _adk_session_id(ctx)
+        if adk_sid:
+            return adk_sid
         return str(self._client.session_id or "")
 
     # ------------------------------------------------------------------

--- a/client/tests/test_telemetry_plugin_session_id.py
+++ b/client/tests/test_telemetry_plugin_session_id.py
@@ -1,23 +1,24 @@
 """Regression tests for per-span ``session_id`` stamping.
 
-After harmonograf#61, :class:`HarmonografTelemetryPlugin` stamps the
-**Client's home / Hello session** on every span instead of the per-ctx
-ADK session id. Under ADK's ``AgentTool`` delegation, each sub-Runner
-has its own ``InMemorySessionService`` and mints a fresh ADK
-session_id per invocation — stamping those directly scatters spans
-across N sessions per adk-web run. Rolling onto the home session
-produces one coherent harmonograf session per process.
+After goldfive#155 / PR #157 added ``Event.session_id`` and
+harmonograf#63 switched server ingest to route goldfive events by
+that per-event id, :class:`HarmonografTelemetryPlugin` stamps the
+per-ctx **ADK session id** on every span rather than rolling every
+span onto the Client's home (Hello) session. Goldfive events now
+carry their own session_id on the wire, so the server lands spans
+and goldfive events on the same ADK session without the plugin
+having to collapse everything onto the home stream.
 
-The ADK session is preserved as a span attribute (``adk.session_id``)
-on INVOCATION spans so debug tooling can still correlate a span back
-to its sub-Runner ADK session.
+These tests replace the harmonograf#61 home-session-rollup assertions
+with the restored pre-#61 contract:
 
-These tests exercise each of the three span-emitting callbacks and
-assert:
-1. The wire-level ``session_id`` field on the Span is the Client's
-   home session (not the per-ctx ADK session_id).
-2. The ADK session_id survives as the ``adk.session_id`` attribute
-   on INVOCATION spans so routing-forensics stays possible.
+1. The wire-level ``session_id`` field on the Span is the per-ctx ADK
+   session id (``ctx.session.id``), NOT the Client's home session.
+2. The ADK session id also rides as the ``adk.session_id`` attribute
+   on INVOCATION spans so routing-forensics stays possible — this is
+   the forensic hook from harmonograf#62 and is preserved verbatim.
+3. Degraded ctx (no session) falls back to the Client's home session
+   so the plugin never crashes pre-connect / in offline replays.
 """
 
 from __future__ import annotations
@@ -130,50 +131,51 @@ def _span_session_ids(client: Client) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Tests — home-session rollup
+# Tests — per-ctx ADK session stamping (the restored pre-#61 contract)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_before_run_stamps_home_session_on_span(
+async def test_before_run_stamps_adk_session_on_span(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
-    """INVOCATION span's wire session_id is the Client's home session —
-    not the per-ctx ADK session — so adk-web runs roll up to one
-    harmonograf session even when ADK sub-Runners mint their own ADK
-    session_ids.
+    """INVOCATION span's wire ``session_id`` is the per-ctx ADK session,
+    not the Client's home session. After goldfive#155, goldfive events
+    also carry their own per-event ``session_id``, so the server will
+    land both kinds on the same ADK session without the plugin having
+    to collapse to a process-global home id.
     """
     ctx = _InvocationContext(invocation_id="inv-1", session_id=ADK_SESSION)
     await plugin.before_run_callback(invocation_context=ctx)
-    assert _span_session_ids(client) == [HOME_SESSION]
+    assert _span_session_ids(client) == [ADK_SESSION]
 
 
 @pytest.mark.asyncio
-async def test_before_model_stamps_home_session_on_span(
+async def test_before_model_stamps_adk_session_on_span(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
     cb = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
     await plugin.before_model_callback(callback_context=cb, llm_request=_LlmRequest())
-    assert _span_session_ids(client) == [HOME_SESSION]
+    assert _span_session_ids(client) == [ADK_SESSION]
 
 
 @pytest.mark.asyncio
-async def test_before_tool_stamps_home_session_on_span(
+async def test_before_tool_stamps_adk_session_on_span(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
     tc = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
     await plugin.before_tool_callback(
         tool=_Tool("search"), tool_args={"q": "hi"}, tool_context=tc
     )
-    assert _span_session_ids(client) == [HOME_SESSION]
+    assert _span_session_ids(client) == [ADK_SESSION]
 
 
 @pytest.mark.asyncio
-async def test_full_invocation_spans_all_carry_home_session(
+async def test_full_invocation_spans_all_carry_ctx_session(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
     """Three callbacks fire across one ADK invocation; all three spans
-    land on the Client's home session (the rollup contract)."""
+    land on the ctx's ADK session (not the Client home session)."""
     ic = _InvocationContext(invocation_id="inv-1", session_id=ADK_SESSION)
     cb = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
     tc = _CallbackContext(invocation_id="inv-1", session_id=ADK_SESSION)
@@ -186,19 +188,18 @@ async def test_full_invocation_spans_all_carry_home_session(
 
     sids = _span_session_ids(client)
     assert len(sids) == 3
-    assert all(sid == HOME_SESSION for sid in sids)
+    assert all(sid == ADK_SESSION for sid in sids)
 
 
 @pytest.mark.asyncio
-async def test_two_adk_sessions_roll_up_to_one_home_session(
+async def test_two_adk_sessions_keep_separate_span_session_ids(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
-    """Two distinct ADK session_ids from a process-shared Client both
-    land on the home session — the intended rollup after #61. ADK's
-    AgentTool delegation produces this pattern naturally (each
-    sub-Runner has its own InMemorySessionService and mints its own
-    session_id); before this fix, that scattered spans across N
-    harmonograf sessions per adk-web run.
+    """Two distinct ADK sessions (e.g. an AgentTool spawning a fresh
+    sub-Runner) keep their spans on their own session_ids. This is the
+    inverse of the harmonograf#61 rollup assertion — harmonograf#63
+    server-side routing for goldfive events makes the rollup
+    unnecessary at the plugin layer.
     """
     await plugin.before_run_callback(
         invocation_context=_InvocationContext("inv-A", ADK_SESSION)
@@ -206,7 +207,7 @@ async def test_two_adk_sessions_roll_up_to_one_home_session(
     await plugin.before_run_callback(
         invocation_context=_InvocationContext("inv-B", OTHER_SESSION)
     )
-    assert _span_session_ids(client) == [HOME_SESSION, HOME_SESSION]
+    assert _span_session_ids(client) == [ADK_SESSION, OTHER_SESSION]
 
 
 # ---------------------------------------------------------------------------
@@ -219,8 +220,12 @@ async def test_before_run_preserves_adk_session_id_as_attribute(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
     """INVOCATION span's ``adk.session_id`` attribute carries the
-    per-ctx ADK session_id so debug tooling can still correlate a
-    span back to the exact sub-Runner ADK session that produced it.
+    per-ctx ADK session id so debug tooling can correlate a span back
+    to the exact sub-Runner ADK session that produced it. Preserved
+    from harmonograf#62 — the forensic hook is still useful even now
+    that ``span.session_id`` also holds the ADK session id, because
+    the attribute survives future routing changes that might repoint
+    ``session_id`` elsewhere.
     """
     ctx = _InvocationContext(invocation_id="inv-1", session_id=ADK_SESSION)
     await plugin.before_run_callback(invocation_context=ctx)
@@ -231,13 +236,15 @@ async def test_before_run_preserves_adk_session_id_as_attribute(
 
 
 @pytest.mark.asyncio
-async def test_missing_adk_session_omits_adk_session_id_attribute(
+async def test_missing_adk_session_falls_back_to_home_session(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
     """If ADK runs without a session service (unit-test harnesses,
-    offline replays), ``_adk_session_id`` returns ``""`` and we omit
-    the attribute rather than stamp an empty string. Span session_id
-    still rolls up to the home session.
+    offline replays, or a bare ctx whose ``session`` is ``None``),
+    ``_adk_session_id`` returns ``""`` and the plugin falls back to
+    the Client's home session rather than stamping an empty string.
+    The ``adk.session_id`` attribute is omitted (there's nothing to
+    stamp).
     """
 
     class _Bare:
@@ -253,16 +260,14 @@ async def test_missing_adk_session_omits_adk_session_id_attribute(
 
 
 @pytest.mark.asyncio
-async def test_missing_home_session_falls_back_to_empty(
+async def test_missing_everything_falls_back_to_empty(
     made: list[FakeTransport],
 ) -> None:
-    """When the Client has no Hello session assigned yet and no explicit
-    session_id was passed, the plugin stamps ``""`` — emit_span_start
-    resolves that to the Client's default (which itself is empty). This
-    is a degraded state (the transport hasn't connected) and we don't
-    want to raise; the downstream server falls back to an auto-created
-    home session on first span. The important thing is we don't crash
-    the plugin when the Client is pre-connect.
+    """Fully degraded state: the Client has no Hello session assigned
+    and the ctx has no session either. The plugin stamps ``""`` rather
+    than crashing — ``emit_span_start`` resolves that to the Client's
+    default (also empty in this harness) and the server auto-creates a
+    home session on first span. The important thing is we don't raise.
     """
     client = Client(
         name="no-home-session",
@@ -272,9 +277,14 @@ async def test_missing_home_session_falls_back_to_empty(
         _transport_factory=make_factory(made),
     )
     plugin = HarmonografTelemetryPlugin(client)
-    ctx = _InvocationContext(invocation_id="inv-1", session_id=ADK_SESSION)
-    await plugin.before_run_callback(invocation_context=ctx)
+
+    class _Bare:
+        invocation_id = "inv-1"
+        agent = _Agent("root")
+        session = None
+
+    await plugin.before_run_callback(invocation_context=_Bare())
     [span] = _span_starts(client)
-    # Home session is empty pre-connect; span session_id is whatever the
-    # emit_span_start default resolves to (also empty in this harness).
+    # Neither the ctx nor the client carry a session; span.session_id
+    # is whatever emit_span_start's default resolves to (also empty).
     assert span.session_id == ""

--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -111,6 +111,43 @@ class _PayloadAssembler:
         return b"".join(self.chunks)
 
 
+class _SessionView:
+    """Read-only StreamContext overlay that pins ``session_id`` to a new
+    value while proxying every other attribute back to the underlying
+    :class:`StreamContext`.
+
+    Created when a goldfive event carries a ``session_id`` different
+    from the stream's Hello session — downstream handlers read
+    ``ctx.session_id`` for bus fan-out and storage writes, so rather
+    than thread the target session through every handler signature we
+    hand them a ctx-shaped view with the correct session pinned. All
+    mutable state (``seen_span_ids``, ``seen_routes``, payload
+    assemblers, heartbeat counters) remains on the real StreamContext
+    so cross-session bookkeeping still works.
+    """
+
+    __slots__ = ("_inner", "session_id")
+
+    def __init__(self, inner: "StreamContext", session_id: str) -> None:
+        # session_id is stored on self so ``ctx.session_id`` reads
+        # return the overridden value; everything else falls through.
+        object.__setattr__(self, "_inner", inner)
+        object.__setattr__(self, "session_id", session_id)
+
+    def __getattr__(self, name: str) -> Any:
+        # Only reached when the attribute isn't on the view itself.
+        return getattr(self._inner, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # Writes pass through to the underlying StreamContext so state
+        # shared across sessions (seen_span_ids, heartbeat counters,
+        # etc.) stays consistent. ``session_id`` is the only name we
+        # deliberately shadow and it's frozen for the view's lifetime.
+        if name == "session_id":
+            raise AttributeError("_SessionView.session_id is read-only")
+        setattr(self._inner, name, value)
+
+
 @dataclass
 class StreamContext:
     """Per-stream state. One StreamTelemetry RPC == one StreamContext."""
@@ -647,60 +684,85 @@ class IngestPipeline:
         Gantt stays live. Unknown payload variants are logged and
         ignored so adding a new event kind in goldfive is
         forward-compatible with an older harmonograf server.
+
+        Routing: goldfive#155 / PR #157 added ``Event.session_id`` and
+        the Runner/Steerer/Executors stamp it on every emitted event so
+        one transport stream can multiplex events across sessions
+        (e.g. ADK's AgentTool mints sub-Runner sessions inside a single
+        adk-web run). When the event carries a session_id we route to
+        it, auto-creating the session+agent row if unseen. An empty
+        ``session_id`` falls back to the stream's Hello session — the
+        pre-#155 behavior — for back-compat with older goldfive clients.
         """
         if event is None:
             return
         kind = event.WhichOneof("payload")
         run_id = event.run_id
         sequence = event.sequence
+
+        event_sid = getattr(event, "session_id", "") or ""
+        if event_sid and event_sid != ctx.session_id:
+            # Route this event onto its declared session. Use a shallow
+            # per-session StreamContext proxy so downstream handlers
+            # (which read ctx.session_id / ctx.agent_id for bus fan-out
+            # and storage writes) see the right session id without
+            # having to thread session_id through every handler
+            # signature. Auto-register the (session, agent) route the
+            # same way span ingest does so the session row exists
+            # before any task-plan / drift fan-out references it.
+            await self._ensure_route(ctx, event_sid, ctx.agent_id)
+            target_ctx = _SessionView(ctx, event_sid)
+        else:
+            target_ctx = ctx
+
         logger.debug(
             "goldfive event session_id=%s run_id=%s sequence=%s kind=%s",
-            ctx.session_id,
+            target_ctx.session_id,
             run_id,
             sequence,
             kind,
         )
         if kind == "run_started":
-            await self._on_run_started(ctx, event.run_started, run_id)
+            await self._on_run_started(target_ctx, event.run_started, run_id)
         elif kind == "goal_derived":
-            await self._on_goal_derived(ctx, event.goal_derived, run_id)
+            await self._on_goal_derived(target_ctx, event.goal_derived, run_id)
         elif kind == "plan_submitted":
-            await self._on_plan_submitted(ctx, event.plan_submitted, run_id)
+            await self._on_plan_submitted(target_ctx, event.plan_submitted, run_id)
         elif kind == "plan_revised":
-            await self._on_plan_revised(ctx, event.plan_revised, run_id)
+            await self._on_plan_revised(target_ctx, event.plan_revised, run_id)
         elif kind == "task_started":
-            await self._on_task_started(ctx, event.task_started, run_id)
+            await self._on_task_started(target_ctx, event.task_started, run_id)
         elif kind == "task_progress":
-            self._on_task_progress(ctx, event.task_progress, run_id)
+            self._on_task_progress(target_ctx, event.task_progress, run_id)
         elif kind == "task_completed":
-            await self._on_task_completed(ctx, event.task_completed, run_id)
+            await self._on_task_completed(target_ctx, event.task_completed, run_id)
         elif kind == "task_failed":
-            await self._on_task_failed(ctx, event.task_failed, run_id)
+            await self._on_task_failed(target_ctx, event.task_failed, run_id)
         elif kind == "task_blocked":
-            await self._on_task_blocked(ctx, event.task_blocked, run_id)
+            await self._on_task_blocked(target_ctx, event.task_blocked, run_id)
         elif kind == "task_cancelled":
-            await self._on_task_cancelled(ctx, event.task_cancelled, run_id)
+            await self._on_task_cancelled(target_ctx, event.task_cancelled, run_id)
         elif kind == "drift_detected":
-            self._on_drift_detected(ctx, event.drift_detected, run_id)
+            self._on_drift_detected(target_ctx, event.drift_detected, run_id)
         elif kind == "run_completed":
-            self._on_run_completed(ctx, event.run_completed, run_id)
+            self._on_run_completed(target_ctx, event.run_completed, run_id)
         elif kind == "run_aborted":
-            self._on_run_aborted(ctx, event.run_aborted, run_id)
+            self._on_run_aborted(target_ctx, event.run_aborted, run_id)
         elif kind == "agent_invocation_started":
             self._on_agent_invocation_started(
-                ctx, event.agent_invocation_started, run_id
+                target_ctx, event.agent_invocation_started, run_id
             )
         elif kind == "agent_invocation_completed":
             self._on_agent_invocation_completed(
-                ctx, event.agent_invocation_completed, run_id
+                target_ctx, event.agent_invocation_completed, run_id
             )
         elif kind == "delegation_observed":
-            self._on_delegation_observed(ctx, event.delegation_observed, run_id)
+            self._on_delegation_observed(target_ctx, event.delegation_observed, run_id)
         else:
             logger.debug(
                 "ignoring unknown goldfive event payload kind=%s on session_id=%s",
                 kind,
-                ctx.session_id,
+                target_ctx.session_id,
             )
 
     # ---- goldfive event handlers -------------------------------------

--- a/server/tests/test_goldfive_ingest.py
+++ b/server/tests/test_goldfive_ingest.py
@@ -416,6 +416,196 @@ async def test_unknown_payload_is_ignored(pipeline):
     assert sub.queue.empty()
 
 
+# ---- per-event session_id routing (goldfive#155 / harmonograf#63) -------
+#
+# ``goldfive.v1.Event`` gained a ``session_id`` field in goldfive#155 / PR
+# #157, and the Runner / Steerer / Executors stamp it on every emitted
+# event so one StreamTelemetry RPC can multiplex events across multiple
+# sessions (e.g. ADK's AgentTool mints a sub-Runner session inside an
+# adk-web run). Harmonograf#63 switches server-side routing from the
+# stream's Hello session to the per-event ``session_id`` with a
+# back-compat fallback to the Hello session when the field is empty.
+
+
+@pytest.mark.asyncio
+async def test_goldfive_event_routes_to_per_event_session_id(pipeline, store):
+    """Event with ``session_id=X`` on a stream Hello'd as ``Y`` lands on
+    session X, not Y. The session row is auto-created on first sighting
+    the same way span ingest auto-creates unseen ``(session, agent)``
+    routes.
+    """
+    pipe, bus, _ = pipeline
+    hello_sid = "sess_home"
+    per_event_sid = "sess_per_event"
+    ctx = _stream_ctx(session_id=hello_sid)
+
+    # Subscribe to both sessions so we can tell which one the fan-out
+    # lands on without relying on storage side-effects.
+    sub_home = await bus.subscribe(hello_sid)
+    sub_target = await bus.subscribe(per_event_sid)
+
+    evt = _make_event()
+    evt.session_id = per_event_sid
+    evt.run_started.run_id = "run-1"
+    evt.run_started.goal_summary = "check routing"
+    await pipe.handle_message(ctx, _wrap(evt))
+
+    # The per-event session got a run_started delta (alongside the
+    # auto-register agent_upsert / session-create deltas that fire on
+    # first sighting of an unseen route).
+    deltas = await _drain(sub_target)
+    run_started = [d for d in deltas if d.kind == DELTA_RUN_STARTED]
+    assert len(run_started) == 1
+    assert run_started[0].payload["run_id"] == "run-1"
+
+    # ...and the Hello session did NOT see a run_started delta.
+    home_deltas = await _drain(sub_home)
+    assert not [d for d in home_deltas if d.kind == DELTA_RUN_STARTED]
+
+    # Session row was auto-created so downstream RPCs can find it.
+    assert await store.get_session(per_event_sid) is not None
+
+
+@pytest.mark.asyncio
+async def test_goldfive_event_empty_session_id_falls_back_to_hello(
+    pipeline, store
+):
+    """Empty ``session_id`` preserves pre-goldfive#155 behavior: events
+    route to the stream's Hello session. Back-compat guard for older
+    goldfive clients and for events emitted before stamping was
+    threaded through every executor path.
+    """
+    pipe, bus, _ = pipeline
+    hello_sid = "sess_home"
+    ctx = _stream_ctx(session_id=hello_sid)
+
+    sub = await bus.subscribe(hello_sid)
+
+    evt = _make_event()
+    # session_id left empty (the pre-#155 shape).
+    assert evt.session_id == ""
+    evt.run_started.run_id = "run-1"
+    evt.run_started.goal_summary = "fallback check"
+    await pipe.handle_message(ctx, _wrap(evt))
+
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_RUN_STARTED
+    assert delta.payload["run_id"] == "run-1"
+
+
+@pytest.mark.asyncio
+async def test_goldfive_plan_persisted_under_per_event_session(pipeline, store):
+    """Storage writes also follow the per-event ``session_id``. A plan
+    emitted with ``session_id=X`` on a stream Hello'd as ``Y`` is
+    persisted as a child of X (via ``session_id`` on :class:`TaskPlan`),
+    so cross-session lookups resolve the plan through the correct
+    session aggregate.
+    """
+    pipe, _, _ = pipeline
+    hello_sid = "sess_home"
+    per_event_sid = "sess_per_event"
+    ctx = _stream_ctx(session_id=hello_sid)
+
+    evt = _make_event()
+    evt.session_id = per_event_sid
+    evt.plan_submitted.plan.CopyFrom(_plan_pb(plan_id="p-routed"))
+    await pipe.handle_message(ctx, _wrap(evt))
+
+    # Plan lists under the per-event session.
+    plans_target = await store.list_task_plans_for_session(per_event_sid)
+    assert [p.id for p in plans_target] == ["p-routed"]
+    assert plans_target[0].session_id == per_event_sid
+
+    # Hello session stays empty — nothing leaked onto it.
+    plans_home = await store.list_task_plans_for_session(hello_sid)
+    assert plans_home == []
+
+    # Task index keyed by per-event session (the hot-path index used by
+    # span-to-task binding lookups).
+    assert pipe._task_index.get(per_event_sid, {}).get("t1") == "p-routed"
+    assert pipe._task_index.get(hello_sid, {}).get("t1") is None
+
+
+@pytest.mark.asyncio
+async def test_span_and_goldfive_event_co_locate_on_adk_session(pipeline, store):
+    """End-to-end: a client emits a span with ``session_id=X`` and a
+    goldfive ``plan_submitted`` event with ``session_id=X`` over the
+    same stream Hello'd as ``Y``. Both MUST land on session X so the
+    frontend's one-session-per-adk-web-run rollup has everything.
+    Regression guard against a future change that routes spans and
+    goldfive events via different codepaths.
+    """
+    from harmonograf_server.pb import types_pb2
+
+    pipe, bus, _ = pipeline
+    hello_sid = "sess_home"
+    adk_sid = "sess_adk_run"
+    ctx = _stream_ctx(session_id=hello_sid)
+
+    # 1. Span with per-span session_id=X (the telemetry_plugin's
+    #    ``_stamp_session_id`` path after harmonograf#63).
+    span_msg = telemetry_pb2.SpanStart(
+        span=types_pb2.Span(
+            id="span-1",
+            session_id=adk_sid,
+            agent_id=ctx.agent_id,
+            kind=types_pb2.SPAN_KIND_INVOCATION,
+            status=types_pb2.SPAN_STATUS_RUNNING,
+            name="invocation",
+        )
+    )
+    span_msg.span.start_time.seconds = 100
+    await pipe.handle_message(ctx, telemetry_pb2.TelemetryUp(span_start=span_msg))
+
+    # 2. Goldfive event with per-event session_id=X (goldfive#155 wire
+    #    stamping from Runner / Steerer / Executors).
+    gf_evt = _make_event()
+    gf_evt.session_id = adk_sid
+    gf_evt.plan_submitted.plan.CopyFrom(_plan_pb(plan_id="p-shared"))
+    await pipe.handle_message(ctx, _wrap(gf_evt))
+
+    # Span lands on the ADK session.
+    spans = await store.get_spans(adk_sid)
+    assert [s.id for s in spans] == ["span-1"]
+
+    # Plan lands on the ADK session.
+    plans = await store.list_task_plans_for_session(adk_sid)
+    assert [p.id for p in plans] == ["p-shared"]
+    assert plans[0].session_id == adk_sid
+
+    # Nothing leaked onto the Hello session.
+    assert await store.get_spans(hello_sid) == []
+    assert await store.list_task_plans_for_session(hello_sid) == []
+
+
+@pytest.mark.asyncio
+async def test_goldfive_event_same_session_as_hello_uses_hello_ctx(
+    pipeline, store
+):
+    """``session_id`` equal to the Hello session is a no-op on the routing
+    path — we must not spuriously auto-create or duplicate state. Regression
+    guard against a future edit that always spawns a _SessionView even when
+    it would add no value.
+    """
+    pipe, bus, _ = pipeline
+    hello_sid = "sess_home"
+    ctx = _stream_ctx(session_id=hello_sid)
+    await _ensure_session(store, session_id=hello_sid)
+
+    sub = await bus.subscribe(hello_sid)
+
+    evt = _make_event()
+    evt.session_id = hello_sid  # stamped to the same session the stream is on
+    evt.plan_submitted.plan.CopyFrom(_plan_pb(plan_id="p-same"))
+    await pipe.handle_message(ctx, _wrap(evt))
+
+    # Plan landed on the Hello session exactly as if session_id had been empty.
+    plans = await store.list_task_plans_for_session(hello_sid)
+    assert [p.id for p in plans] == ["p-same"]
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_TASK_PLAN
+
+
 @pytest.mark.asyncio
 async def test_task_index_repopulates_from_store_after_restart(pipeline, store):
     """A pipeline restart drops ``_task_index``; a subsequent task event


### PR DESCRIPTION
Closes #63.

## Summary

- Switches server-side routing for `TelemetryUp.goldfive_event` from the stream's Hello session to the per-event `session_id` added in goldfive#155 / PR #157. Empty `session_id` still falls back to the Hello session for back-compat with older goldfive clients.
- Reverts the telemetry plugin's `_stamp_session_id` to prefer `ctx.session.id` (the pre-#61 contract) now that goldfive events co-locate with spans server-side. Falls back to `client.session_id` for degraded ctx (no session).
- Keeps the `adk.session_id` span attribute from #62 as a forensic hook.

## Design notes

**Server ingest**: `_handle_goldfive_event` now reads `event.session_id` and, when it differs from the stream's Hello session, auto-registers the `(session, agent)` route (same path span ingest already uses) and dispatches handlers against a `_SessionView` — a shallow proxy that pins `session_id` while proxying every other attribute to the underlying `StreamContext`. This keeps mutable state (seen_span_ids, payload assemblers, heartbeat counters) on the real stream ctx without threading `session_id` through every per-event handler signature.

**AgentTool sub-Runner span rollup**: ADK's `InvocationContext` exposes no parent / root traversal, so the plugin can't walk from a sub-Runner callback back to the outer adk-web session. Rather than reintroduce the #61 home-session-collapse trick (which rolled every ADK session onto one harmonograf session per process), goldfive#155's per-event stamping keeps each sub-Runner's telemetry internally coherent — the sub-Runner's spans AND its goldfive events both land on the sub-Runner's ADK session. Cross-sub-Runner rollup to the outer adk-web session becomes a UI concern (group by `adk.root_session_id` span attribute) rather than a plumbing one.

## Test plan

- [x] `pytest server/tests/test_goldfive_ingest.py` — new tests for per-event session routing, empty fallback, plan persistence under target session, and an end-to-end span+goldfive_event co-location case
- [x] `pytest client/tests/test_telemetry_plugin_session_id.py` — rewritten to assert the ADK-session-stamping contract with fallback-to-home-session for degraded ctx
- [x] `pytest client/` — 169 passed
- [x] `pytest server/` — 268 passed, 1 skipped
- [x] `pytest tests/` (unit, excluding e2e/integration) — 76 passed