### PR TITLE
Dedupe duplicate HarmonografTelemetryPlugin instances (goldfive#166)

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -18,6 +18,13 @@ plugin to the ADK ``App`` that ``adk web`` / ``adk run`` builds::
 The plugin is safe to install alongside ``goldfive.adapters.adk`` 's
 own plugin — they operate on disjoint responsibilities and do not
 interfere with each other's ADK lifecycle callbacks.
+
+Duplicate-install safety: if two ``HarmonografTelemetryPlugin``
+instances end up on the same ADK ``PluginManager`` (easy to do under
+``goldfive.wrap`` + ``adk web`` — one comes from ``App.plugins``, one
+from ``observe()`` or ``add_plugin``), the later instance detects the
+earlier one on its first callback and silently disables itself. See
+harmonograf #68 / goldfive #166.
 """
 
 from __future__ import annotations
@@ -275,10 +282,84 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         # on the normal path and by the cancellation helper on the
         # error path.
         self._tool_span_invocations: dict[int, str] = {}
+        # Duplicate-install guard (harmonograf #68 / goldfive #166). Under
+        # ``goldfive.wrap`` + ``adk web`` + ``App(plugins=[...])`` it is
+        # easy to end up with two ``HarmonografTelemetryPlugin`` instances
+        # attached to the same ADK ``PluginManager``: one from
+        # ``App.plugins`` and one from a downstream ``observe()`` /
+        # ``add_plugin`` call. Each instance fires every callback, so
+        # every span appears twice in harmonograf's Gantt.
+        #
+        # On the first callback we inspect
+        # ``invocation_context.plugin_manager.plugins`` and, if another
+        # plugin named ``"harmonograf-telemetry"`` appears earlier in the
+        # list, flip this flag and short-circuit every callback from then
+        # on. The earliest instance is the authoritative emitter; later
+        # duplicates go silent.
+        #
+        # Semantics: silent-by-default (dedup should not make noise on
+        # healthy runs). We log at INFO exactly once per deduped
+        # instance so operators can see what happened if they wonder why
+        # their callbacks appear to be missing.
+        self._disabled_as_duplicate: bool = False
+        self._duplicate_log_emitted: bool = False
 
     @property
     def client(self) -> Client:
         return self._client
+
+    # ------------------------------------------------------------------
+    # Duplicate-install detection
+    # ------------------------------------------------------------------
+
+    def _maybe_disable_as_duplicate(self, ctx: Any) -> bool:
+        """Return True when this plugin instance should stay silent.
+
+        Inspects ``ctx.plugin_manager.plugins`` (ADK places the plugin
+        manager on the invocation / callback / tool context) and checks
+        whether another plugin with the same ``name`` appears *earlier*
+        in the list than ``self``. When it does, this instance is a
+        duplicate: the earlier instance will handle the callback and we
+        should no-op.
+
+        Idempotent — sets ``self._disabled_as_duplicate = True`` on the
+        first detection and returns the cached flag on subsequent calls
+        so the hot callback path doesn't walk the plugin list twice.
+        Logs at INFO exactly once per deduped instance.
+
+        Never raises: on any error (missing ``plugin_manager``, unusual
+        ``plugins`` shape) falls through to "enabled" so the plugin's
+        normal behaviour is preserved. The fix is an optimistic dedup,
+        not a hard gate.
+        """
+        if self._disabled_as_duplicate:
+            return True
+        pm = _safe_attr(ctx, "plugin_manager", None)
+        if pm is None:
+            return False
+        plugins = _safe_attr(pm, "plugins", None)
+        if not isinstance(plugins, list) or not plugins:
+            return False
+        own_name = getattr(self, "name", "harmonograf-telemetry")
+        # Find the first plugin with the same name. If that plugin is
+        # not ``self``, we are a duplicate.
+        for other in plugins:
+            if _safe_attr(other, "name", None) != own_name:
+                continue
+            if other is self:
+                return False
+            # Earlier instance with the same name: we are the dupe.
+            self._disabled_as_duplicate = True
+            if not self._duplicate_log_emitted:
+                self._duplicate_log_emitted = True
+                log.info(
+                    "telemetry_plugin: duplicate HarmonografTelemetryPlugin "
+                    "instance detected on plugin_manager; this instance will "
+                    "stay silent (earliest instance remains the authoritative "
+                    "emitter). See harmonograf #68 / goldfive #166.",
+                )
+            return True
+        return False
 
     def _stamp_session_id(self, ctx: Any) -> str:
         """Return the harmonograf session id to stamp on a span.
@@ -462,6 +543,8 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     # ------------------------------------------------------------------
 
     async def before_run_callback(self, *, invocation_context: Any) -> None:
+        if self._maybe_disable_as_duplicate(invocation_context):
+            return
         inv_id = str(_safe_attr(invocation_context, "invocation_id", "") or "")
         agent = _safe_attr(invocation_context, "agent")
         name = str(_safe_attr(agent, "name", "") or "invocation")
@@ -520,6 +603,8 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             self._invocation_spans[str(id(invocation_context))] = sid
 
     async def after_run_callback(self, *, invocation_context: Any) -> None:
+        if self._maybe_disable_as_duplicate(invocation_context):
+            return
         inv_id = str(_safe_attr(invocation_context, "invocation_id", "") or "")
         # Close any model-call spans that never saw a non-partial
         # finalize (error paths, client disconnect mid-stream). Without
@@ -608,6 +693,8 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     async def before_model_callback(
         self, *, callback_context: Any, llm_request: Any
     ) -> None:
+        if self._maybe_disable_as_duplicate(callback_context):
+            return
         model = str(_safe_attr(llm_request, "model", "") or "")
         sid = self._client.emit_span_start(
             kind=SpanKind.LLM_CALL,
@@ -621,6 +708,8 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     async def after_model_callback(
         self, *, callback_context: Any, llm_response: Any
     ) -> None:
+        if self._maybe_disable_as_duplicate(callback_context):
+            return
         key = self._model_span_key(callback_context)
         queue = self._model_spans.get(key)
         if not queue:
@@ -692,6 +781,8 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     async def before_tool_callback(
         self, *, tool: Any, tool_args: Any, tool_context: Any
     ) -> None:
+        if self._maybe_disable_as_duplicate(tool_context):
+            return
         tool_name = str(_safe_attr(tool, "name", "") or "tool")
         payload = _serialize_args(tool_args)
         sid = self._client.emit_span_start(
@@ -721,6 +812,8 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         tool_context: Any,
         result: Any,
     ) -> None:
+        if self._maybe_disable_as_duplicate(tool_context):
+            return
         key = id(tool_context)
         sid = self._tool_spans.pop(key, None)
         self._tool_span_invocations.pop(key, None)
@@ -742,6 +835,8 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         tool_context: Any,
         error: Any,
     ) -> None:
+        if self._maybe_disable_as_duplicate(tool_context):
+            return
         key = id(tool_context)
         sid = self._tool_spans.pop(key, None)
         self._tool_span_invocations.pop(key, None)

--- a/client/tests/test_telemetry_plugin_dedup.py
+++ b/client/tests/test_telemetry_plugin_dedup.py
@@ -1,0 +1,298 @@
+"""Tests for duplicate-install dedup in
+:class:`harmonograf_client.telemetry_plugin.HarmonografTelemetryPlugin`.
+
+Scenario covered (harmonograf #68 / goldfive #166):
+
+Under ``goldfive.wrap`` + ``adk web`` it is easy to install two
+``HarmonografTelemetryPlugin`` instances on the same ADK plugin manager:
+one from ``App(plugins=[...])`` and one from ``observe()`` /
+``add_plugin``. Each instance was firing every callback and emitting
+its own span-start / span-end envelopes, so every agent / model / tool
+span showed up twice in the harmonograf Gantt.
+
+The fix is idempotent detection at callback-firing time: when a plugin
+instance sees that another plugin of the same ``name`` sits earlier in
+``ctx.plugin_manager.plugins``, it sets ``_disabled_as_duplicate`` and
+short-circuits all further callbacks. The tests assert:
+
+* two installations → exactly one set of spans
+* single installation → unchanged behaviour
+* dedup applies across every callback shape (run / model / tool)
+* the dedup is a SOFT check — missing / malformed plugin_manager falls
+  through to "enabled"
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from harmonograf_client.buffer import EnvelopeKind
+from harmonograf_client.client import Client
+from harmonograf_client.telemetry_plugin import HarmonografTelemetryPlugin
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+# ---------------------------------------------------------------------------
+# Minimal ADK-shaped fakes
+# ---------------------------------------------------------------------------
+
+
+class _Session:
+    def __init__(self, sid: str) -> None:
+        self.id = sid
+
+
+class _Agent:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _PluginManager:
+    """Mirrors :class:`google.adk.plugins.plugin_manager.PluginManager` just
+    enough for the dedup path — a list of plugins accessible via
+    ``.plugins``."""
+
+    def __init__(self, plugins: list[Any]) -> None:
+        self.plugins = plugins
+
+
+class _InvocationContext:
+    def __init__(
+        self,
+        invocation_id: str,
+        session_id: str,
+        plugins: list[Any],
+    ) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id)
+        self.agent = _Agent("root-agent")
+        self.plugin_manager = _PluginManager(plugins)
+
+
+class _CallbackContext:
+    def __init__(
+        self, invocation_id: str, session_id: str, plugins: list[Any]
+    ) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id)
+        self.plugin_manager = _PluginManager(plugins)
+
+
+class _ToolContext:
+    def __init__(
+        self, invocation_id: str, session_id: str, plugins: list[Any]
+    ) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id)
+        self.plugin_manager = _PluginManager(plugins)
+
+
+class _Tool:
+    def __init__(self, name: str = "run_tool") -> None:
+        self.name = name
+
+
+class _LlmRequest:
+    def __init__(self, model: str = "gpt-test") -> None:
+        self.model = model
+
+
+class _LlmResponse:
+    def __init__(self) -> None:
+        self.partial = False
+        self.error_message = None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="dedup-test",
+        agent_id="agent-D",
+        session_id="home-sess",
+        buffer_size=64,
+        _transport_factory=make_factory(made),
+    )
+
+
+def _span_start_count(client: Client) -> int:
+    return sum(
+        1 for env in client._events.drain() if env.kind is EnvelopeKind.SPAN_START
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duplicate_install_suppresses_second_instance(
+    client: Client,
+) -> None:
+    """Two plugin instances sharing a plugin_manager → only one set of spans.
+
+    Reproduces the harmonograf #68 / goldfive #166 pathology. Without
+    dedup, each of the two instances fires every callback and emits a
+    span-start. With dedup, the later instance detects itself as a
+    duplicate and stays silent.
+    """
+    first = HarmonografTelemetryPlugin(client)
+    second = HarmonografTelemetryPlugin(client)
+    # App(plugins=[first]) then observe()/add_plugin appends `second`.
+    plugins = [first, second]
+
+    ctx = _InvocationContext("inv-1", "sess-1", plugins)
+    await first.before_run_callback(invocation_context=ctx)
+    await second.before_run_callback(invocation_context=ctx)
+
+    # First instance fires normally (1 span-start); second short-circuits.
+    assert _span_start_count(client) == 1
+    assert second._disabled_as_duplicate is True
+    assert first._disabled_as_duplicate is False
+
+
+@pytest.mark.asyncio
+async def test_single_install_unchanged(client: Client) -> None:
+    """Single-install regression: plugin fires as before."""
+    plugin = HarmonografTelemetryPlugin(client)
+    ctx = _InvocationContext("inv-1", "sess-1", [plugin])
+
+    await plugin.before_run_callback(invocation_context=ctx)
+    assert _span_start_count(client) == 1
+    assert plugin._disabled_as_duplicate is False
+
+
+@pytest.mark.asyncio
+async def test_dedup_applies_to_every_callback_shape(client: Client) -> None:
+    """The dedup guard covers run / model / tool callbacks uniformly.
+
+    Without uniform coverage a duplicate instance could stay silent on
+    before_run but still emit spans on before_model / before_tool when
+    those callbacks sometimes fire without a matching before_run (nested
+    AgentTool sub-Runners rebuild CallbackContext mid-flight).
+    """
+    first = HarmonografTelemetryPlugin(client)
+    second = HarmonografTelemetryPlugin(client)
+    plugins = [first, second]
+
+    inv_ctx = _InvocationContext("inv-1", "sess-1", plugins)
+    cb_ctx = _CallbackContext("inv-1", "sess-1", plugins)
+    tool_ctx = _ToolContext("inv-1", "sess-1", plugins)
+
+    # Fire every pre-callback on both plugins.
+    await first.before_run_callback(invocation_context=inv_ctx)
+    await second.before_run_callback(invocation_context=inv_ctx)
+
+    await first.before_model_callback(
+        callback_context=cb_ctx, llm_request=_LlmRequest()
+    )
+    await second.before_model_callback(
+        callback_context=cb_ctx, llm_request=_LlmRequest()
+    )
+
+    await first.before_tool_callback(
+        tool=_Tool(), tool_args={}, tool_context=tool_ctx
+    )
+    await second.before_tool_callback(
+        tool=_Tool(), tool_args={}, tool_context=tool_ctx
+    )
+
+    # 3 callbacks * 1 effective emitter = 3 span-starts (run/model/tool),
+    # not 6. The duplicate instance stays silent on every path.
+    assert _span_start_count(client) == 3
+
+
+@pytest.mark.asyncio
+async def test_dedup_silent_fallthrough_on_missing_plugin_manager(
+    client: Client, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When plugin_manager is missing, the plugin stays enabled.
+
+    Unit-test harnesses, offline replay, and any context shape that
+    omits plugin_manager must continue to work — the dedup path is an
+    optimistic guard, not a hard gate.
+    """
+    plugin = HarmonografTelemetryPlugin(client)
+
+    class _Bare:
+        invocation_id = "inv-1"
+        session = _Session("sess-1")
+        agent = _Agent("root")
+        # Note: no plugin_manager attribute.
+
+    with caplog.at_level(logging.INFO, logger="harmonograf_client.telemetry_plugin"):
+        await plugin.before_run_callback(invocation_context=_Bare())
+
+    assert _span_start_count(client) == 1
+    assert plugin._disabled_as_duplicate is False
+    # No INFO log about dedup emitted on the healthy path.
+    assert not any("duplicate" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_dedup_logs_once_per_deduped_instance(
+    client: Client, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A deduped instance logs at INFO exactly once so operators can see it.
+
+    Hot callback paths fire many times per run; the dedup log must be
+    emitted at most once per plugin instance or it'd become noise.
+    """
+    first = HarmonografTelemetryPlugin(client)
+    second = HarmonografTelemetryPlugin(client)
+    plugins = [first, second]
+    ctx = _InvocationContext("inv-1", "sess-1", plugins)
+
+    with caplog.at_level(logging.INFO, logger="harmonograf_client.telemetry_plugin"):
+        await second.before_run_callback(invocation_context=ctx)
+        await second.before_run_callback(invocation_context=ctx)
+        await second.before_run_callback(invocation_context=ctx)
+
+    dedup_records = [r for r in caplog.records if "duplicate" in r.getMessage()]
+    assert len(dedup_records) == 1
+    assert dedup_records[0].levelno == logging.INFO
+
+
+@pytest.mark.asyncio
+async def test_first_instance_is_always_the_survivor(client: Client) -> None:
+    """Whichever instance appears first in ``plugins`` is the authoritative emitter.
+
+    Defends against registration-order drift: if ``observe()`` runs
+    before ``App(plugins=[...])`` attach, the ``observe()`` instance is
+    the first entry in the list and should be the one that fires.
+    """
+    a = HarmonografTelemetryPlugin(client)
+    b = HarmonografTelemetryPlugin(client)
+
+    # a registered first; b is the dupe.
+    ctx_a = _InvocationContext("inv-1", "sess-1", [a, b])
+    await b.before_run_callback(invocation_context=ctx_a)
+    await a.before_run_callback(invocation_context=ctx_a)
+    assert b._disabled_as_duplicate is True
+    assert a._disabled_as_duplicate is False
+    assert _span_start_count(client) == 1
+
+    # Flip the registration order: a fresh pair in reverse order.
+    c = HarmonografTelemetryPlugin(client)
+    d = HarmonografTelemetryPlugin(client)
+    ctx_b = _InvocationContext("inv-2", "sess-2", [d, c])
+    await c.before_run_callback(invocation_context=ctx_b)
+    await d.before_run_callback(invocation_context=ctx_b)
+    # d registered first; c is the dupe this time.
+    assert c._disabled_as_duplicate is True
+    assert d._disabled_as_duplicate is False
+    assert _span_start_count(client) == 1


### PR DESCRIPTION
## Summary

- Under `goldfive.wrap` + `adk web` + `App(plugins=[...])` it is easy to end up with two `HarmonografTelemetryPlugin` instances on the same ADK `PluginManager`: one from `App.plugins`, one from a downstream `observe()` / `add_plugin` call. Each instance fires every callback, so every agent / model / tool span shows up twice in harmonograf's Gantt.
- Plugin-side idempotent detection: on every callback's first entry, inspect `ctx.plugin_manager.plugins`. When another plugin with name `"harmonograf-telemetry"` appears earlier in the list, flip `_disabled_as_duplicate` and short-circuit all further callbacks. Earliest instance wins; duplicates go silent with one INFO log.
- Paired with goldfive-side `_dedupe_plugins_by_name` + idempotent `_register_plugin_on_runner` in pedapudi/goldfive#169 so the two sides meet in the middle.

## Test plan

- [x] `uv run --extra e2e --with pytest --with pytest-asyncio python -m pytest client/tests/test_telemetry_plugin_dedup.py -x -v` — 6 new tests pass
- [x] `uv run --extra e2e --with pytest --with pytest-asyncio python -m pytest client/tests/ -x` — 186 client tests pass, no regressions
- [x] Verified dedup covers every callback shape (run / model / tool)
- [x] Silent fallthrough verified when `plugin_manager` is missing (unit-test harnesses, offline replay)
- [x] INFO log emitted exactly once per deduped instance — no hot-path noise