### PR TITLE
STEER body validation + author propagation (goldfive#171)

### DIFF
--- a/client/harmonograf_client/_control_bridge.py
+++ b/client/harmonograf_client/_control_bridge.py
@@ -26,6 +26,14 @@ transport:
    channel closed so any in-flight ``channel.acks()`` consumer exits
    its iterator.
 
+STEER annotations are additionally validated before forwarding
+(goldfive#171): empty / whitespace-only bodies and bodies over
+:data:`STEER_BODY_MAX_BYTES` bytes are rejected locally with a
+``FAILURE`` ack so the runner never sees them, and ASCII control
+characters (ord < 32 except ``\\t`` / ``\\n``) are stripped from the
+forwarded body so prompt injection via control sequences can't poison
+downstream LLM calls.
+
 The bridge operates directly on a :class:`ControlChannel` — it is the
 caller's responsibility to attach that channel to the runner (via
 :attr:`Runner.control`, or by passing ``control=`` to
@@ -55,6 +63,49 @@ if TYPE_CHECKING:
     from .client import Client
 
 log = logging.getLogger("harmonograf_client._control_bridge")
+
+
+# STEER body validation (goldfive#171). The cap is a defense against
+# a pathological UI / scripted caller submitting a multi-MB "body" that
+# would otherwise bloat every subsequent LLM call + storage write.
+STEER_BODY_MAX_BYTES = 8192
+
+
+def _sanitise_steer_body(body: str) -> str:
+    """Strip ASCII control characters from ``body`` before forwarding.
+
+    Keeps ``\\t`` (9) and ``\\n`` (10); strips every other ord < 32 so
+    a steer cannot smuggle control sequences into the downstream
+    prompt. The \\r (13) is dropped so ``\\r\\n``-delimited clients
+    don't produce spurious blank lines either. Non-ASCII characters
+    (ord >= 128) pass through unchanged.
+    """
+    if not body:
+        return body
+    keep = (9, 10)  # tab, newline
+    return "".join(ch for ch in body if ord(ch) >= 32 or ord(ch) in keep)
+
+
+def _validate_steer_body(body: str) -> tuple[bool, str]:
+    """Return ``(ok, failure_detail)`` for a STEER body.
+
+    Shape is designed so callers can::
+
+        ok, detail = _validate_steer_body(body)
+        if not ok:
+            send_ack(FAILURE, detail); return
+
+    Validation ordering is: empty first (shortest path), then cap.
+    """
+    if not body or not body.strip():
+        return False, "body empty"
+    # Budget is bytes so multibyte glyph counts don't drift from what
+    # downstream sees on the wire. encode() is O(n); the guard above
+    # keeps this from running on None.
+    encoded = body.encode("utf-8", errors="replace")
+    if len(encoded) > STEER_BODY_MAX_BYTES:
+        return False, f"body too long ({len(encoded)})"
+    return True, ""
 
 
 class ControlBridge:
@@ -131,6 +182,7 @@ class ControlBridge:
     # ------------------------------------------------------------------
 
     async def _events_loop(self) -> None:
+        from goldfive.control import ControlKind
         from goldfive.conv import from_pb_control_event
 
         while True:
@@ -151,6 +203,25 @@ class ControlBridge:
                     f"failed to decode control event: {exc!r}",
                 )
                 continue
+
+            # STEER body validation (goldfive#171). Reject empty /
+            # whitespace-only and over-cap bodies locally so the runner
+            # never sees them — the server's outstanding deliver
+            # resolves via the FAILURE ack instead of timing out. The
+            # scrub step drops ASCII control characters so the forwarded
+            # body can't smuggle escape sequences into an LLM prompt.
+            if msg.kind is ControlKind.STEER:
+                body = str(msg.payload.get("note", "") or "")
+                ok, detail = _validate_steer_body(body)
+                if not ok:
+                    log.debug(
+                        "dropping STEER id=%s with invalid body: %s", msg.id, detail
+                    )
+                    self._client.send_control_ack(msg.id, "failure", detail)
+                    continue
+                sanitised = _sanitise_steer_body(body)
+                if sanitised != body:
+                    msg.payload["note"] = sanitised
 
             try:
                 await self._channel.send(msg)

--- a/client/tests/test_control_bridge.py
+++ b/client/tests/test_control_bridge.py
@@ -58,13 +58,26 @@ def _make_event(
     *,
     control_id: str = "c-1",
     steer_note: str | None = None,
+    steer_author: str = "",
+    steer_annotation_id: str = "",
     rewind_task_id: str | None = None,
 ) -> gf_control_pb2.ControlEvent:
-    """Build a goldfive ``ControlEvent`` proto with the requested kind."""
+    """Build a goldfive ``ControlEvent`` proto with the requested kind.
+
+    STEER gets a non-empty default note so bridge-level body validation
+    (goldfive#171) doesn't reject it; tests that want to exercise the
+    reject path pass ``steer_note`` explicitly (e.g. ``""``).
+    """
     kind_enum = getattr(gf_control_pb2, f"CONTROL_KIND_{kind_name}")
     ev = gf_control_pb2.ControlEvent(id=control_id, kind=kind_enum)
+    if kind_name == "STEER" and steer_note is None:
+        steer_note = "nudge"
     if steer_note is not None:
         ev.steer.note = steer_note
+    if steer_author:
+        ev.steer.author = steer_author
+    if steer_annotation_id:
+        ev.steer.annotation_id = steer_annotation_id
     if rewind_task_id is not None:
         ev.rewind.task_id = rewind_task_id
     return ev
@@ -316,3 +329,205 @@ async def test_observe_attaches_bridge_inside_event_loop(
 
     await runner.close()
     assert bridge._closed is True
+
+
+# ----------------------------------------------------------------------
+# goldfive#171 — STEER body validation + author propagation
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_steer_empty_body_acked_failure_not_forwarded(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    """Empty STEER body → FAILURE ack, no forward to runner."""
+    runner = _runner_with_channel()
+    bridge = ControlBridge(client, runner.control, asyncio.get_running_loop())
+    bridge.start()
+
+    made[0].deliver_control_event(
+        _make_event("STEER", control_id="s-empty", steer_note="")
+    )
+    await _drain()
+
+    # Ack bounced back as failure with the specific detail.
+    assert ("s-empty", "failure", "body empty") in made[0].sent_acks
+    # Runner must NOT have received the message.
+    msg = await asyncio.wait_for(
+        asyncio.shield(asyncio.ensure_future(runner.control.receive(timeout=0.05))),
+        timeout=1.0,
+    )
+    assert msg is None
+
+    await bridge.stop()
+
+
+@pytest.mark.asyncio
+async def test_steer_whitespace_body_acked_failure_not_forwarded(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    runner = _runner_with_channel()
+    bridge = ControlBridge(client, runner.control, asyncio.get_running_loop())
+    bridge.start()
+
+    made[0].deliver_control_event(
+        _make_event("STEER", control_id="s-ws", steer_note="   \t\n  ")
+    )
+    await _drain()
+
+    assert ("s-ws", "failure", "body empty") in made[0].sent_acks
+    msg = await runner.control.receive(timeout=0.05)
+    assert msg is None
+
+    await bridge.stop()
+
+
+@pytest.mark.asyncio
+async def test_steer_oversized_body_acked_failure_not_forwarded(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    """A 12KB body is rejected with the exact length in the detail string."""
+    from harmonograf_client._control_bridge import STEER_BODY_MAX_BYTES
+
+    runner = _runner_with_channel()
+    bridge = ControlBridge(client, runner.control, asyncio.get_running_loop())
+    bridge.start()
+
+    # 12KB body — well above the 8KB cap.
+    oversized = "x" * (12 * 1024)
+    made[0].deliver_control_event(
+        _make_event("STEER", control_id="s-big", steer_note=oversized)
+    )
+    await _drain()
+
+    # Find the ack and assert shape + len in detail.
+    matching = [
+        (cid, res, det)
+        for cid, res, det in made[0].sent_acks
+        if cid == "s-big"
+    ]
+    assert len(matching) == 1
+    cid, res, det = matching[0]
+    assert res == "failure"
+    assert det.startswith("body too long")
+    assert str(len(oversized.encode("utf-8"))) in det
+    # Runner saw nothing.
+    msg = await runner.control.receive(timeout=0.05)
+    assert msg is None
+    assert len(oversized) > STEER_BODY_MAX_BYTES  # sanity
+
+    await bridge.stop()
+
+
+@pytest.mark.asyncio
+async def test_steer_body_at_cap_forwards_successfully(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    """Exactly-at-cap body passes validation and reaches the runner."""
+    from harmonograf_client._control_bridge import STEER_BODY_MAX_BYTES
+
+    runner = _runner_with_channel()
+    bridge = ControlBridge(client, runner.control, asyncio.get_running_loop())
+    bridge.start()
+
+    at_cap = "a" * STEER_BODY_MAX_BYTES
+    made[0].deliver_control_event(
+        _make_event("STEER", control_id="s-cap", steer_note=at_cap)
+    )
+
+    msg = await asyncio.wait_for(runner.control.receive(), timeout=1.0)
+    assert msg is not None
+    assert msg.kind is ControlKind.STEER
+    assert msg.payload["note"] == at_cap
+
+    await bridge.stop()
+
+
+@pytest.mark.asyncio
+async def test_steer_body_control_chars_stripped_before_forward(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    """ASCII control chars (except tab/newline) are removed from the body."""
+    runner = _runner_with_channel()
+    bridge = ControlBridge(client, runner.control, asyncio.get_running_loop())
+    bridge.start()
+
+    # Bel, backspace, escape, DEL(127 — printable-ish, kept), plus kept tab + newline.
+    raw = "hello\x07\x08world\x1b\nmore\tend"
+    made[0].deliver_control_event(
+        _make_event("STEER", control_id="s-scrub", steer_note=raw)
+    )
+
+    msg = await asyncio.wait_for(runner.control.receive(), timeout=1.0)
+    assert msg is not None
+    # Bel (7), backspace (8), escape (27) stripped; tab (9), newline (10) preserved.
+    assert msg.payload["note"] == "helloworld\nmore\tend"
+
+    await bridge.stop()
+
+
+@pytest.mark.asyncio
+async def test_steer_author_and_annotation_id_forwarded_to_channel(
+    client: Client, made: list[FakeTransport]
+) -> None:
+    """``author`` and ``annotation_id`` on SteerPayload land in ControlMessage.payload."""
+    runner = _runner_with_channel()
+    bridge = ControlBridge(client, runner.control, asyncio.get_running_loop())
+    bridge.start()
+
+    made[0].deliver_control_event(
+        _make_event(
+            "STEER",
+            control_id="s-auth",
+            steer_note="pivot",
+            steer_author="alice",
+            steer_annotation_id="ann_xyz",
+        )
+    )
+
+    msg = await asyncio.wait_for(runner.control.receive(), timeout=1.0)
+    assert msg is not None
+    assert msg.payload["note"] == "pivot"
+    assert msg.payload["author"] == "alice"
+    assert msg.payload["annotation_id"] == "ann_xyz"
+
+    await bridge.stop()
+
+
+def test_validate_steer_body_unit() -> None:
+    """Unit test the validation helper directly."""
+    from harmonograf_client._control_bridge import (
+        STEER_BODY_MAX_BYTES,
+        _validate_steer_body,
+    )
+
+    assert _validate_steer_body("") == (False, "body empty")
+    assert _validate_steer_body("   ") == (False, "body empty")
+    assert _validate_steer_body("\t\n ") == (False, "body empty")
+    assert _validate_steer_body("ok") == (True, "")
+    too_long = "x" * (STEER_BODY_MAX_BYTES + 1)
+    ok, detail = _validate_steer_body(too_long)
+    assert ok is False
+    assert detail.startswith("body too long")
+    # Multibyte: 3-byte char × 3000 > 8192 bytes.
+    big_unicode = "☃" * 3000
+    ok, detail = _validate_steer_body(big_unicode)
+    assert ok is False
+    assert detail.startswith("body too long")
+
+
+def test_sanitise_steer_body_unit() -> None:
+    """Unit test the scrub helper directly."""
+    from harmonograf_client._control_bridge import _sanitise_steer_body
+
+    # Empty passes through.
+    assert _sanitise_steer_body("") == ""
+    # Bell, backspace, escape dropped; tab + newline kept.
+    assert _sanitise_steer_body("a\x07b\x08c\x1bd") == "abcd"
+    assert _sanitise_steer_body("a\tb\nc") == "a\tb\nc"
+    # \r dropped.
+    assert _sanitise_steer_body("a\r\nb") == "a\nb"
+    # Non-ASCII passes through unchanged.
+    assert _sanitise_steer_body("héllo☃") == "héllo☃"
+    # Printable ASCII unchanged.
+    assert _sanitise_steer_body("regular text!") == "regular text!"

--- a/server/harmonograf_server/rpc/frontend.py
+++ b/server/harmonograf_server/rpc/frontend.py
@@ -503,6 +503,11 @@ class FrontendServicerMixin:
         if kind == AnnotationKind.STEERING:
             event.kind = gf_control_pb2.CONTROL_KIND_STEER
             event.steer.note = request.body
+            # goldfive#171: propagate author + source annotation id so the
+            # goldfive-side steerer can attribute the drift + dedupe
+            # delivery retries / UI double-fires of the same annotation.
+            event.steer.author = ann.author
+            event.steer.annotation_id = ann.id
         else:
             event.kind = gf_control_pb2.CONTROL_KIND_INJECT_MESSAGE
             event.inject_message.text = request.body

--- a/server/tests/test_rpc_frontend.py
+++ b/server/tests/test_rpc_frontend.py
@@ -316,8 +316,11 @@ async def test_post_annotation_steering_target_span_resolves_agent(harness, stub
     # Subscribe so steering has a path.
     sub = await router.subscribe("sess_stee", "a", "str-1")
 
+    captured: dict = {}
+
     async def ack_agent():
         event = await asyncio.wait_for(sub.queue.get(), timeout=1)
+        captured["event"] = event
         router.record_ack(
             gf_control_pb2.ControlAck(
                 control_id=event.id,
@@ -333,11 +336,19 @@ async def test_post_annotation_steering_target_span_resolves_agent(harness, stub
             target=types_pb2.AnnotationTarget(span_id="sp_sess_stee_0"),
             kind=types_pb2.ANNOTATION_KIND_STEERING,
             body="refocus",
+            author="alice",
             ack_timeout_ms=2000,
         )
     )
     await agent_task
     assert resp.delivery == gf_control_pb2.CONTROL_ACK_RESULT_SUCCESS
+    # goldfive#171: the author + annotation id travel on SteerPayload so
+    # goldfive can attribute the drift + dedupe delivery retries.
+    event = captured["event"]
+    assert event.steer.note == "refocus"
+    assert event.steer.author == "alice"
+    assert event.steer.annotation_id == resp.annotation.id
+    assert event.steer.annotation_id.startswith("ann_")
 
 
 async def test_post_annotation_requires_session_id(harness, stub):


### PR DESCRIPTION
## Summary
- `ControlBridge._events_loop` validates STEER body before forwarding: empty/whitespace → FAILURE ack `"body empty"`, >8KB utf-8 → FAILURE ack `"body too long ({n})"`, ASCII control chars (ord < 32 except tab/newline) stripped. Invalid bodies never reach the runner — the server's pending deliver resolves via the FAILURE ack.
- `PostAnnotation` server path stamps `SteerPayload.author` and `SteerPayload.annotation_id` from the stored annotation so goldfive can attribute drift detail + dedupe delivery retries.

## Paired PR
goldfive#171 side (idempotency on annotation_id + reads the new payload fields): https://github.com/pedapudi/goldfive/pull/175

Requires the new `SteerPayload.author` / `SteerPayload.annotation_id` proto fields from that PR. Ordering: merge goldfive#175 first, then bump the submodule on this branch (or on a follow-up), then merge this PR.

## Test plan
- [x] `.venv/bin/pytest -x -q client/tests/` — 203 passed
- [x] `.venv/bin/pytest -x -q server/tests/` — 271 passed, 1 skipped
- [x] `.venv/bin/pytest -q tests/` (e2e) — 84 passed, 3 skipped
- [x] New tests: `test_control_bridge.py` covers empty/whitespace/oversized/at-cap/control-char-scrub/author+annotation_id forwarding, plus unit tests for the validation + scrub helpers (multibyte aware); `test_rpc_frontend.py` extends the existing steering PostAnnotation test to assert author + annotation_id land on the SteerPayload the router delivers.