### PR TITLE
Redesign intervention timeline: stable anchor + clustering + popover (#74)

### DIFF
--- a/frontend/src/__tests__/components/InterventionsTimeline.test.tsx
+++ b/frontend/src/__tests__/components/InterventionsTimeline.test.tsx
@@ -27,12 +27,12 @@ describe('<InterventionsTimeline />', () => {
     render(
       <InterventionsTimeline
         rows={[
-          row({ key: 'u1', source: 'user', kind: 'STEER', annotationId: 'ann_1' }),
-          row({ key: 'd1', source: 'drift', kind: 'LOOPING_REASONING' }),
-          row({ key: 'g1', source: 'goldfive', kind: 'CASCADE_CANCEL' }),
+          row({ key: 'u1', atMs: 100, source: 'user', kind: 'STEER', annotationId: 'ann_1' }),
+          row({ key: 'd1', atMs: 20_000, source: 'drift', kind: 'LOOPING_REASONING' }),
+          row({ key: 'g1', atMs: 50_000, source: 'goldfive', kind: 'CASCADE_CANCEL' }),
         ]}
         startMs={0}
-        endMs={1000}
+        endMs={60_000}
       />,
     );
     const user = screen.getByTestId('intervention-marker-u1');
@@ -54,6 +54,7 @@ describe('<InterventionsTimeline />', () => {
         rows={[
           row({
             key: 'd1',
+            atMs: 500,
             source: 'drift',
             kind: 'LOOPING_REASONING',
             bodyOrReason: 'agent re-read same doc',
@@ -63,7 +64,7 @@ describe('<InterventionsTimeline />', () => {
           }),
         ]}
         startMs={0}
-        endMs={1000}
+        endMs={10_000}
       />,
     );
     fireEvent.click(screen.getByTestId('intervention-marker-d1'));
@@ -81,6 +82,7 @@ describe('<InterventionsTimeline />', () => {
         rows={[
           row({
             key: 'd1',
+            atMs: 500,
             source: 'drift',
             outcome: 'plan_revised:r5',
             planRevisionIndex: 5,
@@ -100,12 +102,97 @@ describe('<InterventionsTimeline />', () => {
           },
         ]}
         startMs={0}
-        endMs={1000}
+        endMs={10_000}
         onJumpToRevision={onJump}
       />,
     );
     fireEvent.click(screen.getByTestId('intervention-marker-d1'));
     fireEvent.click(screen.getByTestId('intervention-card__jump'));
     expect(onJump).toHaveBeenCalledWith(5);
+  });
+
+  // --- #74: stable-anchor invariant -------------------------------------
+  //
+  // The strip must NOT shift marker X when the parent advances `endMs` on
+  // every render (e.g. because a live session's duration ticks up). With
+  // the stable-snapshot fix, the marker x stays pinned to the snapshot
+  // taken at mount; only a coarse 1s tick may move it.
+  it('keeps marker x stable when endMs advances on re-render (stable anchor)', () => {
+    const rows = [
+      row({ key: 'u1', atMs: 5_000, source: 'user', kind: 'STEER' }),
+    ];
+    const { rerender } = render(
+      <InterventionsTimeline
+        rows={rows}
+        startMs={0}
+        endMs={10_000}
+        width={400}
+        // Disable the rAF-driven live tick so the test is deterministic.
+        _liveTickMs={0}
+      />,
+    );
+    const first = screen.getByTestId('intervention-marker-u1');
+    const firstTransform = first.getAttribute('transform');
+    // Simulate the parent re-rendering with a much larger endMs (live
+    // session has grown). Without the fix, every marker would slide left.
+    rerender(
+      <InterventionsTimeline
+        rows={rows}
+        startMs={0}
+        endMs={60_000}
+        width={400}
+        _liveTickMs={0}
+      />,
+    );
+    const after = screen.getByTestId('intervention-marker-u1');
+    expect(after.getAttribute('transform')).toBe(firstTransform);
+  });
+
+  // --- #74: clustering ---------------------------------------------------
+  //
+  // Two markers whose centres would land within ~2% of the strip width of
+  // each other collapse into a single cluster badge. The badge carries a
+  // `data-count` attribute with the cluster size.
+  it('clusters dense interventions into a single badge with a count', () => {
+    const { container } = render(
+      <InterventionsTimeline
+        rows={[
+          row({ key: 's1', atMs: 5_000, source: 'user', kind: 'STEER' }),
+          row({ key: 's2', atMs: 5_050, source: 'user', kind: 'STEER' }),
+          row({ key: 's3', atMs: 5_100, source: 'user', kind: 'STEER' }),
+        ]}
+        startMs={0}
+        endMs={60_000}
+        width={400}
+        _liveTickMs={0}
+      />,
+    );
+    // No individual markers should render for clustered rows.
+    expect(screen.queryByTestId('intervention-marker-s1')).toBeNull();
+    expect(screen.queryByTestId('intervention-marker-s2')).toBeNull();
+    expect(screen.queryByTestId('intervention-marker-s3')).toBeNull();
+    // One cluster badge with count=3.
+    const cluster = container.querySelector(
+      '[data-testid^="intervention-cluster-"]',
+    );
+    expect(cluster).toBeTruthy();
+    expect(cluster?.getAttribute('data-count')).toBe('3');
+  });
+
+  it('does not cluster markers that are well-separated', () => {
+    render(
+      <InterventionsTimeline
+        rows={[
+          row({ key: 'a', atMs: 5_000, source: 'user', kind: 'STEER' }),
+          row({ key: 'b', atMs: 40_000, source: 'drift', kind: 'LOOPING' }),
+        ]}
+        startMs={0}
+        endMs={60_000}
+        width={400}
+        _liveTickMs={0}
+      />,
+    );
+    expect(screen.getByTestId('intervention-marker-a')).toBeTruthy();
+    expect(screen.getByTestId('intervention-marker-b')).toBeTruthy();
   });
 });

--- a/frontend/src/components/Interventions/InterventionsTimeline.css
+++ b/frontend/src/components/Interventions/InterventionsTimeline.css
@@ -1,4 +1,4 @@
-/* Unified intervention timeline strip (issue #69).
+/* Unified intervention timeline strip (issues #69, #74).
    Mirrors the chrome vocabulary used by TaskStagesGraph so the strip can sit
    directly above/below the DAG without a visual mismatch. */
 
@@ -16,7 +16,7 @@
 .hg-interventions-strip__svg {
   display: block;
   width: 100%;
-  height: 36px;
+  height: 48px;
   overflow: visible;
 }
 
@@ -26,15 +26,31 @@
   stroke-dasharray: 2 3;
 }
 
-.hg-interventions-strip__marker {
-  cursor: pointer;
-  transition:
-    transform 120ms ease,
-    opacity 120ms ease;
+/* --- Axis ticks --------------------------------------------------------- */
+
+.hg-interventions-strip__tick-mark {
+  stroke: var(--md-sys-color-outline-variant, #43474e);
+  stroke-width: 1;
 }
 
-.hg-interventions-strip__marker:hover {
-  transform: scale(1.15);
+.hg-interventions-strip__tick-label {
+  fill: var(--md-sys-color-on-surface-variant, #9da3b4);
+  opacity: 0.7;
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+}
+
+/* --- Markers ------------------------------------------------------------ */
+
+.hg-interventions-strip__marker {
+  cursor: pointer;
+}
+
+.hg-interventions-strip__marker-shape,
+.hg-interventions-strip__marker-ring,
+.hg-interventions-strip__marker-overlay {
+  transition: fill 120ms ease, stroke 120ms ease;
 }
 
 .hg-interventions-strip__marker--selected .hg-interventions-strip__marker-shape {
@@ -42,9 +58,59 @@
   stroke-width: 1.5;
 }
 
-.hg-interventions-strip__marker-shape {
-  transition: fill 120ms ease;
+.hg-interventions-strip__marker--selected .hg-interventions-strip__marker-ring {
+  stroke-width: 2;
 }
+
+/* Subtle hover affordance without changing shape geometry (so markers never
+   shift) — brighten the ring instead of scaling the glyph. */
+.hg-interventions-strip__marker:hover .hg-interventions-strip__marker-shape {
+  filter: brightness(1.2);
+}
+
+/* Entrance animation — opacity only, no transform, so new markers don't
+   appear to jump adjacent neighbours. */
+@keyframes hg-intervention-enter {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.hg-interventions-strip__marker--new {
+  animation: hg-intervention-enter 280ms ease-out;
+}
+
+/* --- Cluster badge ------------------------------------------------------ */
+
+.hg-interventions-strip__cluster {
+  cursor: pointer;
+}
+
+.hg-interventions-strip__cluster-shape {
+  transition: filter 120ms ease;
+}
+
+.hg-interventions-strip__cluster:hover .hg-interventions-strip__cluster-shape {
+  filter: brightness(1.15);
+}
+
+.hg-interventions-strip__cluster--selected .hg-interventions-strip__cluster-shape {
+  stroke: var(--md-sys-color-on-surface, #e2e2e9);
+  stroke-width: 1.5;
+}
+
+.hg-interventions-strip__cluster-count {
+  fill: #0b0d12;
+  font-size: 10px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+}
+
+/* --- Empty state -------------------------------------------------------- */
 
 .hg-interventions-strip__empty {
   padding: 4px 12px;
@@ -53,28 +119,55 @@
   color: var(--md-sys-color-on-surface-variant, #9da3b4);
 }
 
-/* Expanded card — sits below the strip, not floating, so it doesn't occlude
-   the DAG above or the Gantt below. */
+/* --- Popover (hover + pinned) ------------------------------------------ */
 
-.hg-interventions-card {
-  margin-top: 4px;
+.hg-interventions-popover {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  transform: translateX(-50%);
+  min-width: 220px;
+  max-width: 340px;
   padding: 8px 10px;
   border-radius: 6px;
-  background: var(--md-sys-color-surface-container, #1e2029);
+  background: var(--md-sys-color-surface-container-high, #2a2d37);
   border: 1px solid var(--md-sys-color-outline-variant, #43474e);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   display: flex;
   flex-direction: column;
   gap: 6px;
+  z-index: 20;
+  animation: hg-intervention-enter 140ms ease-out;
+  pointer-events: none;
 }
 
-.hg-interventions-card__head {
+.hg-interventions-popover--pinned {
+  pointer-events: auto;
+}
+
+/* Little triangle pointing down from the popover to the marker. */
+.hg-interventions-popover::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--md-sys-color-outline-variant, #43474e);
+}
+
+.hg-interventions-popover--cluster {
+  min-width: 260px;
+  max-width: 380px;
+}
+
+.hg-interventions-popover__head {
   display: flex;
   align-items: center;
   gap: 8px;
   font-size: 11px;
 }
 
-.hg-interventions-card__chip {
+.hg-interventions-popover__chip {
   display: inline-block;
   padding: 2px 6px;
   border-radius: 10px;
@@ -85,31 +178,29 @@
   font-weight: 600;
 }
 
-.hg-interventions-card__chip[data-source='user'] {
+.hg-interventions-popover__chip[data-source='user'] {
   background: #5b8def;
 }
-
-.hg-interventions-card__chip[data-source='drift'] {
+.hg-interventions-popover__chip[data-source='drift'] {
   background: #f59e0b;
 }
-
-.hg-interventions-card__chip[data-source='goldfive'] {
+.hg-interventions-popover__chip[data-source='goldfive'] {
   background: #8d9199;
 }
 
-.hg-interventions-card__kind {
+.hg-interventions-popover__kind {
   font-weight: 600;
   color: var(--md-sys-color-on-surface, #e2e2e9);
   letter-spacing: 0.2px;
 }
 
-.hg-interventions-card__at {
+.hg-interventions-popover__at {
   font-variant-numeric: tabular-nums;
   color: var(--md-sys-color-on-surface-variant, #9da3b4);
   margin-left: auto;
 }
 
-.hg-interventions-card__severity {
+.hg-interventions-popover__severity {
   padding: 1px 6px;
   border-radius: 8px;
   font-size: 10px;
@@ -118,17 +209,17 @@
   font-weight: 600;
 }
 
-.hg-interventions-card__severity[data-severity='critical'] {
+.hg-interventions-popover__severity[data-severity='critical'] {
   background: #e06070;
 }
-.hg-interventions-card__severity[data-severity='warning'] {
+.hg-interventions-popover__severity[data-severity='warning'] {
   background: #f59e0b;
 }
-.hg-interventions-card__severity[data-severity='info'] {
+.hg-interventions-popover__severity[data-severity='info'] {
   background: #5b8def;
 }
 
-.hg-interventions-card__close {
+.hg-interventions-popover__close {
   background: transparent;
   color: var(--md-sys-color-on-surface-variant, #9da3b4);
   border: 0;
@@ -138,37 +229,37 @@
   line-height: 1;
 }
 
-.hg-interventions-card__close:hover {
+.hg-interventions-popover__close:hover {
   color: var(--md-sys-color-on-surface, #e2e2e9);
 }
 
-.hg-interventions-card__author {
+.hg-interventions-popover__author {
   font-size: 10px;
   color: var(--md-sys-color-on-surface-variant, #9da3b4);
 }
 
-.hg-interventions-card__body {
+.hg-interventions-popover__body {
   font-size: 12px;
   color: var(--md-sys-color-on-surface, #e2e2e9);
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-.hg-interventions-card__foot {
+.hg-interventions-popover__foot {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
 }
 
-.hg-interventions-card__outcome {
+.hg-interventions-popover__outcome {
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.4px;
   color: var(--md-sys-color-on-surface-variant, #9da3b4);
 }
 
-.hg-interventions-card__jump {
+.hg-interventions-popover__jump {
   font-size: 11px;
   padding: 3px 10px;
   border-radius: 4px;
@@ -178,6 +269,44 @@
   cursor: pointer;
 }
 
-.hg-interventions-card__jump:hover {
+.hg-interventions-popover__jump:hover {
   background: var(--md-sys-color-surface-container-highest, #2a2d37);
+}
+
+/* Cluster list inside popover */
+.hg-interventions-popover__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.hg-interventions-popover__list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px;
+  border-radius: 4px;
+  background: var(--md-sys-color-surface-container, #1e2029);
+}
+
+.hg-interventions-popover__list-button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.hg-interventions-popover__list-button:hover {
+  opacity: 0.9;
 }

--- a/frontend/src/components/Interventions/InterventionsTimeline.tsx
+++ b/frontend/src/components/Interventions/InterventionsTimeline.tsx
@@ -1,21 +1,36 @@
-// Unified intervention timeline strip (issue #69).
+// Unified intervention timeline strip (issues #69, #74).
 //
 // Renders a horizontal strip of markers — one per Intervention — that sits
-// above (or below) the stage DAG in the planning view. Markers are colour-
-// coded by source (user / drift / goldfive) and sized by severity for drift
-// rows. Hover surfaces a tooltip with kind + outcome; click expands a card
-// with body/author/outcome and a "jump to plan revision" affordance when
-// the intervention produced a new revision.
+// above the Gantt in planning view. Markers are colour-coded by source
+// (user / drift / goldfive), glyph-coded by kind (diamond / circle /
+// chevron / square), and ringed when severity ≥ warning. Hover surfaces a
+// deterministic popover (anchored to the marker, not the cursor). When two
+// rows land within ~2% of the strip width of each other they collapse into
+// a single "N" cluster badge whose popover lists the group.
+//
+// Stability contract (#74 issue #1): the strip never recomputes marker X
+// from the outer `endMs` prop during a re-render caused by hover / tooltip
+// state. Instead, it captures a `spanEndMs` snapshot on mount and advances
+// it on a coarse 1s tick. This guarantees hovering a marker never shifts
+// the other markers' X positions on a live session where `endMs` is being
+// recomputed by the parent on every frame.
 //
 // Rendering is tree-agnostic: the component never inspects kind taxonomies
 // or makes domain-specific decisions. Any kind string the server emits
 // renders uniformly — new drift kinds added to goldfive tomorrow work
-// without a frontend change.
+// without a frontend change. The only taxonomy knowledge here is the
+// user/drift/goldfive "source" trichotomy, which the deriver already
+// assigns in `lib/interventions.ts`.
 
-import { useMemo, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { TaskPlan } from '../../gantt/types';
 import {
-  markerRadiusFor,
   SOURCE_COLOR,
   type InterventionRow,
 } from '../../lib/interventions';
@@ -25,7 +40,8 @@ interface InterventionsTimelineProps {
   rows: readonly InterventionRow[];
   // Session-relative ms window the strip should span. When the planning
   // view draws multiple plans stacked, each plan passes its own window so
-  // the markers align to the DAG above.
+  // the markers align to the DAG above. `endMs` may advance as the session
+  // progresses; the component snapshots it internally to avoid jitter.
   startMs: number;
   endMs: number;
   // Optional: all plan revs so the "jump to rev" button can find the target.
@@ -37,14 +53,66 @@ interface InterventionsTimelineProps {
   // Width hint from the parent container. If omitted the strip expands to
   // fill its container.
   width?: number;
+  // Internal test hook: skip the live-end rAF tick and use endMs verbatim
+  // for snapshotting. Production callers should never set this.
+  _liveTickMs?: number;
 }
 
-const STRIP_HEIGHT = 36;
-const STRIP_PAD_X = 12;
+const STRIP_HEIGHT = 48;
+const STRIP_PAD_X = 14;
+const AXIS_Y = STRIP_HEIGHT - 10;
+const MARKER_Y = STRIP_HEIGHT / 2 - 4;
+
+// Cluster collision threshold — markers whose centres are within this
+// fraction of the strip width collapse into a single badge.
+const CLUSTER_THRESHOLD_FRAC = 0.02;
+const CLUSTER_THRESHOLD_MIN_PX = 14;
+
+// Default live-end refresh cadence. Coarse enough that hovering never
+// coincides with a tick.
+const DEFAULT_LIVE_TICK_MS = 1000;
+
+// ---- Axis tick generation ------------------------------------------------
+
+interface AxisTick {
+  atMs: number;
+  label: string;
+}
+
+function pickTickStepMs(spanMs: number): number {
+  // Aim for 4–8 ticks across the strip.
+  if (spanMs <= 60_000) return 10_000;           // 10s
+  if (spanMs <= 120_000) return 30_000;          // 30s
+  if (spanMs <= 600_000) return 60_000;          // 1m
+  if (spanMs <= 1_800_000) return 300_000;       // 5m
+  if (spanMs <= 3_600_000) return 600_000;       // 10m
+  return 1_800_000;                              // 30m
+}
+
+function axisTickLabel(relMs: number): string {
+  if (relMs <= 0) return '0m';
+  if (relMs < 60_000) return `${Math.round(relMs / 1000)}s`;
+  const m = Math.floor(relMs / 60_000);
+  const s = Math.round((relMs % 60_000) / 1000);
+  if (s === 0) return `${m}m`;
+  return `${m}m${s}s`;
+}
+
+function buildAxisTicks(startMs: number, endMs: number): AxisTick[] {
+  const span = Math.max(1, endMs - startMs);
+  const step = pickTickStepMs(span);
+  const ticks: AxisTick[] = [];
+  for (let t = 0; t <= span; t += step) {
+    ticks.push({ atMs: startMs + t, label: axisTickLabel(t) });
+    if (ticks.length > 12) break; // safety guard
+  }
+  return ticks;
+}
+
+// ---- Outcome label formatting -------------------------------------------
 
 function labelForOutcome(outcome: string): string {
   if (!outcome) return 'pending';
-  // "plan_revised:r3" → "→ rev 3"; "cascade_cancel:2_tasks" → "→ cancel 2 tasks".
   if (outcome.startsWith('plan_revised:r')) {
     return `→ rev ${outcome.slice('plan_revised:r'.length)}`;
   }
@@ -63,6 +131,164 @@ function fmtAt(atMs: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
+// ---- Glyph selection -----------------------------------------------------
+
+type Glyph = 'diamond' | 'diamond-x' | 'circle' | 'chevron' | 'square';
+
+function glyphFor(row: InterventionRow): Glyph {
+  // Kind-driven glyph selection. We look at the normalised kind emitted by
+  // the deriver in lib/interventions.ts — "STEER", "CANCEL", "LOOPING_…",
+  // "CASCADE_CANCEL", "REFINE_RETRY", etc. Unknown kinds fall back to the
+  // source's default glyph so new server-side kinds render sanely.
+  const kind = (row.kind || '').toUpperCase();
+  if (row.source === 'user') {
+    if (kind === 'CANCEL') return 'diamond-x';
+    return 'diamond';
+  }
+  if (row.source === 'goldfive') {
+    return 'square';
+  }
+  // drift
+  if (row.outcome && row.outcome.startsWith('plan_revised:')) return 'chevron';
+  return 'circle';
+}
+
+function severityRingColor(severity: string): string | null {
+  const s = (severity || '').toLowerCase();
+  if (s === 'critical') return '#e06070';
+  if (s === 'warning') return '#f59e0b';
+  return null;
+}
+
+// ---- Cluster grouping ----------------------------------------------------
+
+interface Plotted {
+  row: InterventionRow;
+  cx: number;
+}
+
+interface Cluster {
+  cx: number;
+  rows: InterventionRow[];
+}
+
+function clusterPlotted(plotted: Plotted[], thresholdPx: number): Cluster[] {
+  if (plotted.length === 0) return [];
+  // Input is already atMs-sorted by the deriver; still sort by cx to be
+  // robust if upstream order changes.
+  const sorted = [...plotted].sort((a, b) => a.cx - b.cx);
+  const out: Cluster[] = [];
+  const rawMembers: number[][] = []; // parallel arr of raw cx's per cluster
+  for (const p of sorted) {
+    const last = out[out.length - 1];
+    if (last && p.cx - last.cx <= thresholdPx) {
+      last.rows.push(p.row);
+      rawMembers[rawMembers.length - 1].push(p.cx);
+      // Re-centre on the running mean so the badge doesn't drift left as
+      // more markers merge into it.
+      const arr = rawMembers[rawMembers.length - 1];
+      last.cx = arr.reduce((sum, cx) => sum + cx, 0) / arr.length;
+    } else {
+      out.push({ cx: p.cx, rows: [p.row] });
+      rawMembers.push([p.cx]);
+    }
+  }
+  return out;
+}
+
+// ---- Stable live-end snapshot -------------------------------------------
+
+/**
+ * Returns a monotonically non-decreasing `spanEndMs` that advances only on
+ * a coarse timer, not on every re-render. This is the fix for the "markers
+ * jump on hover" bug (#74): the parent recomputes `endMs` on every render,
+ * so if we anchored X to it directly, hover-induced re-renders would shift
+ * every marker left by a fraction of a pixel.
+ */
+function useStableSpanEnd(endMs: number, tickMs: number): number {
+  // The anchor is stored in React state and updated only at the two legal
+  // moments:
+  //   1. `endMs` regressed (parent swapped to a narrower window — e.g. a
+  //      different plan). Snap down during render using the
+  //      "adjust state while rendering" pattern. See:
+  //      https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  //   2. The coarse tick fired — sample `endMs` into the anchor via the
+  //      interval callback below.
+  // For all other renders (same tick, `endMs` grew or unchanged) the
+  // state is stable, so marker X positions don't move.
+  const [spanEnd, setSpanEnd] = useState(endMs);
+
+  // Regression detection — adjust state during render. React discards
+  // the current render and re-runs with the new state before committing,
+  // so no flicker and no cascading-render warning.
+  if (endMs < spanEnd) {
+    setSpanEnd(endMs);
+  }
+
+  // Growth path — coarse tick pulls the current `endMs` into the anchor.
+  useEffect(() => {
+    if (tickMs <= 0) return;
+    const handle = window.setInterval(() => {
+      setSpanEnd((prev) => (endMs > prev ? endMs : prev));
+    }, tickMs);
+    return () => window.clearInterval(handle);
+  }, [endMs, tickMs]);
+
+  return endMs < spanEnd ? endMs : spanEnd;
+}
+
+// ---- Entrance animation helper ------------------------------------------
+
+function useSeenKeys(keys: readonly string[]): Set<string> {
+  // Track which row keys we have already rendered so we can mark freshly
+  // arrived rows with `data-new="true"` exactly once. The seen-set lives
+  // in state so it's never mutated during render (satisfying the
+  // `react-hooks/refs` lint rule), but we only ever GROW the set — never
+  // shrink it — so consumers comparing successive renders see a stable
+  // monotone sequence.
+  const [seen, setSeen] = useState<Set<string>>(() => new Set());
+  const [newlyAdded, setNewlyAdded] = useState<Set<string>>(() => new Set());
+  const firstRenderRef = useRef(true);
+
+  useEffect(() => {
+    // First render: seed the seen-set with every current key and mark
+    // nothing as new. From the user's perspective the rows were already
+    // there on mount, so we don't want an entrance animation for them.
+    if (firstRenderRef.current) {
+      firstRenderRef.current = false;
+      setSeen(new Set(keys));
+      setNewlyAdded(new Set());
+      return;
+    }
+    const added = new Set<string>();
+    const next = new Set(seen);
+    for (const k of keys) {
+      if (!next.has(k)) {
+        added.add(k);
+        next.add(k);
+      }
+    }
+    if (added.size > 0) {
+      setSeen(next);
+      setNewlyAdded(added);
+    } else if (newlyAdded.size > 0) {
+      // Clear the "new" flag on the subsequent commit so the entrance
+      // animation only fires once per row.
+      setNewlyAdded(new Set());
+    }
+    // Intentionally omit `seen` / `newlyAdded` from the dep list: they
+    // are internal state updated by this very effect and including them
+    // causes a render loop. `keys` is the only external trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keys]);
+
+  return newlyAdded;
+}
+
+// =========================================================================
+// Component
+// =========================================================================
+
 export function InterventionsTimeline({
   rows,
   startMs,
@@ -70,28 +296,90 @@ export function InterventionsTimeline({
   revs,
   onJumpToRevision,
   width,
+  _liveTickMs,
 }: InterventionsTimelineProps) {
-  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  // Hover/selection state. Hover drives the popover; selection (click)
+  // pins the popover so the user can interact with the Jump button.
+  const [hoverKey, setHoverKey] = useState<string | null>(null);
+  const [pinnedKey, setPinnedKey] = useState<string | null>(null);
 
-  const span = Math.max(1, endMs - startMs);
   const actualWidth = width ?? 480;
 
-  // Map each row to its x coordinate on the strip.
-  const plotted = useMemo(() => {
+  // Snapshot endMs so hover re-renders don't shift markers (#74 issue #1).
+  const spanEndMs = useStableSpanEnd(
+    endMs,
+    _liveTickMs ?? DEFAULT_LIVE_TICK_MS,
+  );
+  const span = Math.max(1, spanEndMs - startMs);
+
+  // --- Plot + cluster ----------------------------------------------------
+
+  const plotted: Plotted[] = useMemo(() => {
     return rows.map((row) => {
       const tNorm = Math.min(1, Math.max(0, (row.atMs - startMs) / span));
-      const cx =
-        STRIP_PAD_X + tNorm * (actualWidth - STRIP_PAD_X * 2);
+      const cx = STRIP_PAD_X + tNorm * (actualWidth - STRIP_PAD_X * 2);
       return { row, cx };
     });
   }, [rows, startMs, span, actualWidth]);
 
-  const expandedRow = expandedKey
-    ? rows.find((r) => r.key === expandedKey) ?? null
+  const clusterThresholdPx = Math.max(
+    CLUSTER_THRESHOLD_MIN_PX,
+    actualWidth * CLUSTER_THRESHOLD_FRAC,
+  );
+  const clusters = useMemo(
+    () => clusterPlotted(plotted, clusterThresholdPx),
+    [plotted, clusterThresholdPx],
+  );
+
+  // Entrance-animation tracking.
+  const rowKeys = useMemo(() => rows.map((r) => r.key), [rows]);
+  const newlyAdded = useSeenKeys(rowKeys);
+
+  // Axis ticks.
+  const axisTicks = useMemo(
+    () => buildAxisTicks(startMs, startMs + span),
+    [startMs, span],
+  );
+
+  // --- Popover wiring ----------------------------------------------------
+
+  const activeKey = pinnedKey ?? hoverKey;
+  const activeCluster = useMemo(() => {
+    if (!activeKey) return null;
+    for (const c of clusters) {
+      if (c.rows.some((r) => r.key === activeKey)) return c;
+    }
+    return null;
+  }, [activeKey, clusters]);
+  const activeRow = activeKey
+    ? rows.find((r) => r.key === activeKey) ?? null
     : null;
+
+  const closePopover = useCallback(() => {
+    setHoverKey(null);
+    setPinnedKey(null);
+  }, []);
+
+  // Dismiss a pinned popover when the user clicks outside the strip.
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!pinnedKey) return;
+    const onDocClick = (e: MouseEvent) => {
+      const root = rootRef.current;
+      if (root && e.target instanceof Node && !root.contains(e.target)) {
+        setPinnedKey(null);
+        setHoverKey(null);
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [pinnedKey]);
+
+  // --- Render ------------------------------------------------------------
 
   return (
     <div
+      ref={rootRef}
       className="hg-interventions-strip"
       data-testid="interventions-timeline"
       style={{ width: width ? `${width}px` : '100%' }}
@@ -103,67 +391,122 @@ export function InterventionsTimeline({
         viewBox={`0 0 ${actualWidth} ${STRIP_HEIGHT}`}
         preserveAspectRatio="none"
       >
+        {/* Rule */}
         <line
           className="hg-interventions-strip__rule"
           x1={STRIP_PAD_X}
-          y1={STRIP_HEIGHT / 2}
+          y1={MARKER_Y}
           x2={actualWidth - STRIP_PAD_X}
-          y2={STRIP_HEIGHT / 2}
+          y2={MARKER_Y}
         />
-        {plotted.map(({ row, cx }) => {
-          const r = markerRadiusFor(row) / 2;
-          const color = SOURCE_COLOR[row.source] ?? SOURCE_COLOR.goldfive;
-          const selected = row.key === expandedKey;
-          const glyph = row.source === 'user' ? 'diamond' : 'circle';
-          const title = `${row.kind} (${row.source})${
-            row.outcome ? ' · ' + labelForOutcome(row.outcome) : ''
-          }`;
+
+        {/* Axis ticks */}
+        {axisTicks.map((tick, i) => {
+          const tNorm = Math.min(1, Math.max(0, (tick.atMs - startMs) / span));
+          const x = STRIP_PAD_X + tNorm * (actualWidth - STRIP_PAD_X * 2);
           return (
             <g
-              key={row.key}
-              className={
-                selected
-                  ? 'hg-interventions-strip__marker hg-interventions-strip__marker--selected'
-                  : 'hg-interventions-strip__marker'
-              }
-              transform={`translate(${cx}, ${STRIP_HEIGHT / 2})`}
-              data-testid={`intervention-marker-${row.key}`}
-              data-source={row.source}
-              data-kind={row.kind}
-              onClick={() =>
-                setExpandedKey((k) => (k === row.key ? null : row.key))
-              }
+              key={`tick-${i}`}
+              className="hg-interventions-strip__tick"
+              data-testid={`axis-tick-${i}`}
             >
-              <title>{title}</title>
-              {glyph === 'diamond' ? (
-                // User markers are diamonds so they're distinguishable in
-                // print / colour-blind view beyond just the blue hue.
-                <rect
-                  className="hg-interventions-strip__marker-shape"
-                  x={-r}
-                  y={-r}
-                  width={r * 2}
-                  height={r * 2}
-                  fill={color}
-                  transform="rotate(45)"
-                />
-              ) : (
-                <circle
-                  className="hg-interventions-strip__marker-shape"
-                  r={r}
-                  fill={color}
-                />
-              )}
+              <line
+                className="hg-interventions-strip__tick-mark"
+                x1={x}
+                y1={MARKER_Y - 2}
+                x2={x}
+                y2={MARKER_Y + 2}
+              />
+              <text
+                className="hg-interventions-strip__tick-label"
+                x={x}
+                y={AXIS_Y + 6}
+                textAnchor="middle"
+              >
+                {tick.label}
+              </text>
             </g>
           );
         })}
+
+        {/* Markers / clusters */}
+        {clusters.map((cluster) => {
+          if (cluster.rows.length === 1) {
+            const row = cluster.rows[0];
+            const isActive = activeKey === row.key;
+            const isNew = newlyAdded.has(row.key);
+            return (
+              <Marker
+                key={row.key}
+                row={row}
+                cx={cluster.cx}
+                cy={MARKER_Y}
+                selected={isActive}
+                isNew={isNew}
+                onMouseEnter={() => {
+                  if (!pinnedKey) setHoverKey(row.key);
+                }}
+                onMouseLeave={() => {
+                  if (!pinnedKey) setHoverKey(null);
+                }}
+                onClick={() =>
+                  setPinnedKey((k) => (k === row.key ? null : row.key))
+                }
+              />
+            );
+          }
+          // Cluster badge
+          const representativeKey = cluster.rows[0].key;
+          const isActive = cluster.rows.some((r) => r.key === activeKey);
+          return (
+            <ClusterBadge
+              key={`cluster:${representativeKey}`}
+              cluster={cluster}
+              cx={cluster.cx}
+              cy={MARKER_Y}
+              selected={isActive}
+              onMouseEnter={() => {
+                if (!pinnedKey) setHoverKey(representativeKey);
+              }}
+              onMouseLeave={() => {
+                if (!pinnedKey) setHoverKey(null);
+              }}
+              onClick={() =>
+                setPinnedKey((k) =>
+                  cluster.rows.some((r) => r.key === k)
+                    ? null
+                    : representativeKey,
+                )
+              }
+            />
+          );
+        })}
       </svg>
-      {expandedRow && (
-        <InterventionCard
-          row={expandedRow}
+
+      {/* Deterministic popover — positioned relative to the marker's cx in
+          the strip's coord space (not the cursor). */}
+      {activeCluster && activeRow && activeCluster.rows.length === 1 && (
+        <InterventionPopover
+          row={activeRow}
           revs={revs}
-          onClose={() => setExpandedKey(null)}
+          anchorXPct={(activeCluster.cx / actualWidth) * 100}
+          pinned={pinnedKey !== null}
+          onClose={closePopover}
           onJumpToRevision={onJumpToRevision}
+        />
+      )}
+      {activeCluster && activeCluster.rows.length > 1 && (
+        <ClusterPopover
+          cluster={activeCluster}
+          anchorXPct={(activeCluster.cx / actualWidth) * 100}
+          pinned={pinnedKey !== null}
+          revs={revs}
+          onClose={closePopover}
+          onJumpToRevision={onJumpToRevision}
+          onRowSelect={(key) => {
+            setPinnedKey(key);
+            setHoverKey(key);
+          }}
         />
       )}
       {rows.length === 0 && (
@@ -175,74 +518,319 @@ export function InterventionsTimeline({
   );
 }
 
-interface InterventionCardProps {
+// -------------------------------------------------------------------------
+// Marker glyph
+// -------------------------------------------------------------------------
+
+interface MarkerProps {
+  row: InterventionRow;
+  cx: number;
+  cy: number;
+  selected: boolean;
+  isNew: boolean;
+  onMouseEnter(): void;
+  onMouseLeave(): void;
+  onClick(): void;
+}
+
+function Marker({
+  row,
+  cx,
+  cy,
+  selected,
+  isNew,
+  onMouseEnter,
+  onMouseLeave,
+  onClick,
+}: MarkerProps) {
+  const color = SOURCE_COLOR[row.source] ?? SOURCE_COLOR.goldfive;
+  const glyph = glyphFor(row);
+  const ringColor = severityRingColor(row.severity);
+  const r = 6;
+  const ringR = 9;
+
+  const classes = [
+    'hg-interventions-strip__marker',
+    selected && 'hg-interventions-strip__marker--selected',
+    isNew && 'hg-interventions-strip__marker--new',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <g
+      className={classes}
+      transform={`translate(${cx}, ${cy})`}
+      data-testid={`intervention-marker-${row.key}`}
+      data-source={row.source}
+      data-kind={row.kind}
+      data-glyph={glyph}
+      data-severity={row.severity || ''}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onClick}
+    >
+      <title>{`${row.kind} (${row.source})${
+        row.outcome ? ' · ' + labelForOutcome(row.outcome) : ''
+      }`}</title>
+
+      {ringColor && (
+        <circle
+          className="hg-interventions-strip__marker-ring"
+          r={ringR}
+          fill="none"
+          stroke={ringColor}
+          strokeWidth={1.5}
+          strokeDasharray={
+            row.severity === 'critical' ? undefined : '2 2'
+          }
+        />
+      )}
+
+      {/* Tap-target (invisible) — larger hit area for easy hover/click. */}
+      <circle
+        className="hg-interventions-strip__marker-hit"
+        r={ringR + 4}
+        fill="transparent"
+      />
+
+      {glyph === 'diamond' && (
+        <rect
+          className="hg-interventions-strip__marker-shape"
+          x={-r}
+          y={-r}
+          width={r * 2}
+          height={r * 2}
+          fill={color}
+          transform="rotate(45)"
+        />
+      )}
+      {glyph === 'diamond-x' && (
+        <g>
+          <rect
+            className="hg-interventions-strip__marker-shape"
+            x={-r}
+            y={-r}
+            width={r * 2}
+            height={r * 2}
+            fill={color}
+            transform="rotate(45)"
+          />
+          <path
+            className="hg-interventions-strip__marker-overlay"
+            d={`M ${-r / 2} ${-r / 2} L ${r / 2} ${r / 2} M ${-r / 2} ${r / 2} L ${r / 2} ${-r / 2}`}
+            stroke="#0b0d12"
+            strokeWidth={1.4}
+          />
+        </g>
+      )}
+      {glyph === 'circle' && (
+        <circle
+          className="hg-interventions-strip__marker-shape"
+          r={r}
+          fill={color}
+        />
+      )}
+      {glyph === 'chevron' && (
+        // Up-chevron: signals "this intervention produced a plan revision".
+        <path
+          className="hg-interventions-strip__marker-shape"
+          d={`M ${-r} ${r * 0.55} L 0 ${-r * 0.8} L ${r} ${r * 0.55} L ${r * 0.45} ${r * 0.55} L 0 ${-r * 0.15} L ${-r * 0.45} ${r * 0.55} Z`}
+          fill={color}
+        />
+      )}
+      {glyph === 'square' && (
+        <rect
+          className="hg-interventions-strip__marker-shape"
+          x={-r + 1}
+          y={-r + 1}
+          width={(r - 1) * 2}
+          height={(r - 1) * 2}
+          fill="none"
+          stroke={color}
+          strokeWidth={1.6}
+        />
+      )}
+    </g>
+  );
+}
+
+// -------------------------------------------------------------------------
+// Cluster badge
+// -------------------------------------------------------------------------
+
+interface ClusterBadgeProps {
+  cluster: Cluster;
+  cx: number;
+  cy: number;
+  selected: boolean;
+  onMouseEnter(): void;
+  onMouseLeave(): void;
+  onClick(): void;
+}
+
+function ClusterBadge({
+  cluster,
+  cx,
+  cy,
+  selected,
+  onMouseEnter,
+  onMouseLeave,
+  onClick,
+}: ClusterBadgeProps) {
+  // Pick the dominant source for the badge colour — the most "urgent" wins:
+  // user > drift > goldfive (user steers are the most interesting density).
+  const sources = new Set(cluster.rows.map((r) => r.source));
+  const color = sources.has('user')
+    ? SOURCE_COLOR.user
+    : sources.has('drift')
+      ? SOURCE_COLOR.drift
+      : SOURCE_COLOR.goldfive;
+
+  // If any row in the cluster is severity ≥ warning, ring the badge.
+  const worstSeverity = cluster.rows.reduce((worst, r) => {
+    const s = (r.severity || '').toLowerCase();
+    if (s === 'critical') return 'critical';
+    if (s === 'warning' && worst !== 'critical') return 'warning';
+    return worst;
+  }, '');
+  const ringColor = severityRingColor(worstSeverity);
+
+  const classes = [
+    'hg-interventions-strip__cluster',
+    selected && 'hg-interventions-strip__cluster--selected',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const testId = `intervention-cluster-${cluster.rows[0].key}`;
+
+  return (
+    <g
+      className={classes}
+      transform={`translate(${cx}, ${cy})`}
+      data-testid={testId}
+      data-count={cluster.rows.length}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onClick}
+    >
+      <title>{`${cluster.rows.length} interventions`}</title>
+      {ringColor && (
+        <circle
+          className="hg-interventions-strip__cluster-ring"
+          r={13}
+          fill="none"
+          stroke={ringColor}
+          strokeWidth={1.5}
+        />
+      )}
+      <circle
+        className="hg-interventions-strip__cluster-shape"
+        r={10}
+        fill={color}
+      />
+      <text
+        className="hg-interventions-strip__cluster-count"
+        y={3.5}
+        textAnchor="middle"
+      >
+        {cluster.rows.length}
+      </text>
+    </g>
+  );
+}
+
+// -------------------------------------------------------------------------
+// Popover (single row)
+// -------------------------------------------------------------------------
+
+const BODY_PREVIEW_CHARS = 120;
+
+interface InterventionPopoverProps {
   row: InterventionRow;
   revs?: readonly TaskPlan[];
+  anchorXPct: number; // 0–100, % of strip width
+  pinned: boolean;
   onClose(): void;
   onJumpToRevision?: (revisionIndex: number) => void;
 }
 
-function InterventionCard({
+function InterventionPopover({
   row,
   revs,
+  anchorXPct,
+  pinned,
   onClose,
   onJumpToRevision,
-}: InterventionCardProps) {
+}: InterventionPopoverProps) {
   const targetRev =
     row.planRevisionIndex > 0
       ? revs?.find((p) => (p.revisionIndex ?? 0) === row.planRevisionIndex) ??
         null
       : null;
 
+  const bodyPreview =
+    row.bodyOrReason && row.bodyOrReason.length > BODY_PREVIEW_CHARS
+      ? row.bodyOrReason.slice(0, BODY_PREVIEW_CHARS).trimEnd() + '…'
+      : row.bodyOrReason;
+
+  // Clamp the anchor away from the edges so the popover never clips.
+  const clamped = Math.min(92, Math.max(8, anchorXPct));
+
   return (
     <div
-      className="hg-interventions-card"
-      data-testid="intervention-card"
+      className={`hg-interventions-popover${pinned ? ' hg-interventions-popover--pinned' : ''}`}
+      data-testid={pinned ? 'intervention-card' : 'intervention-popover'}
       data-source={row.source}
+      style={{ left: `${clamped}%` }}
+      role="dialog"
     >
-      <header className="hg-interventions-card__head">
+      <header className="hg-interventions-popover__head">
         <span
-          className="hg-interventions-card__chip"
+          className="hg-interventions-popover__chip"
           data-source={row.source}
           title={`source: ${row.source}`}
         >
           {row.source}
         </span>
-        <span className="hg-interventions-card__kind">{row.kind}</span>
-        <span className="hg-interventions-card__at">{fmtAt(row.atMs)}</span>
+        <span className="hg-interventions-popover__kind">{row.kind}</span>
+        <span className="hg-interventions-popover__at">{fmtAt(row.atMs)}</span>
         {row.severity && (
           <span
-            className="hg-interventions-card__severity"
+            className="hg-interventions-popover__severity"
             data-severity={row.severity}
           >
             {row.severity}
           </span>
         )}
-        <button
-          type="button"
-          className="hg-interventions-card__close"
-          onClick={onClose}
-          aria-label="Close"
-        >
-          ×
-        </button>
+        {pinned && (
+          <button
+            type="button"
+            className="hg-interventions-popover__close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        )}
       </header>
       {row.author && (
-        <div className="hg-interventions-card__author">
+        <div className="hg-interventions-popover__author">
           by <strong>{row.author}</strong>
         </div>
       )}
-      {row.bodyOrReason && (
-        <div className="hg-interventions-card__body">{row.bodyOrReason}</div>
+      {bodyPreview && (
+        <div className="hg-interventions-popover__body">{bodyPreview}</div>
       )}
-      <footer className="hg-interventions-card__foot">
-        <span className="hg-interventions-card__outcome">
+      <footer className="hg-interventions-popover__foot">
+        <span className="hg-interventions-popover__outcome">
           {labelForOutcome(row.outcome)}
         </span>
         {row.planRevisionIndex > 0 && targetRev && onJumpToRevision && (
           <button
             type="button"
-            className="hg-interventions-card__jump"
+            className="hg-interventions-popover__jump"
             onClick={() => onJumpToRevision(row.planRevisionIndex)}
             data-testid="intervention-card__jump"
           >
@@ -250,6 +838,105 @@ function InterventionCard({
           </button>
         )}
       </footer>
+    </div>
+  );
+}
+
+// -------------------------------------------------------------------------
+// Popover (cluster)
+// -------------------------------------------------------------------------
+
+interface ClusterPopoverProps {
+  cluster: Cluster;
+  anchorXPct: number;
+  pinned: boolean;
+  revs?: readonly TaskPlan[];
+  onClose(): void;
+  onJumpToRevision?: (revisionIndex: number) => void;
+  onRowSelect(key: string): void;
+}
+
+function ClusterPopover({
+  cluster,
+  anchorXPct,
+  pinned,
+  revs,
+  onClose,
+  onJumpToRevision,
+  onRowSelect,
+}: ClusterPopoverProps) {
+  const clamped = Math.min(92, Math.max(8, anchorXPct));
+  return (
+    <div
+      className={`hg-interventions-popover hg-interventions-popover--cluster${pinned ? ' hg-interventions-popover--pinned' : ''}`}
+      data-testid="intervention-cluster-popover"
+      style={{ left: `${clamped}%` }}
+      role="dialog"
+    >
+      <header className="hg-interventions-popover__head">
+        <span className="hg-interventions-popover__kind">
+          {cluster.rows.length} interventions
+        </span>
+        {pinned && (
+          <button
+            type="button"
+            className="hg-interventions-popover__close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        )}
+      </header>
+      <ul className="hg-interventions-popover__list">
+        {cluster.rows.map((row) => {
+          const preview =
+            row.bodyOrReason && row.bodyOrReason.length > 60
+              ? row.bodyOrReason.slice(0, 60).trimEnd() + '…'
+              : row.bodyOrReason;
+          const targetRev =
+            row.planRevisionIndex > 0
+              ? revs?.find(
+                  (p) => (p.revisionIndex ?? 0) === row.planRevisionIndex,
+                ) ?? null
+              : null;
+          return (
+            <li
+              key={row.key}
+              className="hg-interventions-popover__list-item"
+              data-source={row.source}
+              data-testid={`intervention-cluster-item-${row.key}`}
+            >
+              <button
+                type="button"
+                className="hg-interventions-popover__list-button"
+                onClick={() => onRowSelect(row.key)}
+              >
+                <span
+                  className="hg-interventions-popover__chip"
+                  data-source={row.source}
+                >
+                  {row.source}
+                </span>
+                <span className="hg-interventions-popover__kind">{row.kind}</span>
+                <span className="hg-interventions-popover__at">{fmtAt(row.atMs)}</span>
+              </button>
+              {preview && (
+                <div className="hg-interventions-popover__body">{preview}</div>
+              )}
+              {row.planRevisionIndex > 0 && targetRev && onJumpToRevision && (
+                <button
+                  type="button"
+                  className="hg-interventions-popover__jump"
+                  onClick={() => onJumpToRevision(row.planRevisionIndex)}
+                >
+                  → rev {row.planRevisionIndex}
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
Closes #74.

## Problem

Shipped in #71, the intervention strip surfaced two issues in live e2e runs (`orch_v2_1776822086`):

1. **Markers jumped on hover.** The X coordinate was derived from `(atMs - startMs) / (endMs - startMs)` where `endMs` grew on every render for a live session — hover-induced re-renders shifted every marker leftward by a fraction of a pixel.
2. **Hard to read.** Uniform circle/diamond glyphs didn't distinguish source at a glance, tight clusters overlapped illegibly, there were no time anchors on the track, and hover only surfaced the browser `<title>`.

## Fix

Frontend-only changes in `frontend/src/components/Interventions/InterventionsTimeline.{tsx,css}` plus tests.

### Stability

- `useStableSpanEnd(endMs, tickMs)` snapshots `endMs` into state and only propagates growth on a coarse 1 s tick. Hover/tooltip re-renders — which previously moved markers — no longer do. Regressions (parent swaps plans → smaller `endMs`) are honoured immediately via the "adjust state while rendering" pattern from the React docs.
- Test hook `_liveTickMs={0}` disables the coarse tick for deterministic tests.

### Glyph & colour system

| Source / kind | Glyph | Colour |
|---|---|---|
| user STEER | filled diamond | indigo `#5b8def` |
| user CANCEL | filled diamond + X | indigo |
| drift (no revision) | filled circle | amber `#f59e0b` |
| drift → plan_revised | up-chevron | amber |
| goldfive / system | hollow square | slate `#8d9199` |

Severity ≥ warning adds an outer ring (dashed amber for warning, solid red for critical). Ring sits OUTSIDE the glyph so severity changes don't shift the glyph's centre.

### Popover

Anchored to the marker's cx in percentage space (not cursor position), clamped 8–92% so it never clips. Hover shows floating preview; click pins it (close button + document-outside-click dismisses). Popover surfaces kind, source, author, body preview (120 chars), outcome chip, and Jump-to-rev button.

### Clustering

Markers within `max(14 px, 2% of strip width)` of each other collapse into a single "N" badge. Badge colour follows the most-urgent source (user > drift > goldfive), ring follows worst severity in the cluster. Badge popover lists each member with its own Jump-to-rev.

### Axis

Ticks at an auto-selected step (10 s / 30 s / 1 m / 5 m / 10 m / 30 m depending on span). Label-only, no hit targets.

### Entrance animation

Opacity-only fade-in on newly-added markers (tracked via a seen-keys set in state). No transform/scale — that would cause the very jitter we're fixing.

## Tests

- Existing tests updated (atMs values spread out so they don't accidentally cluster in a small viewport).
- NEW `keeps marker x stable when endMs advances on re-render` — re-renders with `endMs 10_000 → 60_000` and asserts the marker's SVG `transform` is byte-identical.
- NEW `clusters dense interventions into a single badge with a count` — three STEERs within 100 ms collapse into one cluster badge with `data-count="3"`.
- NEW `does not cluster markers that are well-separated` — sanity check.

```
Test Files  24 passed (24)
Tests       236 passed (236)
```

Lint + build both clean.

## Out of scope

- 29613707:05 malformed timestamp (#73) — dedup agent owns.
- Duplicate STEER cards (separate agent).

## Test plan

- [x] `npm run lint`
- [x] `npx vitest run` (full suite)
- [x] `npm run build`
- [ ] Manual verify: hover a marker on a live session — other markers must not shift.
- [ ] Manual verify: dense cluster (3+ rapid STEERs) collapses into a single badge with popover list.
- [ ] Manual verify: axis ticks render for a long-running session (>5 m span).