### PR TITLE
Per-ADK-agent Gantt rows (closes #79)

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -5,6 +5,18 @@ plan, task, drift, and steering logic now lives in goldfive (see issue
 #2); harmonograf just emits spans so the server's timeline /
 Gantt renders per-invocation, per-model-call, and per-tool-call bars.
 
+Per-ADK-agent attribution (harmonograf#74). A single ``goldfive.wrap``
+run drives a tree of ADK agents — coordinator, specialists, AgentTool
+wrappers, sequential/parallel/loop containers. The plugin stamps every
+span with a per-agent harmonograf ``agent_id`` derived from the client's
+root id and the ADK agent's name (``<client_agent_id>:<agent.name>``),
+so the harmonograf Gantt renders one row per ADK agent instead of
+collapsing the whole tree onto the client root. Parent-agent and kind
+hints ride on the first span emitted by each agent via
+``hgraf.agent.*`` attributes — the server harvests them into the
+agent's ``metadata`` the first time it auto-registers the agent row.
+See :meth:`HarmonografTelemetryPlugin.before_agent_callback`.
+
 Install by passing a pre-built ADK runner with this plugin to
 :class:`goldfive.adapters.adk.ADKAdapter`, or (more commonly) add the
 plugin to the ADK ``App`` that ``adk web`` / ``adk run`` builds::
@@ -33,7 +45,7 @@ import json
 import logging
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Optional
 
 from .client import Client
 from .enums import SpanKind, SpanStatus
@@ -304,9 +316,229 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         self._disabled_as_duplicate: bool = False
         self._duplicate_log_emitted: bool = False
 
+        # Per-ADK-agent attribution (harmonograf#74).
+        #
+        # ``_agent_stash`` maps ``invocation_id -> [per_agent_id, ...]`` as
+        # a stack so nested sub-agent invocations (e.g. coordinator calls
+        # an AgentTool which runs a specialist sub-Runner) pop back to the
+        # caller's id when the callee's ``after_agent_callback`` fires.
+        # Using ``invocation_id`` as the key handles ADK's
+        # CallbackContext-rebuild pattern (plugins rebuild Context objects
+        # between before/after hooks, so ``id(ctx)`` is unstable) and
+        # co-exists with the existing ``_model_spans`` keying by
+        # ``invocation_id``. Sub-Runners spawned by AgentTool get a fresh
+        # ``invocation_id``, so they get their own stack slot — the parent
+        # agent's stash is untouched. Both resolve via
+        # :meth:`_resolve_agent_id`.
+        #
+        # ``_seen_agents`` is a set of ``(session_id, per_agent_id)``
+        # tuples the plugin has already seen on this session. We stamp
+        # ``hgraf.agent.*`` attributes on each agent's FIRST span only;
+        # subsequent spans from the same agent skip those attributes so
+        # every span doesn't pay the metadata cost. The server uses them
+        # to auto-register the agent row on first-sight. Bounded by the
+        # session lifetime — a long-running session with many agents will
+        # accumulate entries but at ~tens-of-bytes per entry this is
+        # negligible.
+        self._agent_stash: dict[str, list[str]] = {}
+        self._seen_agents: set[tuple[str, str]] = set()
+        # Lookup: per_agent_id -> (adk_name, parent_agent_id, kind, branch)
+        # so we can re-stamp metadata attributes on the first span after
+        # an ``after_agent_callback`` clears the stash but a span from
+        # that agent still arrives (edge case: spans enqueued during
+        # agent teardown). Populated by
+        # :meth:`_register_agent_for_ctx`.
+        self._agent_metadata: dict[str, dict[str, str]] = {}
+
     @property
     def client(self) -> Client:
         return self._client
+
+    # ------------------------------------------------------------------
+    # Per-agent attribution (harmonograf#74)
+    # ------------------------------------------------------------------
+
+    def _derive_agent_id(self, agent_name: str) -> str:
+        """Return the stable per-ADK-agent harmonograf id.
+
+        Format: ``<client.agent_id>:<adk_agent_name>``. Embedding the
+        client's own agent_id as a prefix keeps the id globally unique
+        across concurrent runs (the client's agent_id is already a
+        UUID) while a suffix of the ADK agent.name gives operators a
+        human-readable trailing token in the Gantt gutter.
+
+        Returns the client's bare ``agent_id`` when ``agent_name`` is
+        empty, preserving the pre-#74 attribution (everything collapsed
+        onto the client root) as a safe degraded mode.
+        """
+        if not agent_name:
+            return str(self._client.agent_id)
+        return f"{self._client.agent_id}:{agent_name}"
+
+    def _agent_kind_hint(self, agent: Any) -> str:
+        """Best-effort ADK-class → harmonograf ``kind`` hint.
+
+        The server does not currently do anything authoritative with the
+        kind hint — it rides as metadata so operators can tell at a
+        glance whether a row is a worker (``llm``), an AgentTool wrapper
+        (``tool_wrapped``), a workflow container (``workflow``), or the
+        tree root when the agent object is unavailable (``unknown``).
+        New ADK agent classes fall through to ``unknown`` rather than
+        crashing the callback — keep this robust: telemetry must never
+        raise.
+        """
+        if agent is None:
+            return "unknown"
+        # Walk the MRO to handle user subclasses of LlmAgent /
+        # SequentialAgent / etc. without having to import each class.
+        for cls in type(agent).__mro__:
+            n = cls.__name__
+            if n in ("LlmAgent", "Agent"):
+                return "llm"
+            if n in ("SequentialAgent", "ParallelAgent", "LoopAgent"):
+                return "workflow"
+            if n in ("AgentTool",):
+                # AgentTool wraps another agent — it's a tool from the
+                # caller's perspective but harmonograf attributes work
+                # done inside the wrapped agent directly to that agent's
+                # row, not the AgentTool's row. Kept for completeness in
+                # case ADK ever fires agent callbacks on AgentTool
+                # itself (it currently doesn't).
+                return "tool_wrapped"
+        return "unknown"
+
+    def _register_agent_for_ctx(self, ctx: Any) -> str:
+        """Compute the per-agent id for ``ctx`` and prime the metadata cache.
+
+        Called from ``before_agent_callback`` on every agent entry
+        (including AgentTool sub-Runner roots — ADK propagates the
+        plugin manager and fires agent callbacks inside sub-Runners
+        too). Returns the per-agent id the caller should stash.
+
+        Also populates ``_agent_metadata[per_agent_id]`` with the
+        hgraf.agent.* payload the next emitting span from this agent
+        will stamp on its first arrival at the server. The payload is
+        intentionally minimal (name, parent, kind, branch) — the server
+        parses strings into ``Agent.metadata`` without needing a proto
+        schema change or a new wire event.
+        """
+        agent = _safe_attr(ctx, "agent", None)
+        # Different ADK versions expose the agent under either
+        # ``ctx.agent`` (InvocationContext) or
+        # ``ctx._invocation_context.agent`` (CallbackContext). Fall back
+        # through both. ``agent_name`` is the ReadonlyContext property.
+        if agent is None:
+            inv = _safe_attr(ctx, "_invocation_context", None)
+            if inv is not None:
+                agent = _safe_attr(inv, "agent", None)
+        agent_name = ""
+        if agent is not None:
+            agent_name = str(_safe_attr(agent, "name", "") or "")
+        if not agent_name:
+            agent_name = str(_safe_attr(ctx, "agent_name", "") or "")
+        per_agent_id = self._derive_agent_id(agent_name)
+        # Parent: prefer agent.parent_agent.name (ADK BaseAgent exposes
+        # this); fall back to parsing the InvocationContext.branch
+        # (dot-delimited ancestry).
+        parent_name = ""
+        if agent is not None:
+            parent = _safe_attr(agent, "parent_agent", None)
+            if parent is not None:
+                parent_name = str(_safe_attr(parent, "name", "") or "")
+        if not parent_name:
+            branch = _safe_attr(ctx, "branch", None)
+            if branch is None:
+                inv = _safe_attr(ctx, "_invocation_context", None)
+                if inv is not None:
+                    branch = _safe_attr(inv, "branch", None)
+            if isinstance(branch, str) and branch:
+                # Branch format: ``root.child.grandchild``. The current
+                # agent sits at the tail; its immediate parent is
+                # second-to-last. When branch has one segment the current
+                # agent IS the root and there is no parent.
+                segments = branch.split(".")
+                if len(segments) >= 2:
+                    parent_name = segments[-2]
+        parent_id = self._derive_agent_id(parent_name) if parent_name else ""
+        meta = {
+            "hgraf.agent.name": agent_name,
+            "hgraf.agent.kind": self._agent_kind_hint(agent),
+        }
+        if parent_id:
+            meta["hgraf.agent.parent_id"] = parent_id
+        # Also carry the ADK branch for forensic debugging — operators
+        # can read it from the agent metadata to reconstruct the exact
+        # dispatch path that produced an agent row.
+        branch_val = _safe_attr(ctx, "branch", None)
+        if branch_val is None:
+            inv = _safe_attr(ctx, "_invocation_context", None)
+            if inv is not None:
+                branch_val = _safe_attr(inv, "branch", None)
+        if isinstance(branch_val, str) and branch_val:
+            meta["hgraf.agent.branch"] = branch_val
+        self._agent_metadata[per_agent_id] = meta
+        return per_agent_id
+
+    def _resolve_agent_id(self, ctx: Any) -> str:
+        """Return the per-agent id to stamp on a span emitted from ``ctx``.
+
+        Lookup order:
+
+        1. The top of the invocation's agent stack
+           (``_agent_stash[invocation_id][-1]``) when ``ctx`` carries
+           an invocation id and the stack is non-empty. This is the
+           hot path — every span from within a before/after_agent
+           window lands here.
+        2. Fall back to the client's root ``agent_id`` otherwise —
+           preserves pre-#74 behaviour for spans emitted outside any
+           agent window (startup, teardown, unit tests driving one
+           callback without a before_agent).
+        """
+        inv_id = str(_safe_attr(ctx, "invocation_id", "") or "")
+        if inv_id:
+            stack = self._agent_stash.get(inv_id)
+            if stack:
+                return stack[-1]
+        return str(self._client.agent_id)
+
+    def _stamp_agent_attrs(
+        self, per_agent_id: str, attrs: Optional[dict[str, Any]] = None
+    ) -> Optional[dict[str, Any]]:
+        """Return span attributes augmented with ``hgraf.agent.*`` on first-sight.
+
+        Only the FIRST span the server sees for a given
+        ``(session_id, per_agent_id)`` pair needs to carry the metadata
+        payload; subsequent spans inherit the agent row via
+        ``_ensure_route``'s auto-register and don't re-pay the cost.
+        The plugin tracks first-sight locally via ``_seen_agents``,
+        keyed on ``(session_id, per_agent_id)`` because the same
+        per-agent id can appear in multiple sessions over a plugin
+        lifetime (adk-web reuses the process across runs).
+
+        Returns ``attrs`` unchanged (may be ``None``) for already-seen
+        agents so the hot span-emit path doesn't copy dicts for every
+        model / tool call.
+        """
+        if per_agent_id == str(self._client.agent_id):
+            # The client root id is registered by the Hello frame —
+            # never stamp hgraf.agent.* on spans landing on the root.
+            return attrs
+        session_id = self._root_session_id or str(self._client.session_id or "")
+        key = (session_id, per_agent_id)
+        if key in self._seen_agents:
+            return attrs
+        self._seen_agents.add(key)
+        meta = self._agent_metadata.get(per_agent_id, {})
+        if not meta:
+            # Degraded path: span was emitted before ``before_agent_callback``
+            # populated the metadata cache. Stamp a name-only entry so the
+            # server still creates a row.
+            meta = {"hgraf.agent.name": per_agent_id.split(":", 1)[-1]}
+        merged: dict[str, Any] = dict(attrs or {})
+        # Caller-provided attrs win (don't clobber user metadata).
+        for k, v in meta.items():
+            merged.setdefault(k, v)
+        return merged
 
     # ------------------------------------------------------------------
     # Duplicate-install detection
@@ -494,6 +726,14 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
                     exc_info=True,
                 )
 
+        # Drop any leftover agent-stack entries for this invocation
+        # (harmonograf#74). On cancel, after_agent_callback may not fire
+        # on the in-flight agent, leaving a stale stack entry keyed by
+        # ``invocation_id``. Clear the whole entry — ``_agent_stash``
+        # is keyed per-invocation so the cleanup is scoped to the
+        # cancelled invocation without touching concurrent siblings.
+        self._agent_stash.pop(invocation_id, None)
+
         # If the cancelled invocation was the cached ROOT, release the
         # root-session cache and tear down the per-session control sub.
         # Without this, a subsequent run after a user cancel would still
@@ -590,10 +830,17 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             attrs["adk.invocation_id"] = inv_id
         if adk_sid:
             attrs["adk.session_id"] = adk_sid
+        # The INVOCATION span is the outermost bar for this agent's run.
+        # Register the agent (before_agent_callback may not have fired
+        # yet for the root in some ADK flows) and stamp the per-agent
+        # id so the Gantt puts this invocation on the right row.
+        per_agent_id = self._register_agent_for_ctx(invocation_context)
+        augmented_attrs = self._stamp_agent_attrs(per_agent_id, attrs)
         sid = self._client.emit_span_start(
             kind=SpanKind.INVOCATION,
             name=name,
-            attributes=attrs or None,
+            attributes=augmented_attrs or None,
+            agent_id=per_agent_id,
             session_id=self._stamp_session_id(invocation_context),
         )
         if inv_id:
@@ -668,6 +915,67 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
                     )
 
     # ------------------------------------------------------------------
+    # Per-agent lifecycle (harmonograf#74)
+    # ------------------------------------------------------------------
+
+    async def before_agent_callback(
+        self, *, agent: Any, callback_context: Any
+    ) -> None:
+        """Push the per-agent id onto the invocation's agent stack.
+
+        ADK fires this once per agent entry: the root agent, every
+        sub-agent it transfers to, and every sub-agent wrapped by an
+        AgentTool (AgentTool spawns a sub-Runner whose own root agent
+        fires before_agent). The stack structure handles the nested
+        case — coordinator pushes 'coordinator', AgentTool sub-Runner
+        pushes 'research_agent', research's after_agent pops 'research',
+        and the coordinator's subsequent spans stamp 'coordinator'
+        again. Sub-Runner sessions get a fresh ``invocation_id`` so
+        they have their own stack slot.
+
+        Idempotent: the duplicate-install guard short-circuits. If
+        called without a matching after_agent (e.g. a cancelled
+        invocation), the stack is cleaned up by
+        :meth:`_close_stale_spans_for_invocation` on cancellation.
+        """
+        if self._maybe_disable_as_duplicate(callback_context):
+            return
+        per_agent_id = self._register_agent_for_ctx(callback_context)
+        inv_id = str(_safe_attr(callback_context, "invocation_id", "") or "")
+        if not inv_id:
+            # No invocation id: fall back to the ADK agent name so the
+            # stack still balances. Rare — ADK always populates
+            # invocation_id on a real callback — but a zero-id here
+            # would silently collapse every agent onto one stack slot.
+            inv_id = f"_agent:{_safe_attr(agent, 'name', 'unknown')}"
+        self._agent_stash.setdefault(inv_id, []).append(per_agent_id)
+
+    async def after_agent_callback(
+        self, *, agent: Any, callback_context: Any
+    ) -> None:
+        """Pop the per-agent id off the invocation's agent stack.
+
+        Balances :meth:`before_agent_callback`. When the stack drains
+        the entry is removed wholesale so ``_agent_stash`` never grows
+        unbounded across many sequential invocations.
+
+        Defensive on underflow: a stray after_agent (e.g. ADK races the
+        cancellation cleanup) is a no-op rather than raising. Telemetry
+        must not surface internal bookkeeping errors into the
+        orchestration control path.
+        """
+        if self._maybe_disable_as_duplicate(callback_context):
+            return
+        inv_id = str(_safe_attr(callback_context, "invocation_id", "") or "")
+        if not inv_id:
+            inv_id = f"_agent:{_safe_attr(agent, 'name', 'unknown')}"
+        stack = self._agent_stash.get(inv_id)
+        if stack:
+            stack.pop()
+            if not stack:
+                self._agent_stash.pop(inv_id, None)
+
+    # ------------------------------------------------------------------
     # LLM call lifecycle
     # ------------------------------------------------------------------
 
@@ -696,10 +1004,14 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         if self._maybe_disable_as_duplicate(callback_context):
             return
         model = str(_safe_attr(llm_request, "model", "") or "")
+        per_agent_id = self._resolve_agent_id(callback_context)
+        attrs: dict[str, Any] = {"llm.model": model} if model else {}
+        augmented_attrs = self._stamp_agent_attrs(per_agent_id, attrs or None)
         sid = self._client.emit_span_start(
             kind=SpanKind.LLM_CALL,
             name=model or "llm_call",
-            attributes={"llm.model": model} if model else None,
+            attributes=augmented_attrs or None,
+            agent_id=per_agent_id,
             session_id=self._stamp_session_id(callback_context),
         )
         key = self._model_span_key(callback_context)
@@ -785,9 +1097,13 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             return
         tool_name = str(_safe_attr(tool, "name", "") or "tool")
         payload = _serialize_args(tool_args)
+        per_agent_id = self._resolve_agent_id(tool_context)
+        augmented_attrs = self._stamp_agent_attrs(per_agent_id, None)
         sid = self._client.emit_span_start(
             kind=SpanKind.TOOL_CALL,
             name=tool_name,
+            attributes=augmented_attrs or None,
+            agent_id=per_agent_id,
             payload=payload,
             payload_role="input",
             session_id=self._stamp_session_id(tool_context),

--- a/client/tests/test_telemetry_plugin_per_agent.py
+++ b/client/tests/test_telemetry_plugin_per_agent.py
@@ -1,0 +1,439 @@
+"""Tests for per-ADK-agent attribution (harmonograf#74).
+
+The plugin now derives a per-ADK-agent harmonograf ``agent_id`` on each
+``before_agent_callback`` and stamps it on every span emitted during
+that agent's execution (INVOCATION / LLM_CALL / TOOL_CALL). Sub-agents
+invoked via AgentTool spawn a sub-Runner with its own
+``invocation_id``, so their spans correctly land on the sub-agent's
+row rather than collapsing onto the coordinator's.
+
+Contract verified here:
+
+* The per-agent id format is ``<client.agent_id>:<adk_agent_name>``
+  and spans emitted inside a ``before_agent`` window stamp it on
+  ``span.agent_id``.
+* Nested agents (coordinator → AgentTool sub-Runner with specialist)
+  push/pop correctly: the specialist's spans carry the specialist's
+  id, and when control returns to the coordinator, its subsequent
+  spans carry the coordinator's id again.
+* The FIRST span from a given per-agent id carries
+  ``hgraf.agent.{name,parent_id,kind,branch}`` attributes; subsequent
+  spans from the same agent don't pay the stamping cost. The server
+  harvests these into ``Agent.metadata`` on auto-register.
+* Back-compat: spans emitted outside any before/after_agent window
+  fall back to the client's root agent_id.
+* Cancel: ``_close_stale_spans_for_invocation`` clears the agent
+  stash for the cancelled invocation so long-lived plugin instances
+  don't leak per-invocation entries on steering / user-cancel.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from harmonograf_client.buffer import EnvelopeKind
+from harmonograf_client.client import Client
+from harmonograf_client.enums import SpanStatus
+from harmonograf_client.telemetry_plugin import HarmonografTelemetryPlugin
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+ROOT_SESSION = "root-session-1"
+CLIENT_AGENT_ID = "client-root-agent-UUID"
+
+
+# ---------------------------------------------------------------------------
+# ADK-shaped stand-ins (matching the session-id fixtures file)
+# ---------------------------------------------------------------------------
+
+
+class _Session:
+    def __init__(self, sid: str) -> None:
+        self.id = sid
+
+
+class _BaseAgent:
+    """Subclass-matched to look like ``google.adk.agents.Agent`` / ``LlmAgent``.
+
+    The plugin walks ``type(agent).__mro__`` to derive the kind hint;
+    picking ``Agent`` as the class name makes ``_agent_kind_hint``
+    return ``"llm"`` which is the expected default for worker agents.
+    """
+
+    def __init__(self, name: str, parent: Any = None) -> None:
+        self.name = name
+        self.parent_agent = parent
+
+
+class Agent(_BaseAgent):
+    """Class-name matches ADK's ``Agent``/``LlmAgent`` mapping."""
+
+
+class SequentialAgent(_BaseAgent):
+    """Class-name matches ADK's workflow container mapping."""
+
+
+class _InvocationContext:
+    def __init__(
+        self,
+        invocation_id: str,
+        session_id: str,
+        agent: Any,
+        branch: str = "",
+    ) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id)
+        self.agent = agent
+        self.branch = branch
+
+
+class _CallbackContext:
+    """ADK unifies CallbackContext / ToolContext under one surface.
+
+    Tests pass ``_invocation_context`` so the plugin can recover the
+    agent object when the callback only has a CallbackContext (real
+    ADK flows hit this path).
+    """
+
+    def __init__(
+        self,
+        invocation_id: str,
+        session_id: str,
+        agent: Any,
+        branch: str = "",
+    ) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id)
+        self.branch = branch
+        # The plugin probes both ctx.agent and ctx._invocation_context.agent.
+        self._invocation_context = _InvocationContext(
+            invocation_id, session_id, agent, branch
+        )
+
+
+class _Tool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _LlmRequest:
+    def __init__(self, model: str = "mock/llm") -> None:
+        self.model = model
+
+
+class _LlmResponse:
+    def __init__(self) -> None:
+        self.partial = False
+        self.error_message = None
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="per-agent-test",
+        agent_id=CLIENT_AGENT_ID,
+        session_id="home",
+        buffer_size=256,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def plugin(client: Client) -> HarmonografTelemetryPlugin:
+    return HarmonografTelemetryPlugin(client)
+
+
+def _span_starts(client: Client) -> list[Any]:
+    out: list[Any] = []
+    for env in client._events.drain():
+        if env.kind is EnvelopeKind.SPAN_START:
+            out.append(env.payload.span)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-agent id derivation
+# ---------------------------------------------------------------------------
+
+
+def test_derive_agent_id_format(plugin: HarmonografTelemetryPlugin) -> None:
+    """Per-agent id is ``<client.agent_id>:<adk_name>`` — stable + unique."""
+    assert plugin._derive_agent_id("coordinator") == f"{CLIENT_AGENT_ID}:coordinator"
+    assert plugin._derive_agent_id("research_agent") == f"{CLIENT_AGENT_ID}:research_agent"
+    # Empty name falls back to the bare client id — pre-#74 behavior.
+    assert plugin._derive_agent_id("") == CLIENT_AGENT_ID
+
+
+def test_agent_kind_hint(plugin: HarmonografTelemetryPlugin) -> None:
+    """Class-name heuristic produces the expected kind hint per ADK shape."""
+    assert plugin._agent_kind_hint(Agent("a")) == "llm"
+    assert plugin._agent_kind_hint(SequentialAgent("s")) == "workflow"
+    assert plugin._agent_kind_hint(None) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Agent stash drives span.agent_id stamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_before_agent_pushes_per_agent_id_onto_stack(
+    plugin: HarmonografTelemetryPlugin,
+) -> None:
+    """before_agent pushes the agent's id; subsequent spans stamp it."""
+    coord = Agent("coordinator")
+    cb = _CallbackContext("inv-1", ROOT_SESSION, coord)
+    await plugin.before_agent_callback(agent=coord, callback_context=cb)
+    assert plugin._agent_stash["inv-1"] == [f"{CLIENT_AGENT_ID}:coordinator"]
+
+
+@pytest.mark.asyncio
+async def test_after_agent_pops_stack(plugin: HarmonografTelemetryPlugin) -> None:
+    """after_agent pops; when empty, the stash entry is removed."""
+    coord = Agent("coordinator")
+    cb = _CallbackContext("inv-1", ROOT_SESSION, coord)
+    await plugin.before_agent_callback(agent=coord, callback_context=cb)
+    await plugin.after_agent_callback(agent=coord, callback_context=cb)
+    assert "inv-1" not in plugin._agent_stash
+
+
+@pytest.mark.asyncio
+async def test_nested_agent_stack_pushes_and_pops_correctly(
+    plugin: HarmonografTelemetryPlugin,
+) -> None:
+    """Coordinator → AgentTool(research) pattern.
+
+    AgentTool spawns a sub-Runner with a different invocation_id, so
+    the two agents don't even share a stack — the test uses matching
+    invocation_id to stress the stacking logic itself (same invocation,
+    nested ``before_agent``). Both paths are valid real-world shapes
+    depending on how the delegation is wired.
+    """
+    coord = Agent("coordinator")
+    research = Agent("research", parent=coord)
+    cb = _CallbackContext("inv-shared", ROOT_SESSION, coord)
+    await plugin.before_agent_callback(agent=coord, callback_context=cb)
+    # Research enters on the SAME invocation — hypothetical but
+    # exercises the stack push/pop path.
+    cb_research = _CallbackContext("inv-shared", ROOT_SESSION, research)
+    await plugin.before_agent_callback(agent=research, callback_context=cb_research)
+    assert plugin._agent_stash["inv-shared"] == [
+        f"{CLIENT_AGENT_ID}:coordinator",
+        f"{CLIENT_AGENT_ID}:research",
+    ]
+    # Research finishes; coordinator's id is back on top.
+    await plugin.after_agent_callback(agent=research, callback_context=cb_research)
+    assert plugin._agent_stash["inv-shared"] == [f"{CLIENT_AGENT_ID}:coordinator"]
+    await plugin.after_agent_callback(agent=coord, callback_context=cb)
+    assert "inv-shared" not in plugin._agent_stash
+
+
+# ---------------------------------------------------------------------------
+# Spans emitted inside an agent window stamp that agent's id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_model_span_stamped_with_per_agent_id(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """LLM_CALL spans emitted inside a coordinator's before_agent window
+    carry the coordinator's per-agent id, not the client root id."""
+    coord = Agent("coordinator")
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext("inv-1", ROOT_SESSION, coord)
+    )
+    cb = _CallbackContext("inv-1", ROOT_SESSION, coord)
+    await plugin.before_agent_callback(agent=coord, callback_context=cb)
+    await plugin.before_model_callback(
+        callback_context=cb, llm_request=_LlmRequest("gpt-test")
+    )
+    spans = _span_starts(client)
+    # First span = before_run INVOCATION (coordinator), second = LLM_CALL.
+    assert len(spans) == 2
+    assert spans[0].agent_id == f"{CLIENT_AGENT_ID}:coordinator"
+    assert spans[1].agent_id == f"{CLIENT_AGENT_ID}:coordinator"
+
+
+@pytest.mark.asyncio
+async def test_tool_span_stamped_with_per_agent_id(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """TOOL_CALL spans stamp the per-agent id too."""
+    research = Agent("research_agent")
+    cb = _CallbackContext("inv-1", ROOT_SESSION, research)
+    await plugin.before_agent_callback(agent=research, callback_context=cb)
+    await plugin.before_tool_callback(
+        tool=_Tool("read_file"), tool_args={"path": "a.md"}, tool_context=cb
+    )
+    spans = _span_starts(client)
+    assert len(spans) == 1
+    assert spans[0].agent_id == f"{CLIENT_AGENT_ID}:research_agent"
+
+
+@pytest.mark.asyncio
+async def test_sub_runner_specialists_each_get_own_agent_id(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """AgentTool sub-Runner pattern: each specialist invocation gets its
+    own invocation_id, so spans from research / web_developer / reviewer
+    stamp distinct per-agent ids — the production Gantt shape that
+    harmonograf#74 unlocks.
+    """
+    coord = Agent("coordinator")
+    research = Agent("research_agent", parent=coord)
+    web_dev = Agent("web_developer_agent", parent=coord)
+
+    # Coordinator begins.
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext("inv-coord", ROOT_SESSION, coord)
+    )
+    cb_coord = _CallbackContext("inv-coord", ROOT_SESSION, coord)
+    await plugin.before_agent_callback(agent=coord, callback_context=cb_coord)
+
+    # Sub-Runner for research — fresh invocation_id.
+    cb_research = _CallbackContext(
+        "inv-research", ROOT_SESSION, research, branch="coordinator.research_agent"
+    )
+    await plugin.before_agent_callback(agent=research, callback_context=cb_research)
+    await plugin.before_tool_callback(
+        tool=_Tool("read_spec"), tool_args={}, tool_context=cb_research
+    )
+    await plugin.after_agent_callback(agent=research, callback_context=cb_research)
+
+    # Sub-Runner for web_developer — another fresh invocation_id.
+    cb_web = _CallbackContext(
+        "inv-web", ROOT_SESSION, web_dev, branch="coordinator.web_developer_agent"
+    )
+    await plugin.before_agent_callback(agent=web_dev, callback_context=cb_web)
+    await plugin.before_model_callback(
+        callback_context=cb_web, llm_request=_LlmRequest("gpt-dev")
+    )
+    await plugin.after_agent_callback(agent=web_dev, callback_context=cb_web)
+
+    await plugin.after_agent_callback(agent=coord, callback_context=cb_coord)
+
+    spans = _span_starts(client)
+    agent_ids = [s.agent_id for s in spans]
+    # Coordinator INVOCATION span + research TOOL_CALL + web LLM_CALL.
+    assert agent_ids == [
+        f"{CLIENT_AGENT_ID}:coordinator",
+        f"{CLIENT_AGENT_ID}:research_agent",
+        f"{CLIENT_AGENT_ID}:web_developer_agent",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# First-sight hgraf.agent.* attribute stamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_span_stamps_hgraf_agent_attributes(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """The first span from a new per-agent id carries name/parent/kind/branch."""
+    coord = Agent("coordinator")
+    research = Agent("research_agent", parent=coord)
+    # Prime the root session cache.
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext("inv-coord", ROOT_SESSION, coord)
+    )
+    cb = _CallbackContext(
+        "inv-research",
+        ROOT_SESSION,
+        research,
+        branch="coordinator.research_agent",
+    )
+    await plugin.before_agent_callback(agent=research, callback_context=cb)
+    await plugin.before_tool_callback(
+        tool=_Tool("read_file"), tool_args={}, tool_context=cb
+    )
+    # Drain and pick the research tool span.
+    spans = _span_starts(client)
+    research_span = next(
+        s for s in spans if s.agent_id == f"{CLIENT_AGENT_ID}:research_agent"
+    )
+    attrs = dict(research_span.attributes or {})
+    assert attrs["hgraf.agent.name"].string_value == "research_agent"
+    assert attrs["hgraf.agent.kind"].string_value == "llm"
+    assert (
+        attrs["hgraf.agent.parent_id"].string_value
+        == f"{CLIENT_AGENT_ID}:coordinator"
+    )
+    assert (
+        attrs["hgraf.agent.branch"].string_value == "coordinator.research_agent"
+    )
+
+
+@pytest.mark.asyncio
+async def test_second_span_from_same_agent_skips_hgraf_attrs(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """The hot path doesn't re-stamp hgraf.agent.* on every span."""
+    research = Agent("research_agent")
+    cb = _CallbackContext("inv-1", ROOT_SESSION, research)
+    await plugin.before_agent_callback(agent=research, callback_context=cb)
+    await plugin.before_tool_callback(
+        tool=_Tool("t1"), tool_args={}, tool_context=cb
+    )
+    await plugin.before_tool_callback(
+        tool=_Tool("t2"), tool_args={}, tool_context=cb
+    )
+    spans = _span_starts(client)
+    # First tool span has the hgraf.agent attrs; second does not.
+    attrs1 = dict(spans[0].attributes or {})
+    attrs2 = dict(spans[1].attributes or {})
+    assert "hgraf.agent.name" in attrs1
+    assert "hgraf.agent.name" not in attrs2
+
+
+@pytest.mark.asyncio
+async def test_root_client_agent_id_never_gets_hgraf_stamps(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Spans that stamp the client's bare agent_id (pre-agent window,
+    degraded fallback) don't carry hgraf.agent.* — those would
+    duplicate the Hello-frame agent registration."""
+    cb = _CallbackContext("inv-no-agent", ROOT_SESSION, Agent("ignored"))
+    # No before_agent_callback → _resolve_agent_id falls back to the
+    # client's root agent_id.
+    await plugin.before_tool_callback(
+        tool=_Tool("anon"), tool_args={}, tool_context=cb
+    )
+    spans = _span_starts(client)
+    assert len(spans) == 1
+    assert spans[0].agent_id == CLIENT_AGENT_ID
+    attrs = dict(spans[0].attributes or {})
+    assert "hgraf.agent.name" not in attrs
+
+
+# ---------------------------------------------------------------------------
+# Cancellation cleans up the stash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_cancellation_clears_agent_stash_entry(
+    plugin: HarmonografTelemetryPlugin,
+) -> None:
+    """``on_cancellation`` drops the cancelled invocation's stash entry.
+
+    Without this, a USER_STEER / USER_CANCEL mid-agent would leak the
+    stack entry across subsequent runs, eventually causing wrong
+    per-agent attribution.
+    """
+    coord = Agent("coordinator")
+    cb = _CallbackContext("inv-1", ROOT_SESSION, coord)
+    await plugin.before_agent_callback(agent=coord, callback_context=cb)
+    assert "inv-1" in plugin._agent_stash
+    plugin.on_cancellation("inv-1")
+    assert "inv-1" not in plugin._agent_stash

--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -388,7 +388,16 @@ class IngestPipeline:
         # stream's defaults from Hello when not set.
         agent_id = pb_span.agent_id or ctx.agent_id
         session_id = pb_span.session_id or ctx.session_id
-        await self._ensure_route(ctx, session_id, agent_id, name=pb_span.name)
+        # Harvest per-ADK-agent hints stamped by the telemetry plugin
+        # (harmonograf#74) — the first span from a new ADK agent
+        # carries hgraf.agent.{name,parent_id,kind,branch} so the
+        # server can register the row with the right human-readable
+        # name + parent link without needing a dedicated
+        # AgentRegister wire event.
+        agent_hints = _extract_agent_hints(pb_span.attributes) if pb_span.attributes else {}
+        await self._ensure_route(
+            ctx, session_id, agent_id, name=pb_span.name, agent_hints=agent_hints
+        )
 
         span = pb_span_to_storage(
             pb_span, agent_id=agent_id, session_id=session_id
@@ -429,10 +438,19 @@ class IngestPipeline:
         agent_id: str,
         *,
         name: str = "",
+        agent_hints: Optional[dict[str, str]] = None,
     ) -> None:
         """Auto-register (session, agent) the first time we see them on
         this stream. The session inherits the stream's framework metadata
         from Hello so cross-session views still know what produced it.
+
+        ``agent_hints`` (harmonograf#74) carries ``hgraf.agent.*``
+        attributes harvested from the first span emitted by this
+        per-ADK-agent id. The plugin stamps them on first-sight so the
+        server can register the agent with a human-readable name and
+        parent-agent link without a new wire event. Subsequent spans
+        from the same agent skip the stamp (``seen_routes`` short-
+        circuits the whole method), so hints only matter once.
         """
         key = (session_id, agent_id)
         if key in ctx.seen_routes:
@@ -463,14 +481,34 @@ class IngestPipeline:
                 agent_id,
             )
         if await self._store.get_agent(session_id, agent_id) is None:
+            # Prefer explicit ADK agent name from the span hints over
+            # the bare first-span name (span.name is the LLM model for
+            # LLM_CALL / tool name for TOOL_CALL — not useful as an
+            # agent label). Fall back to the span name, then the
+            # agent_id itself.
+            hints = agent_hints or {}
+            adk_name = hints.get("hgraf.agent.name", "")
+            display_name = adk_name or name or agent_id
+            meta: dict[str, str] = {}
+            if adk_name:
+                meta["adk.agent.name"] = adk_name
+            parent_id = hints.get("hgraf.agent.parent_id", "")
+            if parent_id:
+                meta["harmonograf.parent_agent_id"] = parent_id
+            kind = hints.get("hgraf.agent.kind", "")
+            if kind:
+                meta["harmonograf.agent_kind"] = kind
+            branch = hints.get("hgraf.agent.branch", "")
+            if branch:
+                meta["adk.agent.branch"] = branch
             agent = Agent(
                 id=agent_id,
                 session_id=session_id,
-                name=name or agent_id,
-                framework=Framework.UNKNOWN,
+                name=display_name,
+                framework=Framework.ADK if adk_name else Framework.UNKNOWN,
                 framework_version=ctx.framework_version or "",
                 capabilities=[],
-                metadata={},
+                metadata=meta,
                 connected_at=now,
                 last_heartbeat=now,
                 status=AgentStatus.CONNECTED,
@@ -478,9 +516,12 @@ class IngestPipeline:
             await self._store.register_agent(agent)
             self._bus.publish_agent_upsert(agent)
             logger.info(
-                "auto agent registered session_id=%s agent_id=%s",
+                "auto agent registered session_id=%s agent_id=%s name=%s kind=%s parent=%s",
                 session_id,
                 agent_id,
+                display_name,
+                kind or "<none>",
+                parent_id or "<none>",
             )
             # If the span's agent_id differs from the transport's registered
             # agent_id (e.g. ADK sub-agent name vs identity-file UUID), tell
@@ -1111,6 +1152,40 @@ def _span_status_to_task_status(status: SpanStatus) -> Optional[TaskStatus]:
     if status == SpanStatus.CANCELLED:
         return TaskStatus.CANCELLED
     return None
+
+
+_AGENT_HINT_KEYS = (
+    "hgraf.agent.name",
+    "hgraf.agent.parent_id",
+    "hgraf.agent.kind",
+    "hgraf.agent.branch",
+)
+
+
+def _extract_agent_hints(attributes: Any) -> dict[str, str]:
+    """Pull ``hgraf.agent.*`` string-valued attributes from a span's attribute map.
+
+    Used by ``_ensure_route`` to populate an auto-registered Agent row's
+    ``name`` / ``metadata`` fields without a dedicated wire event. The
+    plugin stamps these on the FIRST span emitted by each per-ADK-agent
+    id; ``_ensure_route``'s ``seen_routes`` short-circuit means later
+    spans from the same agent don't re-pay the attribute scan cost.
+
+    Returns an empty dict when no hints are present, so the caller
+    sees the same shape as older clients that don't stamp them —
+    preserving back-compat for observe-mode agents that still ship
+    spans without ``hgraf.agent.*``.
+    """
+    out: dict[str, str] = {}
+    for key in _AGENT_HINT_KEYS:
+        av = attributes.get(key)
+        if av is None:
+            continue
+        if av.HasField("string_value"):
+            val = av.string_value
+            if val:
+                out[key] = val
+    return out
 
 
 def _payload_ref_kwargs(refs) -> dict:

--- a/server/tests/test_ingest_extensive.py
+++ b/server/tests/test_ingest_extensive.py
@@ -391,3 +391,144 @@ async def test_task_report_attr_on_span_publishes_task_report(pipeline):
         kinds[d.kind] = d.payload
     assert DELTA_TASK_REPORT in kinds
     assert kinds[DELTA_TASK_REPORT]["report"] == "phase 1 done"
+
+
+# ---------------------------------------------------------------------------
+# Per-ADK-agent attribution (harmonograf#74) — ``hgraf.agent.*`` hints
+# stamped by the telemetry plugin on each per-agent first span get
+# harvested into the auto-registered ``Agent.metadata`` row.
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_hints_harvested_into_new_agent_metadata(pipeline, store):
+    """First span from a new ADK agent registers its row with name + kind + parent."""
+    ctx, _ = await pipeline.handle_hello(
+        _hello(agent_id="client-root", session_id="sess_tree")
+    )
+    msg = _span_msg(
+        "sp-1",
+        agent_id="client-root:research_agent",
+        session_id="sess_tree",
+        attrs={
+            "hgraf.agent.name": "research_agent",
+            "hgraf.agent.kind": "llm",
+            "hgraf.agent.parent_id": "client-root:coordinator",
+            "hgraf.agent.branch": "coordinator.research_agent",
+        },
+    )
+    await pipeline.handle_message(ctx, msg)
+    ag = await store.get_agent("sess_tree", "client-root:research_agent")
+    assert ag is not None
+    assert ag.name == "research_agent"
+    assert ag.metadata["adk.agent.name"] == "research_agent"
+    assert ag.metadata["harmonograf.agent_kind"] == "llm"
+    assert (
+        ag.metadata["harmonograf.parent_agent_id"]
+        == "client-root:coordinator"
+    )
+    assert ag.metadata["adk.agent.branch"] == "coordinator.research_agent"
+
+
+async def test_agent_hints_do_not_overwrite_existing_registration(pipeline, store):
+    """Second span with different hints doesn't mutate the existing row.
+
+    ``_ensure_route`` short-circuits via ``ctx.seen_routes`` after the
+    first per-(session, agent) pair lands, so later spans never
+    re-enter the hint-harvest path. This keeps the auto-register write
+    off the hot path at the cost of ignoring late/conflicting hints —
+    the right tradeoff for observability.
+    """
+    ctx, _ = await pipeline.handle_hello(
+        _hello(agent_id="client-root", session_id="sess_tree2")
+    )
+    msg1 = _span_msg(
+        "sp-1",
+        agent_id="client-root:coord",
+        session_id="sess_tree2",
+        attrs={"hgraf.agent.name": "coord", "hgraf.agent.kind": "llm"},
+    )
+    await pipeline.handle_message(ctx, msg1)
+    msg2 = _span_msg(
+        "sp-2",
+        agent_id="client-root:coord",
+        session_id="sess_tree2",
+        attrs={"hgraf.agent.name": "coord-mutated", "hgraf.agent.kind": "workflow"},
+    )
+    await pipeline.handle_message(ctx, msg2)
+    ag = await store.get_agent("sess_tree2", "client-root:coord")
+    assert ag is not None
+    assert ag.name == "coord"
+    assert ag.metadata["harmonograf.agent_kind"] == "llm"
+
+
+async def test_multiple_distinct_agents_all_register_separately(pipeline, store):
+    """Spans from N ADK agents produce N rows — the core harmonograf#74 fix.
+
+    Regression guard: before this fix, a goldfive-wrapped ADK tree with
+    coordinator + research + web_developer + reviewer + debugger
+    landed one ``Agent`` row (the client root). With
+    ``hgraf.agent.*`` harvest, each sub-agent gets its own row.
+    """
+    ctx, _ = await pipeline.handle_hello(
+        _hello(agent_id="presentation-client", session_id="sess_multi_adk")
+    )
+    agents = [
+        ("coordinator", ""),
+        ("research_agent", "presentation-client:coordinator"),
+        ("web_developer_agent", "presentation-client:coordinator"),
+        ("reviewer_agent", "presentation-client:coordinator"),
+        ("debugger_agent", "presentation-client:coordinator"),
+    ]
+    for idx, (adk_name, parent) in enumerate(agents):
+        attrs = {"hgraf.agent.name": adk_name, "hgraf.agent.kind": "llm"}
+        if parent:
+            attrs["hgraf.agent.parent_id"] = parent
+        msg = _span_msg(
+            f"sp-{idx}",
+            agent_id=f"presentation-client:{adk_name}",
+            session_id="sess_multi_adk",
+            attrs=attrs,
+        )
+        await pipeline.handle_message(ctx, msg)
+
+    rows = await store.list_agents_for_session("sess_multi_adk")
+    row_ids = {r.id for r in rows}
+    # The hello-registered client-root agent row + one per ADK agent.
+    assert "presentation-client" in row_ids
+    assert "presentation-client:coordinator" in row_ids
+    assert "presentation-client:research_agent" in row_ids
+    assert "presentation-client:web_developer_agent" in row_ids
+    assert "presentation-client:reviewer_agent" in row_ids
+    assert "presentation-client:debugger_agent" in row_ids
+
+    # Parent links wired correctly (coordinator has none; specialists
+    # point at coordinator).
+    by_id = {r.id: r for r in rows}
+    coord = by_id["presentation-client:coordinator"]
+    research = by_id["presentation-client:research_agent"]
+    assert "harmonograf.parent_agent_id" not in coord.metadata
+    assert (
+        research.metadata["harmonograf.parent_agent_id"]
+        == "presentation-client:coordinator"
+    )
+
+
+async def test_agent_registered_without_hints_back_compat(pipeline, store):
+    """Observability-mode clients that don't stamp hgraf.agent.* still work.
+
+    Back-compat contract: older clients (no per-agent stamping) just
+    get a row with name=span.name and framework=UNKNOWN. Nothing in
+    the ingest path should assume hints are present.
+    """
+    ctx, _ = await pipeline.handle_hello(
+        _hello(agent_id="root", session_id="sess_back_compat")
+    )
+    msg = _span_msg("sp-1", agent_id="legacy-agent", session_id="sess_back_compat")
+    await pipeline.handle_message(ctx, msg)
+    ag = await store.get_agent("sess_back_compat", "legacy-agent")
+    assert ag is not None
+    # span.name is "span-sp-1" per _span_msg; without hints that's
+    # what the row inherits as its display name.
+    assert ag.name == "span-sp-1"
+    assert "adk.agent.name" not in ag.metadata
+    assert "harmonograf.agent_kind" not in ag.metadata

--- a/tests/e2e/test_presentation_agent.py
+++ b/tests/e2e/test_presentation_agent.py
@@ -399,6 +399,103 @@ class TestPresentationGoldfiveRunner:
             )
 
 
+class TestOrchestratedPerAgentRows:
+    """Regression for harmonograf#74 — per-ADK-agent Gantt rows.
+
+    Before the fix, a goldfive-wrapped presentation tree (coordinator +
+    research + web_developer + reviewer + debugger) produced a SINGLE
+    ``agents`` row in the harmonograf store — the client-root id — and
+    every span attributed to that one id. The Gantt UI therefore
+    collapsed the whole tree onto one row.
+
+    After the fix, the :class:`HarmonografTelemetryPlugin` stamps each
+    ADK agent with its own derived per-agent id
+    (``<client.agent_id>:<adk_name>``) and emits
+    ``hgraf.agent.{name,parent_id,kind,branch}`` on the first span of
+    each agent, which the server harvests into the auto-registered
+    ``Agent.metadata``. The test below runs a mock orchestrated pass
+    and asserts the store has one row per ADK agent with the right
+    parent-agent links.
+    """
+
+    @pytest.mark.asyncio
+    async def test_orchestrated_mock_run_registers_one_row_per_adk_agent(
+        self,
+        presentation_agent_orchestrated_module: Any,
+        harmonograf_server: dict,
+    ) -> None:
+        from harmonograf_client import Client
+
+        client = Client(
+            name="pres-per-agent",
+            server_addr=harmonograf_server["addr"],
+            framework="ADK",
+        )
+        try:
+            runner, _memory_sink, _bound_client, _harmonograf_sink = (
+                presentation_agent_orchestrated_module.build_goldfive_runner(
+                    topic="waffles",
+                    mock=True,
+                    client=client,
+                )
+            )
+            outcome = await runner.run("make a presentation about waffles")
+            await runner.close()
+            assert outcome.success is True, outcome.reason
+        finally:
+            await asyncio.to_thread(client.shutdown, 5.0)
+
+        store = harmonograf_server["store"]
+        # Poll until agents land — spans flow over the wire async.
+        deadline = asyncio.get_event_loop().time() + 5.0
+        rows: list[Any] = []
+        while asyncio.get_event_loop().time() < deadline:
+            sessions = await store.list_sessions()
+            rows = []
+            for s in sessions or []:
+                rows.extend(await store.list_agents_for_session(s.id))
+            # Expect at least the coordinator + research specialist (the
+            # two agents that actually fire callbacks in mock mode).
+            coord_hits = [
+                r for r in rows if r.metadata.get("adk.agent.name") == "coordinator_agent"
+            ]
+            if coord_hits:
+                break
+            await asyncio.sleep(0.1)
+
+        # The client-root id appears as one row (Hello-registered); the
+        # per-agent rows appear as additional rows with
+        # ``adk.agent.name`` metadata.
+        adk_named_rows = [r for r in rows if r.metadata.get("adk.agent.name")]
+        adk_names = {r.metadata["adk.agent.name"] for r in adk_named_rows}
+        assert "coordinator_agent" in adk_names, (
+            f"expected coordinator_agent row; got adk names {adk_names!r} across {len(rows)} rows"
+        )
+        # Every per-agent row must carry a real display name
+        # (``Agent.name``), a kind metadata, and either no parent (for
+        # the coordinator / root) or a parent_agent_id that references
+        # another per-agent row in this same session.
+        for row in adk_named_rows:
+            assert row.name, f"agent row missing display name: {row.id}"
+            assert row.metadata.get("harmonograf.agent_kind"), (
+                f"agent row missing kind metadata: {row.id} / {row.metadata!r}"
+            )
+        # If the run drove into a sub-agent (mock mode routes through
+        # research), confirm the parent link is wired up.
+        specialists = [
+            r for r in adk_named_rows
+            if r.metadata.get("adk.agent.name") != "coordinator_agent"
+        ]
+        if specialists:
+            coord_id = coord_hits[0].id
+            for spec in specialists:
+                parent = spec.metadata.get("harmonograf.parent_agent_id")
+                assert parent == coord_id, (
+                    f"specialist {spec.metadata['adk.agent.name']} has parent "
+                    f"{parent!r}; expected coordinator id {coord_id!r}"
+                )
+
+
 async def _wait_for_plan_with_tasks(
     store: Any, *, expected_task_ids: set, timeout: float
 ) -> list[Any]:

--- a/tests/reference_agents/presentation_agent_orchestrated/agent.py
+++ b/tests/reference_agents/presentation_agent_orchestrated/agent.py
@@ -308,8 +308,6 @@ def build_goldfive_runner(
             "for a real OpenAI-backed run"
         )
 
-    adapter = ADKAdapter(tree)
-
     sinks: list[Any] = []
     memory_sink = InMemorySink()
     sinks.append(memory_sink)
@@ -318,15 +316,24 @@ def build_goldfive_runner(
     if explicit_client is None:
         explicit_client = _get_or_create_client()
 
+    # Install the telemetry plugin on the single backing Runner so per-
+    # ADK-agent spans flow (harmonograf#74). Without this, the programmatic
+    # runner path drives ADK with no plugins and the per-agent Gantt rows
+    # never get populated — the e2e regression test against this helper
+    # would then report a false negative.
+    plugins: list[Any] = []
     harmonograf_sink = None
     if explicit_client is not None:
         try:
-            from harmonograf_client import HarmonografSink
+            from harmonograf_client import HarmonografSink, HarmonografTelemetryPlugin
 
+            plugins.append(HarmonografTelemetryPlugin(explicit_client))
             harmonograf_sink = HarmonografSink(explicit_client)
             sinks.append(harmonograf_sink)
         except Exception as e:  # noqa: BLE001
-            log.warning("HarmonografSink unavailable (%s)", e)
+            log.warning("HarmonografSink/Plugin unavailable (%s)", e)
+
+    adapter = ADKAdapter(tree, plugins=plugins or None)
 
     try:
         logging_sink = goldfive.sinks.LoggingSink()


### PR DESCRIPTION
## Summary

Fix the long-standing Gantt collapsing every span onto one `agent_id`. Every LlmAgent in a goldfive-wrapped ADK tree now gets its own harmonograf `agent_id`, so the Gantt renders one row per ADK agent with the real sub-agent spans attached.

- Telemetry plugin derives a stable per-agent id (`<client.agent_id>:<adk_name>`) on each `before_agent_callback` and stamps it on every downstream span via a per-invocation agent-id stack.
- First span from each per-agent id carries `hgraf.agent.{name,parent_id,kind,branch}` attributes; the server harvests them into auto-registered `Agent.metadata`. No new wire event, no proto schema change.
- Back-compat: observe-mode clients that don't stamp the attrs still register the pre-#79 way (name = span.name, framework = UNKNOWN).

## Root cause

`HarmonografTelemetryPlugin.emit_span_start` never overrode `agent_id`, so `Client.emit_span_start` defaulted it to `self._agent_id` (the Hello-frame client root). `_ensure_route` saw only that one `(session_id, agent_id)` pair per stream and never auto-registered sub-agent rows — the span names carried the ADK agent name but `spans.agent_id` was always the client root.

## Layer-by-layer diff

- **Plugin** (`client/harmonograf_client/telemetry_plugin.py`): new `before_agent_callback` / `after_agent_callback` maintain `_agent_stash[invocation_id]`; `_resolve_agent_id` reads the stack top; `_stamp_agent_attrs` injects `hgraf.agent.*` on the first span for each new `(session_id, per_agent_id)` pair. Every existing `emit_span_start` callsite passes `agent_id=per_agent_id`. Cancellation path clears the stash entry for the cancelled invocation so long-lived plugin instances don't leak.
- **Server** (`server/harmonograf_server/ingest.py`): `_ensure_route` accepts optional `agent_hints` and populates `Agent.name` + metadata keys `adk.agent.name`, `harmonograf.parent_agent_id`, `harmonograf.agent_kind`, `adk.agent.branch`. `_extract_agent_hints` helper pulls string attributes from the span's attribute map.
- **Reference agent** (`tests/reference_agents/presentation_agent_orchestrated/agent.py`): `build_goldfive_runner` now installs `HarmonografTelemetryPlugin` on the backing `ADKAdapter` when a client is provided, so the programmatic runner path matches the `_build_app` path.
- **Frontend**: no code change required. `AgentRegistry` already renders one row per agent; the server now feeds it the real set.

## Test plan

- [x] 12 new unit tests in `client/tests/test_telemetry_plugin_per_agent.py` cover id derivation, stack push/pop, nested agents, first-sight attribute stamping, back-compat fallback, cancellation cleanup
- [x] 4 new server tests in `server/tests/test_ingest_extensive.py` cover the `hgraf.agent.*` harvest path and multi-agent registration
- [x] 1 new e2e test in `tests/e2e/test_presentation_agent.py` drives the orchestrated tree end-to-end and asserts per-ADK-agent rows land in storage with the right metadata + parent links
- [x] All 215 existing client tests + 285 existing server tests + existing presentation_agent e2e suite pass unchanged
- [ ] Live e2e against `USER_MODEL_NAME=openai/Qwen3.5-35B-A3B-Q4_K_M.gguf` against kikuchi — full orchestrated run with real sub-agent dispatch (deferred — requires external infra)