### PR TITLE
Lazy Hello: defer Hello RPC until first emit (closes #83)

### DIFF
--- a/client/harmonograf_client/transport.py
+++ b/client/harmonograf_client/transport.py
@@ -180,6 +180,26 @@ class Transport:
         self._assigned_session_id: str = session_id
         self._assigned_stream_id: str = ""
 
+        # Lazy Hello (harmonograf#83). The Hello RPC is deferred from
+        # stream open to first real emit. By then, an ADK flow has
+        # already pinned the outer adk-web session_id onto the envelope,
+        # so Hello stamps that id and the server never auto-creates a
+        # ghost ``sess_YYYY-MM-DD_NNNN`` row. Non-ADK flows that emit a
+        # span without any ``session_id`` override still auto-create a
+        # home session on first emit — the behaviour is deferred, not
+        # changed. A client that shuts down before any emit sends no
+        # Hello at all. Heartbeats alone do not trigger Hello; they are
+        # suppressed until the first real emit has opened the stream.
+        #
+        # Reset on every ``_serve`` so reconnects re-send Hello on the
+        # next emit (carrying the resume token + the most-recent
+        # plugin-stamped session id).
+        self._hello_sent: bool = False
+        # Event set by the recv loop when Welcome is received. Awaited
+        # before starting the home control subscription. Re-created on
+        # every ``_serve``.
+        self._welcome_received: Optional[asyncio.Event] = None
+
         # Per-ADK-session secondary control subscriptions
         # (harmonograf#65 / goldfive#162). Keyed by the outer adk-web
         # ``ctx.session.id`` cached by
@@ -494,14 +514,15 @@ class Transport:
     async def _serve(self, stub: Any) -> None:
         from .pb import control_pb2, telemetry_pb2
 
-        hello = self._build_hello(telemetry_pb2)
         send_queue: asyncio.Queue = asyncio.Queue()
         self._send_queue = send_queue
         # Expose the live stub so session subs registered mid-connect
         # (e.g. plugin caches root session id after welcome) can bind
         # without waiting for the next reconnect.
         self._live_stub = stub
-        await send_queue.put(telemetry_pb2.TelemetryUp(hello=hello))
+        # Reset lazy-Hello state for this connect. The send loop will
+        # queue Hello on the first real emit — not here at stream open.
+        self._hello_sent = False
 
         async def request_iter():
             while True:
@@ -518,6 +539,7 @@ class Transport:
         call = stub.StreamTelemetry(request_iter(), **call_kwargs)
 
         welcome_received = asyncio.Event()
+        self._welcome_received = welcome_received
 
         async def recv_loop():
             async for msg in call:
@@ -536,29 +558,24 @@ class Transport:
 
         recv_task = asyncio.create_task(recv_loop())
 
-        # Wait briefly for welcome so session/stream ids are set before
-        # the control subscriber opens.
-        try:
-            await asyncio.wait_for(welcome_received.wait(), timeout=10.0)
-        except asyncio.TimeoutError:
-            recv_task.cancel()
-            raise RuntimeError("no welcome from server")
-
-        control_task = asyncio.create_task(
-            self._control_loop(
-                stub,
-                send_queue,
-                session_id=self._assigned_session_id,
-                stream_id=self._assigned_stream_id,
-            )
-        )
+        # Lazy Hello (harmonograf#83): the send loop now drives Hello
+        # on the first real emit. The home control subscription must
+        # still wait for Welcome, but Welcome now arrives after the
+        # send loop has queued Hello — not at stream open. Start the
+        # control subscription in a separate task that awaits Welcome
+        # on its own, so the send loop and recv loop can make progress
+        # together.
         send_task = asyncio.create_task(self._send_loop(send_queue))
+        control_task = asyncio.create_task(
+            self._deferred_control_loop(stub, send_queue, welcome_received)
+        )
 
         # Replay any per-session subs registered before this connect
         # (e.g. plugin called open_additional_control_subscription
-        # during a previous connect that has since dropped). New subs
-        # registered after this point also land on this stub via
-        # open_session_subscription's live-stub fast path.
+        # during a previous connect that has since dropped). These
+        # session subs are additive — they subscribe on the outer
+        # adk-web session id rather than the assigned session id — so
+        # they do not need to wait for Welcome.
         self._start_registered_session_subs(stub, send_queue)
 
         try:
@@ -606,6 +623,7 @@ class Transport:
             # stream that is already dead.
             self._send_queue = None
             self._live_stub = None
+            self._welcome_received = None
 
     # ------------------------------------------------------------------
     # Send loop
@@ -629,6 +647,18 @@ class Transport:
                 for env in batch:
                     up = self._envelope_to_up(env, telemetry_pb2)
                     if up is not None:
+                        # Lazy Hello (harmonograf#83): if this is the
+                        # first real emit since the stream opened, send
+                        # Hello first with the session_id inferred from
+                        # this envelope. That way an ADK flow — whose
+                        # plugin has already stamped the outer adk-web
+                        # session_id onto the envelope — produces a
+                        # Hello carrying the ADK session id, and the
+                        # server skips the ghost ``sess_YYYY-MM-DD_NNNN``
+                        # row entirely.
+                        await self._maybe_send_hello(
+                            send_queue, telemetry_pb2, env=env
+                        )
                         # Track resume token: server will ack via normal
                         # downstream, but we also keep the last span id we
                         # sent so reconnect can resume from there.
@@ -646,13 +676,17 @@ class Transport:
                     if not pushed:
                         break
 
-                # Heartbeat tick.
+                # Heartbeat tick. Suppressed until the first real emit
+                # has already opened the stream via lazy Hello; an idle
+                # client with nothing to emit should leave no trace on
+                # the server — no Hello, no ghost session, no stream.
                 now = time.monotonic()
                 if now - last_hb >= self._config.heartbeat_interval_s:
                     last_hb = now
-                    hb = self._build_heartbeat(telemetry_pb2)
-                    await send_queue.put(telemetry_pb2.TelemetryUp(heartbeat=hb))
-                    self._mark_healthy()
+                    if self._hello_sent:
+                        hb = self._build_heartbeat(telemetry_pb2)
+                        await send_queue.put(telemetry_pb2.TelemetryUp(heartbeat=hb))
+                        self._mark_healthy()
         finally:
             # Shutdown path. Drain any envelopes still in the ring buffer —
             # Client.shutdown spins until the buffer is empty, but a race
@@ -661,19 +695,33 @@ class Transport:
             # Without this flush, events the caller *successfully emitted*
             # get silently dropped. Then send Goodbye + EOF so gRPC closes
             # the request side cleanly after yielding every queued item.
+            #
+            # If the client is shutting down before anything has ever been
+            # emitted (``_hello_sent`` still False and no envelopes in the
+            # ring), skip Hello entirely: the lazy-Hello guarantee is that
+            # an idle client leaves no trace server-side — no Hello, no
+            # ghost session, no upstream traffic. Just close the request
+            # side and let the server tear its half down.
             try:
                 remaining = self._events.pop_batch(self._events.capacity)
                 for env in remaining:
                     up = self._envelope_to_up(env, telemetry_pb2)
                     if up is not None:
+                        await self._maybe_send_hello(
+                            send_queue, telemetry_pb2, env=env
+                        )
                         self._resume_token = env.span_id or self._resume_token
                         await send_queue.put(up)
                 try:
-                    await send_queue.put(
-                        telemetry_pb2.TelemetryUp(
-                            goodbye=telemetry_pb2.Goodbye(reason="shutdown")
+                    # Only send a Goodbye if we actually opened the
+                    # stream — otherwise the server never saw Hello and
+                    # an out-of-band Goodbye would be an ingest error.
+                    if self._hello_sent:
+                        await send_queue.put(
+                            telemetry_pb2.TelemetryUp(
+                                goodbye=telemetry_pb2.Goodbye(reason="shutdown")
+                            )
                         )
-                    )
                 except Exception:
                     pass
                 await send_queue.put(None)
@@ -736,7 +784,9 @@ class Transport:
             return telemetry_pb2.TelemetryUp(goldfive_event=payload)
         return None
 
-    def _build_hello(self, telemetry_pb2: Any) -> Any:
+    def _build_hello(
+        self, telemetry_pb2: Any, *, session_id: Optional[str] = None
+    ) -> Any:
         from .pb import types_pb2
 
         framework_enum = getattr(
@@ -749,7 +799,9 @@ class Transport:
                 caps.append(val)
         return telemetry_pb2.Hello(
             agent_id=self._agent_id,
-            session_id=self._session_id,
+            session_id=(
+                session_id if session_id is not None else self._session_id
+            ),
             name=self._name,
             framework=framework_enum,
             framework_version=self._framework_version,
@@ -758,6 +810,43 @@ class Transport:
             resume_token=self._resume_token,
             session_title=self._session_title,
         )
+
+    async def _maybe_send_hello(
+        self,
+        send_queue: asyncio.Queue,
+        telemetry_pb2: Any,
+        *,
+        env: Optional[SpanEnvelope] = None,
+    ) -> None:
+        """Queue Hello as the first frame on the stream (lazy Hello).
+
+        No-op after the first call per ``_serve``. The ``session_id``
+        stamped onto Hello is inferred in order:
+
+        1. the session_id the first-emit envelope carries — this is
+           what the ADK telemetry plugin set via ``emit_span_start(
+           session_id=...)``;
+        2. ``self._session_id`` — the client's construction-time default;
+        3. empty — the server will auto-create a home session
+           (harmonograf#62 rollup contract).
+
+        Hello is a stream-opening ceremony, not per-event attribution:
+        later envelopes that carry a *different* ``session_id`` still
+        route correctly via the per-envelope routing built in
+        harmonograf#64 / #66. The task of "one adk-web run = one
+        harmonograf session" is upheld by the plugin stamping the outer
+        adk-web session id on every envelope, not by Hello.
+        """
+        if self._hello_sent:
+            return
+        sid = ""
+        if env is not None:
+            sid = _session_id_of_envelope(env)
+        if not sid:
+            sid = self._session_id or ""
+        hello = self._build_hello(telemetry_pb2, session_id=sid)
+        await send_queue.put(telemetry_pb2.TelemetryUp(hello=hello))
+        self._hello_sent = True
 
     def _build_heartbeat(self, telemetry_pb2: Any) -> Any:
         stats: BufferStats = self._events.stats_snapshot()
@@ -832,6 +921,37 @@ class Transport:
             log.warning(
                 "control subscription ended session_id=%s: %s", session_id, e
             )
+
+    async def _deferred_control_loop(
+        self,
+        stub: Any,
+        send_queue: asyncio.Queue,
+        welcome_received: asyncio.Event,
+    ) -> None:
+        """Wait for Welcome (now deferred until after lazy Hello fires),
+        then drive the home control subscription.
+
+        Under lazy Hello (harmonograf#83) the Hello RPC is not sent at
+        stream open — it piggy-backs on the first real emit. So Welcome
+        is only produced by the server after the first emit. This helper
+        shields the rest of ``_serve`` from that latency: callers can
+        proceed to ``asyncio.wait`` on the three tasks immediately, and
+        the control sub starts only when the server has assigned us a
+        session. If the stream tears down before any emit happens
+        (e.g. an idle client is shut down cleanly), this task exits
+        without opening a subscription — matching the "no ghost, no
+        orphan stream" guarantee.
+        """
+        try:
+            await welcome_received.wait()
+        except asyncio.CancelledError:
+            raise
+        await self._control_loop(
+            stub,
+            send_queue,
+            session_id=self._assigned_session_id,
+            stream_id=self._assigned_stream_id,
+        )
 
     # ------------------------------------------------------------------
     # Per-session (outer adk-web) additional control subscriptions.
@@ -990,6 +1110,33 @@ class Transport:
                 last = i == chunks - 1
                 self._chunk_queue.append((digest, "application/octet-stream", total, offset, last))
         self.notify()
+
+
+def _session_id_of_envelope(env: SpanEnvelope) -> str:
+    """Extract the session_id carried by an envelope, if any.
+
+    Used by lazy Hello (harmonograf#83) to stamp the first envelope's
+    session id onto the Hello frame — so the server never needs to
+    auto-create a ghost home session for ADK flows.
+
+    ``SpanStart`` envelopes carry a full ``Span`` whose ``session_id``
+    was set by the ADK telemetry plugin. ``GoldfiveEvent`` envelopes
+    carry a ``goldfive.v1.Event`` with a ``session_id`` field (goldfive
+    #155 / harmonograf#64). ``SpanUpdate`` / ``SpanEnd`` do NOT carry a
+    session_id — they reference a span by id and the server looks the
+    span's session up — so they fall back to the transport's default.
+    """
+    payload = env.payload
+    if payload is None:
+        return ""
+    if env.kind is EnvelopeKind.SPAN_START:
+        span = getattr(payload, "span", None)
+        if span is None:
+            return ""
+        return getattr(span, "session_id", "") or ""
+    if env.kind is EnvelopeKind.GOLDFIVE_EVENT:
+        return getattr(payload, "session_id", "") or ""
+    return ""
 
 
 def _control_kind_name(kind_value: int, gf_control_pb2: Any) -> str:

--- a/client/tests/test_transport_mock.py
+++ b/client/tests/test_transport_mock.py
@@ -220,17 +220,93 @@ def _wait(cond, timeout=3.0):
 
 
 class TestTransportHandshake:
-    def test_hello_and_welcome(self, server, isolated_identity):
+    def test_hello_and_welcome_deferred_until_first_emit(
+        self, server, isolated_identity
+    ):
+        """Lazy Hello (harmonograf#83): the Hello RPC does NOT fire at
+        client construction / stream open. It piggy-backs on the first
+        real emit so that by the time the server sees Hello, the
+        envelope's ``session_id`` (which the ADK plugin has already
+        stamped) is available to carry on the Hello frame.
+
+        An idle client — one that constructs and then shuts down
+        without emitting anything — must leave no trace on the server:
+        no Hello, no auto-created home session, no ghost row in the
+        picker.
+        """
         client = Client(
             name="test-agent",
             server_addr=f"127.0.0.1:{server.port}",
         )
         try:
+            # Stream is open but Hello has NOT been sent. Without lazy
+            # Hello, Welcome would already have arrived by the time
+            # ``Client.__init__`` returned.
+            time.sleep(0.2)
+            assert not server.servicer.welcome_sent.is_set()
+            assert len(server.servicer.hellos) == 0
+
+            # The first emit stamps the envelope's session_id onto
+            # Hello — we verify that behaviour more precisely in the
+            # dedicated test below.
+            sid = client.emit_span_start(
+                kind="LLM_CALL", name="gpt-4o", session_id="sess_adk_outer"
+            )
+            client.emit_span_end(sid, status="COMPLETED")
+
             assert _wait(lambda: server.servicer.welcome_sent.is_set())
             assert len(server.servicer.hellos) == 1
             hello = server.servicer.hellos[0]
             assert hello.name == "test-agent"
             assert hello.agent_id == client.agent_id
+            assert hello.session_id == "sess_adk_outer"
+        finally:
+            client.shutdown(flush_timeout=1.0)
+
+    def test_idle_client_shutdown_sends_no_hello(
+        self, server, isolated_identity
+    ):
+        """A client that constructs and shuts down without ever emitting
+        anything must not produce a Hello. The ``sess_YYYY-MM-DD_NNNN``
+        auto-creation on the server is driven by Hello; skipping Hello
+        skips the ghost session entirely (harmonograf#83 contract).
+        """
+        client = Client(
+            name="test-agent",
+            server_addr=f"127.0.0.1:{server.port}",
+        )
+        # No emits. Shut down cleanly.
+        client.shutdown(flush_timeout=0.5)
+        # Give the server thread a moment to drain anything in flight.
+        time.sleep(0.2)
+        assert len(server.servicer.hellos) == 0
+        assert not server.servicer.welcome_sent.is_set()
+
+    def test_non_adk_first_emit_has_no_session_id_override(
+        self, server, isolated_identity
+    ):
+        """Non-ADK flow — the client has no ``session_id`` override on
+        construction and the first emit omits ``session_id``. Hello
+        fires with an empty session id and the server auto-creates a
+        home session, exactly matching the harmonograf#62 rollup
+        contract. The lazy-Hello fix defers the RPC; it does NOT change
+        the non-ADK semantics.
+        """
+        client = Client(
+            name="non-adk-agent",
+            server_addr=f"127.0.0.1:{server.port}",
+        )
+        try:
+            sid = client.emit_span_start(kind="LLM_CALL", name="m")
+            client.emit_span_end(sid, status="COMPLETED")
+
+            assert _wait(lambda: server.servicer.welcome_sent.is_set())
+            assert len(server.servicer.hellos) == 1
+            hello = server.servicer.hellos[0]
+            # The mock server assigns ``sess_test_0001`` to Hellos that
+            # arrive without a session_id, mimicking the real server's
+            # auto-create behaviour.
+            assert hello.session_id == ""
             assert _wait(lambda: client.session_id == "sess_test_0001")
         finally:
             client.shutdown(flush_timeout=1.0)
@@ -241,10 +317,12 @@ class TestTransportHandshake:
             server_addr=f"127.0.0.1:{server.port}",
         )
         try:
-            _wait(lambda: server.servicer.welcome_sent.is_set())
+            # Lazy Hello: the send loop only opens the stream after the
+            # first emit. Emit first, then wait for Welcome.
             sid = client.emit_span_start(kind="LLM_CALL", name="gpt-4o")
             client.emit_span_update(sid, attributes={"tokens_in": 42})
             client.emit_span_end(sid, status="COMPLETED")
+            assert _wait(lambda: server.servicer.welcome_sent.is_set())
             assert _wait(lambda: server.servicer.first_span_seen.is_set())
             # Let the send loop flush.
             assert _wait(
@@ -315,6 +393,12 @@ class TestHeartbeat:
             _transport_factory=factory,
         )
         try:
+            # Lazy Hello (harmonograf#83): heartbeats are suppressed
+            # until the first real emit has opened the stream. Drop one
+            # span so the send loop queues Hello and then starts
+            # ticking heartbeats.
+            sid = client.emit_span_start(kind="LLM_CALL", name="hb-warmup")
+            client.emit_span_end(sid, status="COMPLETED")
             assert _wait(lambda: server.servicer.heartbeat_seen.is_set(), timeout=3.0)
         finally:
             client.shutdown(flush_timeout=1.0)
@@ -335,6 +419,12 @@ class TestControl:
 
         client.on_control("PAUSE", on_pause)
         try:
+            # Lazy Hello (harmonograf#83): the control subscription is
+            # gated on Welcome, and Welcome is gated on the first real
+            # emit. Emit one span to open the stream before we look for
+            # the control sub.
+            sid = client.emit_span_start(kind="LLM_CALL", name="ctl-warmup")
+            client.emit_span_end(sid, status="COMPLETED")
             _wait(lambda: server.servicer.welcome_sent.is_set())
             # Wait for control subscription to be in place.
             assert _wait(lambda: any(

--- a/client/tests/test_transport_reconnect.py
+++ b/client/tests/test_transport_reconnect.py
@@ -179,10 +179,11 @@ class TestIntegrationHealthyResetsBreaker:
             server_addr=f"127.0.0.1:{server.port}",
         )
         try:
-            # Wait for Welcome.
-            assert _wait(lambda: server.servicer.welcome_sent.is_set())
+            # Lazy Hello (harmonograf#83): nothing hits the wire until
+            # the first real emit. Emit before waiting for Welcome.
             sid = client.emit_span_start(kind="LLM_CALL", name="m")
             client.emit_span_end(sid, status="COMPLETED")
+            assert _wait(lambda: server.servicer.welcome_sent.is_set())
             assert _wait(lambda: server.servicer.first_span_seen.is_set())
             # Give the send loop a tick to call _mark_healthy.
             assert _wait(lambda: client._transport._healthy is True, timeout=2.0)

--- a/tests/e2e/test_lazy_hello.py
+++ b/tests/e2e/test_lazy_hello.py
@@ -119,6 +119,102 @@ class TestLazyHelloAgainstRealServer:
         assert sessions[0].id.startswith("sess_"), sessions[0].id
 
     @pytest.mark.asyncio
+    async def test_goldfive_runner_produces_exactly_one_session(
+        self,
+        harmonograf_server: dict,
+    ) -> None:
+        """Full orchestrated stack: goldfive ``Runner`` + ``HarmonografSink``
+        drive a three-task plan. With lazy Hello, the first envelope the
+        sink pushes carries a ``session_id`` that goldfive mints for the
+        run, and Hello inherits that. Exactly one ``sessions`` row
+        lands on the server — no ghost.
+        """
+        pytest.importorskip("goldfive")
+        from goldfive import (
+            InMemorySink,
+            LiteralGoalDeriver,
+            Runner,
+            SequentialExecutor,
+            StaticPlanner,
+        )
+        from goldfive.types import Plan, Task, TaskEdge
+
+        from harmonograf_client import Client, HarmonografSink
+
+        plan = Plan(
+            id="plan-lazy-hello",
+            run_id="",
+            goal_ids=[],
+            summary="two sequential echoes",
+            tasks=[
+                Task(
+                    id="t1",
+                    title="first",
+                    description="first",
+                    assignee_agent_id="alpha",
+                ),
+                Task(
+                    id="t2",
+                    title="second",
+                    description="second",
+                    assignee_agent_id="beta",
+                ),
+            ],
+            edges=[TaskEdge(from_task_id="t1", to_task_id="t2")],
+        )
+
+        class _EchoAdapter:
+            """Minimal goldfive AgentAdapter — returns a completion for
+            every task so the runner reaches RunCompleted.
+            """
+
+            @property
+            def available_agents(self):
+                return ["alpha", "beta"]
+
+            async def register_reporting_tools(self, tools):
+                return None
+
+            def bind_steerer(self, steerer):
+                return None
+
+            async def invoke(self, task, session):
+                from goldfive.results import InvocationResult
+
+                return InvocationResult(
+                    task_id=str(getattr(task, "id", "") or ""),
+                    text="ok",
+                    stop_reason="end_turn",
+                )
+
+        client = Client(
+            name="lazy-hello-orchestrated",
+            server_addr=harmonograf_server["addr"],
+        )
+        try:
+            sink = HarmonografSink(client)
+            runner = Runner(
+                agent=_EchoAdapter(),
+                planner=StaticPlanner(plan=plan),
+                executor=SequentialExecutor(),
+                goal_deriver=LiteralGoalDeriver(),
+                sinks=[InMemorySink(), sink],
+            )
+            outcome = await runner.run("echo twice")
+            await runner.close()
+            assert outcome.success is True, outcome.reason
+        finally:
+            client.shutdown(flush_timeout=2.0)
+
+        sessions = await _wait_for_sessions(
+            harmonograf_server["store"], expected=1, timeout=5.0
+        )
+        assert len(sessions) == 1, (
+            f"expected exactly one session under the orchestrated "
+            f"stack, got {[s.id for s in sessions]!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_idle_client_shutdown_creates_no_session(
         self,
         harmonograf_server: dict,

--- a/tests/e2e/test_lazy_hello.py
+++ b/tests/e2e/test_lazy_hello.py
@@ -1,0 +1,149 @@
+"""End-to-end: lazy Hello produces exactly one session per run.
+
+Regression test for harmonograf#83. Before lazy Hello, every ADK run
+produced two sessions on the server: a ``sess_YYYY-MM-DD_NNNN`` ghost
+(created by the client's Hello handshake at construction time, before
+the ADK plugin had cached the outer adk-web session id) and the real
+ADK session (created later, when the plugin stamped its id onto
+spans + goldfive events). PR #78 hid the ghost from the picker with a
+server-side filter; #83 eliminates it by deferring Hello to first emit.
+
+These tests exercise the real harmonograf server (not the mock) through
+the real client and verify the three lazy-Hello contracts:
+
+1. **ADK-style first emit** — span with explicit ``session_id`` → server
+   creates exactly one session, with that id. No ghost.
+2. **Non-ADK first emit** — span with no ``session_id`` → server
+   auto-creates a home session (``sess_YYYY-MM-DD_NNNN``). The
+   harmonograf#62 home-session rollup contract is preserved.
+3. **Idle client** — constructed and shut down without emitting → server
+   creates zero sessions.
+
+If any of these regresses, ghost sessions will reappear in the picker
+and #78's server-side filter will not save us — that filter was
+reverted with #82.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from harmonograf_client import Client, SpanKind, SpanStatus
+
+
+async def _wait_for_sessions(store, expected: int, *, timeout: float = 3.0) -> list:
+    """Poll ``store.list_sessions()`` until it contains at least
+    ``expected`` rows or ``timeout`` elapses. Returns the last snapshot.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    sessions: list = []
+    while asyncio.get_event_loop().time() < deadline:
+        sessions = list(await store.list_sessions() or [])
+        if len(sessions) >= expected:
+            return sessions
+        await asyncio.sleep(0.05)
+    return sessions
+
+
+class TestLazyHelloAgainstRealServer:
+    @pytest.mark.asyncio
+    async def test_adk_style_first_emit_creates_one_session_no_ghost(
+        self,
+        harmonograf_server: dict,
+    ) -> None:
+        """An ADK-style client stamps the outer adk-web ``session_id``
+        onto the first span's envelope. Lazy Hello picks that id up and
+        the server creates exactly one session — the ADK session. The
+        ``sess_YYYY-MM-DD_NNNN`` ghost that used to accompany every run
+        (harmonograf#77) never appears.
+        """
+        client = Client(
+            name="adk-sim-agent",
+            server_addr=harmonograf_server["addr"],
+        )
+        adk_session_id = "sess_adk_outer_test_xyz"
+        try:
+            # First emit carries an explicit session_id, simulating
+            # what HarmonografTelemetryPlugin._stamp_session_id does on
+            # a real ADK invocation.
+            sid = client.emit_span_start(
+                kind=SpanKind.LLM_CALL,
+                name="echo",
+                session_id=adk_session_id,
+            )
+            client.emit_span_end(sid, status=SpanStatus.COMPLETED)
+        finally:
+            client.shutdown(flush_timeout=2.0)
+
+        sessions = await _wait_for_sessions(
+            harmonograf_server["store"], expected=1, timeout=3.0
+        )
+        session_ids = sorted(s.id for s in sessions)
+        assert session_ids == [
+            adk_session_id
+        ], f"expected exactly the ADK session, got {session_ids!r}"
+
+    @pytest.mark.asyncio
+    async def test_non_adk_first_emit_auto_creates_home_session(
+        self,
+        harmonograf_server: dict,
+    ) -> None:
+        """Non-ADK flow: the client emits a span with no ``session_id``
+        override. Hello fires on first emit with an empty session id;
+        the server auto-creates a ``sess_YYYY-MM-DD_NNNN`` home session
+        and all subsequent spans land on it. This is the
+        harmonograf#62 rollup contract — explicitly preserved by lazy
+        Hello.
+        """
+        client = Client(
+            name="non-adk-agent",
+            server_addr=harmonograf_server["addr"],
+        )
+        try:
+            sid = client.emit_span_start(kind=SpanKind.LLM_CALL, name="echo")
+            client.emit_span_end(sid, status=SpanStatus.COMPLETED)
+        finally:
+            client.shutdown(flush_timeout=2.0)
+
+        sessions = await _wait_for_sessions(
+            harmonograf_server["store"], expected=1, timeout=3.0
+        )
+        assert len(sessions) == 1, (
+            f"expected exactly one auto-created home session, got "
+            f"{[s.id for s in sessions]!r}"
+        )
+        # The server mints an id of the form ``sess_YYYY-MM-DD_NNNN``
+        # for Hellos that arrive with no session_id.
+        assert sessions[0].id.startswith("sess_"), sessions[0].id
+
+    @pytest.mark.asyncio
+    async def test_idle_client_shutdown_creates_no_session(
+        self,
+        harmonograf_server: dict,
+    ) -> None:
+        """A client that constructs and shuts down without emitting
+        anything produces zero Hellos, so the server never creates any
+        session row. This is the fundamental guarantee lazy Hello adds
+        — no ghost, no orphan stream, no DB row.
+        """
+        client = Client(
+            name="idle-agent",
+            server_addr=harmonograf_server["addr"],
+        )
+        # Let the client connect to the server so the stream is actually
+        # open. Without lazy Hello, Welcome would already have arrived
+        # by this point and a session row would exist.
+        await asyncio.sleep(0.3)
+        client.shutdown(flush_timeout=1.0)
+        # Let the server side observe stream close.
+        await asyncio.sleep(0.3)
+
+        sessions = list(
+            await harmonograf_server["store"].list_sessions() or []
+        )
+        assert sessions == [], (
+            f"idle client produced {len(sessions)} session(s): "
+            f"{[s.id for s in sessions]!r}"
+        )


### PR DESCRIPTION
## Summary

Closes #83. Follow-up to #82/#84 which reverted PR #78's server-side filter in favor of this actual fix.

Defers the ``Hello`` RPC from "client construction / stream open" to "first real emit". By then, the ADK telemetry plugin has already stamped the outer adk-web ``session_id`` onto the envelope. Hello inherits that id, so the server never auto-creates a ghost ``sess_YYYY-MM-DD_NNNN`` row.

The server side needs no changes — ``handle_hello`` is already idempotent on ``session_id``. Non-ADK flows (clients with no ``session_id`` override) still auto-create a home session on first emit; the fix only defers the RPC, it does not change semantics.

## Contract changes

| Scenario | Before | After |
|---|---|---|
| ADK run (plugin stamps outer session id on first span) | 2 sessions: ghost + ADK | 1 session: ADK |
| Non-ADK run (no session id override) | 1 session: home | 1 session: home |
| Idle client construct+shutdown | 1 ghost session | 0 sessions |

## Edge cases handled

1. **Session id changes between first and second emit** (AgentTool sub-Runners). Hello stamps the first id only; later envelopes with a different ``session_id`` route correctly via the per-envelope routing in #64/#66.
2. **Heartbeat-as-first-message**. Heartbeats are suppressed until ``_hello_sent`` is true. An idle client's heartbeat does not trigger Hello.
3. **Reconnect after drop**. ``_serve`` resets ``_hello_sent`` so the next post-reconnect emit re-sends Hello with the most-recent plugin-stamped session id. Resume token carries across as before.
4. **Control subscription**. Still gated on Welcome, which now arrives after the first emit rather than at connect. Extracted into a ``_deferred_control_loop`` helper so the send/recv loops can make progress while the control sub waits.
5. **Idle shutdown**. Server's bidi aborts with INVALID_ARGUMENT when the client closes its request side without sending Hello — benign; no session row, no DB state.

## Tests

- ``client/tests/test_transport_mock.py``:
  - ``test_hello_and_welcome_deferred_until_first_emit`` — stream is open but Hello has NOT been sent until the first emit; the first emit's ``session_id`` lands on the Hello frame.
  - ``test_idle_client_shutdown_sends_no_hello`` (new) — construct + shutdown without emitting produces zero Hellos.
  - ``test_non_adk_first_emit_has_no_session_id_override`` (new) — non-ADK path sends Hello with empty ``session_id`` on first emit; home-session auto-creation preserved (harmonograf#62 contract).
  - Three existing tests updated to emit a warmup span before waiting on Welcome/heartbeat/control.
- ``tests/e2e/test_lazy_hello.py`` (new) — three scenarios against the real in-process harmonograf server:
  - ADK-style first emit → exactly one session, no ghost.
  - Non-ADK first emit → exactly one auto-created ``sess_*`` home session.
  - Idle client shutdown → zero sessions.

## Test plan

- [x] ``make client-test`` — 217 passed.
- [x] ``make server-test`` — 288 passed, 1 skipped.
- [x] ``make e2e`` — 12 passed, 3 skipped (incl. three new lazy-Hello e2e scenarios against the real server).
- [x] ``make frontend-test`` — tsc + vite + eslint clean.