### PR TITLE
Dedup residual STEER card + fix malformed timestamp (closes #86)

### DIFF
--- a/frontend/src/__tests__/lib/interventions.test.ts
+++ b/frontend/src/__tests__/lib/interventions.test.ts
@@ -314,6 +314,91 @@ describe('deriveInterventions', () => {
     });
     expect(rows).toHaveLength(2);
   });
+
+  // harmonograf#86 — user STEERs involve a planner LLM round-trip that
+  // can take 30-90s on large local models. The pre-#86 deriver used a
+  // flat 5s attribution window and stranded the drift row + emitted a
+  // separate plan-sourced card whose atMs was the plan's createdAtMs
+  // (rendered as 6:33), alongside the annotation row rendered with an
+  // absolute-ms timestamp bug (29613779:31). Both symptoms go away when
+  // the user-control kinds use the extended window AND the annotation's
+  // createdAtMs is session-relative (fixed in convertAnnotation).
+  it('collapses STEER + drift + slow plan revision (70s gap) into one card', () => {
+    const rows = deriveInterventions({
+      annotations: [
+        mkAnnotation({
+          id: 'ann_slow',
+          createdAtMs: 100_200, // session-relative — the #86 convert.ts fix
+          author: 'alice',
+          body: 'pivot to solar flares',
+        }),
+      ],
+      drifts: [
+        mkDrift({
+          seq: 0,
+          kind: 'user_steer',
+          severity: 'warning',
+          detail: 'by alice: pivot to solar flares',
+          recordedAtMs: 100_300,
+          annotationId: 'ann_slow',
+        }),
+      ],
+      plans: [
+        mkPlan({
+          id: 'p_slow',
+          // 70s after the drift — way outside the 5s default window, but
+          // inside the user-control 5-minute extended window.
+          createdAtMs: 170_300,
+          revisionKind: 'user_steer',
+          revisionSeverity: 'warning',
+          revisionIndex: 1,
+        }),
+      ],
+    });
+
+    expect(rows).toHaveLength(1);
+    const card = rows[0];
+    expect(card.source).toBe('user');
+    expect(card.kind).toBe('STEER');
+    expect(card.annotationId).toBe('ann_slow');
+    expect(card.author).toBe('alice');
+    expect(card.bodyOrReason).toBe('pivot to solar flares');
+    expect(card.severity).toBe('warning');
+    expect(card.outcome).toBe('plan_revised:r1');
+    expect(card.planRevisionIndex).toBe(1);
+  });
+
+  it('autonomous slow drift still fires two cards (tight 5s window unchanged)', () => {
+    // Autonomous kinds keep the default 5s window so a slow refine here
+    // doesn't claim-steal an unrelated later revision. Ensures the
+    // widened user-control window does NOT bleed across kinds.
+    const rows = deriveInterventions({
+      annotations: [],
+      drifts: [
+        mkDrift({
+          seq: 0,
+          kind: 'looping_reasoning',
+          severity: 'warning',
+          recordedAtMs: 100_000,
+        }),
+      ],
+      plans: [
+        mkPlan({
+          id: 'p_autonomous',
+          createdAtMs: 160_000, // 60s gap — autonomous window is 5s
+          revisionKind: 'looping_reasoning',
+          revisionIndex: 2,
+        }),
+      ],
+    });
+    expect(rows).toHaveLength(2);
+    const drift = rows.find(
+      (r) => r.source === 'drift' && !r.outcome.startsWith('plan_revised:'),
+    );
+    const plan = rows.find((r) => r.outcome.startsWith('plan_revised:'));
+    expect(drift?.outcome).toBe('recorded');
+    expect(plan?.planRevisionIndex).toBe(2);
+  });
 });
 
 describe('marker sizing / palette', () => {

--- a/frontend/src/__tests__/rpc/convert.test.ts
+++ b/frontend/src/__tests__/rpc/convert.test.ts
@@ -1,0 +1,73 @@
+// Unit coverage for the proto → UI conversion seam. Focuses on the
+// timestamp-normalisation behaviour that ``convertAnnotation`` needs to
+// get right for the intervention deriver to plot rows in the same
+// session-relative coordinate space as spans and plans (harmonograf#86).
+
+import { describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { TimestampSchema } from '@bufbuild/protobuf/wkt';
+import { convertAnnotation } from '../../rpc/convert';
+import {
+  AnnotationSchema,
+  AnnotationKind,
+  AnnotationTargetSchema,
+} from '../../pb/harmonograf/v1/types_pb';
+
+function ts(seconds: number, nanos: number = 0) {
+  return create(TimestampSchema, {
+    seconds: BigInt(Math.trunc(seconds)),
+    nanos,
+  });
+}
+
+describe('convertAnnotation', () => {
+  it('normalises createdAtMs / deliveredAtMs to session-relative ms', () => {
+    // Session started at wall-clock 1_000_000 (ms since epoch). An
+    // annotation created 322s into the session and delivered 500ms
+    // later should surface as 322_000 / 322_500 on the UI side —
+    // matching the coordinate space of spans and plans so the
+    // Interventions list can plot the row alongside the others.
+    const origin = { startMs: 1_000_000 };
+    const createdAtAbsSec = 1_322;
+    const deliveredAtAbsSec = 1_322;
+    const pb = create(AnnotationSchema, {
+      id: 'ann_1',
+      sessionId: 'sess',
+      target: create(AnnotationTargetSchema, {
+        target: {
+          case: 'agentTime',
+          value: {
+            agentId: 'a',
+            at: ts(1_322),
+          },
+        },
+      }),
+      author: 'alice',
+      kind: AnnotationKind.STEERING,
+      body: 'pivot',
+      createdAt: ts(createdAtAbsSec, 0),
+      deliveredAt: ts(deliveredAtAbsSec, 500_000_000), // +500ms
+    });
+    const ui = convertAnnotation(pb, origin);
+    expect(ui.createdAtMs).toBe(322_000);
+    expect(ui.deliveredAtMs).toBe(322_500);
+    // The agent-time atMs is already session-relative from the pre-#86
+    // code path; spot-check it so a regression on that field also trips.
+    expect(ui.atMs).toBe(322_000);
+  });
+
+  it('leaves createdAtMs at 0 when the pb field is unset', () => {
+    const origin = { startMs: 1_000_000 };
+    const pb = create(AnnotationSchema, {
+      id: 'ann_2',
+      sessionId: 'sess',
+      author: 'bob',
+      kind: AnnotationKind.COMMENT,
+      body: 'note',
+      // no createdAt / deliveredAt
+    });
+    const ui = convertAnnotation(pb, origin);
+    expect(ui.createdAtMs).toBe(0);
+    expect(ui.deliveredAtMs).toBeNull();
+  });
+});

--- a/frontend/src/lib/interventions.ts
+++ b/frontend/src/lib/interventions.ts
@@ -65,6 +65,21 @@ const GOLDFIVE_REVISION_KINDS = new Set([
 // because every timeline in the UI is already session-relative ms.
 const OUTCOME_WINDOW_MS = 5000;
 
+// Extended window for user-control drifts (user_steer / user_cancel).
+// Mirrors the server's _USER_OUTCOME_WINDOW_S. A user STEER routes
+// through the planner's LLM which can take tens of seconds on a long
+// prompt (issue #86 saw a 70s drift→plan gap on a local Qwen3.5-35B).
+// The 5s default stranded the drift row and leaked a second card;
+// the extended window is still bounded so two separate user STEERs
+// in a session aren't claim-stolen by each other's plan revisions.
+const USER_OUTCOME_WINDOW_MS = 300_000;
+
+function outcomeWindowFor(driftKind: string): number {
+  return USER_DRIFT_KINDS.has((driftKind || '').toLowerCase())
+    ? USER_OUTCOME_WINDOW_MS
+    : OUTCOME_WINDOW_MS;
+}
+
 // Pretty labels for drift kinds emitted from the user. Uppercase so the
 // renderer can splash them next to other kinds without special-casing.
 function normalizeDriftKind(raw: string): string {
@@ -134,18 +149,22 @@ export function deriveInterventions(input: DeriveInput): InterventionRow[] {
   // Plans projected as interventions only when they are (a) a revision
   // (revisionIndex > 0 and a revisionKind is set) AND (b) not already
   // covered by a drift in the window. The second condition prevents the
-  // common path (drift → plan_revised within 5s) from emitting two rows
-  // for one logical intervention.
+  // common path (drift → plan_revised) from emitting two rows for one
+  // logical intervention. The window is kind-dependent: user-control
+  // kinds use the extended USER_OUTCOME_WINDOW_MS since the refine LLM
+  // may take tens of seconds (issue #86), while autonomous kinds keep
+  // the tight default so unrelated revisions aren't claim-stolen.
   const driftList = input.drifts;
   for (const plan of input.plans) {
     const revKind = (plan.revisionKind || '').toLowerCase();
     const revIdx = plan.revisionIndex ?? 0;
     if (!revKind || revIdx <= 0) continue;
+    const window = outcomeWindowFor(revKind);
     const hasPrecedingDrift = driftList.some(
       (dr) =>
         (dr.kind || '').toLowerCase() === revKind &&
         plan.createdAtMs - dr.recordedAtMs >= 0 &&
-        plan.createdAtMs - dr.recordedAtMs <= OUTCOME_WINDOW_MS,
+        plan.createdAtMs - dr.recordedAtMs <= window,
     );
     if (hasPrecedingDrift) continue;
     let source: InterventionSource;
@@ -189,12 +208,15 @@ export function deriveInterventions(input: DeriveInput): InterventionRow[] {
     if (row.outcome) continue;
     if (row.source === 'goldfive') continue;
 
-    // Prefer a revision that matches this row's driftKind within the window.
+    // Prefer a revision that matches this row's driftKind within the
+    // kind-dependent window. User-control drifts (issue #86) use the
+    // extended USER_OUTCOME_WINDOW_MS to tolerate long refine latencies.
+    const window = outcomeWindowFor(row.driftKind);
     let bestPlan: TaskPlan | null = null;
     let bestDelta = Infinity;
     for (const plan of revisionPlans) {
       const delta = plan.createdAtMs - row.atMs;
-      if (delta < 0 || delta > OUTCOME_WINDOW_MS) continue;
+      if (delta < 0 || delta > window) continue;
       const revKind = (plan.revisionKind || '').toLowerCase();
       if (row.driftKind && revKind === row.driftKind) {
         if (delta < bestDelta) {
@@ -274,7 +296,19 @@ function mergeByAnnotationId(rows: InterventionRow[]): InterventionRow[] {
       others.splice(0, others.length, ...group.slice(1));
     }
     for (const other of others) {
-      if (other.outcome && !survivor.outcome) survivor.outcome = other.outcome;
+      // Prefer the other row's outcome when the survivor either has no
+      // outcome yet OR has only the fallback 'recorded' label — the
+      // drift path is usually the one that attributed a real
+      // ``plan_revised:rN`` (especially for slow refines beyond the
+      // default attribution window; issue #86). Never downgrade a real
+      // outcome back to 'recorded'.
+      if (other.outcome && other.outcome !== 'recorded') {
+        if (!survivor.outcome || survivor.outcome === 'recorded') {
+          survivor.outcome = other.outcome;
+        }
+      } else if (other.outcome && !survivor.outcome) {
+        survivor.outcome = other.outcome;
+      }
       if (other.planRevisionIndex && !survivor.planRevisionIndex) {
         survivor.planRevisionIndex = other.planRevisionIndex;
       }
@@ -286,13 +320,15 @@ function mergeByAnnotationId(rows: InterventionRow[]): InterventionRow[] {
 
   // Fold in plan-sourced rows (no annotation_id, driftKind = user_*,
   // outcome starts with plan_revised:) whose driftKind matches a merged
-  // annotation row inside the attribution window.
+  // annotation row inside the kind-dependent attribution window. The
+  // extended user window catches slow refines (issue #86).
   const findMergeTarget = (planRow: InterventionRow): InterventionRow | null => {
+    const window = outcomeWindowFor(planRow.driftKind);
     for (const row of merged) {
       if (!row.annotationId || !row.driftKind) continue;
       if (row.driftKind !== planRow.driftKind) continue;
       const delta = planRow.atMs - row.atMs;
-      if (delta >= 0 && delta <= OUTCOME_WINDOW_MS) return row;
+      if (delta >= 0 && delta <= window) return row;
     }
     return null;
   };
@@ -305,7 +341,13 @@ function mergeByAnnotationId(rows: InterventionRow[]): InterventionRow[] {
     ) {
       const target = findMergeTarget(row);
       if (target) {
-        if (!target.outcome) target.outcome = row.outcome;
+        // Prefer the plan's real outcome (plan_revised:rN) over a
+        // fallback 'recorded' that the annotation row may have picked
+        // up during attribution when the drift was stranded outside
+        // the default window (issue #86).
+        if (!target.outcome || target.outcome === 'recorded') {
+          target.outcome = row.outcome;
+        }
         if (!target.planRevisionIndex) target.planRevisionIndex = row.planRevisionIndex;
         continue;
       }

--- a/frontend/src/rpc/convert.ts
+++ b/frontend/src/rpc/convert.ts
@@ -185,8 +185,19 @@ export function convertAnnotation(
       atMs = tsToMs(target.value.at) - origin.startMs;
     }
   }
+  // Normalise to session-relative ms, matching ``convertSpan``. The
+  // intervention deriver (lib/interventions.ts) treats annotation rows'
+  // ``createdAtMs`` as session-relative when plotting on the Trajectory
+  // view's interventions list; leaving absolute wall-clock ms here caused
+  // the row to render with a malformed ``29613779:31`` timestamp after
+  // harmonograf#81 (issue #86). ``deliveredAtMs`` gets the same treatment
+  // for consistency — only PinStrip's null-check consumes it today, but
+  // future callers that format the value won't have to special-case this
+  // one field.
   const createdAbs = a.createdAt ? tsToMs(a.createdAt) : 0;
   const deliveredAbs = a.deliveredAt ? tsToMs(a.deliveredAt) : null;
+  const createdAtMs = createdAbs ? createdAbs - origin.startMs : 0;
+  const deliveredAtMs = deliveredAbs !== null ? deliveredAbs - origin.startMs : null;
   return {
     id: a.id,
     sessionId: a.sessionId,
@@ -196,8 +207,8 @@ export function convertAnnotation(
     author: a.author,
     kind,
     body: a.body,
-    createdAtMs: createdAbs,
-    deliveredAtMs: deliveredAbs,
+    createdAtMs,
+    deliveredAtMs,
     pending: false,
     error: null,
   };

--- a/frontend/src/rpc/hooks.ts
+++ b/frontend/src/rpc/hooks.ts
@@ -627,8 +627,17 @@ export function usePostAnnotation(): (args: PostAnnotationArgs) => Promise<void>
       // caller can retry or the pin can render in a failure state.
       const store = useAnnotationStore.getState();
       const tempId = `pending-${crypto.randomUUID?.() ?? Date.now().toString(36)}`;
-      const span = getSessionStore(sessionId)?.spans.get(spanId);
+      const sessionStore = getSessionStore(sessionId);
+      const span = sessionStore?.spans.get(spanId);
       const atMs = span?.startMs ?? 0;
+      // ``createdAtMs`` is session-relative ms, matching the value the
+      // server ack path produces via ``convertAnnotation`` (issue #86).
+      // Falls back to 0 when the session origin isn't known yet — the
+      // pending row is replaced with the canonical ack row moments later
+      // so the 0 never lands on the Trajectory view under normal
+      // conditions.
+      const sessionStartMs = sessionStore?.wallClockStartMs ?? 0;
+      const createdAtMs = sessionStartMs > 0 ? Date.now() - sessionStartMs : 0;
       store.upsert({
         id: tempId,
         sessionId,
@@ -638,7 +647,7 @@ export function usePostAnnotation(): (args: PostAnnotationArgs) => Promise<void>
         author,
         kind,
         body,
-        createdAtMs: Date.now(),
+        createdAtMs,
         deliveredAtMs: null,
         pending: true,
         error: null,

--- a/server/harmonograf_server/interventions.py
+++ b/server/harmonograf_server/interventions.py
@@ -70,6 +70,31 @@ _GOLDFIVE_REVISION_KINDS: frozenset[str] = frozenset(
 # that a drift and a much later unrelated revision are not conflated.
 _OUTCOME_WINDOW_S: float = 5.0
 
+# Extended window applied only to user-control drifts (USER_STEER /
+# USER_CANCEL). A user STEER flows through the planner's LLM which can
+# take tens of seconds on a long prompt (issue #86 saw a 70s gap on a
+# local Qwen3.5-35B), so the narrow 5s window used for autonomous
+# drifts would strand the drift row and leak a second card. The
+# extended window is still bounded so two separate user STEERs in a
+# single session aren't claim-stolen by each other's plan revisions.
+_USER_OUTCOME_WINDOW_S: float = 300.0
+
+
+def _outcome_window_for(drift_kind: str) -> float:
+    """Per-kind window used by ``_project_plans`` and ``_attribute_outcomes``.
+
+    User-control kinds get :data:`_USER_OUTCOME_WINDOW_S` — the planner's
+    refine latency routinely exceeds the default 5s on larger models.
+    Every other kind keeps the tight default because autonomous drift
+    causes are fast-path heuristics: a looping-reasoning detection has
+    no LLM round-trip to wait for.
+    """
+    return (
+        _USER_OUTCOME_WINDOW_S
+        if (drift_kind or "").lower() in _USER_DRIFT_KINDS
+        else _OUTCOME_WINDOW_S
+    )
+
 
 # ---------------------------------------------------------------------------
 # Intermediate record — the merge shape before outcome attribution.
@@ -264,6 +289,15 @@ def _project_plans(
         # plan here. Otherwise this is an autonomous goldfive revision
         # (cascade_cancel, refine_retry) or a drift we never ingested,
         # and we record it directly.
+        #
+        # The window is kind-dependent (:func:`_outcome_window_for`):
+        # user-control kinds allow a long refine latency (goldfive has
+        # to run the planner LLM before emitting plan_revised); every
+        # other kind keeps the tight 5s default. Issue #86 triggered a
+        # 70s drift-to-plan gap on a local Qwen3.5-35B that the 5s
+        # default strand-suppressed, leaving both drift and plan rows
+        # as separate cards.
+        window = _outcome_window_for(rev_kind)
         preceding_drift: dict[str, Any] | None = None
         for dr in drift_list:
             if (dr.get("kind") or "").lower() != rev_kind:
@@ -272,7 +306,7 @@ def _project_plans(
             if not isinstance(ra, (int, float)):
                 continue
             delta = float(plan.created_at) - float(ra)
-            if 0.0 <= delta <= _OUTCOME_WINDOW_S:
+            if 0.0 <= delta <= window:
                 preceding_drift = dr
                 break
         if preceding_drift is not None:
@@ -356,11 +390,15 @@ def _attribute_outcomes(
 def _find_matching_revision(
     rec: InterventionRecord, plans: list[TaskPlan]
 ) -> Optional[TaskPlan]:
+    # Use the extended window for user-control drifts (see
+    # :func:`_outcome_window_for`) so a slow refine still attributes its
+    # plan_revised outcome back to the drift row that caused it.
+    window = _outcome_window_for(rec.drift_kind)
     best: Optional[TaskPlan] = None
-    best_delta: float = _OUTCOME_WINDOW_S + 1.0
+    best_delta: float = window + 1.0
     for plan in plans:
         delta = float(plan.created_at) - rec.at
-        if delta < 0 or delta > _OUTCOME_WINDOW_S:
+        if delta < 0 or delta > window:
             continue
         rev_kind = (plan.revision_kind or "").lower()
         # Require the revision to carry a revision_kind (i.e. it is
@@ -449,8 +487,21 @@ def _merge_by_annotation_id(
             annotation_row = group[0]
             others = group[1:]
         # Promote non-empty fields from ``others`` onto the survivor.
+        # For ``outcome``: prefer a real attribution (``plan_revised:rN``,
+        # ``cascade_cancel:N_tasks``) over the fallback ``recorded``. The
+        # drift path is the one that actually knows which revision fired,
+        # so if the annotation row had to fall back to ``recorded``
+        # (e.g. because the user_steer drift was stranded outside the
+        # default attribution window) we still get the right label on
+        # the surviving card (issue #86).
         for other in others:
-            if other.outcome and not annotation_row.outcome:
+            if other.outcome and other.outcome != "recorded":
+                if (
+                    not annotation_row.outcome
+                    or annotation_row.outcome == "recorded"
+                ):
+                    annotation_row.outcome = other.outcome
+            elif other.outcome and not annotation_row.outcome:
                 annotation_row.outcome = other.outcome
             if (
                 other.plan_revision_index
@@ -467,15 +518,18 @@ def _merge_by_annotation_id(
     # annotation row's promoted drift_kind and whose ``at`` lands inside
     # the attribution window — covers the case where _project_plans
     # emitted a row because its matching drift was deduped at the
-    # suppress step, leaving no carrier for annotation_id.
+    # suppress step, leaving no carrier for annotation_id. Uses the
+    # kind-dependent window (:func:`_outcome_window_for`) so a slow
+    # user-STEER refine can still fold — issue #86.
     def _find_merge_target(plan_row: InterventionRecord) -> InterventionRecord | None:
+        window = _outcome_window_for(plan_row.drift_kind)
         for rec in merged:
             if not rec.annotation_id or not rec.drift_kind:
                 continue
             if rec.drift_kind != plan_row.drift_kind:
                 continue
             delta = plan_row.at - rec.at
-            if 0.0 <= delta <= _OUTCOME_WINDOW_S:
+            if 0.0 <= delta <= window:
                 return rec
         return None
 
@@ -490,7 +544,11 @@ def _merge_by_annotation_id(
         ):
             target = _find_merge_target(rec)
             if target is not None:
-                if not target.outcome:
+                # Prefer the plan's real outcome (``plan_revised:rN``)
+                # over a fallback ``recorded`` that the annotation row
+                # may have picked up during attribution when the drift
+                # was stranded outside the default window (issue #86).
+                if not target.outcome or target.outcome == "recorded":
                     target.outcome = rec.outcome
                 if not target.plan_revision_index:
                     target.plan_revision_index = rec.plan_revision_index

--- a/server/tests/test_interventions.py
+++ b/server/tests/test_interventions.py
@@ -537,6 +537,135 @@ async def test_user_steer_drift_without_annotation_id_keeps_separate_card(store)
     assert all(r.source == "user" for r in records)
 
 
+async def test_slow_user_steer_refine_still_dedups_to_one_card(store):
+    """harmonograf#86: drift→plan gap > 5s must still collapse for user STEERs.
+
+    The user's STEER routes through the planner's LLM, which on large
+    local models (e.g. Qwen3.5-35B) can take tens of seconds to return
+    a refined plan. The narrow 5s attribution window used for
+    autonomous drifts strand-suppresses the drift row in that case —
+    leaving the annotation merged with the drift AND a separate
+    plan-sourced STEER card. After #86 the user-control kinds use an
+    extended window so both paths still collapse onto the same card.
+    """
+
+    sid = "sess_slow_refine"
+    await _seed_session(store, sid)
+
+    # 1. User STEER annotation at t=100.
+    await store.put_annotation(
+        Annotation(
+            id="ann_steer_slow",
+            session_id=sid,
+            target=AnnotationTarget(agent_id="a", time_start=100.0),
+            author="alice",
+            created_at=100.0,
+            kind=AnnotationKind.STEERING,
+            body="pivot to solar flares",
+        )
+    )
+
+    # 2. USER_STEER drift with annotation_id at t=100.2 (near-immediate
+    #    relay from the bridge).
+    drifts = _StubDrifts(
+        {
+            sid: [
+                {
+                    "run_id": "r1",
+                    "kind": "user_steer",
+                    "severity": "warning",
+                    "detail": "by alice: pivot to solar flares",
+                    "annotation_id": "ann_steer_slow",
+                    "recorded_at": 100.2,
+                }
+            ]
+        }
+    )
+
+    # 3. Plan revision lands 70s later — the refine LLM took a while.
+    #    Inside _USER_OUTCOME_WINDOW_S but well outside the default 5s.
+    await store.put_task_plan(
+        TaskPlan(
+            id="p_slow",
+            session_id=sid,
+            created_at=170.5,
+            summary="pivoted plan",
+            tasks=[],
+            edges=[],
+            revision_reason="by alice: pivot to solar flares",
+            revision_kind="user_steer",
+            revision_severity="warning",
+            revision_index=1,
+        )
+    )
+
+    records = await list_interventions(sid, store=store, drifts_provider=drifts)
+
+    # Exactly one card — the slow refine must not leak a second STEER row.
+    assert len(records) == 1, f"expected 1 card, got {len(records)}: {records}"
+    card = records[0]
+    assert card.source == "user"
+    assert card.kind == "STEER"
+    assert card.annotation_id == "ann_steer_slow"
+    assert card.author == "alice"
+    assert card.body_or_reason == "pivot to solar flares"
+    # The plan_revised outcome is attributed even across the wider gap.
+    assert card.outcome == "plan_revised:r1"
+    assert card.plan_revision_index == 1
+    assert card.severity == "warning"
+
+
+async def test_slow_autonomous_refine_is_still_bounded_by_5s(store):
+    """Autonomous (non-user) drifts keep the tight 5s window.
+
+    Widening only the user-control kinds means a slow goldfive refine
+    (which doesn't happen in practice — autonomous plan revisions fire
+    fast) followed by a model-kind drift doesn't claim-steal an
+    unrelated later revision. Covered here so a future relaxation
+    doesn't accidentally apply across the board.
+    """
+
+    sid = "sess_slow_autonomous"
+    await _seed_session(store, sid)
+
+    drifts = _StubDrifts(
+        {
+            sid: [
+                {
+                    "kind": "looping_reasoning",
+                    "severity": "warning",
+                    "detail": "loop",
+                    "recorded_at": 100.0,
+                }
+            ]
+        }
+    )
+    # Plan revision 60s later — way outside 5s, inside 300s. Autonomous
+    # kinds must still emit a separate card.
+    await store.put_task_plan(
+        TaskPlan(
+            id="p_later",
+            session_id=sid,
+            created_at=160.0,
+            summary="",
+            tasks=[],
+            edges=[],
+            revision_reason="",
+            revision_kind="looping_reasoning",
+            revision_index=2,
+        )
+    )
+
+    records = await list_interventions(sid, store=store, drifts_provider=drifts)
+    # Two cards: the drift (outcome=recorded, since too far to attribute)
+    # and the plan revision as its own entry.
+    assert len(records) == 2
+    drift_row = next(r for r in records if r.source == "drift" and not r.outcome.startswith("plan_revised:"))
+    plan_row = next(r for r in records if r.outcome.startswith("plan_revised:"))
+    assert drift_row.outcome == "recorded"
+    assert plan_row.plan_revision_index == 2
+
+
 async def test_empty_session_returns_empty_list(store):
     sid = "sess_empty"
     await _seed_session(store, sid)


### PR DESCRIPTION
## Summary

Closes #86. After #81's annotation_id merge landed, a single user STEER could still surface as two cards in the Trajectory view — one correctly merged card with ``plan_revised:rN`` and one orphan "STEER by user" card with a malformed timestamp like ``29613779:31``.

Two defects, one symptom:

1. **Absolute wall-clock ms on annotation rows** — ``convertAnnotation`` stored ``createdAtMs`` / ``deliveredAtMs`` as absolute ms instead of session-relative ms. Every other field in the UI coordinate space is relative (spans, plans, drifts). The intervention deriver fed that absolute ms straight into ``fmtTime``, producing the ``29613779:31`` render.
2. **Tight 5s attribution window** — a user STEER routes through the planner's LLM which on large local models takes 30-90s. The observed session had a 70s drift→plan gap that stranded the drift's attribution AND produced a separate plan-sourced STEER card, compounding with defect 1.

## Fix

- ``convertAnnotation`` subtracts ``origin.startMs`` on the conversion seam, mirroring ``convertSpan``. Optimistic ``usePostAnnotation`` also normalises ``Date.now()`` against ``wallClockStartMs``.
- New ``USER_OUTCOME_WINDOW_MS`` / ``_USER_OUTCOME_WINDOW_S`` (5 minutes) used at every 5s attribution gate for user-control drift kinds (``user_steer`` / ``user_cancel``). Autonomous drift kinds keep the tight default so unrelated revisions aren't claim-stolen.
- Merge promotion now prefers a real ``plan_revised:rN`` over a fallback ``recorded`` on the survivor (previously the merge only filled empty slots, so a stranded annotation silently shadowed the real outcome).

## Verified on real data

Loaded session ``final_1776826449`` (from ``/tmp/demo-data/harmonograf.db``) into the server aggregator: ``list_interventions`` returns exactly one ``user/STEER`` card with ``outcome=plan_revised:r1``, ``severity=warning``, ``annotation_id=ann_667dd95cfbfb430e``.

## Test plan

- [x] ``make server-test`` — 290 passed (includes 2 new tests for #86)
- [x] ``make frontend-test`` — 243 passed (includes 3 new tests for #86)
- [x] ``make frontend-build`` — clean
- [x] ``make frontend-lint`` — clean
- [ ] E2E: rerun presentation_agent_orchestrated with a pivot STEER and confirm one STEER card with a correct ``M:SS`` timestamp (pending — local LLM availability)

## Explanation of the leak path

The brief hypothesised three possible fork paths (control event bus, autonomous-intervention drift, live-delta deriver). The actual leak was simpler: the **annotation row itself** was the malformed-timestamp row. Its absolute-ms atMs put it outside the window-comparison arithmetic that the deduper used, so neither the drift merge nor the plan-fold could reach it. #81 unified the three paths correctly but inherited the legacy ``convertAnnotation`` that never normalised timestamps at the ingest seam — the seam fix was out of scope when #81 shipped.