### PR TITLE
Autofit Gantt viewport + clear live-activity on completed sessions (closes #89)

### DIFF
--- a/frontend/src/__tests__/components/LiveActivityPanel.test.tsx
+++ b/frontend/src/__tests__/components/LiveActivityPanel.test.tsx
@@ -1,0 +1,186 @@
+// Covers harmonograf#89: the Live Activity header must clear once the
+// session is no longer LIVE. Without this, INVOCATION spans that never got
+// a clean endMs (server shut down mid-run, agent process exited without
+// flushing) stay "RUNNING" forever and the header reports N running agents
+// on a session the user has already confirmed is done.
+
+import { act, render, screen } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { SessionStore } from '../../gantt/index';
+import type { Agent, Span, SpanKind, SpanStatus } from '../../gantt/types';
+
+type WatchMock = {
+  store: SessionStore;
+  connected: boolean;
+  initialBurstComplete: boolean;
+  error: string | null;
+  sessionStatus: 'UNKNOWN' | 'LIVE' | 'COMPLETED' | 'ABORTED';
+  lastEventAtMs: number;
+};
+
+let mockStore: SessionStore | undefined;
+let mockWatch: WatchMock | undefined;
+let mockSessionId: string | null = 'session-1';
+
+vi.mock('../../rpc/hooks', async () => {
+  // Preserve the real sessionIsInactive helper; only mock the hooks that
+  // touch the live RPC client.
+  const actual =
+    await vi.importActual<typeof import('../../rpc/hooks')>(
+      '../../rpc/hooks',
+    );
+  return {
+    ...actual,
+    getSessionStore: (id: string | null) => (id ? mockStore : undefined),
+    useSessionWatch: () => mockWatch ?? null,
+  };
+});
+
+vi.mock('../../state/uiStore', () => {
+  const state = {
+    currentSessionId: 'session-1',
+    liveActivityCollapsed: false,
+    toggleLiveActivity: () => {},
+    selectSpan: () => {},
+  };
+  return {
+    useUiStore: <T,>(selector: (s: typeof state) => T) => {
+      // Keep the selector pointed at the latest mockSessionId so a test
+      // that clears it reflects immediately.
+      return selector({ ...state, currentSessionId: mockSessionId ?? '' });
+    },
+  };
+});
+
+import { LiveActivityPanel } from '../../components/LiveActivity/LiveActivityPanel';
+
+function agent(id: string, name = id): Agent {
+  return {
+    id,
+    name,
+    framework: 'ADK',
+    capabilities: [],
+    status: 'CONNECTED',
+    connectedAtMs: 0,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+  };
+}
+
+function span(
+  id: string,
+  agentId: string,
+  kind: SpanKind,
+  opts: { endMs?: number | null; status?: SpanStatus; startMs?: number } = {},
+): Span {
+  return {
+    id,
+    sessionId: 'session-1',
+    agentId,
+    parentSpanId: null,
+    kind,
+    name: 'work',
+    status: opts.status ?? 'RUNNING',
+    startMs: opts.startMs ?? 0,
+    endMs: opts.endMs ?? null,
+    links: [],
+    attributes: {},
+    payloadRefs: [],
+    error: null,
+    lane: -1,
+    replaced: false,
+  };
+}
+
+function baseWatch(overrides: Partial<WatchMock> = {}): WatchMock {
+  return {
+    store: mockStore!,
+    connected: true,
+    initialBurstComplete: true,
+    error: null,
+    sessionStatus: 'LIVE',
+    lastEventAtMs: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('<LiveActivityPanel /> stale-state fix (harmonograf#89)', () => {
+  beforeEach(() => {
+    mockStore = new SessionStore();
+    mockSessionId = 'session-1';
+    // Seed two agents and a still-open INVOCATION for each — exactly the
+    // shape that leaves "2 RUNNING" stuck on a completed session.
+    mockStore.agents.upsert(agent('coordinator_agent', 'coordinator'));
+    mockStore.agents.upsert(agent('web_developer_agent', 'web_developer'));
+    mockStore.spans.append(
+      span('inv-coord', 'coordinator_agent', 'INVOCATION', { startMs: 100 }),
+    );
+    mockStore.spans.append(
+      span('inv-web', 'web_developer_agent', 'INVOCATION', { startMs: 200 }),
+    );
+    mockWatch = baseWatch();
+  });
+  afterEach(() => {
+    mockStore = undefined;
+    mockWatch = undefined;
+  });
+
+  it('shows "2 running" while the session is LIVE', () => {
+    mockWatch = baseWatch({ sessionStatus: 'LIVE' });
+    render(<LiveActivityPanel />);
+    expect(screen.getByText(/2 running/i)).toBeInTheDocument();
+  });
+
+  it('clears the header when the session has transitioned to COMPLETED', () => {
+    mockWatch = baseWatch({ sessionStatus: 'COMPLETED' });
+    render(<LiveActivityPanel />);
+    // The panel flips to the empty "No active work" state rather than
+    // listing stale INVOCATIONs.
+    expect(screen.queryByText(/running/i)).toBeNull();
+    expect(screen.getByText(/no active work/i)).toBeInTheDocument();
+  });
+
+  it('clears the header on ABORTED sessions too', () => {
+    mockWatch = baseWatch({ sessionStatus: 'ABORTED' });
+    render(<LiveActivityPanel />);
+    expect(screen.queryByText(/running/i)).toBeNull();
+    expect(screen.getByText(/no active work/i)).toBeInTheDocument();
+  });
+
+  it('clears via the inactivity-grace fallback when status never transitioned', () => {
+    // Server forgot to emit SessionEnded, but the stream has been quiet
+    // for a long time and we're disconnected — treat as inactive.
+    const longAgo = Date.now() - 5 * 60_000;
+    mockWatch = baseWatch({
+      sessionStatus: 'UNKNOWN',
+      connected: false,
+      lastEventAtMs: longAgo,
+    });
+    // The panel samples wall-clock inside a setInterval callback (to keep
+    // the render body pure). Advance fake timers past the first tick so
+    // nowWallMs populates with a real value, then the staleness heuristic
+    // fires. Without this, the initial render sees nowWallMs=0 and can't
+    // evaluate the fallback.
+    vi.useFakeTimers({ now: Date.now() });
+    try {
+      render(<LiveActivityPanel />);
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+      expect(screen.queryByText(/running/i)).toBeNull();
+      expect(screen.getByText(/no active work/i)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/__tests__/gantt/viewportFit.test.ts
+++ b/frontend/src/__tests__/gantt/viewportFit.test.ts
@@ -1,0 +1,111 @@
+// Viewport-level tests for fitAll() and jumpToLastActivity() on the Gantt
+// renderer. These cover harmonograf#89's core fix: completed sessions should
+// open fitted to activity, and panning past the last span should offer a
+// click-to-jump-back affordance. The renderer is exercised without attaching
+// any canvases — every method under test operates on viewport + SpanIndex
+// state and doesn't touch the drawing context.
+
+import { describe, expect, it } from 'vitest';
+import { GanttRenderer } from '../../gantt/renderer';
+import { SessionStore } from '../../gantt/index';
+import { defaultViewport, viewportStart } from '../../gantt/viewport';
+import type { Span } from '../../gantt/types';
+
+function appendSpan(store: SessionStore, startMs: number, endMs: number | null): void {
+  const span: Span = {
+    id: `s-${startMs}-${endMs ?? 'open'}`,
+    sessionId: 'sess',
+    agentId: 'agent-a',
+    parentSpanId: null,
+    kind: 'INVOCATION',
+    name: 'work',
+    status: endMs === null ? 'RUNNING' : 'COMPLETED',
+    startMs,
+    endMs,
+    lane: 0,
+    attributes: {},
+    payloadRefs: [],
+    links: [],
+    replaced: false,
+    error: null,
+  };
+  store.spans.append(span);
+}
+
+describe('GanttRenderer.fitAll (harmonograf#89 autofit)', () => {
+  it('fits to maxEndMs with a small right-side margin', () => {
+    const store = new SessionStore();
+    appendSpan(store, 0, 16 * 60_000); // 16 minutes of work
+    const r = new GanttRenderer(store);
+
+    r.fitAll();
+    const v = r.getViewport();
+
+    // liveFollow off — completed sessions don't track a cursor.
+    expect(v.liveFollow).toBe(false);
+    // Window covers the full activity with ~5% headroom.
+    expect(v.windowMs).toBeGreaterThan(16 * 60_000);
+    expect(v.windowMs).toBeLessThan(17 * 60_000);
+    // endMs reaches at least maxEnd so the last span is visible.
+    expect(v.endMs).toBeGreaterThanOrEqual(16 * 60_000);
+    // Left edge never goes before session start.
+    expect(viewportStart(v)).toBeLessThanOrEqual(0 + 1);
+  });
+
+  it('leaves viewport unchanged when there are no spans and no nowMs', () => {
+    const store = new SessionStore();
+    const r = new GanttRenderer(store);
+    const before = r.getViewport();
+    r.fitAll();
+    // maxEndMs = 0, nowMs = 0 → maxEnd clamped to 1. Window floors at
+    // ZOOM_MIN_MS (30s). That's acceptable — there's nothing to see either
+    // way and the user will switch sessions. The key invariant is: no crash
+    // and viewport is still valid (left edge >= 0).
+    const after = r.getViewport();
+    expect(viewportStart(after)).toBeGreaterThanOrEqual(0 - 1);
+    expect(after.liveFollow).toBe(false);
+    // defaultViewport() returns liveFollow=true; we should have explicitly
+    // flipped it in fitAll.
+    expect(before.liveFollow).toBe(true);
+  });
+});
+
+describe('GanttRenderer.jumpToLastActivity (harmonograf#89 D)', () => {
+  it('preserves zoom level and lands near the last recorded span', () => {
+    const store = new SessionStore();
+    appendSpan(store, 0, 60_000);
+    appendSpan(store, 10 * 60_000, 11 * 60_000);
+    const r = new GanttRenderer(store);
+
+    // Shrink to a 60-second window anchored way out in the future.
+    r.setViewport({
+      ...defaultViewport(),
+      windowMs: 60_000,
+      endMs: 60 * 60_000, // 1h in — well past activity at 11m.
+      liveFollow: false,
+    });
+    const before = r.getViewport();
+    expect(viewportStart(before)).toBeGreaterThan(11 * 60_000);
+
+    r.jumpToLastActivity();
+    const after = r.getViewport();
+
+    // Window duration preserved.
+    expect(after.windowMs).toBe(60_000);
+    // liveFollow stays off — we're jumping to a fixed point.
+    expect(after.liveFollow).toBe(false);
+    // Left edge is strictly before the last span end so it's visible.
+    expect(viewportStart(after)).toBeLessThan(11 * 60_000);
+    // And the right edge is past the last span end so there's breathing room.
+    expect(after.endMs).toBeGreaterThanOrEqual(11 * 60_000);
+  });
+
+  it('is a no-op when the session has no spans', () => {
+    const store = new SessionStore();
+    const r = new GanttRenderer(store);
+    const before = r.getViewport();
+    r.jumpToLastActivity();
+    const after = r.getViewport();
+    expect(after).toEqual(before);
+  });
+});

--- a/frontend/src/__tests__/rpc/hooks.test.ts
+++ b/frontend/src/__tests__/rpc/hooks.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { getSessionStore } from '../../rpc/hooks';
+import {
+  getSessionStore,
+  sessionIsInactive,
+  INACTIVITY_COMPLETED_MS,
+} from '../../rpc/hooks';
 
 // Note: convertTaskPlan / convertTask / taskStatusFromInt are module-private
 // inside src/rpc/hooks.ts. Testing them directly would require a production
@@ -15,5 +19,75 @@ describe('getSessionStore', () => {
 
   it('returns undefined for a sessionId that has never been watched', () => {
     expect(getSessionStore('never-seen')).toBeUndefined();
+  });
+});
+
+describe('sessionIsInactive (harmonograf#89)', () => {
+  const T0 = 1_000_000_000_000;
+  const base = {
+    sessionStatus: 'UNKNOWN' as const,
+    lastEventAtMs: T0,
+    initialBurstComplete: true,
+    connected: true,
+  };
+
+  it('returns false before the initial burst completes', () => {
+    expect(
+      sessionIsInactive(
+        { ...base, sessionStatus: 'COMPLETED', initialBurstComplete: false },
+        T0,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true for an explicit COMPLETED status', () => {
+    expect(
+      sessionIsInactive({ ...base, sessionStatus: 'COMPLETED' }, T0),
+    ).toBe(true);
+  });
+
+  it('returns true for an explicit ABORTED status', () => {
+    expect(
+      sessionIsInactive({ ...base, sessionStatus: 'ABORTED' }, T0),
+    ).toBe(true);
+  });
+
+  it('returns false for a LIVE session even if the stream is momentarily quiet', () => {
+    expect(
+      sessionIsInactive(
+        { ...base, sessionStatus: 'LIVE', connected: true },
+        T0 + 5 * 60_000,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true when UNKNOWN, disconnected, and inactive past the threshold', () => {
+    expect(
+      sessionIsInactive(
+        { ...base, connected: false, lastEventAtMs: T0 },
+        T0 + INACTIVITY_COMPLETED_MS + 1,
+      ),
+    ).toBe(true);
+  });
+
+  it('stays false while still inside the inactivity grace window', () => {
+    expect(
+      sessionIsInactive(
+        { ...base, connected: false, lastEventAtMs: T0 },
+        T0 + INACTIVITY_COMPLETED_MS - 1,
+      ),
+    ).toBe(false);
+  });
+
+  it('stays false while the stream is still connected, even if quiet', () => {
+    // Heartbeats on the server side keep a live session from flipping to
+    // "inactive" purely on a long quiet stretch — only a disconnect +
+    // staleness should trigger the fallback heuristic.
+    expect(
+      sessionIsInactive(
+        { ...base, connected: true, lastEventAtMs: T0 },
+        T0 + 10 * 60_000,
+      ),
+    ).toBe(false);
   });
 });

--- a/frontend/src/components/Gantt/GanttPlaceholder.tsx
+++ b/frontend/src/components/Gantt/GanttPlaceholder.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { GanttCanvas } from '../../gantt/GanttCanvas';
 import { SessionStore } from '../../gantt/index';
 import { seedDemoSession } from '../../gantt/mockData';
 import { useUiStore } from '../../state/uiStore';
-import { useSessionWatch } from '../../rpc/hooks';
+import { useSessionWatch, sessionIsInactive } from '../../rpc/hooks';
 import { PinStrip } from '../Interaction/PinStrip';
 import { RangeSelectionLayer } from '../Interaction/RangeSelectionLayer';
 import { ApprovalEditor } from '../Interaction/ApprovalEditor';
@@ -31,6 +31,7 @@ function getMockStore(sessionId: string): SessionStore {
 
 export function GanttPlaceholder() {
   const sessionId = useUiStore((s) => s.currentSessionId);
+  const activeRenderer = useUiStore((s) => s.activeRenderer);
   const watch = useSessionWatch(sessionId);
   const mock = useMemo(
     () => (sessionId ? getMockStore(sessionId) : new SessionStore()),
@@ -54,6 +55,36 @@ export function GanttPlaceholder() {
     handle = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(handle);
   }, [sessionId, store, useLive]);
+
+  // Completed-session autofit: when we load a session that's already done,
+  // the default live-follow viewport happily advances wall-clock past the
+  // last span and presents an empty canvas. Fit-all once per session so the
+  // user lands on the whole run. We gate on `initialBurstComplete` so the
+  // math sees real spans, not an empty index. `fitAll()` clears liveFollow,
+  // and we only fire once per session id to avoid fighting subsequent user
+  // pans. The ref key is sessionId-scoped so rejoining a different session
+  // re-evaluates.
+  const autofittedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!sessionId || !useLive || !activeRenderer) return;
+    if (autofittedRef.current === sessionId) return;
+    if (!watch.initialBurstComplete) return;
+    if (!sessionIsInactive(watch)) return;
+    // Guard: if the session has zero spans (e.g. a stillborn run), fitAll
+    // would collapse to a 0-width window. Skip and let the default 5-min
+    // viewport stand — there's nothing to look at anyway.
+    if (store.spans.maxEndMs() <= 0) return;
+    activeRenderer.fitAll();
+    autofittedRef.current = sessionId;
+  }, [
+    sessionId,
+    useLive,
+    activeRenderer,
+    watch,
+    watch.initialBurstComplete,
+    watch.sessionStatus,
+    store,
+  ]);
 
   if (!sessionId) {
     return (

--- a/frontend/src/components/LiveActivity/LiveActivityPanel.tsx
+++ b/frontend/src/components/LiveActivity/LiveActivityPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useUiStore } from '../../state/uiStore';
-import { useSessionWatch } from '../../rpc/hooks';
+import { useSessionWatch, sessionIsInactive } from '../../rpc/hooks';
 import { colorForAgent } from '../../theme/agentColors';
 import { formatDuration } from '../../lib/format';
 import type { Span, AttributeValue } from '../../gantt/types';
@@ -76,11 +76,32 @@ export function LiveActivityPanel() {
   const store = watch.store;
   const items: ActiveItem[] = [];
 
-  // Find all running INVOCATION spans across agents.
-  const allSpans = store.spans.queryRange(
-    -Number.MAX_SAFE_INTEGER,
-    Number.MAX_SAFE_INTEGER,
+  // Suppress the "LIVE ACTIVITY · N RUNNING" header entirely once the
+  // session is done. INVOCATION spans that never got an explicit end event
+  // (the server runs out before the ADK runner cleanly closes them) would
+  // otherwise keep the header stuck on agents that haven't actually been
+  // doing anything for minutes. Once the session is COMPLETED/ABORTED or
+  // the stream has been quiet long enough, nothing is "running".
+  //
+  // nowWallMs starts at 0 on first render (Date.now is impure so it's only
+  // sampled inside the setInterval callback). When we don't have a wall
+  // clock yet we still honor the explicit COMPLETED/ABORTED status; the
+  // staleness-based fallback needs a real reference time, so we pass
+  // lastEventAtMs - this guarantees the fallback branch's (nowWallMs -
+  // lastEventAtMs) comparison evaluates to 0 and the helper returns false,
+  // exactly what we want until the tick populates nowWallMs.
+  const inactive = sessionIsInactive(
+    watch,
+    nowWallMs > 0 ? nowWallMs : watch.lastEventAtMs,
   );
+
+  // Find all running INVOCATION spans across agents.
+  const allSpans = inactive
+    ? []
+    : store.spans.queryRange(
+        -Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+      );
   const runningByAgent = new Map<string, Span>();
   for (const s of allSpans) {
     if (s.kind !== 'INVOCATION' || s.endMs !== null) continue;

--- a/frontend/src/gantt/GanttCanvas.tsx
+++ b/frontend/src/gantt/GanttCanvas.tsx
@@ -400,6 +400,10 @@ export function GanttCanvas({ store, height, renderOverlay }: Props) {
           ⟳ Return to live
         </button>
       )}
+      <EmptyWindowHint renderer={renderer} store={store} tick={overlayTick} />
+      {/* overlayTick read above so React re-evaluates visibility when the
+          renderer's onViewportChange fires — otherwise a post-activity pan
+          wouldn't redraw the hint. */}
       {hiddenAgentIds.size > 0 && (
         <button
           onClick={showAllAgents}
@@ -447,6 +451,63 @@ function layer(z: number): React.CSSProperties {
     zIndex: z,
     pointerEvents: 'none',
   };
+}
+
+// Inline hint shown when the user has panned/zoomed to a window that
+// contains no spans on a session with recorded activity. Clicking it slides
+// the viewport to the last activity while preserving zoom — the common
+// failure mode (#89) is opening a completed session whose default 5-minute
+// live window lands past the last span. This also serves as a safety net
+// for that same shape on a live session where the user pans into the
+// future.
+interface EmptyWindowHintProps {
+  renderer: GanttRenderer;
+  store: SessionStore;
+  tick: number;
+}
+function EmptyWindowHint({ renderer, store, tick }: EmptyWindowHintProps) {
+  // Read through renderer state rather than holding our own — the renderer
+  // is the source of truth and tick ensures we re-evaluate on viewport
+  // changes. `tick` is load-bearing here: React wouldn't otherwise notice
+  // that getViewport() has returned something new.
+  void tick;
+  const v = renderer.getViewport();
+  const maxEnd = store.spans.maxEndMs();
+  // Gate: only show when there's recorded activity, we're not in live
+  // follow (so not actively tracking a cursor that will catch up), and
+  // the viewport left edge sits past the last activity. The right-edge
+  // margin keeps the hint from flickering on/off during drag-zoom at the
+  // boundary.
+  if (maxEnd <= 0) return null;
+  if (v.liveFollow) return null;
+  const vs = v.endMs - v.windowMs;
+  const beyondEnd = vs > maxEnd;
+  if (!beyondEnd) return null;
+  return (
+    <button
+      data-testid="gantt-empty-window-hint"
+      onClick={() => renderer.jumpToLastActivity()}
+      style={{
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        padding: '10px 18px',
+        borderRadius: 999,
+        border: '1px solid var(--md-sys-color-outline-variant, #43474e)',
+        background: 'var(--md-sys-color-surface-container-high, #262931)',
+        color: 'var(--md-sys-color-on-surface, #e2e2e9)',
+        cursor: 'pointer',
+        fontSize: 13,
+        fontWeight: 500,
+        boxShadow: '0 4px 16px rgba(0,0,0,0.4)',
+        zIndex: 10,
+      }}
+      title="Jump to the last recorded activity in this session"
+    >
+      No activity in this window &middot; Jump to last activity
+    </button>
+  );
 }
 
 // Expose renderer through a ref-less side-channel for stress harness.

--- a/frontend/src/gantt/renderer.ts
+++ b/frontend/src/gantt/renderer.ts
@@ -476,6 +476,26 @@ export class GanttRenderer {
     });
   }
 
+  // Slide the current zoom window to land just past the last recorded span
+  // end, preserving window duration. Used by the "no activity in this window
+  // — jump to last activity" hint on completed sessions. Unlike fitAll(),
+  // this keeps the user's current zoom level, so a 30-second window doesn't
+  // get zoomed out to cover the full run; they just stop looking at empty
+  // space. Clears liveFollow since we're jumping to a fixed point.
+  jumpToLastActivity(): void {
+    const maxEnd = this.store.spans.maxEndMs();
+    if (maxEnd <= 0) return;
+    const windowMs = this.viewport.windowMs;
+    // Anchor so the last activity sits at ~80% of the visible width, leaving
+    // a narrow margin on the right for visual breathing room.
+    const endMs = Math.max(windowMs, maxEnd + windowMs * 0.2);
+    this.setViewport({
+      ...this.viewport,
+      endMs,
+      liveFollow: false,
+    });
+  }
+
   focusAgent(agentId: string | null): void {
     this.focusedAgentId = agentId;
     this.bgDirty = true;

--- a/frontend/src/rpc/hooks.ts
+++ b/frontend/src/rpc/hooks.ts
@@ -22,7 +22,24 @@ import {
 import { useAnnotationStore } from '../state/annotationStore';
 import { packLanes } from '../gantt/layout';
 import type { ListSessionsResponse } from '../pb/harmonograf/v1/frontend_pb.js';
+import { SessionStatus as PbSessionStatus } from '../pb/harmonograf/v1/types_pb.js';
 import { applyGoldfiveEvent } from './goldfiveEvent';
+
+// Translate the generated SessionStatus enum to the closed string set
+// consumers actually care about. Unknown numeric values fall through to
+// 'UNKNOWN' so a forward-compatible server can't blow the UI up.
+function lifecycleFromPb(status: PbSessionStatus): SessionLifecycle {
+  switch (status) {
+    case PbSessionStatus.LIVE:
+      return 'LIVE';
+    case PbSessionStatus.COMPLETED:
+      return 'COMPLETED';
+    case PbSessionStatus.ABORTED:
+      return 'ABORTED';
+    default:
+      return 'UNKNOWN';
+  }
+}
 
 // --- Sessions list (polled) -------------------------------------------------
 
@@ -71,11 +88,26 @@ export function useSessions(pollIntervalMs = 5000): SessionsState {
 
 // --- Session watch (server-streaming) --------------------------------------
 
+// Lifecycle status exposed to consumers. We translate the wire enum so UI
+// code can switch on a small closed set without importing the generated
+// pb.ts types everywhere. 'UNKNOWN' means the stream hasn't delivered the
+// initial session payload yet.
+export type SessionLifecycle = 'UNKNOWN' | 'LIVE' | 'COMPLETED' | 'ABORTED';
+
 interface WatchSessionState {
   store: SessionStore;
   connected: boolean;
   initialBurstComplete: boolean;
   error: string | null;
+  // Session lifecycle as of the last stream event that reported it. Starts
+  // at 'UNKNOWN' before the initial session frame arrives; flips to
+  // COMPLETED/ABORTED when SessionEnded is received or the server initially
+  // reports an already-finished session during burst replay.
+  sessionStatus: SessionLifecycle;
+  // Wall-clock ms of the last event received on this stream. Consumers use
+  // this as a heuristic for "still live" when the server side hasn't
+  // transitioned status yet (e.g. if SessionEnded was never emitted).
+  lastEventAtMs: number;
 }
 
 // One SessionStore per sessionId, shared across hook consumers. Stores persist
@@ -83,6 +115,8 @@ interface WatchSessionState {
 // a second time rejoins the existing stream.
 const storeCache = new Map<string, SessionStore>();
 const originCache = new Map<string, SessionOrigin>();
+const statusCache = new Map<string, SessionLifecycle>();
+const lastEventCache = new Map<string, number>();
 const refCounts = new Map<string, number>();
 const abortControllers = new Map<string, AbortController>();
 
@@ -101,6 +135,44 @@ function getOrCreateStore(sessionId: string): SessionStore {
 export function getSessionStore(sessionId: string | null): SessionStore | undefined {
   if (!sessionId) return undefined;
   return storeCache.get(sessionId);
+}
+
+// Inactivity threshold (wall-clock ms) after which the heuristic treats a
+// session as "effectively completed" even if the server hasn't emitted a
+// SessionEnded yet. Kept generous so a momentarily chatty-but-slow agent
+// doesn't flip the viewport to fit-all mid-run.
+export const INACTIVITY_COMPLETED_MS = 30_000;
+
+/**
+ * True if a session is done (or effectively done) and the Gantt should stop
+ * following a live cursor. Accepts the structure returned by
+ * :func:`useSessionWatch` and a wall-clock reference for deterministic tests.
+ * Returns false until the initial burst is complete so we don't autofit on a
+ * fresh session whose first event hasn't arrived yet.
+ */
+export function sessionIsInactive(
+  state: Pick<
+    WatchSessionState,
+    'sessionStatus' | 'lastEventAtMs' | 'initialBurstComplete' | 'connected'
+  >,
+  nowWallMs: number = Date.now(),
+  inactivityMs: number = INACTIVITY_COMPLETED_MS,
+): boolean {
+  if (!state.initialBurstComplete) return false;
+  if (state.sessionStatus === 'COMPLETED' || state.sessionStatus === 'ABORTED') {
+    return true;
+  }
+  // Fallback: server didn't flip status but the stream has been quiet and
+  // we've been disconnected long enough that any live session would have
+  // heartbeated by now.
+  if (
+    !state.connected &&
+    state.lastEventAtMs > 0 &&
+    nowWallMs - state.lastEventAtMs > inactivityMs
+  ) {
+    return true;
+  }
+  return false;
 }
 
 // Reactive hook that re-renders whenever the agent registry changes for the
@@ -125,6 +197,8 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
     connected: false,
     initialBurstComplete: false,
     error: null,
+    sessionStatus: 'UNKNOWN',
+    lastEventAtMs: 0,
   });
 
   useEffect(() => {
@@ -135,6 +209,11 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
       connected: refCounts.get(sessionId) ? true : false,
       initialBurstComplete: false,
       error: null,
+      // Seed from module-level caches so a second consumer that joins an
+      // already-open subscription sees the last reported status immediately,
+      // not 'UNKNOWN' until the next event lands.
+      sessionStatus: statusCache.get(sessionId) ?? 'UNKNOWN',
+      lastEventAtMs: lastEventCache.get(sessionId) ?? 0,
     };
     setTick((n) => n + 1);
 
@@ -173,6 +252,14 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
           const kind = update.kind;
           if (!kind.case) continue;
 
+          // Every payload counts as a liveness tick. We don't guard on kind
+          // because all variants (including heartbeat-ish messages) prove
+          // the server considers the session active.
+          const nowWall = Date.now();
+          lastEventCache.set(sessionId, nowWall);
+          stateRef.current = { ...stateRef.current, lastEventAtMs: nowWall };
+          let statusChanged = false;
+
           switch (kind.case) {
             case 'session': {
               const s = kind.value;
@@ -181,6 +268,26 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
               origin = { startMs };
               originCache.set(sessionId, origin);
               store.wallClockStartMs = startMs;
+              const nextStatus = lifecycleFromPb(s.status);
+              if (statusCache.get(sessionId) !== nextStatus) {
+                statusCache.set(sessionId, nextStatus);
+                stateRef.current = { ...stateRef.current, sessionStatus: nextStatus };
+                statusChanged = true;
+              }
+              break;
+            }
+            case 'sessionEnded': {
+              const next = lifecycleFromPb(kind.value.finalStatus);
+              // Treat any terminal transition as COMPLETED-ish if the
+              // server didn't set final_status; better to auto-fit than
+              // leave the viewport stuck following a live cursor that
+              // will never advance again.
+              const resolved = next === 'UNKNOWN' ? 'COMPLETED' : next;
+              if (statusCache.get(sessionId) !== resolved) {
+                statusCache.set(sessionId, resolved);
+                stateRef.current = { ...stateRef.current, sessionStatus: resolved };
+                statusChanged = true;
+              }
               break;
             }
             case 'agent': {
@@ -381,6 +488,13 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
             }
             default:
               break;
+          }
+          if (statusChanged) {
+            // Only rerender on lifecycle flips; per-event ticks would thrash
+            // every consumer of the hook. Other event kinds already push
+            // updates through the SessionStore subscribe channels that
+            // React chrome subscribes to directly.
+            setTick((n) => n + 1);
           }
         }
       } catch (e) {


### PR DESCRIPTION
## Summary

Fixes harmonograf#89: on completed sessions the Gantt defaults to a 5-minute live-follow window that advances wall-clock past the session's last span, so users land on an empty canvas even when spans exist. The Live Activity header also stays stuck on "N RUNNING" forever because INVOCATION spans never got a clean endMs.

- Track session lifecycle + last-event ms in `useSessionWatch`; populate from the initial `session` payload and the previously-unhandled `SessionEnded` case.
- New `sessionIsInactive()` helper — explicit COMPLETED/ABORTED or a 30s disconnect/inactivity fallback for servers that never emit SessionEnded.
- On initial burst complete, if the session is inactive, call `renderer.fitAll()` once per session id so the viewport frames the whole run.
- Suppress `LiveActivityPanel`'s running header on inactive sessions.
- `renderer.jumpToLastActivity()` + inline "No activity in this window" hint inside `GanttCanvas` for any post-activity pan (safety net beyond the autofit).

## Before / after

Before: opening session `final2_1776831209` (71 spans across 5 agent rows, activity 0-16m) showed empty rows because the default viewport was 19m-24m, and the header reported "LIVE ACTIVITY · 2 RUNNING" on coordinator + web_developer agents.

After: viewport auto-fits to cover the full 16-minute run with ~5% right-side margin; live-activity header flips to "No active work".

## Test plan

- [x] `pnpm test` — 258 tests pass (27 files; 15 new tests).
- [x] `pnpm lint` — clean.
- [x] `pnpm build` — tsc + vite build clean.
- [ ] CI server/client/frontend/standalone green.
- [ ] Manual verification against `final2_1776831209` on :5173.

## Files

- `frontend/src/rpc/hooks.ts` — lifecycle tracking + `sessionIsInactive`.
- `frontend/src/gantt/renderer.ts` — `jumpToLastActivity()`.
- `frontend/src/gantt/GanttCanvas.tsx` — inline empty-window hint.
- `frontend/src/components/Gantt/GanttPlaceholder.tsx` — one-shot autofit on inactive session load.
- `frontend/src/components/LiveActivity/LiveActivityPanel.tsx` — suppress running header on inactive sessions.
- `frontend/src/__tests__/rpc/hooks.test.ts`, `__tests__/gantt/viewportFit.test.ts`, `__tests__/components/LiveActivityPanel.test.tsx` — new coverage.