### PR TITLE
docs: refresh top-level + tour + quickstart for current state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,52 +1,140 @@
 # AGENTS.md
 
-This file provides guidance to agents, including Claude Code, Antigravity, Opencode, when working with code in this repository.
+This file provides guidance to agents — Claude Code, Antigravity, Opencode,
+and anyone else — working with code in this repository. Treat it as the
+durable project charter.
 
 ## Project vision
 
-Harmonograf is an observability console for multi-agent workflows. **Goldfive
-is optional.** Harmonograf works standalone for any agent that emits spans via
-`harmonograf_client.Client`; plans, tasks, and drift come from
-[goldfive](https://github.com/pedapudi/goldfive) if you opt in via the
-`orchestration` extra. See [`docs/standalone-observability.md`](docs/standalone-observability.md)
-for the standalone guide and [`docs/goldfive-integration.md`](docs/goldfive-integration.md)
-for the orchestration path.
+Harmonograf is the observability + HCI companion to
+[goldfive](https://github.com/pedapudi/goldfive) for multi-agent
+orchestration. **Goldfive is optional for read-only observation**:
+harmonograf works for any agent that emits spans via
+`harmonograf_client.Client` or attaches a `HarmonografTelemetryPlugin` to a
+bare ADK `App`. Plans, tasks, drift, and the full intervention surface light
+up when the run goes through `goldfive.wrap(...)`. See
+[`docs/standalone-observability.md`](docs/standalone-observability.md) for
+the no-goldfive path and
+[`docs/goldfive-integration.md`](docs/goldfive-integration.md) for the
+full-orchestration path.
 
 When goldfive *is* in the picture: goldfive owns the plan, the task state
 machine, the drift taxonomy, the reporting tools, and the re-invocation loop.
 Harmonograf owns the session, the span timeline, the canonical storage, the
-Gantt/graph frontend, and the control router that lets a human intervene on
-the same connection they observe on.
+frontend (Gantt / Graph / Trajectory / Notes / Settings), the intervention
+aggregator, and the control router that lets a human intervene on the same
+connection they observe on.
 
-The line is load-bearing: orchestration changes belong in goldfive; observability
-and UI changes belong in harmonograf. If a change has to straddle both, the
-goldfive-side change lands first and harmonograf follows.
+The line is load-bearing: orchestration changes belong in goldfive;
+observability and UI changes belong in harmonograf. If a change has to
+straddle both, the goldfive-side change lands first and harmonograf follows.
 
 ### Proto coupling caveat
 
-Phase A of the goldfive migration (issue #6) moved plan/task/drift types into
-goldfive's proto package. Harmonograf's `TelemetryUp.goldfive_event` therefore
-references `goldfive.v1.Event` directly, and the generated pb stubs import
-from `goldfive.pb.goldfive.v1`. Consequence: `harmonograf_client` cannot be
-*installed* without goldfive present, but user code can (and should) be
-goldfive-import-free in the standalone case. The `standalone-test` CI job
-enforces this via `grep -i goldfive examples/standalone_observability/spans_only.py`.
+Phase A of the goldfive migration (issue #6, COMPLETED) moved plan/task/drift
+types into goldfive's proto package. Harmonograf's `TelemetryUp.goldfive_event`
+therefore references `goldfive.v1.Event` directly, and the generated pb stubs
+import from `goldfive.pb.goldfive.v1`. Consequence: `harmonograf_client`
+cannot be *installed* without goldfive present, but user code can (and
+should) be goldfive-import-free in the standalone case. The
+`standalone-test` CI job enforces this via
+`grep -i goldfive examples/standalone_observability/spans_only.py`.
+
+## Repository layout
+
+```
+harmonograf/
+  server/harmonograf_server/       # gRPC server (asyncio, grpcio + sonora)
+    ingest.py                      # telemetry ingest pipeline
+    bus.py                         # per-session fan-out bus
+    control_router.py              # frontend → agent control routing
+    interventions.py               # intervention history aggregator (#69/#71)
+    rpc/                           # RPC servicer impls (telemetry, control, frontend)
+    storage/                       # SQLite + in-memory stores
+    pb/                            # generated Python pb stubs (from proto/)
+  client/harmonograf_client/       # Python client library
+    client.py                      # top-level handle + identity/heartbeat
+    transport.py                   # buffered bidi gRPC transport (lazy Hello)
+    buffer.py                      # ring buffer + envelope kinds
+    sink.py                        # goldfive.EventSink adapter
+    observe.py                     # observe(runner) helper (issue #22)
+    telemetry_plugin.py            # ADK BasePlugin for lifecycle spans (#74/#80)
+    _control_bridge.py             # control-stream ↔ goldfive.ControlChannel bridge
+    pb/                            # generated Python pb stubs
+  frontend/                        # React + Vite + TypeScript
+    src/components/shell/views/    # ActivityView, GraphView, TrajectoryView, NotesView, SettingsView
+    src/components/Interventions/  # intervention timeline strip (#76)
+    src/components/Gantt/          # gantt chrome (minimap, legend, ctx badges)
+    src/gantt/                     # canvas renderer, layout, drift/span kinds
+    src/state/                     # Zustand stores (sessions, popover, ui, annotations)
+    src/rpc/                       # connect-rpc client + sessions syncer
+    src/pb/                        # generated TS pb stubs
+  proto/harmonograf/v1/            # harmonograf proto (imports goldfive/v1/*)
+  docs/                            # durable, tree-based documentation
+  tests/
+    e2e/                           # end-to-end tests
+    reference_agents/              # demo/reference ADK agents
+  examples/standalone_observability/ # non-goldfive examples
+  .agents/skills/                  # structured skill bundles for AI coders
+  third_party/                     # adk-python clone lives here (git-ignored)
+  Makefile                         # make install / demo / test / proto
+```
 
 ## High-level architecture
 
 Three components, and changes usually span more than one of them:
 
-1. **Visual frontend** (`frontend/`) — a Gantt-chart-style view. X-axis is time, Y-axis is one row per agent, and each block represents an agent activity (span, tool call, transfer). Blocks are interactive (clickable) to drill into details. Plan and task state surfaces are rendered from goldfive events (`PlanSubmitted`, `PlanRevised`, `TaskStarted`, `TaskCompleted`, `TaskFailed`, `DriftDetected`, …) delivered through the harmonograf server. This is the human-facing surface for observing and coordinating agents.
+1. **Visual frontend** (`frontend/`) — a six-view shell (Sessions, Activity,
+   Graph, Trajectory, Notes, Settings). Activity is the Gantt: X-axis is
+   time, Y-axis is one row per ADK agent (auto-registered from span attrs
+   per harmonograf#74/#80), each block is an agent activity (span, tool
+   call, transfer). Trajectory is the intervention-history ribbon
+   (#69/#76). Plan, task, and drift state surfaces are rendered from
+   goldfive events (`PlanSubmitted`, `PlanRevised`, `TaskStarted`,
+   `TaskCompleted`, `TaskFailed`, `DriftDetected`, `AgentInvocationStarted`,
+   `DelegationObserved`, …) delivered through the harmonograf server.
 
-2. **Client library** (`client/`) — embedded inside agent processes. Two public surfaces: `Client` handles the span transport, payload upload, control-handler registration, identity, heartbeat; `HarmonografSink` is a `goldfive.EventSink` that translates goldfive `Event` envelopes into harmonograf `TelemetryUp` frames. Users construct a `goldfive.Runner`, install a `HarmonografSink`, and the run's plan/task/drift events reach the frontend alongside the span stream. An optional `HarmonografTelemetryPlugin` (ADK `BasePlugin`) emits spans for ADK callbacks when users want framework-level telemetry.
+2. **Client library** (`client/`) — embedded inside agent processes. Public
+   surfaces:
+   - `Client` — span transport, payload upload, control-handler
+     registration, identity, heartbeat; lazy Hello (harmonograf#85) so no
+     ghost session is created until the first real emit.
+   - `HarmonografSink` — `goldfive.EventSink` that translates goldfive
+     `Event` envelopes into `TelemetryUp.goldfive_event` frames.
+   - `HarmonografTelemetryPlugin` — ADK `BasePlugin` that emits spans for
+     lifecycle callbacks and stacks per-ADK-agent ids onto each span so the
+     server can auto-register one Gantt row per agent in the wrapped tree.
+     Dedups itself silently if installed twice (#68).
+   - `observe(runner)` — one-line helper that attaches the sink + optional
+     control bridge to an existing `goldfive.Runner`. See issue #22.
 
-3. **Server process** (`server/`) — hosts the frontend and terminates connections from client libraries across all participating agents. It is the fan-in point: many clients, one server, one UI. It owns the canonical timeline (sessions, agents, spans, annotations, payloads) and the derived plan/task index built from goldfive events. It is also the bridge that lets the frontend coordinate agents, not just observe them.
+3. **Server process** (`server/`) — terminates gRPC connections from every
+   client and gRPC-Web connections from every frontend. Owns the canonical
+   timeline (sessions, agents, spans, annotations, payloads) and the
+   derived plan / task / drift index built from goldfive events. Aggregates
+   the intervention history view across annotations + drift ring +
+   plan-revision metadata (`interventions.py`, `ListInterventions` RPC,
+   #69/#71). Merges duplicate user-control interventions inside a 5-minute
+   window (#81, #87). Routes control events from the frontend to the
+   correct per-agent subscribers.
 
 Key cross-cutting concerns to keep in mind when designing any piece:
-- The data model for observability (session, agent, span, payload, annotation, control event) is defined once in `proto/harmonograf/v1/*.proto` and shared across all three components.
-- Plan, task, drift, and reporting-tool types are defined once in `proto/goldfive/v1/*.proto` and imported into harmonograf's proto tree. Do not re-declare them in harmonograf.
-- The frontend is not read-only — interactions flow back through the server to clients, so the client library needs a bidirectional channel, not just telemetry egress.
-- "Coordinating" implies the server may mediate control (pause, resume, steer, cancel), not just display — design client APIs with that in mind rather than treating it purely as an observability tool.
+- The data model for observability (session, agent, span, payload,
+  annotation, control event, intervention) is defined once in
+  `proto/harmonograf/v1/*.proto` and shared across all three components.
+- Plan, task, drift, and reporting-tool types are defined once in
+  `proto/goldfive/v1/*.proto` and imported into harmonograf's proto tree.
+  Do not re-declare them in harmonograf.
+- The frontend is not read-only — interactions flow back through the server
+  to clients, so the client library needs a bidirectional channel, not just
+  telemetry egress.
+- "Coordinating" implies the server mediates control (pause, resume, steer,
+  cancel), not just display — design client APIs with that in mind rather
+  than treating it purely as an observability tool.
+- Sessions unify the ADK session id (what the user sees in `adk web`) with
+  harmonograf's session id. Goldfive events and spans route by
+  `ctx.session.id` / per-event `session_id` respectively, so one outer
+  session gathers everything the user drove (harmonograf#63/#66).
 
 ## Goldfive integration
 
@@ -61,20 +149,48 @@ Orchestration semantics — session-state keys, reporting tool bodies, drift
 taxonomy, refine pipeline, invariant validator, parallel DAG walker — are
 goldfive concerns. When a question is "why does the agent state machine behave
 this way?", the answer lives in the goldfive repo. When a question is "why did
-the timeline render this span where it did?", the answer lives here.
+the timeline render this span where it did?" or "why did this STEER dedupe
+with that drift?", the answer lives here.
 
 ## Component boundaries
 
-- **Span emission is harmonograf's job.** ADK callbacks (BEFORE/AFTER model/tool/run, state_delta, transfer, escalate) are turned into spans by `HarmonografTelemetryPlugin`. Goldfive does not produce spans.
-- **Task state is goldfive's job.** State transitions happen inside goldfive's `DefaultSteerer` when a reporting tool is called or when an ADK event implies a transition. Harmonograf learns about those transitions only through goldfive events on the sink.
-- **Control routing is harmonograf's job.** The frontend → server → agent path (pause, resume, steer, cancel, annotate) rides harmonograf's control stream. Goldfive exposes hooks that let an orchestrated run react to delivered control events, but the wire is harmonograf's.
-- **Session is harmonograf's job.** Goldfive has a `run_id`; harmonograf pairs it with a `session_id` at the storage layer. One goldfive run maps to one harmonograf session.
+- **Span emission is harmonograf's job.** ADK callbacks (BEFORE/AFTER
+  model/tool/run/agent, state_delta, transfer, escalate) are turned into
+  spans by `HarmonografTelemetryPlugin`. Goldfive does not produce spans.
+- **Per-ADK-agent attribution is harmonograf's job.** The plugin stacks
+  `per_agent_id = "{client_id}:{adk_name}"` via before/after_agent callbacks
+  and rides agent hints (name, parent, kind, branch, framework) on the first
+  span each agent emits. The server's `_ensure_route` auto-registers agents
+  from those hints (harmonograf#74/#80).
+- **Task state is goldfive's job.** State transitions happen inside
+  goldfive's `DefaultSteerer` when a reporting tool is called or when an ADK
+  event implies a transition. Harmonograf learns about those transitions
+  only through goldfive events on the sink.
+- **Control routing is harmonograf's job.** The frontend → server → agent
+  path (pause, resume, steer, cancel, annotate) rides harmonograf's control
+  stream. Goldfive's `ControlChannel` exposes hooks that let an orchestrated
+  run react to delivered control events, but the wire is harmonograf's.
+  `ControlBridge` validates STEER body (empty / >8 KiB UTF-8 rejected, ASCII
+  control chars stripped) pre-forward; the server stamps
+  `SteerPayload.author` + `SteerPayload.annotation_id` before delivery
+  (harmonograf#72).
+- **Session is harmonograf's job.** Goldfive has a `run_id`; harmonograf
+  pairs it with a `session_id` at the storage layer. Under ADK, the outer
+  `adk-web` session id is pinned on `goldfive.Session.id`, so one goldfive
+  run + its outer ADK chat lane collapse onto one harmonograf session
+  (harmonograf#63/#66).
+- **Intervention aggregation is harmonograf's job.** `interventions.py`
+  derives the chronological list from annotations + ingest drift ring +
+  `task_plans.revision_kind`, with a 5-minute merge window for user-control
+  kinds and a tight window for autonomous drift (#81/#87). The
+  `ListInterventions(session_id)` unary RPC returns it; the frontend has a
+  live deriver that mirrors the shape for in-flight deltas.
 
 ## Things explicitly deleted from the pre-goldfive era
 
 If you see these in docs or code, they are retired — do not bring them back:
 
-- `HarmonografAgent`, `HarmonografRunner`, `attach_adk`, `make_adk_plugin`, `make_harmonograf_agent`, `make_harmonograf_runner` — replaced by `goldfive.Runner` + `HarmonografSink`.
+- `HarmonografAgent`, `HarmonografRunner`, `attach_adk`, `make_adk_plugin`, `make_harmonograf_agent`, `make_harmonograf_runner` — replaced by `goldfive.Runner` + `HarmonografSink` + `observe()`.
 - `_AdkState`, `PlannerHelper`, `LLMPlanner`, `PassthroughPlanner` — replaced by goldfive's steerer/planner.
 - `state_protocol.py` with the `harmonograf.*` session-state keys — replaced by goldfive's `SessionContext`.
 - `invariants.py`, `metrics.py` in the client — invariant checking is goldfive's responsibility.
@@ -83,3 +199,81 @@ If you see these in docs or code, they are retired — do not bring them back:
 
 The full inventory of what moved, what stayed, and what was deleted is in
 [docs/goldfive-migration-plan.md](docs/goldfive-migration-plan.md).
+
+## Running tests
+
+From the repo root:
+
+```bash
+make test               # server + client + frontend (pnpm build + lint)
+make server-test        # just server/tests/ (pytest, asyncio)
+make client-test        # just client/tests/
+make frontend-test      # pnpm build + pnpm lint
+make e2e                # end-to-end tests under tests/e2e/
+```
+
+The proto stubs are checked in; only regenerate them (`make proto`) when
+you edit `proto/harmonograf/v1/*.proto`. `make proto` resolves goldfive's
+proto tree via the installed package (editable-dep-aware; no hardcoded
+path).
+
+## PR workflow
+
+- Branch names follow `kind/short-description` or `kind/harmonograf-NN-slug`
+  when tied to an issue. Examples: `docs/top-level-refresh`,
+  `fix/harmonograf-89-gantt-viewport`.
+- Commits, branches, and PR titles do **not** use a Claude / AI co-author
+  trailer. The user scrubs them.
+- Prefer small PRs. When a change straddles server + client + frontend,
+  split by layer when feasible; otherwise call out the three-way coupling
+  in the PR body.
+- PR CI gates: server pytest, client pytest, frontend `pnpm build &&
+  pnpm lint`, `standalone-test` (proves `examples/standalone_observability/
+  spans_only.py` has no `goldfive` imports).
+- Self-merge after CI green unless the user requests review.
+
+## Documentation layout
+
+Under `docs/`:
+
+- `tour/` — 15-minute tour, mental model, terminology map, front-door index.
+- `user-guide/` — UI reference by region (Gantt, Graph, Trajectory, drawer,
+  control actions, annotations, keyboard shortcuts, etc.).
+- `dev-guide/` — setup, architecture, per-component internals, testing,
+  debugging, protos, contribution workflow.
+- `protocol/` — wire reference (telemetry, control, frontend-RPC, span
+  lifecycle, payload flow, wire-ordering).
+- `design/` — per-component design notes (data model, client, server,
+  frontend, HCI model, information flow).
+- `adr/` — Architecture Decision Records ("we decided X because Y").
+- `runbooks/` — triage for common failure modes.
+- `internals/` — annotated hot-path tours.
+- Top-level: `quickstart.md`, `overview.md`, `operator-quickstart.md`,
+  `standalone-observability.md`, `goldfive-integration.md`,
+  `goldfive-migration-plan.md` (completed), `reporting-tools.md` (redirect
+  to goldfive), `milestones.md`, `index.md`.
+
+For architectural decisions reach for `docs/adr/` first; it lists *why* a
+given shape exists, which is usually the thing you need before a refactor.
+
+## Skill system
+
+Structured skill bundles live under `.agents/skills/`, each one a focused
+"how to do X" recipe with explicit file touchpoints. Categories include:
+
+- Proto edits: `hgraf-add-proto-field`, `hgraf-add-proto-message`,
+  `hgraf-bump-proto-version`.
+- Taxonomy/vocabulary additions: `hgraf-add-drift-kind`,
+  `hgraf-add-span-kind`, `hgraf-add-control-kind`,
+  `hgraf-add-annotation-kind`, `hgraf-add-capability`.
+- Frontend UX: `hgraf-add-drawer-tab`, `hgraf-add-gantt-overlay`,
+  `hgraf-add-renderer-overlay`, `hgraf-add-keyboard-shortcut`,
+  `hgraf-update-frontend-component`.
+- Ops / debugging: `hgraf-debug-frontend-state`, `hgraf-debug-task-stuck`,
+  `hgraf-profile-callback-perf`, `hgraf-tune-heartbeat`,
+  `hgraf-interpret-invariant-violations`, `hgraf-run-demo`.
+- Workflow: `hgraf-review-pr`, `hgraf-spawn-agent-team`,
+  `hgraf-write-e2e-scenario`, `hgraf-read-memory-bank`.
+
+When you're about to do one of these things, load the matching skill first
+— they encode the exact list of files to touch.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
 # Harmonograf
 
-**The observability console for multi-agent workflows.**
+**The observability + HCI companion to [goldfive](https://github.com/pedapudi/goldfive)
+for multi-agent orchestration.**
 
-Harmonograf renders agent activity as a Gantt-style timeline, lets humans
-intervene with control events on the same connection it observes them on, and
-works two ways:
+Harmonograf renders agent activity as a Gantt-style timeline, surfaces the
+plan / task / drift story goldfive emits, tracks every human intervention
+chronologically in a dedicated Trajectory view, and lets operators push back —
+pause, resume, steer, cancel — on the same connection it observes runs on.
 
-- **Standalone** — emit spans from any agent, from any framework, via the
-  `harmonograf_client.Client`. No orchestration. The Gantt, inspector, and
-  control surfaces light up; the Tasks panel stays empty. See
-  [`docs/standalone-observability.md`](docs/standalone-observability.md).
-- **With [goldfive](https://github.com/pedapudi/goldfive)** — opt in to the
-  orchestration extra (`uv sync --extra orchestration`) and harmonograf also
-  shows plans, tasks, and drift. Goldfive owns the plan / task state machine /
-  drift taxonomy / reporting tools; harmonograf is the screen you watch it on.
-  See [`docs/goldfive-integration.md`](docs/goldfive-integration.md).
+Three integration modes, same server, same UI:
 
-Both modes target the same server, the same wire format, and the same UI —
-the difference is purely which panels populate.
+- **`goldfive.wrap` + `HarmonografTelemetryPlugin`** — full orchestration
+  observability + steering. Plans, tasks, drift, per-ADK-agent Gantt rows,
+  and the full intervention history all light up. See
+  [`docs/goldfive-integration.md`](docs/goldfive-integration.md).
+- **Observation-only via `HarmonografTelemetryPlugin` on a bare ADK App** —
+  no orchestration, no plans/tasks, just per-invocation / per-model-call /
+  per-tool-call spans on the Gantt. Useful when you already have your own
+  orchestrator and just want the console.
+- **Standalone (non-ADK)** — construct a `harmonograf_client.Client` directly
+  from any Python process and call `emit_span_start/update/end`. The home
+  session auto-creates on first emit; no ADK, no goldfive usage surface.
+  See [`docs/standalone-observability.md`](docs/standalone-observability.md).
+
+Goldfive owns the plan / task state machine / drift taxonomy / reporting
+tools. Harmonograf is the screen you watch those run on — and the keyboard
+you reach back through.
 
 ---
 
@@ -38,16 +46,41 @@ screen you watch that story on:
 - **One canonical timeline.** The server terminates goldfive event streams from
   every participating agent and fans them out to any number of frontend
   subscribers. One server, many agents, many viewers.
-- **Plan-aware UI.** The Gantt, the inspector, and the plan-diff drawer all
-  render goldfive's plan / task / drift semantics directly. When goldfive fires
-  a `PlanRevised` event, the frontend shows the diff with the old plan side by
-  side.
+- **Plan-aware UI.** The Gantt, the inspector, the task strip, and the
+  Trajectory view all render goldfive's plan / task / drift semantics
+  directly. When goldfive fires a `PlanRevised` event, the frontend shows the
+  diff side-by-side and logs it in the intervention timeline.
+- **Per-ADK-agent rows.** Under `goldfive.wrap`, every ADK agent in the tree
+  (coordinator, specialists, AgentTool wrappers, sequential/parallel
+  containers) gets its own Gantt row, auto-registered the first time it
+  emits. You see the tree, not a collapsed root (harmonograf#74 / #80).
+- **Intervention history, first class.** The Trajectory view lists every
+  point where the plan changed direction — STEER / CANCEL / PAUSE from the
+  UI, autonomous drift, plan revisions — on one merged chronological ribbon
+  (harmonograf#69 / #71 / #76).
 - **Bidirectional by default.** The same connection that streams telemetry up
   also streams control down — pause, resume, steer, cancel, annotate — so the
   UI is a coordination surface, not a read-only dashboard.
+- **Lazy Hello, unified sessions.** Under ADK, the client defers its Hello
+  until the first real emit, so there are no ghost `sess_…` rows in the
+  session picker. Goldfive events and spans route together onto the ADK
+  session id the user sees in `adk web` (harmonograf#66 / #85).
 
-Integration is a single-line install: construct a `goldfive.Runner`, attach a
-`HarmonografSink`, and the run's events start materialising in the UI.
+Integration is a two-line install: `runner = harmonograf_client.observe(goldfive.wrap(root_agent))`
+and the run's plans, tasks, drift, spans, and steering wire all light up at once.
+
+### Views
+
+Harmonograf has six views in the nav rail:
+
+| View | What it shows |
+|---|---|
+| **Sessions** | Session picker — one row per session (post-lazy-Hello) with agent counts, attention badges, time-ago labels. |
+| **Activity** (Gantt) | Per-ADK-agent rows, time on X, bars for every LLM call / tool call / transfer / invocation. The task strip at the bottom shows current stages with per-task status chips. Minimap, live-tail cursor, transport bar. |
+| **Graph** | Agent topology — nodes are agents, edges are transfers and tool invocations. Minimap in the corner. |
+| **Trajectory** | Intervention history ribbon (harmonograf#69 / #76) — one marker per intervention (STEER, CANCEL, drift, plan revision), glyph-by-kind, color-by-source (user vs. autonomous), severity ring, density clustering. Click any marker to see who, when, why, and what happened next. |
+| **Notes** | Session-wide annotation stream. |
+| **Settings** | Server URL, theme, keyboard shortcuts reference. |
 
 ### Screenshots
 
@@ -59,7 +92,7 @@ Integration is a single-line install: construct a `goldfive.Runner`, attach a
 
 ![Agent topology graph view](docs/images/06-graph-view.png)
 
-**Session picker** — browse all sessions with agent counts, attention badges, and time-ago labels.
+**Session picker** — browse all sessions with agent counts, attention badges, and time-ago labels. One row per session post-lazy-Hello (harmonograf#85).
 
 ![Session picker overlay](docs/images/11-session-picker.png)
 
@@ -75,36 +108,46 @@ Integration is a single-line install: construct a `goldfive.Runner`, attach a
 
 ## Get running in 10 minutes
 
-### Standalone (no goldfive)
+### Hello world — `make demo`
 
-The shortest path: boot the server + frontend, and emit synthetic spans
-from a plain Python script. Nothing else.
+The fastest path to a live multi-agent rollout on screen: boot the
+server + frontend + `adk web` and drive the `presentation_agent_orchestrated`
+reference agent.
 
 ```bash
 git clone https://github.com/pedapudi/harmonograf
 cd harmonograf
-git submodule update --init --recursive
 git clone --depth 1 https://github.com/google/adk-python.git third_party/adk-python
-uv sync
+make install
+make demo                        # server + frontend + adk web
+```
+
+Then open:
+- Harmonograf UI at <http://127.0.0.1:5173>
+- `adk web` at <http://127.0.0.1:8080>
+- Pick `presentation_agent_orchestrated` in the ADK picker and drive a prompt.
+
+The agent tree + goldfive wrap come from the `presentation_agent_orchestrated`
+reference (see [`tests/reference_agents/presentation_agent_orchestrated/`](tests/reference_agents/presentation_agent_orchestrated/README.md)).
+Plans, tasks, drift, per-ADK-agent rows, and intervention markers all light
+up live. Set `$OPENAI_API_KEY` / `$GOOGLE_API_KEY` for live LLM use; leave
+them unset and the orchestrated agent falls back to a canned mock plan.
+
+### Standalone (no goldfive, no ADK)
+
+Emit synthetic spans from a plain Python script:
+
+```bash
 make demo-standalone    # server + frontend + spans_only.py
 ```
 
 The frontend renders a session with a Gantt; Tasks panel stays empty.
 Full walkthrough: [`docs/standalone-observability.md`](docs/standalone-observability.md).
 
-### With goldfive orchestration
+### Observation-only (bare ADK, no goldfive.wrap)
 
-The fastest path to see plans + tasks + drift is the goldfive
-observability quickstart. It installs goldfive + harmonograf, boots this
-stack via `make demo`, runs a CallableAdapter agent in a second shell,
-and shows the events flowing into the UI — no LLM credentials required.
-
-1. `make install` in this repo (see the full [quickstart](docs/quickstart.md) for prereqs).
-2. `uv sync --extra orchestration` to opt in to the goldfive API.
-3. `make demo` to bring up the server + frontend + ADK web.
-4. In a second shell run `examples/harmonograf_observed/agent.py` from the goldfive repo.
-
-Full walkthrough (lives in the goldfive repo): **[observability-with-harmonograf.md](https://github.com/pedapudi/goldfive/blob/main/docs/guides/observability-with-harmonograf.md)**.
+Attach a `HarmonografTelemetryPlugin` to an `App`'s `plugins=[…]`. See
+[`examples/standalone_observability/adk_telemetry.py`](examples/standalone_observability/adk_telemetry.py).
 
 ---
 
@@ -129,9 +172,9 @@ flowchart TD
 
 | Component | Path | Language | Role |
 |---|---|---|---|
-| **Frontend** | `frontend/` | TypeScript / React / Vite | Gantt timeline, agent topology graph, plan-diff drawer, inspector, transport bar. Talks gRPC-Web to the server. |
-| **Server** | `server/` | Python / asyncio / grpcio | Terminates connections from every client, owns the canonical timeline, stores it (SQLite or in-memory), and fans out live updates to any number of frontend subscribers. Also the control bridge. |
-| **Client library** | `client/` | Python | Embedded inside each agent. Provides `Client` (span transport, payload upload, control handlers) and `HarmonografSink` — a `goldfive.EventSink` that forwards goldfive plan / task / drift events into the harmonograf telemetry stream. |
+| **Frontend** | `frontend/` | TypeScript / React / Vite | Sessions list, Activity (Gantt), Graph, Trajectory (intervention history), Notes, Settings. Talks gRPC-Web to the server. |
+| **Server** | `server/` | Python / asyncio / grpcio | Terminates connections from every client, owns the canonical timeline, stores it (SQLite or in-memory), fans out live updates to any number of frontend subscribers, aggregates interventions, and routes control. |
+| **Client library** | `client/` | Python | Embedded inside each agent. Provides `Client` (span transport, payload upload, control handlers), `HarmonografSink` (a `goldfive.EventSink` that forwards plan / task / drift events), and `HarmonografTelemetryPlugin` (ADK `BasePlugin` emitting per-callback spans with per-ADK-agent attribution). |
 
 Orchestration semantics — plans, tasks, drift kinds, reporting tools, refine
 pipeline, session-state protocol — live in [goldfive](https://github.com/pedapudi/goldfive).
@@ -177,9 +220,10 @@ make demo
 on `127.0.0.1:7531` (gRPC) + `:7532` (gRPC-Web), the Vite frontend on
 `http://127.0.0.1:5173`, and `adk web` hosting two reference-agent variants on
 `http://127.0.0.1:8080` — `presentation_agent` (observation; plain ADK +
-telemetry plugin) and `presentation_agent_orchestrated` (the same tree wrapped
-with `goldfive.wrap(...)` so you see the full plan / dispatch / drift stream).
-Pick a variant in the ADK picker, drive a rollout, and watch the timeline
+`HarmonografTelemetryPlugin`) and `presentation_agent_orchestrated` (the same
+tree wrapped with `goldfive.wrap(...)` so you see the full plan / dispatch /
+drift stream, per-ADK-agent Gantt rows, and intervention history). Pick a
+variant in the ADK picker, drive a rollout, and watch the timeline
 materialise live in the harmonograf tab. Ctrl-C tears all three down.
 
 ---
@@ -188,16 +232,21 @@ materialise live in the harmonograf tab. Ctrl-C tears all three down.
 
 | Doc | Purpose |
 |---|---|
-| [docs/overview.md](docs/overview.md) | Longer-form writeup: motivation, design principles, current features, non-goals, roadmap. Start here after this README. |
+| [docs/tour/](docs/tour/index.md) | Start-here tour: three doors, 15-minute walkthrough, mental model, terminology map. |
 | [docs/quickstart.md](docs/quickstart.md) | Step-by-step from clone to running demo, with troubleshooting and local-LLM wiring. |
-| [docs/goldfive-integration.md](docs/goldfive-integration.md) | How harmonograf consumes goldfive: `HarmonografSink`, the `goldfive_event` envelope, the split of responsibilities. |
-| [docs/goldfive-migration-plan.md](docs/goldfive-migration-plan.md) | The design record for the harmonograf → goldfive migration; what moved, what stayed, what was deleted. |
-| [docs/operator-quickstart.md](docs/operator-quickstart.md) | Flags, retention, health probes, bearer-token auth — the ops-facing reference. |
-| [docs/user-guide/](docs/user-guide/) | Navigating the UI: Gantt, graph, inspector, diff drawer, transport bar, keyboard shortcuts. |
+| [docs/overview.md](docs/overview.md) | Longer-form writeup: motivation, design principles, current features, non-goals, roadmap. |
+| [docs/goldfive-integration.md](docs/goldfive-integration.md) | How harmonograf consumes goldfive: `HarmonografTelemetryPlugin`, `HarmonografSink`, `observe()`, `goldfive_event` envelope, per-ADK-agent rows, session unification. |
+| [docs/standalone-observability.md](docs/standalone-observability.md) | Non-ADK flow: emit spans from any Python process with `harmonograf_client.Client`. |
+| [docs/operator-quickstart.md](docs/operator-quickstart.md) | Flags, retention, health probes, bearer-token auth, STEER from the UI — the ops-facing reference. |
+| [docs/reporting-tools.md](docs/reporting-tools.md) | Redirect to goldfive's reporting-tool reference (owned there post-migration). |
+| [docs/user-guide/](docs/user-guide/) | Navigating the UI: Gantt, graph, trajectory, inspector, transport bar, keyboard shortcuts. |
 | [docs/dev-guide/](docs/dev-guide/) | Building from source, adding a storage backend, wiring a new framework adapter, writing tests. |
 | [docs/protocol/](docs/protocol/) | Wire protocol, proto reference, span lifecycle, control stream. |
 | [docs/design/](docs/design/) | Per-component design notes — data model, client library, server, frontend, human-interaction model, information flow. |
-| [docs/milestones.md](docs/milestones.md) | Incremental delivery plan. |
+| [docs/runbooks/](docs/runbooks/) | Triage for common failures — drift not firing, task stuck, demo-wont-start, etc. |
+| [docs/internals/](docs/internals/) | Annotated tours of hot paths (ingest bus, sqlite, session store, renderer, drift catalog). |
+| [docs/milestones.md](docs/milestones.md) | Shipped + in-flight incremental delivery. |
+| [docs/goldfive-migration-plan.md](docs/goldfive-migration-plan.md) | Design record for the harmonograf → goldfive migration. COMPLETED 2026-04-18. |
 
 Orchestration references (reporting tools, drift taxonomy, task state machine,
 session-state protocol) now live in the [goldfive](https://github.com/pedapudi/goldfive)

--- a/docs/goldfive-integration.md
+++ b/docs/goldfive-integration.md
@@ -26,9 +26,14 @@ uv sync --extra orchestration
 | Session-state protocol (`SessionContext` on ADK state) | goldfive | `goldfive.adapters.adk` |
 | Orchestration modes (sequential, parallel DAG walker, delegated) | goldfive | `goldfive.executors`, `goldfive.runner` |
 | Span timeline, session, storage | harmonograf | `server/`, `client/harmonograf_client/client.py` |
-| Gantt / graph / inspector / plan-diff UI | harmonograf | `frontend/` |
+| Per-ADK-agent attribution on spans | harmonograf | `client/harmonograf_client/telemetry_plugin.py` (plugin) + `server/harmonograf_server/ingest.py::_ensure_route` (auto-register) |
+| Intervention history aggregation | harmonograf | `server/harmonograf_server/interventions.py`, `ListInterventions` RPC |
+| Gantt / Graph / Trajectory / Notes / Settings UI | harmonograf | `frontend/` |
 | Control routing (pause, resume, steer, cancel, annotate) | harmonograf | `proto/harmonograf/v1/control.proto`, `server/harmonograf_server/control_router.py` |
+| STEER body validation + author stamping | harmonograf | `client/harmonograf_client/_control_bridge.py`, server `SteerPayload` handler |
 | `goldfive.EventSink` adapter | harmonograf | `client/harmonograf_client/sink.py` |
+| `observe(runner)` one-line sink attach | harmonograf | `client/harmonograf_client/observe.py` |
+| ADK telemetry plugin | harmonograf | `client/harmonograf_client/telemetry_plugin.py` |
 
 ## Wire shape
 
@@ -201,6 +206,66 @@ app = App(
 
 The plugin is pure observability — it makes no orchestration decisions and
 composes cleanly with goldfive's own ADK adapter.
+
+### Per-ADK-agent Gantt rows (harmonograf#74 / #80)
+
+A single `goldfive.wrap` run drives a tree of ADK agents — coordinator,
+specialists, `AgentTool` wrappers, `SequentialAgent` / `ParallelAgent` /
+`LoopAgent` containers. The plugin stamps every span with a per-agent id
+derived from the client's root agent id and the ADK agent's name
+(`per_agent_id = "{client_agent_id}:{adk_name}"`) via
+`before_agent_callback` / `after_agent_callback`, so the Activity view
+renders **one Gantt row per ADK agent** instead of collapsing the whole
+tree onto the root.
+
+Each ADK agent's **first** span carries `hgraf.agent.*` attribute hints
+— `name`, `parent`, `kind`, `branch`, `framework`. The server's
+`_ensure_route` harvests them into the agent's `metadata` the first
+time it auto-registers the agent row. Subsequent spans just reference
+the already-registered agent id.
+
+Nothing about this requires user code to opt in — the plugin handles it
+transparently whenever you install it, whether via `observe()` or by
+adding it to `App.plugins=[...]`.
+
+### Plugin dedup (harmonograf#68)
+
+Under `goldfive.wrap` + `adk web`, it is easy to end up with two
+`HarmonografTelemetryPlugin` instances on the same ADK `PluginManager`
+(one from `App.plugins`, one from `observe()` or `add_plugin`). The
+later-installed instance detects the earlier one on its first callback
+and silently disables itself — span emission is not doubled and no
+error is raised. See also goldfive#166.
+
+### Session unification (harmonograf#63 / #66)
+
+Under ADK, the outer `adk-web` session id is pinned on
+`goldfive.Session.id`. Spans route to the server by `ctx.session.id`;
+goldfive events route by per-event `session_id`. The result: one outer
+ADK chat lane + its goldfive run + its span stream all collapse onto a
+single harmonograf session. The session picker shows one row for the
+whole run, not one per component.
+
+### Lazy Hello (harmonograf#85)
+
+The transport defers its Hello RPC until the first real emit. For ADK
+runs this means the ADK session id is known at Hello time, so there's no
+need for the server to auto-create a placeholder `sess_2026-…` row that
+later has to merge with the real session. Idle Client instances never
+open a stream at all.
+
+### Intervention emission
+
+Goldfive events flowing through `HarmonografSink` include the user-control
+drift kinds (`user_steer`, `user_cancel`) that goldfive emits when a
+control event is consumed. Those events land on the server's ingest drift
+ring, which the **intervention aggregator** (`server/harmonograf_server/
+interventions.py`) joins against annotations and `task_plans.revision_kind`
+to produce the chronological view the Trajectory frontend renders.
+
+`ListInterventions(session_id)` exposes the aggregate over a unary RPC;
+the frontend has a live deriver that mirrors the shape for in-flight
+deltas during a running session.
 
 ## Running the reference demo
 

--- a/docs/goldfive-migration-plan.md
+++ b/docs/goldfive-migration-plan.md
@@ -1,15 +1,26 @@
 # Harmonograf → Goldfive Migration Plan
 
-> **STATUS: COMPLETED (Phase D landed 2026-04-18).**
+> **STATUS: COMPLETED (Phase D landed 2026-04-18). Preserved as a design
+> record; no further updates expected.**
+>
 > All four phases merged on `main`:
 > - Phase A — proto migration + goldfive dependency ([#6](https://github.com/pedapudi/harmonograf/pull/6), closes [#2](https://github.com/pedapudi/harmonograf/issues/2))
 > - Phase B — `HarmonografSink` + goldfive event ingest ([#7](https://github.com/pedapudi/harmonograf/pull/7), closes [#3](https://github.com/pedapudi/harmonograf/issues/3))
 > - Phase C — delete legacy client orchestration, rewire demos on goldfive ([#9](https://github.com/pedapudi/harmonograf/pull/9), closes [#4](https://github.com/pedapudi/harmonograf/issues/4))
-> - Phase D — e2e validation + cleanup + integration guide (this PR, closes [#5](https://github.com/pedapudi/harmonograf/issues/5) and meta [#1](https://github.com/pedapudi/harmonograf/issues/1))
+> - Phase D — e2e validation + cleanup + integration guide (closes [#5](https://github.com/pedapudi/harmonograf/issues/5) and meta [#1](https://github.com/pedapudi/harmonograf/issues/1))
 >
-> The current integration surface is documented in
-> [goldfive-integration.md](goldfive-integration.md). The rest of this file is
-> preserved as the design record.
+> **For current state, read:**
+> - [goldfive-integration.md](goldfive-integration.md) — the live integration
+>   contract (`goldfive.wrap` + `observe()`, per-ADK-agent rows, session
+>   unification, plugin dedup, intervention emission).
+> - [standalone-observability.md](standalone-observability.md) — the
+>   non-goldfive path for clients that just want the span console.
+> - [milestones.md](milestones.md) §"Post-migration shipped (2026-04)" —
+>   log of per-agent rows, intervention history, lazy Hello, session
+>   unification, STEER validation, plugin dedup.
+>
+> The rest of this file is the original architectural scratchpad that
+> drove the migration. Keep for history; do not edit further.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,18 +55,23 @@ to observe and steer them.
 | File | What it is |
 |---|---|
 | [quickstart.md](quickstart.md) | Step-by-step from clone to running demo, with troubleshooting and local-LLM wiring. |
-| [operator-quickstart.md](operator-quickstart.md) | Server flags, retention, health probes, bearer-token auth — the ops-facing reference. |
+| [operator-quickstart.md](operator-quickstart.md) | Server flags, retention, health probes, bearer-token auth, operator workflow (watch a run, steer it, read intervention cards). |
 | [overview.md](overview.md) | Longer-form motivation and design principles; what ships today and what's deliberately out of scope. |
-| [reporting-tools.md](reporting-tools.md) | The seven `report_*` tools your agents use to communicate task state; when to call each one. |
+| [goldfive-integration.md](goldfive-integration.md) | The `goldfive.wrap` + `observe()` contract: per-ADK-agent rows, session unification, intervention emission. |
+| [standalone-observability.md](standalone-observability.md) | The non-ADK path: emit spans from any Python process with `harmonograf_client.Client`. |
+| [reporting-tools.md](reporting-tools.md) | Redirect to the goldfive reporting-tool reference (the tools live in goldfive post-migration). |
 | [user-guide/index.md](user-guide/index.md) | UI reference hub — overview of regions of the shell and the contents list below. |
 | [user-guide/sessions.md](user-guide/sessions.md) | Session picker, filters, attention badges. |
+| [user-guide/actors.md](user-guide/actors.md) | Actor attribution model — per-ADK-agent rows, goldfive-actor row for drift/steer events. |
 | [user-guide/gantt-view.md](user-guide/gantt-view.md) | Reading the Gantt: bars, colors, status glyphs, cross-agent edges. |
 | [user-guide/graph-view.md](user-guide/graph-view.md) | The agent topology / sequence diagram view. |
+| [user-guide/trajectory-view.md](user-guide/trajectory-view.md) | Intervention history ribbon — markers, clusters, popovers, plan-rev links. |
 | [user-guide/drawer.md](user-guide/drawer.md) | Inspector drawer: summary, task, payload, timeline, links, annotations, control tabs. |
 | [user-guide/tasks-and-plans.md](user-guide/tasks-and-plans.md) | Current task strip, task panel, plan revisions. |
 | [user-guide/control-actions.md](user-guide/control-actions.md) | Pause, resume, steer, rewind, approve — every way the UI talks back to agents. |
 | [user-guide/annotations.md](user-guide/annotations.md) | Human notes on spans, tasks, agents; deliver-to-agent mode. |
 | [user-guide/keyboard-shortcuts.md](user-guide/keyboard-shortcuts.md) | Keyboard map; source of truth is `frontend/src/lib/shortcuts.ts`. |
+| [user-guide/glossary.md](user-guide/glossary.md) | Quick-reference term map. |
 | [user-guide/troubleshooting.md](user-guide/troubleshooting.md) | Common UI failure modes and how to recover. |
 | [user-guide/cookbook.md](user-guide/cookbook.md) | Recipes for common user tasks. |
 | [user-guide/faq.md](user-guide/faq.md) | Frequently asked questions. |
@@ -101,12 +106,12 @@ the server, or debugging a wire-level issue.
 |---|---|
 | [protocol/index.md](protocol/index.md) | Protocol reference hub and reading order by role. |
 | [protocol/overview.md](protocol/overview.md) | The three RPC tiers (telemetry / control / frontend RPCs), the first-connect flow, and versioning. |
-| [protocol/telemetry-stream.md](protocol/telemetry-stream.md) | `StreamTelemetry` bidirectional stream, `Hello`/`Welcome`, resume tokens, goodbye. |
+| [protocol/telemetry-stream.md](protocol/telemetry-stream.md) | `StreamTelemetry` bidirectional stream, lazy `Hello` / `Welcome`, resume tokens, goodbye. |
 | [protocol/control-stream.md](protocol/control-stream.md) | `SubscribeControl` server-streaming RPC; control event / ack lifecycle; capability negotiation. |
-| [protocol/frontend-rpcs.md](protocol/frontend-rpcs.md) | `ListSessions`, `WatchSession`, `GetPayload`, `GetSpanTree`, `PostAnnotation`, `SendControl`, `DeleteSession`, `GetStats`. |
-| [protocol/data-model.md](protocol/data-model.md) | Harmonograf-owned `types.proto` messages (Session, Agent, Span, PayloadRef, ErrorInfo, Annotation, ControlEvent, ControlAck). Plan / Task / TaskEdge / DriftKind are imported from `goldfive/v1/types.proto`. |
+| [protocol/frontend-rpcs.md](protocol/frontend-rpcs.md) | `ListSessions`, `WatchSession`, `GetPayload`, `GetSpanTree`, `PostAnnotation`, `SendControl`, `DeleteSession`, `ListInterventions`, `GetStats`. |
+| [protocol/data-model.md](protocol/data-model.md) | Harmonograf-owned `types.proto` messages (Session, Agent, Span, PayloadRef, ErrorInfo, Annotation, Intervention, ControlEvent, ControlAck). Plan / Task / TaskEdge / DriftKind are imported from `goldfive/v1/types.proto`. |
 | [protocol/task-state-machine.md](protocol/task-state-machine.md) | Redirect — plan / task / drift / reporting tools / invariant validator all live in goldfive after the migration. |
-| [protocol/span-lifecycle.md](protocol/span-lifecycle.md) | SpanStart / SpanUpdate / SpanEnd, attribute merging, `hgraf.task_id` binding, cross-agent links. |
+| [protocol/span-lifecycle.md](protocol/span-lifecycle.md) | SpanStart / SpanUpdate / SpanEnd, attribute merging, `hgraf.task_id` + `hgraf.agent.*` binding, cross-agent links. |
 | [protocol/payload-flow.md](protocol/payload-flow.md) | Content-addressed payload uploads, chunked transport, eviction, server-side re-request. |
 | [protocol/wire-ordering.md](protocol/wire-ordering.md) | Happens-before guarantees, control-ack colocation, duplicate span dedup on reconnect, resume_token semantics. |
 
@@ -121,11 +126,11 @@ shape matters.
 | File | What it is |
 |---|---|
 | [internals/index.md](internals/index.md) | Reading order, per-hot-path guide, source-reference conventions. |
-
-Individual tours (per the reading order in `internals/index.md`):
-`server-ingest-bus.md`, `storage-sqlite.md`,
-`session-store-task-registry.md`, `renderer-pipeline.md`,
-`drift-taxonomy-catalog.md`.
+| [internals/server-ingest-bus.md](internals/server-ingest-bus.md) | Ingest pipeline + per-session bus fan-out. |
+| [internals/storage-sqlite.md](internals/storage-sqlite.md) | SQLite schema + WAL semantics. |
+| [internals/session-store-task-registry.md](internals/session-store-task-registry.md) | Frontend session store + task registry. |
+| [internals/renderer-pipeline.md](internals/renderer-pipeline.md) | Canvas Gantt renderer pipeline. |
+| [internals/drift-taxonomy-catalog.md](internals/drift-taxonomy-catalog.md) | Drift-kind → UI mapping. |
 
 Tours of the pre-goldfive orchestration layer (HarmonografAgent, the
 ADK state machine, invariants) were removed with the goldfive migration;
@@ -175,6 +180,32 @@ when you want to understand why a given design choice exists.
 | [adr/0011a-span-lifecycle-inference-superseded.md](adr/0011a-span-lifecycle-inference-superseded.md) | Retirement record for the old span-lifecycle-inference approach. |
 | [adr/0012-three-orchestration-modes.md](adr/0012-three-orchestration-modes.md) | Why sequential / parallel / delegated, and not one unified path. |
 | [adr/0013-drift-as-first-class.md](adr/0013-drift-as-first-class.md) | Why drift is a first-class event with its own taxonomy and refine pipeline. |
+
+---
+
+## Runbooks
+
+Triage guides for recurring failure modes. Start here when something is
+broken end-to-end.
+
+| File | What it is |
+|---|---|
+| [runbooks/index.md](runbooks/index.md) | Runbook index. |
+| [runbooks/agent-not-connecting.md](runbooks/agent-not-connecting.md) | Agent can't reach the server. |
+| [runbooks/agent-disconnects-repeatedly.md](runbooks/agent-disconnects-repeatedly.md) | Flapping transport. |
+| [runbooks/demo-wont-start.md](runbooks/demo-wont-start.md) | `make demo` failures. |
+| [runbooks/drift-not-firing.md](runbooks/drift-not-firing.md) | Expected drift never appears on the Trajectory view. |
+| [runbooks/task-stuck-in-pending.md](runbooks/task-stuck-in-pending.md) | A task never transitions from PENDING. |
+| [runbooks/task-stuck-in-running.md](runbooks/task-stuck-in-running.md) | A task stays RUNNING forever. |
+| [runbooks/context-window-exceeded.md](runbooks/context-window-exceeded.md) | Model ran out of context mid-run. |
+| [runbooks/frontend-shows-stale-data.md](runbooks/frontend-shows-stale-data.md) | UI isn't updating. |
+| [runbooks/high-latency-callbacks.md](runbooks/high-latency-callbacks.md) | Callbacks taking too long. |
+| [runbooks/minimap-desync.md](runbooks/minimap-desync.md) | Minimap offsets. |
+| [runbooks/payloads-missing.md](runbooks/payloads-missing.md) | Payload body unavailable. |
+| [runbooks/post-crash-recovery.md](runbooks/post-crash-recovery.md) | After a server crash. |
+| [runbooks/span-tree-looks-wrong.md](runbooks/span-tree-looks-wrong.md) | Span parent/child looks off. |
+| [runbooks/sqlite-errors.md](runbooks/sqlite-errors.md) | SQLite WAL / locking failures. |
+| [runbooks/thinking-not-visible.md](runbooks/thinking-not-visible.md) | Model's thinking section isn't rendering. |
 
 ---
 

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -6,12 +6,13 @@ Inside each milestone, 4–5 streams run in parallel.
 
 Auth is deferred to its own project — local-only for now.
 
-> **Note (2026-04).** Milestones A–D below predate the goldfive migration.
+> **Note (2026-04).** Milestones A–E below predate the goldfive migration.
 > References to `attach_adk`, `HarmonografAgent`, reporting-tool
 > interception, etc. describe the pre-migration implementation — the
 > integration surface today is `goldfive.Runner` + `HarmonografSink` +
 > an optional `HarmonografTelemetryPlugin`. The milestone *goals* are
-> still useful context; the code pointers are not.
+> still useful context; the code pointers are not. See the
+> "Post-migration shipped" section at the bottom for the current delta.
 
 The roadmap at a glance — five milestones, each ending in a thing the user can run and react to:
 
@@ -133,3 +134,57 @@ End state: repo is in a state you could send to a colleague.
 
 - **Auth** — its own project, out of current scope since the demo is
   local-only. Tracked separately.
+
+---
+
+## Post-migration shipped (2026-04)
+
+Everything below landed after the goldfive migration. These are the
+changes reflected in the current README / AGENTS.md / integration docs
+and account for the drift from milestones A–E's pre-migration pointers.
+
+- **Per-ADK-agent Gantt rows** (harmonograf#74, #80). `HarmonografTelemetryPlugin`
+  stacks `per_agent_id = "{client_id}:{adk_name}"` via before/after_agent
+  callbacks and rides hints on the first span; `_ensure_route` on the
+  server auto-registers the agent. One row per ADK agent in the wrapped
+  tree, not one collapsed root.
+
+- **Intervention history** (harmonograf#69, #71). Server `interventions.py`
+  merges annotations + ingest drift ring + `task_plans.revision_kind`
+  into a unified chronological list. `ListInterventions(session_id)`
+  unary RPC returns it. Frontend has a live deriver that mirrors the
+  shape for in-flight deltas.
+
+- **Intervention timeline redesign** (harmonograf#76). Stable X anchor,
+  glyph-by-kind, color-by-source, severity ring, density clustering,
+  deterministic popover, axis ticks, fade-only entrance.
+
+- **Intervention card dedup** (harmonograf#81, #87 closed #75, #73, #86).
+  User-control kinds merge by `annotation_id` inside a 5-minute window;
+  autonomous drifts keep tight window + own cards. `convertAnnotation`
+  stores session-relative ms (bug previously caused visual clustering
+  mismatches).
+
+- **Lazy Hello** (harmonograf#85). Client defers Hello RPC until first
+  emit. No ghost `sess_2026-…` sessions per ADK run. Non-ADK client
+  flows still auto-create home session on first emit.
+
+- **Session unification** (harmonograf#63, #66). Outer adk-web session id
+  pinned on `goldfive.Session.id`; spans route by `ctx.session.id`,
+  goldfive events route by per-event `session_id`.
+
+- **STEER body validation + author** (harmonograf#72). Client
+  `ControlBridge._events_loop` validates body (empty / >8 KiB UTF-8
+  rejected, ASCII control chars stripped) before forward; server stamps
+  `SteerPayload.author` + `SteerPayload.annotation_id`.
+
+- **Plugin dedup** (harmonograf#68). Second `HarmonografTelemetryPlugin`
+  instance on the same ADK `PluginManager` silently no-ops beyond the
+  first.
+
+- **Session picker** shows one row per session post-lazy-Hello.
+
+### In flight
+
+- **Gantt viewport UX on completed sessions** (harmonograf#89) — opens
+  past last span; being fixed in parallel.

--- a/docs/operator-quickstart.md
+++ b/docs/operator-quickstart.md
@@ -1,6 +1,9 @@
 # Operator Quickstart
 
-A minimal walkthrough for getting a local Harmonograf instance running end-to-end: server, frontend, and one real agent emitting spans. Every command below is copy-pasteable from the repository root.
+The operator view: how to start watching a running goldfive rollout, how
+to steer it live from the UI, and how to interpret the intervention cards
+the Trajectory view shows. Every command below is copy-pasteable from the
+repository root.
 
 For deeper architectural context see [docs/design/03-server.md](design/03-server.md) and [docs/design/02-client-library.md](design/02-client-library.md).
 
@@ -181,10 +184,74 @@ cd server && uv run python -m harmonograf_server \
 
 Periodic metrics snapshots (sessions / spans / ingest rate / active streams) are emitted every `--metrics-interval-seconds` (default `30`); set to `0` to disable.
 
-## 9. Known limitations
+## 9. Watching a live goldfive run
+
+Once the server, frontend, and an agent are up:
+
+1. The **Sessions** picker auto-selects the newest live session. Post
+   lazy-Hello (harmonograf#85) there is one row per ADK session you drive
+   — no ghost rows per app-build. The session id pinned on the row is
+   whatever `adk web` / your orchestrator passed through as
+   `goldfive.Session.id` (harmonograf#66).
+2. The **Activity** (Gantt) view renders one row per ADK agent in the
+   wrapped tree. Rows auto-register on the first span each agent emits —
+   coordinator, specialists, and any `AgentTool` / sequential / parallel /
+   loop wrappers (harmonograf#74 / #80).
+3. The **Trajectory** view (↪ in the nav rail) is the operator's primary
+   handle — one horizontal ribbon with one marker per intervention event.
+
+## 10. Steering from the UI
+
+Every intervention path lives in one of three places:
+
+- **Inspector drawer → Control tab.** Pick any span in Activity, open the
+  drawer, and use the Control tab to send PAUSE, RESUME, STEER (free-form
+  text), or CANCEL. The client's `ControlBridge` validates the STEER body
+  (empty / over 8 KiB UTF-8 rejected, ASCII control chars stripped) before
+  forwarding; the server stamps `author` + `annotation_id` (harmonograf#72).
+- **Keyboard shortcut (Space).** Toggles global PAUSE / RESUME in the
+  Gantt view.
+- **Annotation with deliver-to-agent.** Posting an annotation on a span /
+  task with the "deliver to agent" box checked synthesizes a STEER
+  targeting the annotated actor.
+
+Every successful STEER / CANCEL / PAUSE you issue becomes one marker in
+Trajectory. If the same target sees a second user-control intervention
+within 5 minutes, its card **merges** with the previous one so the
+timeline doesn't spray out duplicates (harmonograf#81 / #87 closing
+prior #75 / #73 / #86).
+
+## 11. Reading intervention cards
+
+Clicking a marker in Trajectory opens the intervention popover. Each card
+carries:
+
+- **Source** — `user` (you, via the UI) vs. autonomous (goldfive's steerer).
+  Colour and marker glyph differ by source.
+- **Kind** — STEER, CANCEL, PAUSE, RESUME for user-control; `tool_error`,
+  `agent_refusal`, `new_work_discovered`, `task_failed_recoverable`, …
+  for autonomous drift. Glyphs differ by kind.
+- **Severity** — info / warn / critical, rendered as an outer ring on the
+  marker.
+- **Body** — the STEER text or drift detail.
+- **Author** — who issued the intervention (usually `operator` for user
+  control).
+- **Outcome** — if the intervention was immediately followed (within ~5 s)
+  by a plan revision or cascade-cancel, the card links to it
+  (`plan_revised:rN`, `cascade_cancel:N_tasks`). See
+  [`server/harmonograf_server/interventions.py`](../server/harmonograf_server/interventions.py)
+  for the join logic.
+
+If markers look clustered or the timestamps feel off, see
+harmonograf#87 — convertAnnotation now stores session-relative ms, which
+is the shape the density clusterer expects.
+
+## 12. Known limitations
 
 - **In-memory vs. sqlite.** `make server-run` uses `--store sqlite` against `<repo>/data`. `--store memory` is fine for tests but loses everything on restart.
 - **sonora CORS shim.** The server monkey-patches `sonora.asgi` at startup to work around a bytes/str comparison bug in sonora's preflight path (see `server/harmonograf_server/_sonora_shim.py`, commit `5c00817`). An `INFO` line is logged on startup confirming the shim is active. If you upgrade sonora and the preflight path is fixed upstream, the shim can be removed.
 - **No TLS.** The gRPC and gRPC-Web listeners are plaintext. Keep them on loopback; `--host` values other than `127.0.0.1` log a warning.
 - **Frontend does not currently send a bearer token.** If you start the server with `--auth-token`, the UI will be rejected with 401 until frontend auth lands. Run the UI against an unauthenticated dev server for now.
 - **Single-process, single-node.** There is no clustering, no replication, no horizontal scale. One server process owns the canonical timeline.
+- **Gantt viewport on completed sessions** currently opens past the last
+  span rather than framed on it; tracked as harmonograf#89 (in flight).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -154,41 +154,75 @@ landing continuously.
 ### Client library (`client/`)
 
 - **`Client`** — non-blocking handle over a buffered gRPC transport
-  (`buffer.py`, `transport.py`) that survives server restarts and short network
-  blips without dropping telemetry; owns identity, heartbeat, control-handler
-  registration.
+  (`buffer.py`, `transport.py`) that survives server restarts and short
+  network blips without dropping telemetry; owns identity, heartbeat,
+  control-handler registration. **Lazy Hello** (harmonograf#85): no RPC is
+  made until the first real emit, so ADK runs don't create ghost
+  `sess_2026-…` sessions per app-build.
 - **`HarmonografSink`** — `goldfive.EventSink` adapter that ships every
   goldfive plan / task / drift event up the telemetry stream via a
   `TelemetryUp.goldfive_event` variant.
-- **`HarmonografTelemetryPlugin`** — optional ADK `BasePlugin` that emits
-  harmonograf spans for ADK lifecycle callbacks.
+- **`HarmonografTelemetryPlugin`** — ADK `BasePlugin` that emits harmonograf
+  spans for ADK lifecycle callbacks. Stamps `per_agent_id =
+  "{client_id}:{adk_name}"` via before/after_agent so the server renders one
+  Gantt row per ADK agent in the wrapped tree; dedups itself silently when
+  installed twice (harmonograf#68/#74/#80).
+- **`observe(runner)`** — one-line helper that attaches the sink + control
+  bridge to an existing `goldfive.Runner`. Pure observability — never
+  touches planning, steering, execution, or goal derivation (issue #22).
 - **Heartbeat + liveness tracking** so the UI can show stuck / slow agents.
 - **Agent identity on disk** so a restarted agent reclaims its Gantt row.
 
 ### Server (`server/`)
 
 - **gRPC + gRPC-Web** on separate listeners (`:7531` and `:7532`).
-- **Ingest pipeline** with fan-out bus for live subscribers.
-- **SQLite and in-memory stores** behind a common interface; retention sweeper for
-  terminal sessions.
-- **Control router** for frontend → agent messages.
-- **Health probes** (`/healthz`, `/readyz`) always open; optional bearer-token
-  auth via `--auth-token`.
+- **Ingest pipeline** with fan-out bus for live subscribers; routes spans by
+  `ctx.session.id` and goldfive events by per-event `session_id` so the outer
+  adk-web session gathers everything the user drove (harmonograf#63/#66).
+- **Auto-registration of ADK agents** from first-span hints — the plugin
+  rides `hgraf.agent.*` attrs (name, parent, kind, branch, framework) and
+  `_ensure_route` harvests them on first contact (harmonograf#74/#80).
+- **Intervention aggregator** (`interventions.py`) merging annotations +
+  drift ring + `task_plans.revision_kind` into one chronological list;
+  `ListInterventions(session_id)` unary RPC exposes it; user-control kinds
+  merge inside a 5-minute window (harmonograf#69/#71/#81/#87).
+- **SQLite and in-memory stores** behind a common interface; retention sweeper
+  for terminal sessions.
+- **Control router** for frontend → agent messages. `ControlBridge` on the
+  client validates STEER body and the server stamps author +
+  annotation_id (harmonograf#72).
+- **Health probes** (`/healthz`, `/readyz`) always open; optional
+  bearer-token auth via `--auth-token`.
 - **Stats RPC** (`make stats`) for "how is the server doing right now".
 - **Metrics snapshots** emitted periodically to logs.
 
 ### Frontend (`frontend/`)
 
-- **Gantt canvas** — per-agent rows, interactive blocks, zoom + pan, minimap,
-  live-tail cursor.
-- **Agent topology graph view** — nodes = agents, edges = transfers and tool
-  invocations.
-- **Span inspector drawer** — arguments, return values, errors, payloads.
-- **Plan-diff banner + drawer** — shows added/removed/reordered tasks after a
+The shell has six views, switched via the nav rail on the left:
+
+- **Sessions picker** — one row per ADK session post-lazy-Hello
+  (harmonograf#85), with agent counts, attention badges, time-ago labels.
+- **Activity (Gantt)** — per-ADK-agent rows (auto-registered from
+  first-span hints per harmonograf#74/#80), interactive blocks, zoom + pan,
+  minimap, live-tail cursor, context-window badges, task plan strip,
+  transport bar.
+- **Graph** — agent topology view: nodes = ADK agents, edges = transfers
+  and tool invocations.
+- **Trajectory** — intervention history ribbon (harmonograf#69/#76): one
+  marker per drift / user-control event / plan revision, glyph-by-kind,
+  color-by-source, severity ring, density clustering, deterministic
+  popover, axis ticks.
+- **Notes** — session-wide annotation stream.
+- **Settings** — server URL, theme, keyboard shortcuts reference.
+
+Cross-cutting UI:
+
+- **Inspector drawer** — arguments, return values, errors, payloads;
+  Control tab for pause/resume/STEER/cancel.
+- **Plan-revision banner** — shows added/removed/reordered tasks after a
   refine.
-- **Transport bar** — play/pause/scrub for session playback.
-- **Session picker** with auto-select of the newest live session.
-- **App shell** — drawer nav, view switcher, keyboard shortcuts.
+- **Current task strip** — live title/status chip for the task currently
+  bound to the focused agent.
 
 ### Protocol (`proto/harmonograf/v1/`)
 
@@ -225,25 +259,47 @@ defensible product position, not a TODO.
 
 ---
 
+## Recently shipped
+
+Highlights from the post-migration era (2026-04):
+
+- Per-ADK-agent Gantt rows via first-span hints and server auto-register
+  (harmonograf#74, #80).
+- Intervention history data model + `ListInterventions` RPC + Trajectory
+  view + intervention timeline redesign (harmonograf#69, #71, #76).
+- Intervention card dedup: user-control kinds merge within a 5-minute
+  window; autonomous drifts keep a tight window and their own cards
+  (harmonograf#81 / #87, closed #75 / #73 / #86).
+- Lazy Hello: ADK runs no longer create ghost `sess_…` rows (harmonograf#85).
+- Session unification: outer adk-web session id pinned on
+  `goldfive.Session.id`; spans route by `ctx.session.id`, events by
+  per-event `session_id` (harmonograf#63, #66).
+- STEER body validation + author/annotation_id stamping (harmonograf#72).
+- Plugin dedup: second `HarmonografTelemetryPlugin` is silently a no-op
+  (harmonograf#68).
+
 ## Roadmap
 
-These are directions, not commitments. See [docs/milestones.md](milestones.md) for
-the live milestone plan.
+These are directions, not commitments. See
+[docs/milestones.md](milestones.md) for the live milestone plan.
 
-- **Richer coordination surface.** Today the UI can pause, resume, and send notes;
-  next is structured steering — pinning tasks, forcing re-plans from a particular
-  point, rewinding.
-- **Second framework adapter.** Strands or OpenAI Agents SDK is the likely second
-  target. The client library's core is already framework-agnostic; the work is
-  mostly wiring and deciding which framework-specific features to expose.
-- **Persistent session archive + playback.** Replay a completed session the way
-  you would scrub through a video, including stepping through every tool call.
-- **Cross-session analytics.** "How often does this agent hit `tool_error` on
-  task X?" — the data is already there, the frontend surface isn't.
+- **Gantt viewport UX on completed sessions** (harmonograf#89, in flight)
+  — session opens at last-span frame instead of past it.
+- **Richer coordination surface.** Structured steering: pinning tasks,
+  forcing re-plans from a particular point, rewinding.
+- **Second framework adapter.** Strands or OpenAI Agents SDK is the likely
+  second target. Goldfive's core is already framework-agnostic; the work
+  is mostly wiring and deciding which framework-specific features to
+  expose.
+- **Persistent session archive + playback.** Replay a completed session
+  the way you would scrub through a video, including stepping through
+  every tool call.
+- **Cross-session analytics.** "How often does this agent hit `tool_error`
+  on task X?" — the data is already there, the frontend surface isn't.
 - **Auth v1.** At minimum, per-session tokens and a path to SSO for shared
   deployments. Not a v0 concern.
-- **Structured eval hooks.** Not an evaluation harness itself, but a clean seam
-  for plugging one in.
+- **Structured eval hooks.** Not an evaluation harness itself, but a clean
+  seam for plugging one in.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -162,21 +162,38 @@ make demo SERVER_PORT=17531 FRONTEND_PORT=15173 ADK_WEB_PORT=18080
    ```
 
 3. Switch to the **harmonograf tab** at `http://127.0.0.1:5173`. The session
-   picker should auto-select the newest live session. You should see:
-   - A row per agent (`coordinator_agent`, `research_agent`,
-     `web_developer_agent`, `reviewer_agent`, and `debugger_agent` if the
-     reviewer surfaces issues).
+   picker should auto-select the newest live session. Post-lazy-Hello
+   (harmonograf#85) you'll see exactly one row in the picker per ADK session
+   you drive, not one per restart. On the Activity (Gantt) view you should
+   see:
+   - One row per ADK agent in the wrapped tree — `coordinator_agent`,
+     `research_agent`, `web_developer_agent`, `reviewer_agent`, and
+     `debugger_agent` if the reviewer surfaces issues. Each row is
+     auto-registered the first time the agent emits a span (harmonograf#80).
    - Blocks on the timeline filling in as each task moves through started →
      running → completed.
    - A live-tail cursor following the head of the run.
-   - A plan-diff banner if the coordinator replans mid-run (e.g. because the
-     reviewer flagged an issue and the debugger was added).
+   - A plan-revision banner if the coordinator replans mid-run (e.g. because
+     the reviewer flagged an issue and the debugger was added).
 
 4. Click any block to open the **inspector drawer** and see the tool call
    arguments, return value, and any payloads.
 
-5. When you are done, Ctrl-C the `make demo` shell. All three processes exit
-   together.
+5. Switch to the **Trajectory** view via the nav rail (↪ icon). You'll see
+   a horizontal intervention ribbon with one marker per point where the
+   plan changed direction — drift events, plan revisions, and anything you
+   STEER/CANCEL/PAUSE from the UI. Click a marker to see who, when, why,
+   and what happened next.
+
+6. Try steering: pick a span in Activity view, open the drawer's Control
+   tab, and send a STEER. The server forwards it via the control stream,
+   your agent reacts on its next turn, and a new marker lights up in
+   Trajectory. If you STEER twice within five minutes on the same target,
+   the intervention card merges them into one — that's harmonograf#81/#87
+   user-control dedup.
+
+7. When you are done, Ctrl-C the `make demo` shell. All three processes
+   exit together.
 
 ---
 
@@ -199,13 +216,17 @@ A healthy first run looks like this on stdout:
 
 In the harmonograf frontend, a successful rollout looks like:
 
-- 4–5 agent rows populated within a few seconds of sending the ADK prompt.
-- Task blocks that transition colour as they complete (harmonograf uses a
-  monotonic state machine — blocks never go backwards).
+- 4–5 agent rows populated within a few seconds of sending the ADK prompt
+  (the plugin auto-registers each ADK agent on its first `before_agent`
+  callback).
+- Task blocks that transition colour as they complete (goldfive's task
+  state machine is monotonic — blocks never go backwards).
 - A small liveness indicator on each row that pulses while the agent is
   actively emitting.
 - A completed session badge at the top of the timeline when the coordinator
   calls `report_task_completed` on the root task.
+- One intervention marker on the **Trajectory** view per drift or
+  user-control event (if any). Plan revisions produce an up-chevron marker.
 
 ---
 
@@ -280,16 +301,45 @@ make install
 
 ---
 
+## Other paths
+
+### Standalone observability (no ADK, no goldfive)
+
+If you want to emit spans from a plain Python process with no orchestration
+framework at all:
+
+```bash
+make demo-standalone
+```
+
+That boots server + frontend and runs `examples/standalone_observability/
+spans_only.py` against them. See
+[standalone-observability.md](standalone-observability.md) for the full
+non-ADK story.
+
+### Bare-ADK observation (no goldfive.wrap)
+
+If you already have your own orchestrator and just want the console:
+attach a `HarmonografTelemetryPlugin` to your `App(plugins=[...])`. See
+[`examples/standalone_observability/adk_telemetry.py`](../examples/standalone_observability/adk_telemetry.py).
+Plans, tasks, drift, and intervention history will stay empty — but the
+Gantt, inspector, and control surfaces all light up.
+
 ## What to read next
 
-- [overview.md](overview.md) — motivation, design principles, what ships, what
-  doesn't, roadmap.
-- [operator-quickstart.md](operator-quickstart.md) — every server flag, health
-  probes, retention, bearer-token auth.
-- [reporting-tools.md](reporting-tools.md) — the canonical agent ↔ harmonograf
-  protocol.
-- [docs/user-guide/](user-guide/) — the UI walk-through with keyboard shortcuts.
-- [docs/dev-guide/](dev-guide/) — building from source, adding a storage
-  backend, writing tests, contribution workflow.
-- [docs/protocol/](protocol/) — proto reference, session-state schema, drift
+- [tour/15-minute-tour.md](tour/15-minute-tour.md) — narrative
+  walkthrough of the problem, the primitives, and a single rollout end to
+  end.
+- [overview.md](overview.md) — motivation, design principles, what ships,
+  what doesn't, roadmap.
+- [operator-quickstart.md](operator-quickstart.md) — every server flag,
+  health probes, retention, bearer-token auth.
+- [goldfive-integration.md](goldfive-integration.md) — the full
+  orchestration-observability contract.
+- [standalone-observability.md](standalone-observability.md) — the non-ADK
+  flow.
+- [user-guide/](user-guide/) — the UI walk-through with keyboard shortcuts.
+- [dev-guide/](dev-guide/) — building from source, adding a storage backend,
+  writing tests, contribution workflow.
+- [protocol/](protocol/) — proto reference, session-state schema, drift
   taxonomy, plan-diff semantics.

--- a/docs/reporting-tools.md
+++ b/docs/reporting-tools.md
@@ -1,13 +1,14 @@
 # Reporting tools
 
 > **Owned by goldfive.** After the goldfive migration, reporting tools
-> (`report_task_started`, `report_task_completed`, `report_task_failed`,
-> `report_task_blocked`, `report_task_progress`, `report_new_work_discovered`,
-> `report_plan_divergence`) live in [goldfive](https://github.com/pedapudi/goldfive).
-> The canonical reference, behaviour, and side-effect table are in the
-> goldfive docs — this page is a redirect so stale bookmarks don't mislead.
+> (`report_task_started`, `report_task_progress`, `report_task_completed`,
+> `report_task_failed`, `report_task_blocked`,
+> `report_new_work_discovered`, `report_plan_divergence`) live in
+> [goldfive](https://github.com/pedapudi/goldfive). The canonical
+> reference, behaviour, and side-effect table are in the goldfive docs —
+> this page is a redirect so stale bookmarks don't mislead.
 
-For current behaviour:
+## Where to look
 
 - **Reference**: `goldfive.reporting` (`proto/goldfive/v1/reporting_tools.proto`
   + `goldfive.reporting` Python module + `goldfive.BUILTIN_REPORTING_TOOLS`).
@@ -18,9 +19,30 @@ For current behaviour:
   monotonic task state machine and reacts to reporting-tool calls to fire
   `TaskStarted` / `TaskCompleted` / `TaskFailed` / `DriftDetected` events.
 
-From harmonograf's side, those events surface in the frontend as the
-plan/task/drift views because `HarmonografSink` ships every goldfive
-`Event` through `TelemetryUp.goldfive_event` (see
-[goldfive-integration.md](goldfive-integration.md)). Harmonograf does not
-intercept reporting tools, does not apply state transitions, and does not
-own the `harmonograf.*` session-state keys that the old design used.
+## Tool-loop detector exemption
+
+Goldfive runs a tool-loop detector that treats consecutive identical tool
+calls as drift. The reporting tools are **exempt** from that detector —
+progress-reporting resets the detection window — so agents calling
+`report_task_progress` repeatedly to announce fine-grained progress don't
+accidentally trigger a drift escalation. See the detector docs in the
+goldfive repo for the exact semantics.
+
+## State protocol keys
+
+The reporting tools update goldfive-side state (via
+`DefaultSteerer` + `SessionContext`); harmonograf does not intercept them
+and does not own `harmonograf.*` session-state keys (those were retired
+with the pre-goldfive orchestrator). The keys the tools write live in
+goldfive's `SessionContext` on ADK `session.state`, documented in the
+goldfive session-state reference.
+
+## Harmonograf's role
+
+Harmonograf surfaces these events in the frontend — per-task bars on the
+Gantt, the plan-revision banner, the task panel, and every intervention
+marker on the Trajectory view — because `HarmonografSink` ships every
+goldfive `Event` through `TelemetryUp.goldfive_event` (see
+[goldfive-integration.md](goldfive-integration.md)). Harmonograf never
+intercepts reporting tools, never applies state transitions, and never
+writes session-state keys on its own.

--- a/docs/standalone-observability.md
+++ b/docs/standalone-observability.md
@@ -185,15 +185,30 @@ child = client.emit_span_start(
 ## Sessions
 
 A session is the top-level scope that groups spans from one or more
-agents collaborating on one task. The Client auto-creates a session on
-first emission; the server assigns a canonical `sess_YYYY-MM-DD_NNNN`
-id and broadcasts it back. Access via `client.session_id`.
+agents collaborating on one task. For standalone (non-ADK) clients, the
+Client auto-creates a home session on first emit: the server stamps a
+canonical `sess_YYYY-MM-DD_NNNN` id and broadcasts it back. Access via
+`client.session_id`.
 
 Pass `session_id=` to the `Client(...)` constructor to join an existing
 session — useful when multiple agents collaborate on the same workflow
 and you want one row per agent on the same Gantt.
 
 `session_title` is a friendly label shown in the session picker.
+
+### Lazy Hello (harmonograf#85)
+
+Under ADK — i.e. when you pair this client with `HarmonografTelemetryPlugin`
+inside an `App` — the Hello is **deferred** until the first real emit, and
+the ADK session id (whatever `adk web` passes through) is stamped on that
+Hello. That collapses `adk-web` session, ADK run, and harmonograf session
+into one row in the session picker (see [goldfive-integration.md](goldfive-integration.md)
+for the full session-unification picture).
+
+For the pure-standalone path documented on this page — no ADK, direct
+`emit_span_*` calls — the behavior is unchanged from before: the Client
+auto-creates a home session on its first emit. No ghost sessions either
+way.
 
 ## Agents
 
@@ -253,20 +268,27 @@ orchestration — they do not interfere.
 
 The standalone case leaves some panels empty:
 
-| Panel | Standalone | With goldfive |
+| Panel | Standalone | With goldfive.wrap |
 | --- | --- | --- |
-| Gantt (one row per agent) | populated | populated |
+| Sessions picker | populated | populated |
+| Activity (Gantt, per-agent rows) | populated | populated |
 | Span inspector drawer | populated | populated |
 | Messages panel | populated | populated |
 | Payload viewer | populated | populated |
-| Session picker | populated | populated |
-| Tasks panel | **empty** | populated |
-| Plan-diff drawer | **empty** | populated |
-| Drift banner | **empty** | populated |
+| Graph view | populated | populated |
+| Task panel / plan-revision banner | **empty** | populated |
+| Trajectory (intervention history) | **empty** | populated |
+| Drift markers / plan-diff drawer | **empty** | populated |
 
 The empty states are intentional and well-handled: no spinners, no
-error toasts. The panels show "No plan submitted for this session" and
-similar.
+error toasts. The Trajectory view renders "No interventions recorded"
+when there's nothing to show; the task panel shows "No plan submitted
+for this session".
+
+For standalone non-ADK clients, each Client gets its own Gantt row
+unless you explicitly share a `session_id`. One process = one agent =
+one row (unlike the `goldfive.wrap` path where one process drives many
+ADK agents across many rows per harmonograf#74/#80).
 
 ## Running the examples
 

--- a/docs/tour/15-minute-tour.md
+++ b/docs/tour/15-minute-tour.md
@@ -104,19 +104,27 @@ flowchart TD
   current plan and the drift context. The planner returns a revised plan.
   The frontend renders the diff as a banner with added / removed / reordered
   tasks.
-- **Reporting tools.** The protocol agents use to tell harmonograf what
+- **Reporting tools.** The protocol agents use to tell goldfive what
   they're doing. `report_task_started`, `report_task_progress`,
   `report_task_completed`, `report_task_failed`, `report_task_blocked`,
-  `report_new_work_discovered`, `report_plan_divergence`. Every sub-agent
-  gets these tools injected automatically.
-- **session.state.** ADK's shared mutable dict. Harmonograf writes the
-  current task (`harmonograf.current_task_id`, `...title`, `...description`)
-  before every model call, and reads back progress, outcomes, notes, and the
-  divergence flag. This is how agents and the orchestrator exchange context
-  without passing it through prompts.
+  `report_new_work_discovered`, `report_plan_divergence`. Every
+  sub-agent under `goldfive.wrap(...)` gets these tools injected
+  automatically by goldfive's ADK adapter. Goldfive owns them; see
+  [docs/reporting-tools.md](../reporting-tools.md) for the redirect.
+- **session.state / SessionContext.** ADK's shared mutable dict.
+  Goldfive's `SessionContext` carries the current task (and the rest of
+  the plan-execution state) on `session.state`. Harmonograf does not
+  write it — post-migration that's goldfive's job.
 - **Control events.** Out-of-band instructions from the frontend to the
-  agents: pause, resume, steer, status query. They ride down a separate gRPC
-  stream and are acknowledged upstream on the telemetry stream.
+  agents: pause, resume, steer, cancel. They ride down a separate gRPC
+  stream and are acknowledged upstream on the telemetry stream. The
+  server records every control event as an **Intervention** on the
+  session, surfaced in the Trajectory view.
+- **Interventions.** Harmonograf's unified chronological log of every
+  point the plan changed direction — user-driven (STEER / CANCEL /
+  PAUSE) or autonomous (drift). Rendered on the Trajectory view as a
+  horizontal marker ribbon with glyph-by-kind, color-by-source, and
+  severity rings (harmonograf#69 / #76).
 
 That's it. Nine primitives. Everything else in harmonograf is plumbing
 around these.
@@ -141,24 +149,30 @@ flowchart TD
 ```
 
 **Client library** (`client/`). Embedded inside each agent process. Exposes
-`Client` for span transport, `HarmonografSink` (a `goldfive.EventSink`) to
-ship plan/task/drift events up the telemetry stream, and an optional
-`HarmonografTelemetryPlugin` ADK `BasePlugin` that emits spans on lifecycle
-callbacks. The orchestration logic — task state machine, drift taxonomy,
-refine pipeline, planner — lives in
+`Client` for span transport (with lazy Hello so no ghost sessions are
+created under ADK), `HarmonografSink` (a `goldfive.EventSink`) to ship
+plan/task/drift events up the telemetry stream, `HarmonografTelemetryPlugin`
+(ADK `BasePlugin`) that emits spans on lifecycle callbacks and stacks
+per-ADK-agent ids so the tree renders one row per agent, and an
+`observe(runner)` helper that attaches both in one line. The
+orchestration logic — task state machine, drift taxonomy, refine
+pipeline, planner — lives in
 [goldfive](https://github.com/pedapudi/goldfive); the harmonograf client
 is the observability tap on top of it.
 
 **Server** (`server/`). Terminates every client connection. Owns the
 canonical timeline. Persists it to SQLite (or in-memory for tests). Fans out
 live updates to any number of frontend subscribers. Routes control messages
-from the frontend to the correct agent. It is the fan-in point: many clients,
-one server, one UI.
+from the frontend to the correct agent. Aggregates intervention history
+across annotations, drift ring, and plan revisions. It is the fan-in
+point: many clients, one server, one UI.
 
-**Frontend** (`frontend/`). A React/Vite app. Talks gRPC-Web to the server.
-Renders the Gantt canvas, the agent topology graph, the plan-diff banner and
-drawer, the inspector drawer, the transport bar. Live-subscribes to every
-session update; no refresh needed.
+**Frontend** (`frontend/`). A React/Vite app. Talks gRPC-Web to the
+server. Six views: Sessions picker, Activity (Gantt), Graph, Trajectory,
+Notes, Settings. Renders the Gantt canvas, the agent topology graph, the
+intervention timeline, the plan-revision banner and drawer, the inspector
+drawer, the transport bar. Live-subscribes to every session update; no
+refresh needed.
 
 All three components share one data model, defined in
 `proto/harmonograf/v1/*.proto` and regenerated via `make proto`. See
@@ -201,26 +215,30 @@ sequenceDiagram
 Now in detail, at a level you can see in the harmonograf UI:
 
 **Step 1 — the coordinator plans.** ADK routes your prompt to
-`presentation_agent`. `goldfive.Runner` owns the outer loop and asks the
-coordinator LLM to produce a plan via `goldfive.LLMPlanner`. It emits a structured plan with
-tasks like `research_python`, `design_outline`, `build_slides`, `review`.
-Harmonograf's client library sees the plan and calls `TaskRegistry.upsertPlan`
-on the server, which stores it and pushes it out to any subscribed frontend.
+`presentation_agent_orchestrated`. Under `goldfive.wrap(...)`, goldfive's
+`Runner` owns the outer loop and asks `LLMGoalDeriver` + `LLMPlanner`
+to derive a goal and emit a plan with tasks like `research_python`,
+`design_outline`, `build_slides`, `review`. Goldfive fires
+`PlanSubmitted`; `HarmonografSink` ships it up as a
+`TelemetryUp.goldfive_event`; the server stores it and pushes a
+`DELTA_TASK_PLAN` to every subscribed frontend.
 
 **Step 2 — the frontend learns about the session.** The harmonograf UI's
-session picker auto-selects the newest live session. The Gantt view renders
-one row per agent that has connected so far (initially just
-`coordinator_agent`). The task panel under the Gantt shows the plan as a
-flat list. The plan-revision banner briefly flashes that a new plan arrived.
+session picker auto-selects the newest live session. Under lazy Hello
+(harmonograf#85), the session id pinned on the row is the outer `adk-web`
+session id, not a synthetic `sess_…` placeholder. The Activity (Gantt)
+view renders one row per ADK agent as each agent emits its first span —
+the coordinator appears first, then the specialists as goldfive
+dispatches them. The task panel under the Gantt shows the plan; the
+plan-revision banner briefly flashes that a new plan arrived.
 
-**Step 3 — the first task starts.** The coordinator picks
-`research_python`, writes `harmonograf.current_task_id = "t1"` into
-`session.state`, and transfers to `research_agent`. The `research_agent`
-row appears on the Gantt. Its first action is to call
-`report_task_started(task_id="t1")` — a no-op-looking tool call that
-harmonograf's `before_tool_callback` intercepts and turns into a
-`PENDING → RUNNING` transition on task `t1`. The task panel recolors; the
-Gantt shows a new bar.
+**Step 3 — the first task starts.** Goldfive picks `research_python` and
+dispatches `research_agent` via its ADK adapter. The `research_agent` row
+appears on the Gantt the moment the plugin sees `before_agent_callback`.
+Its first model turn produces a `report_task_started(task_id="t1")` call;
+goldfive's `DefaultSteerer` intercepts it, transitions the task PENDING
+→ RUNNING, and fires a `TaskStarted` event. The sink ships it, the
+server updates its index, and the frontend repaints the bar.
 
 **Step 4 — tool calls stream in.** `research_agent` makes a few tool calls:
 a web search, a summarize call, maybe a payload-producing call that returns
@@ -234,43 +252,49 @@ vocabulary.
 
 **Step 5 — the task completes, the next one starts.** `research_agent`
 calls `report_task_completed(task_id="t1", summary="Python is a...")`.
-Harmonograf's interception marks the task `COMPLETED` and writes the summary
-into `harmonograf.completed_task_results` so downstream tasks see it as
-context. Control returns to the coordinator, which picks the next task and
-transfers to `web_developer_agent`. You see a new row appear on the Gantt,
-and a bezier curve — a cross-agent edge — connecting the transfer span to
+Goldfive's steerer transitions the task RUNNING → COMPLETED and fires
+`TaskCompleted`. Goldfive dispatches the next task (`build_slides`) to
+`web_developer_agent`. That agent's row auto-registers on its first span,
+and a bezier curve — a cross-agent edge — connects the transfer span to
 the new invocation.
 
 **Step 6 — something drifts.** The `reviewer_agent` runs and finds an
 issue with the generated HTML. It calls
 `report_new_work_discovered(parent_task_id="t3", title="fix HTML bug",
-assignee="debugger_agent")`. Harmonograf's interception fires a *refine* —
-a deferential call back into the planner with the current plan and the
-drift context (drift kind: `new_work_discovered`). The planner returns a
-revised plan with a new task spliced in. `TaskRegistry.upsertPlan` diffs the
-old and new plans and stores the result. The frontend renders the diff as a
-banner: "plan revised: +1 task". You can open the plan-diff drawer to see
-the added task highlighted in green, or switch to the **Trajectory** view
-(`↪ Trajectory` in the nav rail) to see the full rev-by-rev history as a
-horizontal ribbon with one segment per rev and drift markers on each
-segment. Clicking a drift marker shows the kind, severity, and detail that
-caused the refine. See
-[docs/user-guide/trajectory-view.md](../user-guide/trajectory-view.md) for
-the vocabulary. In the Gantt itself, the drift also materializes a
-`goldfive` actor row at the top of the plot with a bar at the time of the
-refine — that row is part of the actor attribution model
-([docs/user-guide/actors.md](../user-guide/actors.md)). This is drift as a
-first-class event. Full mechanism:
-[docs/protocol/task-state-machine.md](../protocol/task-state-machine.md).
+assignee="debugger_agent")`. Goldfive emits a `DriftDetected` event with
+kind `new_work_discovered`, fires a *refine* — a deferential call back
+into the planner with the current plan and the drift context — and the
+planner returns a revised plan with a new task spliced in. Goldfive
+emits `PlanRevised`. Harmonograf stores the new revision, diffs it
+against the previous plan, and the frontend renders the diff as a banner
+("plan revised: +1 task"). Open the plan-diff drawer to see the added
+task highlighted, or switch to **Trajectory** (↪ in the nav rail) to see
+the whole intervention history — every drift, every plan revision,
+every user-control event — as a horizontal marker ribbon. Click the new
+marker to see drift kind, severity, body, author, and outcome
+(`plan_revised:r2`). See
+[docs/user-guide/trajectory-view.md](../user-guide/trajectory-view.md).
+In the Gantt itself the drift also materializes a `goldfive` actor row
+at the top of the plot — part of the actor attribution model
+([docs/user-guide/actors.md](../user-guide/actors.md)). Full mechanism:
+[docs/protocol/task-state-machine.md](../protocol/task-state-machine.md)
+(which redirects to goldfive for the authoritative protocol).
 
 **Step 7 — you intervene.** Say you notice `debugger_agent` is taking too
-long. You press Space to pause all agents, or click a specific row to pause
-just that agent. The frontend sends a `SendControl` RPC to the server, which
-fans it out over `SubscribeControl` to the right agents. The agents
-acknowledge upstream on the telemetry stream. The frontend renders the
-acknowledgments. Then you unpause by pressing Space again. See
-[docs/user-guide/control-actions.md](../user-guide/control-actions.md) for
-every handle you have.
+long. You press Space to pause all agents, or click a specific row to
+pause just that agent. Alternatively, open the inspector drawer's
+Control tab on the stuck span and type a STEER ("ignore the HTML
+validator warnings and ship"). The frontend sends a `SendControl` RPC
+to the server; the client's `ControlBridge` validates the STEER body
+(harmonograf#72) and delivers it to goldfive's `ControlChannel`. The
+server stamps `author` + `annotation_id` and records it on the session
+as an Intervention. A new marker appears on the Trajectory view. If you
+STEER the same target twice inside five minutes, the two interventions
+**merge** into one card (harmonograf#81 / #87 user-control dedup).
+Acknowledgments ride upstream on the telemetry stream so the Gantt
+shows "paused at span X" in the right position. See
+[docs/user-guide/control-actions.md](../user-guide/control-actions.md)
+for every handle you have.
 
 **Step 8 — completion.** The coordinator calls `report_task_completed` on
 the root task. The session's status flips to `COMPLETED`. The Gantt shows a

--- a/docs/tour/index.md
+++ b/docs/tour/index.md
@@ -4,19 +4,24 @@ This is the front door. If you just landed in this repository and have no idea
 what harmonograf is, or why it exists, or where the documentation lives — start
 here.
 
-Harmonograf is a **console for observing, understanding, and coordinating
-multi-agent systems.** Think of it as what you'd want if you were trying to run
-a fleet of LLM agents that cooperate on real work: a live Gantt chart of what
-every agent is doing, a plan of what they're *supposed* to be doing, a visible
-diff whenever reality and plan drift apart, and a bidirectional channel so you
-can actually steer the run instead of just watching it.
+Harmonograf is the **observability + HCI companion to
+[goldfive](https://github.com/pedapudi/goldfive)** for multi-agent
+systems. Think of it as what you'd want if you were trying to run a
+fleet of LLM agents that cooperate on real work: a live Gantt chart of
+what every agent is doing, a plan of what they're *supposed* to be
+doing, a visible diff whenever reality and the plan drift apart, a
+chronological log of every intervention (yours or autonomous), and a
+bidirectional channel so you can actually steer the run instead of just
+watching it.
 
-The headline screen looks like a Gantt chart — one row per agent, time on the
-horizontal axis, a colored bar for every LLM call, tool call, transfer, or task.
-But the interesting bits are underneath: an explicit task state machine, a
-drift taxonomy, a refine pipeline that re-plans live, and a protocol designed
-so that the frontend can talk back to the agents on the same connection the
-telemetry came up on.
+Six views in the nav rail: **Sessions**, **Activity** (Gantt, one row
+per ADK agent), **Graph** (agent topology), **Trajectory**
+(intervention history ribbon), **Notes**, **Settings**. The headline
+screen is Activity — time on the horizontal axis, a colored bar for
+every LLM call, tool call, transfer, or task. Underneath it:
+goldfive's explicit task state machine, drift taxonomy, and refine
+pipeline, with a protocol designed so the frontend can talk back to the
+agents on the same connection the telemetry came up on.
 
 ## Three doors
 

--- a/docs/tour/mental-model.md
+++ b/docs/tour/mental-model.md
@@ -4,11 +4,15 @@
 > tools, task state machine, `session.state["harmonograf.*"]` keys,
 > `_AdkState`, `state_protocol.extract_agent_writes`, walker) now live
 > in [goldfive](https://github.com/pedapudi/goldfive). Harmonograf still
-> owns the span timeline, the control stream, the session + storage, and
-> the UI. Read the mental model with that substitution in mind — the
-> *composition* story is accurate; the module names are out of date.
-> See [../goldfive-integration.md](../goldfive-integration.md) for the
-> current surface.
+> owns the span timeline, the control stream, the session + storage,
+> the intervention aggregator, and the UI (six views: Sessions,
+> Activity, Graph, Trajectory, Notes, Settings). Read the mental model
+> with that substitution in mind — the *composition* story is accurate;
+> the module names are out of date. See
+> [../goldfive-integration.md](../goldfive-integration.md) for the
+> current surface and
+> [../milestones.md#post-migration-shipped-2026-04](../milestones.md)
+> for what's shipped since the migration.
 
 This document is not a glossary. A glossary defines terms in isolation; a
 mental model explains how the pieces *compose*. By the end you should be
@@ -375,8 +379,13 @@ handshake.
 The control kinds currently include:
 
 - `PAUSE` / `RESUME` — freeze or unfreeze an agent's next turn
-- `STEER` — inject a note / nudge into the agent's next prompt
-- `STATUS_QUERY` — ask the agent for an explicit status report
+- `STEER` — inject a note / nudge into the agent's next prompt. Body is
+  validated on the client (`ControlBridge`): empty or >8 KiB UTF-8 is
+  rejected, ASCII control chars stripped (harmonograf#72). Server stamps
+  `author` + `annotation_id`.
+- `CANCEL` — cancel in-flight work, optionally cascading through the
+  plan DAG.
+- `STATUS_QUERY` — ask the agent for an explicit status report.
 - (more as the coordination surface grows)
 
 Acks come back **upstream on the telemetry stream**, not on the control
@@ -386,6 +395,46 @@ spans the agent emitted before issuing the ack, so the UI can show
 delivery; the telemetry stream carries the acknowledgment. Every new
 client adapter forgets this exactly once. See
 [docs/protocol/wire-ordering.md](../protocol/wire-ordering.md).
+
+## Interventions: the chronological log of every plan change
+
+Every control event you send, plus every autonomous drift goldfive fires
+via `HarmonografSink`, becomes an **Intervention** on the session. The
+server's `interventions.py` aggregator joins:
+
+- `annotations` (STEER / HUMAN_RESPONSE rows)
+- ingest drift ring (`drift_detected` events, including `user_steer` /
+  `user_cancel` kinds)
+- `task_plans.revision_kind` (plan revisions carrying the drift kind or
+  autonomous kinds like `cascade_cancel`)
+
+…into one chronological list. The `ListInterventions(session_id)` unary
+RPC returns it; the frontend has a live deriver that mirrors the shape
+for in-flight deltas (harmonograf#69 / #71). User-control kinds merge
+inside a 5-minute window (harmonograf#81 / #87) so rapid-fire STEERs on
+the same target show up as one card.
+
+This is the single data source behind the **Trajectory view**: each
+intervention is a marker on the horizontal ribbon, glyph-by-kind,
+color-by-source (user vs. autonomous), outer ring by severity. Clicking
+a marker opens a popover with body, author, and outcome. If the
+intervention was immediately followed by a plan revision or cascade
+cancel, the popover links to it. This is where harmonograf's story of
+*who did what, when, and what happened next* actually lives.
+
+## Per-ADK-agent attribution
+
+Under `goldfive.wrap(...)`, one `goldfive.Runner` drives a tree of ADK
+agents (coordinator, specialists, `AgentTool` wrappers, sequential /
+parallel / loop containers). `HarmonografTelemetryPlugin` stacks a
+`per_agent_id = "{client_id}:{adk_name}"` via `before_agent_callback` /
+`after_agent_callback` so the Activity view renders one Gantt row per
+ADK agent. Each agent's first span carries `hgraf.agent.*` hints (name,
+parent, kind, branch, framework) which the server's `_ensure_route`
+harvests into the agent's metadata the first time it auto-registers.
+Nothing in user code opts into this — the plugin handles it, whether
+installed via `observe()` or via `App.plugins=[...]`. See
+harmonograf#74 / #80.
 
 User-facing view: [docs/user-guide/control-actions.md](../user-guide/control-actions.md).
 

--- a/docs/tour/terminology-map.md
+++ b/docs/tour/terminology-map.md
@@ -15,7 +15,7 @@ read [mental-model.md](mental-model.md) instead.
 
 ```mermaid
 graph TD
-    Session[Session<br/>one agent rollout] --> Agent[Agent<br/>one actor]
+    Session[Session<br/>one agent rollout] --> Agent[Agent<br/>one ADK agent = one row]
     Session --> Plan[Plan<br/>DAG of tasks]
     Agent --> Span[Span<br/>event with duration]
     Plan --> Task[Task<br/>unit of work]
@@ -25,10 +25,13 @@ graph TD
     Plan -.refine on drift.-> Plan
     Session --> Annotation[Annotation<br/>human note]
     Session --> ControlEvent[ControlEvent<br/>frontend->agent]
-    Session --> SessionState[session.state<br/>harmonograf.* keys]
-    SessionState -.read by.-> Agent
+    Session --> Intervention[Intervention<br/>every plan-change event]
+    Session --> SessionCtx[goldfive.SessionContext<br/>on session.state]
+    SessionCtx -.read by.-> Agent
     Agent -.reporting tools.-> Task
     ControlEvent -.ack upstream.-> Span
+    ControlEvent -.becomes.-> Intervention
+    Plan -.drift/revision.-> Intervention
 ```
 
 Read the diagram as "these are the nouns and how they reference each
@@ -78,15 +81,21 @@ In prose:
   harmonograf agent row on the Gantt.
 - **ADK callbacks → harmonograf spans.** Every
   `before_model_callback` / `after_model_callback` / `before_tool_callback`
-  fires a span emission. Harmonograf attaches to these callbacks via
-  `HarmonografAdkPlugin`.
-- **ADK function tools → harmonograf reporting tools.** The seven
-  `report_*` tools are ordinary ADK function tools; harmonograf
-  intercepts them in `before_tool_callback` to apply state transitions.
-  An agent calls them just like any other tool.
-- **ADK `session.state` dict → harmonograf `session.state` with
-  `harmonograf.*` keys.** Harmonograf reserves the `harmonograf.`
-  prefix; everything else is untouched.
+  / `before_agent_callback` / `after_agent_callback` fires a span
+  emission. Harmonograf attaches to these callbacks via
+  `HarmonografTelemetryPlugin`. Agent callbacks also stack
+  `per_agent_id` so the Gantt renders one row per ADK agent
+  (harmonograf#74 / #80).
+- **ADK function tools → goldfive reporting tools.** The seven
+  `report_*` tools are ordinary ADK function tools, injected by
+  `goldfive.adapters.adk.ADKAdapter`. Goldfive's `DefaultSteerer`
+  intercepts them in `before_tool_callback` to apply state transitions
+  and fire events. Harmonograf observes those events via
+  `HarmonografSink`, it does not intercept the tools.
+- **ADK `session.state` dict → goldfive's `SessionContext` on `session.state`.**
+  Goldfive owns the session-state protocol post-migration. The old
+  `harmonograf.*` keys are retired; see
+  `goldfive.adapters._adk_plugin.SESSION_CONTEXT_STATE_KEY`.
 - **ADK events → harmonograf drift signals.** `on_event_callback`
   watches for `transfer`, `escalate`, and `state_delta` events as
   belt-and-suspenders drift signals.
@@ -257,15 +266,22 @@ one-to-one. Here are the ones that trip people up:
 
 | UI term | Backend primitive | Notes |
 |---|---|---|
-| **Sessions view** | the Gantt view | The nav rail calls the main view "Sessions"; everywhere else it's called "Gantt". Same page. |
-| **Row** | an `Agent` | One row per agent. |
+| **Sessions view** | the session picker | One row per ADK session post-lazy-Hello (harmonograf#85). |
+| **Activity view** | the Gantt view | The main timeline. Selected from the nav rail under the `!` icon. |
+| **Graph view** | agent topology graph | Nodes = ADK agents, edges = transfers / tool invocations. |
+| **Trajectory view** | the intervention history ribbon (#69 / #76) | One marker per Intervention; glyph-by-kind, color-by-source, severity ring. |
+| **Notes view** | session-wide annotation stream | Every annotation posted on the session. |
+| **Row** | an `Agent` | One row per ADK agent — auto-registered from first-span hints (harmonograf#74 / #80). |
+| **goldfive row** | the synthetic actor row for goldfive events | Drift and user-steer events materialise bars here. |
 | **Bar** | a `Span` | Color = span kind, fill pattern = status. |
 | **Ghost bar** | a predicted span from a `Task` (dashed, 30% opacity) | The planner's prediction; replaced by a real bar once the task actually runs. |
 | **Breathing bar** | a running span | 2-second pulse animation while `end_time` is null. |
 | **Cross-agent edge** | a `SpanLink` of kind transfer | Bezier curve between two bars on different rows. |
 | **Plan-revision banner** | a refine result | Appears when a new plan revision arrives. |
 | **Plan-diff drawer** | the diff against the previous revision | Shows added / removed / reordered / re-parented / re-assigned tasks. |
-| **Current task strip** | the task currently bound to the active span in the focused agent | Reads `harmonograf.current_task_id` from `session.state`. |
+| **Intervention marker** | one `Intervention` | On Trajectory; clickable popover with author, body, outcome. |
+| **Intervention card dedup** | user-control merging within 5 min | Second STEER/CANCEL/PAUSE on the same target collapses into the first card (harmonograf#81 / #87). |
+| **Current task strip** | the task currently bound to the active span | Post-migration the source is goldfive's `SessionContext`, not `harmonograf.*` keys. |
 | **Live-tail cursor** | server's `latest_span_time` per session | The right-edge follower on the Gantt. |
 | **Transport bar** | frontend control emitting `SendControl` events | Pause / resume / follow-live / zoom. |
 | **Inspector drawer** | the `GetSpanTree` or task-specific data for the selection | Tabs: Summary, Task, Payload, Timeline, Links, Annotations, Control. |

--- a/examples/standalone_observability/README.md
+++ b/examples/standalone_observability/README.md
@@ -2,20 +2,22 @@
 
 **Use harmonograf as an observability console — without goldfive
 orchestration.** Emit spans via `harmonograf_client.Client`, and the
-frontend's Gantt / agent panels render them the same as any other
-source. Plans, tasks, and drift (goldfive's signals) stay out of the
-picture; the Tasks panel is simply empty.
+frontend's Sessions / Activity (Gantt) / Graph views render them the
+same as any other source. Plans, tasks, drift, and intervention history
+(goldfive's signals) stay out of the picture: the task panel and
+Trajectory views are empty.
 
 See [`docs/standalone-observability.md`](../../docs/standalone-observability.md)
-for the full story.
+for the full story, including the lazy-Hello / home-session semantics
+for non-ADK clients (harmonograf#85).
 
 ## What's in this directory
 
 | File | What it does | Imports goldfive? |
 | --- | --- | --- |
-| [`spans_only.py`](spans_only.py) | Hand-authored synthetic spans via `Client.emit_span_*` — the "no-framework" path. | No. |
-| [`adk_telemetry.py`](adk_telemetry.py) | A real ADK agent instrumented with `HarmonografTelemetryPlugin`. Telemetry only. | No. |
-| [`with_orchestration.py`](with_orchestration.py) | Counterpoint: goldfive's `Runner` + `observe()` to light up plans + tasks + drift. | **Yes** — needs `uv sync --extra orchestration`. |
+| [`spans_only.py`](spans_only.py) | Hand-authored synthetic spans via `Client.emit_span_*` — the "no-framework, no-ADK" path. | No. |
+| [`adk_telemetry.py`](adk_telemetry.py) | A real ADK agent instrumented with `HarmonografTelemetryPlugin` on `App(plugins=[...])`. Telemetry only — no `goldfive.wrap`. | No. |
+| [`with_orchestration.py`](with_orchestration.py) | Counterpoint: `goldfive.wrap(...)` + `harmonograf_client.observe()` to light up plans + tasks + drift + intervention history. | **Yes** — needs `uv sync --extra orchestration`. |
 
 Verify the first two truly have zero goldfive references:
 
@@ -64,10 +66,15 @@ make demo-standalone
 
 | Panel | spans_only.py | adk_telemetry.py | with_orchestration.py |
 | --- | --- | --- | --- |
-| Gantt (agent activity) | populated | populated | populated |
+| Sessions picker | populated (1 session) | populated (1 session) | populated (1 session) |
+| Activity (Gantt, agent rows) | populated (1 row) | populated (N rows, one per ADK agent) | populated (N rows per goldfive.wrap tree) |
+| Graph view | populated | populated | populated |
 | Messages | populated | populated | populated |
-| Tasks | **empty** | **empty** | populated |
-| Plan view | **empty** | **empty** | populated |
-| Drift indicators | **empty** | **empty** | populated |
+| Tasks / plan banner | **empty** | **empty** | populated |
+| Trajectory (interventions) | **empty** | **empty** | populated |
+| Drift markers | **empty** | **empty** | populated |
 
-Empty Tasks panel is the expected standalone state — not an error.
+Empty task panel / Trajectory is the expected standalone state — not an
+error. The `adk_telemetry.py` path gets per-ADK-agent rows for free
+because the plugin stacks per-agent ids even without `goldfive.wrap`
+(harmonograf#74 / #80).

--- a/tests/reference_agents/README.md
+++ b/tests/reference_agents/README.md
@@ -5,8 +5,23 @@ This directory holds reference ADK agents used for demos (`make demo`,
 are illustrative samples — not production code — and exist to exercise
 the `harmonograf_client` instrumentation against a real ADK runner.
 
-Keep dependencies minimal: a reference agent should pull in ADK and
-`harmonograf_client` and nothing else from this repo. Do not import
-from `client/` internals or from `server/` runtime code; if a reference
-agent needs a helper, the helper belongs in the public client API
-first.
+Two sibling packages:
+
+| Package | Mode | What it proves |
+|---|---|---|
+| [`presentation_agent/`](presentation_agent/) | Observation | `HarmonografTelemetryPlugin` attached to a plain ADK `App`. No `goldfive.wrap`. Plans/tasks/drift stay empty; per-span telemetry, per-ADK-agent Gantt rows, and control still work. |
+| [`presentation_agent_orchestrated/`](presentation_agent_orchestrated/) | Orchestration | Same agent tree wrapped with `goldfive.wrap(...)` before `App()` sees it. Goldfive derives a goal, plans specialists, dispatches, fires drift; harmonograf shows plan/task/drift/intervention surface end-to-end. |
+
+Both packages share the same coordinator + research + web_developer +
+reviewer + debugger tree, loaded by absolute file path from
+`third_party/goldfive/examples/presentation_agent/agent.py` so the two
+stay byte-identical.
+
+`make demo` stages both under `.demo-agents/` and `adk web` lists them
+both in the picker — pick whichever mode you want to drive from the UI.
+
+Keep dependencies minimal: a reference agent should pull in ADK,
+`harmonograf_client`, and (for the orchestrated sibling) `goldfive`;
+nothing else from this repo. Do not import from `client/` internals or
+from `server/` runtime code; if a reference agent needs a helper, the
+helper belongs in the public client API first.

--- a/tests/reference_agents/presentation_agent_orchestrated/README.md
+++ b/tests/reference_agents/presentation_agent_orchestrated/README.md
@@ -12,9 +12,11 @@ intentional difference is that this module wraps the tree with
 | Layer | Observation (`presentation_agent`) | Orchestration (`presentation_agent_orchestrated`) |
 |---|---|---|
 | Routing | Coordinator LLM picks the next sub-agent via its instruction text. | Goldfive derives a goal, plans the specialists, and dispatches them in order. |
-| Plan | None — the LLM's transcript *is* the plan. | Explicit `TaskPlan` with `research → build → review → debug`. |
-| Drift | Not detected; the coordinator just keeps generating. | `TaskCompleted` fires per sub-agent; adapter-return mismatches trigger plan revision. |
-| Steering | Transcript-level only. | Goldfive's steering + HITL seams surface into harmonograf, so PAUSE / STEER / CANCEL take effect mid-run. |
+| Plan | None — the LLM's transcript *is* the plan. | Explicit `Plan` with `research → build → review → debug`; revisions stored with per-rev diffs. |
+| Drift | Not detected; the coordinator just keeps generating. | `TaskCompleted` fires per sub-agent; adapter-return mismatches trigger plan revision; all drift events ride `HarmonografSink` to the server. |
+| Steering | Transcript-level only. | Goldfive's steering + HITL seams surface into harmonograf via `ControlBridge`, so PAUSE / STEER / CANCEL from the UI take effect mid-run (harmonograf#72 validates STEER body; server stamps author / annotation_id). |
+| Trajectory | Empty. | Every drift / plan-rev / user-control event shows up as an intervention marker (harmonograf#69 / #71 / #76); user-control kinds merge inside a 5 min window (#81 / #87). |
+| Per-agent rows | Plugin attribution still works — one row per ADK agent (harmonograf#74 / #80). | Same — plugin is installed on the wrapped Runner's ADK adapter. |
 
 If you want to see the full goldfive drift / refine / user-actor
 behaviour end-to-end in `adk web`, load this package. Observation mode
@@ -33,6 +35,12 @@ then lists both by name:
 
 Pick whichever you want to drive from the ADK UI; the harmonograf tab
 receives the appropriate telemetry regardless of which one is running.
+
+Under lazy Hello (harmonograf#85), the client defers its Hello until
+the first real emit, so there's no ghost session row for whichever
+variant you didn't pick. Session unification (#66) pins the outer
+adk-web session id on `goldfive.Session.id`, so the row you see in the
+picker matches the ADK session you're driving.
 
 ## Env vars
 


### PR DESCRIPTION
## Summary

Comprehensively refresh harmonograf's top-level and cross-cutting documentation
to reflect everything shipped post-goldfive-migration:

- **Per-ADK-agent Gantt rows** (harmonograf#74 / #80)
- **Intervention history** + `ListInterventions` RPC + Trajectory view redesign (#69 / #71 / #76)
- **Intervention card dedup** — 5-min window for user-control, tight for autonomous (#81 / #87, closed #75 / #73 / #86)
- **Lazy Hello** — no ghost sessions under ADK (#85)
- **Session unification** — outer adk-web id pinned on goldfive session (#63 / #66)
- **STEER body validation + author stamping** (#72)
- **Plugin dedup** — second `HarmonografTelemetryPlugin` is silently a no-op (#68)

Also covers the current six-view UI (Sessions / Activity / Graph / Trajectory /
Notes / Settings), the `observe(runner)` one-line helper, the two-variant
presentation_agent reference setup, and the current `make demo` flow.

## Files touched (per brief)

- `README.md` — project description, integration-mode triptych, architecture table, demo walkthrough, docs table.
- `AGENTS.md` — project vision, repo layout map, architecture / component boundaries, test + PR workflow, documentation layout, skill system.
- `docs/quickstart.md` — step-by-step expanded to include Trajectory and STEER; bare-ADK / standalone side-paths.
- `docs/overview.md` — current feature set rewritten; "Recently shipped" section added; roadmap trimmed.
- `docs/operator-quickstart.md` — added "Watch a live run", "Steer from the UI", "Read intervention cards" sections; #89 noted as in-flight.
- `docs/index.md` — doc-tree index rebuilt to match current docs; added Trajectory/actors/glossary user-guide entries, runbooks list, new internals files.
- `docs/milestones.md` — "Post-migration shipped (2026-04)" section with the full list of shipped issues.
- `docs/standalone-observability.md` — lazy-Hello home-session nuance; updated populated/empty panels table.
- `docs/goldfive-integration.md` — expanded split of responsibilities; new sections for per-agent rows, plugin dedup, session unification, lazy Hello, intervention emission.
- `docs/goldfive-migration-plan.md` — banner refreshed; points at current docs; marked historical-only.
- `docs/reporting-tools.md` — redirect expanded with tool-loop-detector exemption + state-protocol pointers.
- `docs/tour/15-minute-tour.md` — mental-model primitives refreshed (reporting tools → goldfive, intervention added); end-to-end walkthrough rewritten around goldfive.Runner + Trajectory.
- `docs/tour/index.md` — lead rewritten around goldfive-companion role + six views.
- `docs/tour/mental-model.md` — top banner refreshed; added Interventions and Per-ADK-agent-attribution sections; STEER body validation noted.
- `docs/tour/terminology-map.md` — UI vocabulary table updated for six views + intervention vocabulary; ADK callback mapping updated for agent callbacks; graph mermaid adds Intervention.
- `examples/standalone_observability/README.md` — panel table adds Trajectory; clarifies per-agent rows under `adk_telemetry.py`.
- `tests/reference_agents/README.md` — explains the two-variant setup.
- `tests/reference_agents/presentation_agent_orchestrated/README.md` — orchestration-mode table adds Trajectory + per-agent rows; lazy-Hello session-unification note.

## Test plan

- [ ] `make test` green (docs-only change but confirm CI passes).
- [ ] Preview rendered markdown — no broken cross-links.
- [ ] Self-merge after CI green.

Constraints honored: isolated worktree; no Claude co-author trailer; sibling
dirs (docs/design, docs/protocol, docs/dev-guide, docs/user-guide,
docs/runbooks, docs/internals, .agents/skills) not touched.