### PR TITLE
docs(design,protocol,adr,internals): refresh for current architecture

### DIFF
--- a/docs/adr/0021-session-id-pinning.md
+++ b/docs/adr/0021-session-id-pinning.md
@@ -1,0 +1,72 @@
+# ADR 0021 — Pin `goldfive.Session.id` to the outer adk-web session id
+
+## Status
+
+Accepted (2026-04, harmonograf #65 / goldfive #161 / harmonograf #62).
+
+## Context
+
+A single `goldfive.wrap`'d adk-web run drives a tree of ADK agents:
+coordinator, specialists, `AgentTool` wrappers, sequential/parallel
+containers. ADK `AgentTool` builds its own sub-`Runner` inside the tool
+call, and that sub-Runner mints a fresh `InMemorySessionService` with a
+brand-new session id. Left alone, every sub-Runner produces its own
+`Hello` with its own session id, and one adk-web run fans out across N
+harmonograf sessions — one per sub-Runner — on the Gantt.
+
+Worse, the plan view shows `goldfive.Session.id`, which was also being
+minted per sub-Runner. The plan ended up on the outer session and the
+execution spans on sub-Runner sessions, so the plan pane and the Gantt
+pane were rendering different session rows for the same run.
+
+## Decision
+
+The `HarmonografTelemetryPlugin` caches the outer adk-web
+`ctx.session.id` on the ROOT `before_run_callback` and stamps it on
+every span emitted for the rest of the run — root, sub-Runners, and all.
+The per-ctx sub-Runner session id is still captured as the
+`adk.session_id` span attribute for forensic debugging.
+
+On the goldfive side (goldfive #161), `goldfive.Session.id` is pinned
+to the same outer adk-web session id at `goldfive.wrap` time, so plan
+events carry the same `session_id` the spans do.
+
+See `HarmonografTelemetryPlugin.__init__` / `before_run_callback` /
+`_stamp_session_id` in
+[`client/harmonograf_client/telemetry_plugin.py`](../../client/harmonograf_client/telemetry_plugin.py).
+
+## Consequences
+
+**Good.**
+- One adk-web run → one harmonograf session row → one unified timeline.
+- The plan pane and the Gantt render on the same session, so
+  operators never see "my plan is on session A but the spans are on
+  session B."
+- Session switching stays stable across sub-Runner invocations —
+  closing and reopening the session picker doesn't produce a ghost
+  session per `AgentTool` call.
+
+**Bad.**
+- The harmonograf server has no way to distinguish sub-Runner
+  activity from root-Runner activity beyond the `adk.session_id`
+  attribute. Forensic users who want per-sub-Runner analysis have to
+  dig into span attributes.
+- Non-ADK clients don't automatically get this behavior — they rely
+  on whatever their own SDK's session concept produces. That's why
+  the lazy-Hello ADR (0022) exists as a complementary fix.
+- If the outer adk-web session id is missing or malformed for some
+  reason, the plugin falls back to the per-ctx id and the old
+  behavior returns. This is intentional — a weird ADK install
+  should still produce a working (if split) session rather than no
+  session at all.
+
+## Implemented in
+
+- [`client/harmonograf_client/telemetry_plugin.py`](../../client/harmonograf_client/telemetry_plugin.py)
+- Goldfive: `Session.id` pinned at `goldfive.wrap` call site (goldfive #161).
+- [Design 12 — Client library and ADK](../design/12-client-library-and-adk.md)
+
+## See also
+
+- [ADR 0022 — Lazy Hello](0022-lazy-hello.md) — complementary fix for
+  non-ADK clients and multi-session adk-web trees.

--- a/docs/adr/0022-lazy-hello.md
+++ b/docs/adr/0022-lazy-hello.md
@@ -1,0 +1,85 @@
+# ADR 0022 — Lazy Hello: defer the stream-opening RPC until first emit
+
+## Status
+
+Accepted (2026-04, harmonograf #83 / #85).
+
+## Context
+
+The pre-2026-04 client library sent `Hello` immediately on
+`StreamTelemetry` open — before any span had been emitted. This
+produced two problems:
+
+1. **Ghost sessions on the Gantt.** A long-lived module-level
+   `Client` (the usual presentation-agent / adk-web pattern)
+   connects at process start but doesn't emit anything until the
+   user triggers an ADK invocation. The server would happily create
+   a `sess_<date>_<nnnn>` row from the Hello and populate the
+   session picker with it, even though no spans, tasks, or events
+   ever landed. Pairs of these ghost rows accumulated with every
+   restart.
+2. **Session id can't be derived from the first span.** The
+   harmonograf telemetry plugin derives the session id from
+   `ctx.session.id` inside the first `before_run_callback` (see
+   [ADR 0021](0021-session-id-pinning.md)). A Hello sent at stream
+   open has to use whatever session id the Client was constructed
+   with — not the actual adk-web session — so the server
+   auto-creates a second session and the first real span has to be
+   routed to it via per-span session-id override. Non-ADK clients
+   that use a similar pattern lost their session rollup entirely.
+
+## Decision
+
+The client transport defers the `Hello` RPC until the first real
+`TelemetryUp` is ready to send. When the first envelope carries a
+`session_id` (because the plugin stamped the outer adk-web session id
+on it), the transport uses that as `Hello.session_id`. The result:
+the home session that Hello creates is already the correct session,
+from the very first event.
+
+For non-ADK clients that never emit, no Hello is sent — no session
+row appears, no ghost entries in the picker, no storage footprint.
+
+See `_maybe_send_hello` in
+[`client/harmonograf_client/transport.py`](../../client/harmonograf_client/transport.py).
+
+## Consequences
+
+**Good.**
+- No ghost `sess_*` rows from processes that open a Client but
+  never emit. The session picker shows exactly the set of sessions
+  that actually produced events.
+- Combined with [ADR 0021](0021-session-id-pinning.md), one adk-web
+  run = one harmonograf session, visible from the very first span.
+- Non-ADK clients get session rollup "for free" when they stamp a
+  `session_id` on their first emit — the home session is stamped
+  with that id rather than whatever the Client was constructed with.
+- Recoverable: if an agent starts emitting and then disconnects, the
+  reconnect path re-runs lazy Hello against the reconnect's first
+  envelope. Session id stays consistent.
+
+**Bad.**
+- Welcome is also delayed until the first emit. Control subscribe
+  cannot open before Welcome, so `SubscribeControl` is correspondingly
+  delayed. This is fine in practice — there are no control events to
+  deliver before the agent has done anything — but operators
+  debugging control delivery must understand that `SubscribeControl`
+  appearing after the first span is expected, not a bug.
+- The server sees a brief open-without-Hello state on reconnects.
+  The transport is careful to send Hello before any non-Hello
+  envelope to preserve the per-stream invariant (`Hello must be
+  first`), but the stream is nominally "open" for a few
+  milliseconds before that first Hello lands.
+- Reconnect logic is slightly more subtle: the transport must clear
+  `_hello_sent` on reconnect and re-derive the session id from the
+  next envelope, not from the one that was in flight when the old
+  stream died.
+
+## Implemented in
+
+- [`client/harmonograf_client/transport.py`](../../client/harmonograf_client/transport.py) — `_maybe_send_hello`, `_hello_sent` flag, `_session_id_of_envelope`.
+- [Protocol — telemetry-stream](../protocol/telemetry-stream.md) — Hello semantics and the lazy-emit contract.
+
+## See also
+
+- [ADR 0021 — Session id pinning](0021-session-id-pinning.md).

--- a/docs/adr/0023-intervention-dedup-by-annotation-id.md
+++ b/docs/adr/0023-intervention-dedup-by-annotation-id.md
@@ -1,0 +1,92 @@
+# ADR 0023 — Intervention dedup by `annotation_id`
+
+## Status
+
+Accepted (2026-04, harmonograf #71 / #75 / #81 / #87, goldfive #171 / #176 / #177).
+
+## Context
+
+An intervention — a point in a run where the plan changes direction —
+can surface on the wire from three different primitives, often all at
+once for a single user action:
+
+1. A **`PostAnnotation`** arrives with kind=STEERING. It persists as an
+   `annotations` row and is routed through the control path as a
+   `STEER` event.
+2. Goldfive receives the STEER, flips its drift detector, and emits a
+   **`DriftDetected`** event with kind=`user_steer`.
+3. Goldfive's planner refines the plan and emits a
+   **`PlanRevised`** event whose `revision_kind=user_steer`.
+
+Without dedup, a single user STEER surfaces as **three** cards in the
+Intervention timeline: an annotation row, a drift row, and a plan
+revision row. Operators saw this as noise and couldn't tell which was
+the "real" event.
+
+## Decision
+
+Every stop on the pipeline that can carry a back-reference to the
+source annotation does so:
+
+- `goldfive.v1.SteerPayload` adds `author` (field 3) and
+  `annotation_id` (field 4). Harmonograf's `PostAnnotation` handler
+  populates both from the stored annotation row when it synthesizes
+  the STEER event (see
+  [`server/harmonograf_server/rpc/frontend.py`](../../server/harmonograf_server/rpc/frontend.py)).
+- `goldfive.v1.DriftDetected` adds `annotation_id` (field 6).
+  Goldfive stamps it when a user-originated drift propagates from a
+  STEER that carried one.
+- `TaskPlan.revision_kind` and the drift that triggered a refine
+  carry the annotation_id forward so the plan revision row can also
+  be joined on it.
+
+The aggregator (`server/harmonograf_server/interventions.py`)
+collapses all rows that share an `annotation_id` into a single
+user-authored card, merging outcome, severity, and plan-revision
+metadata onto the annotation-derived row. Autonomous drifts (no
+annotation_id, e.g. `looping_reasoning`) keep their own cards.
+
+The frontend deriver (`frontend/src/lib/interventions.ts`) mirrors
+the aggregator for live updates: a STEER annotation, drift, and plan
+revision all arriving on the live stream collapse into one row
+incrementally without a server round-trip.
+
+## Consequences
+
+**Good.**
+- One user STEER = one card. Operators see exactly the set of
+  distinct interventions without double-counting.
+- The dedup contract is structural, not temporal: it survives out-of-
+  order arrival, reconnects, and late drift emissions.
+- Autonomous drifts (ones goldfive mints on its own) keep their own
+  rows automatically, because they never carry an `annotation_id`.
+- Forward-compatible: if goldfive later introduces a new user-control
+  kind (e.g. `user_rewind`), stamping the annotation_id on the
+  resulting drift is enough — the aggregator doesn't need code
+  changes.
+
+**Bad.**
+- The attribution window is heuristic. A drift that legitimately
+  fires within 5 minutes of a user STEER but is unrelated to it (e.g.
+  a separate loop-detection drift) is attributed to the STEER's
+  outcome column. The 5-minute window (for user-control kinds;
+  autonomous kinds use a tight 5s) was tuned against real sessions;
+  shorter windows dropped legitimate plan revisions on slow LLMs,
+  longer windows caused false merges.
+- Every layer (harmonograf wire, goldfive wire, sink, aggregator,
+  frontend deriver) has to thread the `annotation_id` through
+  consistently. One missed propagation site reintroduces the triple
+  card.
+- Plans don't currently carry an `annotation_id` field — the join
+  onto the plan row happens indirectly through the preceding drift.
+  A user STEER that somehow skips the drift (the refine pipeline
+  shortcuts) would leave the plan row unattributed. So far this
+  path has not been observed in practice.
+
+## Implemented in
+
+- [`server/harmonograf_server/interventions.py`](../../server/harmonograf_server/interventions.py)
+- [`server/harmonograf_server/rpc/frontend.py`](../../server/harmonograf_server/rpc/frontend.py) — `PostAnnotation` populates `SteerPayload.author` + `annotation_id`.
+- [`frontend/src/lib/interventions.ts`](../../frontend/src/lib/interventions.ts) — client-side dedup mirror.
+- Goldfive: `SteerPayload.author` / `annotation_id` (control.proto), `DriftDetected.annotation_id` (events.proto).
+- [Design 13 — Human interaction model](../design/13-human-interaction-model.md).

--- a/docs/adr/0024-per-adk-agent-gantt-rows.md
+++ b/docs/adr/0024-per-adk-agent-gantt-rows.md
@@ -1,0 +1,119 @@
+# ADR 0024 — Per-ADK-agent Gantt rows via plugin-side id stacking and server auto-register
+
+## Status
+
+Accepted (2026-04, harmonograf #74 / #80).
+
+## Context
+
+Before this change, the harmonograf Gantt had one row per client
+process — i.e. one row per `Client` instance. A `goldfive.wrap` run
+with a coordinator agent delegating to specialists via `AgentTool`
+rendered as a single row with every tool call stacked on top of the
+coordinator's invocation. Operators couldn't tell which agent was
+doing which work; the one-row-per-process collapsing was load-bearing
+but completely hid multi-agent dynamics from the UI.
+
+The obvious fix — register every ADK agent in the tree as a separate
+harmonograf `Agent` — has two sub-problems:
+
+1. **Identity:** the harmonograf `agent_id` must be stable per
+   `(client, adk-agent-name)` pair across reconnects and restarts.
+2. **Registration:** the server must learn about a new agent without
+   requiring the client to emit a dedicated wire event (that would
+   require a proto change and a new ingest path).
+
+## Decision
+
+### Plugin-side: stack per-agent ids on callback entry
+
+`HarmonografTelemetryPlugin.before_agent_callback` derives a
+per-agent id `{client_id}:{adk-agent-name}` and pushes it onto a
+per-invocation stack. Every span emitted while that agent is active
+carries that id as its `agent_id`. `after_agent_callback` pops.
+
+The stack handles nested agents correctly: a coordinator calling
+`AgentTool(specialist)` yields
+`coordinator-id → coordinator-id:coordinator → coordinator-id:specialist`
+and the specialist's LLM/tool spans land on the specialist row, while
+the coordinator's own spans stay on the coordinator row.
+
+### Plugin-side: metadata hints on the first span
+
+Because the server has never seen this per-agent id before, the first
+span it ever emits carries four optional attributes that describe the
+agent:
+
+- `hgraf.agent.name` — the human-readable ADK agent name.
+- `hgraf.agent.parent_id` — derived per-agent id of the immediate
+  parent in the ADK tree, if any.
+- `hgraf.agent.kind` — ADK-framework hint (`coordinator`, `specialist`,
+  `agent_tool`, `sequential_container`, etc.).
+- `hgraf.agent.branch` — ADK's dotted ancestry string
+  (`root.coordinator.specialist`), kept for forensic debugging.
+
+### Server-side: harvest hints and auto-register
+
+`IngestPipeline._ensure_route` runs on every SpanStart. If it's the
+first time it's seen a given `(session_id, agent_id)` pair, it
+inspects the span's attributes for `hgraf.agent.*` keys and populates
+the `Agent.metadata` accordingly:
+
+- `adk.agent.name` = `hgraf.agent.name`
+- `harmonograf.parent_agent_id` = `hgraf.agent.parent_id`
+- `harmonograf.agent_kind` = `hgraf.agent.kind`
+- `adk.agent.branch` = `hgraf.agent.branch`
+
+It then writes an `Agent` row (framework=ADK when the name hint is
+present) and fans out an `AgentJoined` delta on the bus. Subsequent
+spans from the same agent take the short path (`seen_routes`
+short-circuits the whole method).
+
+See `_ensure_route` in
+[`server/harmonograf_server/ingest.py`](../../server/harmonograf_server/ingest.py)
+and `_register_agent_for_ctx` in
+[`client/harmonograf_client/telemetry_plugin.py`](../../client/harmonograf_client/telemetry_plugin.py).
+
+## Consequences
+
+**Good.**
+- The Gantt renders one row per ADK agent in the tree. Coordinator /
+  specialist / AgentTool / container agents all get their own row and
+  the parent-child structure is reconstructable from
+  `harmonograf.parent_agent_id` metadata.
+- Back-compatible: clients running the old plugin (or non-ADK
+  clients) don't emit hints. The server treats them as single-row
+  agents and nothing breaks.
+- No new wire event. The `hgraf.agent.*` attributes ride on a
+  first-span-only stamp — hot-path spans don't pay the cost after
+  the first-sight.
+- The server decides the human-readable display name using
+  `hgraf.agent.name` when present, falling back to the bare span
+  name and finally to the agent_id. This avoids rendering an LLM
+  model name (the usual `span.name` for `LLM_CALL`) as an agent
+  label.
+
+**Bad.**
+- The plugin's stack is per-invocation. If ADK fires
+  `before_agent_callback` from a code path that bypasses the
+  invocation-id propagation (rare but possible with custom callback
+  contexts), the stack misses the push and spans land on the root.
+  A degraded path in `_stamp_agent_attrs` handles the case by
+  stamping a minimal `hgraf.agent.name` derived from the id suffix.
+- Agents never removed from the Gantt. If an ADK agent briefly
+  exists and then is never invoked again, its row persists for the
+  life of the session. This is the right tradeoff — a row that
+  disappeared mid-session would be confusing — but it means
+  long-running processes accumulate agent rows indefinitely.
+- The alias map that `ControlRouter.register_alias` maintains maps
+  the ADK agent name to the stream's root agent id. Control sent
+  to the ADK-agent display name is forwarded to the stream that
+  actually owns it, but the agent itself sees the control event
+  at the root level — per-ADK-agent control is not implemented.
+
+## Implemented in
+
+- [`client/harmonograf_client/telemetry_plugin.py`](../../client/harmonograf_client/telemetry_plugin.py)
+- [`server/harmonograf_server/ingest.py`](../../server/harmonograf_server/ingest.py) — `_ensure_route`, `_extract_agent_hints`.
+- [Design 04 — Frontend and interaction](../design/04-frontend-and-interaction.md)
+- [Design 12 — Client library and ADK](../design/12-client-library-and-adk.md)

--- a/docs/adr/0025-intervention-timeline-viz.md
+++ b/docs/adr/0025-intervention-timeline-viz.md
@@ -1,0 +1,114 @@
+# ADR 0025 — Intervention timeline visualization: three-channel encoding
+
+## Status
+
+Accepted (2026-04, harmonograf #76).
+
+## Context
+
+The Intervention timeline (see
+[ADR 0023](0023-intervention-dedup-by-annotation-id.md)) renders a
+horizontal strip of markers for every intervention in a session. A
+single strip has to communicate three dimensions at a glance:
+
+- **Source** — was this a user action, a drift detector, or a
+  goldfive autonomous escalation?
+- **Kind** — what kind of action (STEER vs CANCEL vs PAUSE for
+  user-authored; which drift kind for drift-authored; etc.)?
+- **Severity** — does this need the operator's attention right now
+  (critical red ring) or is it informational?
+
+Early designs collided these into one visual channel (color per
+kind). It failed on colorblind accessibility and also failed on
+"drift vs goldfive vs user" being the usually-interesting axis —
+operators wanted to scan for "who did this, the user or the
+system?" before they cared about the specific kind.
+
+A second problem: live sessions advance `endMs` every frame, and
+if the marker X position recomputed from `endMs` on every render,
+hovering a marker shifted the others left by a few pixels, making
+the popover anchor drift and clustering boundaries jitter.
+
+## Decision
+
+The `InterventionsTimeline` component encodes the three dimensions
+on three independent visual channels:
+
+1. **Source → color.** One color per source, sampled from a
+   deliberately limited palette so the legend is legible at a
+   glance:
+   - `user` → blue (`#5b8def`)
+   - `drift` → amber (`#f59e0b`)
+   - `goldfive` → grey (`#8d9199`)
+2. **Kind → glyph.** Diamond / circle / chevron / square, assigned
+   per kind within a source. Each source has its own glyph set so
+   a user's "STEER diamond" and a drift's "diamond" don't look
+   identical.
+3. **Severity → ring.** Markers get a dashed amber ring at
+   `warning`, a solid red ring at `critical`. No ring at `info` or
+   when severity is absent.
+
+Clustering: two markers within `max(14px, 2% of strip width)` of
+each other collapse into a single "N" cluster badge whose popover
+lists the group. The density threshold is a floor so zoomed-in
+strips don't cluster aggressively.
+
+Stability: the component captures `endMs` as a `spanEndMs` snapshot
+on mount and advances it on a coarse 1s tick via
+`useStableSpanEnd`. Hover state changes never cause the X-axis
+anchor to recompute, so hovering one marker never shifts the
+others.
+
+The popover is deterministically anchored to the marker's center,
+not the cursor. Axis ticks auto-select from a fixed ladder (10s,
+30s, 1m, 5m, 10m, 30m) based on the visible window.
+
+See
+[`frontend/src/components/Interventions/InterventionsTimeline.tsx`](../../frontend/src/components/Interventions/InterventionsTimeline.tsx)
+and `SOURCE_COLOR` in
+[`frontend/src/lib/interventions.ts`](../../frontend/src/lib/interventions.ts).
+
+## Consequences
+
+**Good.**
+- Three independent channels mean source, kind, and severity can
+  all be read separately without legend gymnastics. Operators
+  learn "amber means a drift" on first sight.
+- Colorblind accessibility: any two of the three channels survive
+  any common color-vision condition. A deuteranopic user who can't
+  distinguish amber from grey still sees the glyph and the ring.
+- The stable X anchor is the single most-requested fix from early
+  user testing. Hovering never jitters the strip.
+- Tree-agnostic: the component never inspects kind taxonomies or
+  source-specific strings. New drift kinds, new user-authored
+  kinds, new goldfive escalation kinds all render identically
+  without code changes.
+- Popover stability survives rapid marker density: the cluster
+  badge is anchored too, so hovering a cluster that overlaps
+  another cluster doesn't shuffle them.
+
+**Bad.**
+- Four glyphs per source is a hard cap before distinct shapes
+  start colliding. If the intervention taxonomy grows past that,
+  the strip will have to reduce glyph variety or split per-source.
+- The 2% clustering floor is heuristic. Very wide strips (24"
+  monitors) can under-cluster; very narrow strips (side-panel
+  width) can over-cluster. No per-user tuning.
+- Severity ring semantics ("warning = dashed amber, critical =
+  solid red") duplicate information for user-authored interventions
+  — a user STEER is never critical — but the aggregator is source-
+  agnostic so the ring logic is applied uniformly. The redundancy
+  is minor and the alternative (per-source severity encoding) was
+  worse.
+- The stable X anchor means the rightmost edge of the strip doesn't
+  track the session's live-ness in real time. The ~1s snapshot
+  cadence is fine for the intervention use case but would be wrong
+  if the strip were re-used to show, e.g., per-second LLM token
+  output.
+
+## Implemented in
+
+- [`frontend/src/components/Interventions/InterventionsTimeline.tsx`](../../frontend/src/components/Interventions/InterventionsTimeline.tsx)
+- [`frontend/src/lib/interventions.ts`](../../frontend/src/lib/interventions.ts)
+- [Design 04 — Frontend and interaction](../design/04-frontend-and-interaction.md)
+- [Design 13 — Human interaction model](../design/13-human-interaction-model.md)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -88,6 +88,22 @@ If you are new to harmonograf, read in this order:
 - [0020 — No authentication or multi-tenancy in v0](0020-no-auth-in-v0.md)
   — loopback-first plus optional shared bearer token; auth v1 is a
   future concern.
+- [0021 — Pin `goldfive.Session.id` to the outer adk-web session id](0021-session-id-pinning.md)
+  — one adk-web run = one harmonograf session, even with AgentTool
+  sub-Runners minting their own session ids.
+- [0022 — Lazy Hello](0022-lazy-hello.md) — defer the `Hello` RPC
+  until the first real emit; eliminates ghost `sess_*` rows and lets
+  the home session stamp with the correct id from the start.
+- [0023 — Intervention dedup by `annotation_id`](0023-intervention-dedup-by-annotation-id.md)
+  — one user STEER can surface as an annotation, a drift, and a
+  plan revision; dedup structurally on the source annotation id.
+- [0024 — Per-ADK-agent Gantt rows with auto-registration](0024-per-adk-agent-gantt-rows.md)
+  — per-agent id stacking in the plugin + first-span `hgraf.agent.*`
+  hints + server-side auto-register give one Gantt row per ADK
+  agent without a new wire event.
+- [0025 — Intervention timeline viz on three channels](0025-intervention-timeline-viz.md)
+  — source (color) × kind (glyph) × severity (ring) plus stable
+  X-anchor hover; colorblind-safe by construction.
 
 ## Writing a new ADR
 

--- a/docs/design/01-data-model-and-rpc.md
+++ b/docs/design/01-data-model-and-rpc.md
@@ -1,9 +1,40 @@
 # 01 — Data Model & RPC Protocol
 
-Status: **ACCEPTED** (open questions resolved 2026-04-10)
-Scope: the wire. Shared primitives used by all three components, plus the gRPC service that connects agents to the server.
+Status: **ACCEPTED** (open questions resolved 2026-04-10; goldfive migration reflected below).
 
-This is the most load-bearing document in the set: the span abstraction and the RPC contract constrain what every other component can do.
+Scope: the wire. Shared primitives used by all three components, plus
+the gRPC service that connects agents to the server.
+
+This is the most load-bearing document in the set: the span abstraction
+and the RPC contract constrain what every other component can do.
+
+> **Migration note (2026-04).** Orchestration types
+> (`Task` / `TaskPlan` / `TaskEdge` / `UpdatedTaskStatus` /
+> `TaskStatus`) and control types
+> (`ControlKind` / `ControlEvent` / `ControlAck` / `ControlTarget` /
+> per-kind payloads) moved out of `harmonograf/v1/types.proto`
+> and into `goldfive/v1/{types,control,events}.proto` during Phase A
+> of the goldfive migration. Harmonograf imports them wherever they
+> cross the wire. The `TelemetryUp` `task_plan = 9` and
+> `task_status_update = 10` variants are **reserved** — plan / task
+> state now rides inside `TelemetryUp.goldfive_event = 11`.
+>
+> See [`../protocol/data-model.md`](../protocol/data-model.md) for the
+> current wire-level detail and
+> [`../goldfive-integration.md`](../goldfive-integration.md) for the
+> integration seam.
+>
+> Newer design decisions that postdate this doc:
+>
+> - [ADR 0021 — Session id pinning](../adr/0021-session-id-pinning.md)
+>   — one adk-web run = one harmonograf session.
+> - [ADR 0022 — Lazy Hello](../adr/0022-lazy-hello.md) — defer the
+>   `Hello` RPC until first emit to eliminate ghost session rows.
+> - [ADR 0023 — Intervention dedup by `annotation_id`](../adr/0023-intervention-dedup-by-annotation-id.md).
+> - [ADR 0024 — Per-ADK-agent Gantt rows with auto-registration](../adr/0024-per-adk-agent-gantt-rows.md)
+>   — `hgraf.agent.*` hint attributes on the first span drive
+>   server-side auto-register.
+> - [ADR 0025 — Intervention timeline viz](../adr/0025-intervention-timeline-viz.md).
 
 ---
 

--- a/docs/design/03-server.md
+++ b/docs/design/03-server.md
@@ -5,6 +5,23 @@ Scope: the Python process that terminates agent telemetry, persists session stat
 
 This doc presupposes the wire protocol in `01-data-model-and-rpc.md` and the frontend interactions in `04-frontend-and-interaction.md`. Storage and routing decisions here exist to serve those.
 
+> **Companion doc.** Operator-lens walkthrough of the same code is in
+> [11-server-architecture.md](11-server-architecture.md), which
+> covers the current state including session routing, agent
+> auto-registration, the drift ring, and the intervention
+> aggregator. This doc focuses on the *design rationale* for why the
+> server is shaped the way it is; doc 11 focuses on *what you find*
+> when you open the server package.
+>
+> **Post-migration deltas (2026-04).** The server now dispatches
+> `TelemetryUp.goldfive_event` envelopes (field 11) carrying
+> `goldfive.v1.Event` variants for plan / task / drift / run
+> lifecycle. `TaskPlan` (field 9) and `UpdatedTaskStatus` (field 10)
+> are **reserved** — plan / task state rides inside goldfive events.
+> New RPCs since this doc: `ListInterventions` (harmonograf #87).
+> New in-memory structures: `_drifts_by_session` ring (500 cap per
+> session) for late-subscribe replay.
+
 ---
 
 ## 1. Design goals

--- a/docs/design/04-frontend-and-interaction.md
+++ b/docs/design/04-frontend-and-interaction.md
@@ -1,9 +1,35 @@
 # 04 — Frontend & Human Interaction Model
 
-Status: **DRAFT — awaiting review**
+Status: **DRAFT — reflects 2026-04 state**
 Scope: the Gantt console. What the user sees, how they interact, how it renders fast, what colors mean.
 
 This doc presupposes the span/session/control model defined in `01-data-model-and-rpc.md`. If that model changes, this doc changes with it.
+
+> **Companion docs.**
+>
+> - Architecture: [10-frontend-architecture.md](10-frontend-architecture.md).
+> - Interaction model: [13-human-interaction-model.md](13-human-interaction-model.md)
+>   has the up-to-date STEER / intervention / timeline semantics.
+> - Renderer internals: [../internals/renderer-pipeline.md](../internals/renderer-pipeline.md).
+>
+> **Post-migration deltas (2026-04).**
+>
+> - Per-ADK-agent rows: the Gantt renders one row per ADK agent in
+>   the tree (coordinator, specialists, `AgentTool` wrappers)
+>   rather than one row per client process
+>   ([ADR 0024](../adr/0024-per-adk-agent-gantt-rows.md)).
+> - Synthetic actor rows: `__user__` and `__goldfive__` rows
+>   materialize lazily from `DriftDetected` events, so operator
+>   interventions and goldfive autonomous escalations render on
+>   their own rows. See
+>   [10-frontend-architecture.md §7](10-frontend-architecture.md#7-actor-attribution-and-span-synthesis).
+> - Intervention timeline strip above the Gantt: unified
+>   chronological view of user STEER / CANCEL, drift detections,
+>   and plan revisions, deduplicated by `annotation_id`
+>   ([ADR 0023](../adr/0023-intervention-dedup-by-annotation-id.md),
+>   [ADR 0025](../adr/0025-intervention-timeline-viz.md)).
+> - Delegation edges: dashed cross-agent beziers from
+>   `DelegationObserved` events make `AgentTool` handoffs visible.
 
 ---
 

--- a/docs/design/10-frontend-architecture.md
+++ b/docs/design/10-frontend-architecture.md
@@ -1,45 +1,65 @@
 # 10. Frontend Architecture
 
-## Executive Summary
+Status: **CURRENT** (2026-04).
 
-The Harmonograf frontend is a dynamic, high-performance web interface designed for observability, human-in-the-loop (HITL) steering, and granular interactions within multi-agent systems. Built with React and Vite, the frontend connects to the Harmonograf server via gRPC-Web and visualizes complex asynchronous workflows using a specialized Gantt-chart rendering engine built heavily around HTML5 Canvas for unbounded scalability.
+The harmonograf frontend is a React 18 + TypeScript single-page app
+that renders multi-agent runs on a custom-canvas Gantt. The chrome
+(nav rail, drawer, picker, inspector) is React; the Gantt itself
+bypasses React entirely and runs its own `requestAnimationFrame` loop
+against mutable stores.
 
-With modern multi-agent systems increasingly performing concurrent sub-tasks involving tools, retries, branching logic, and cross-agent communication, traditional chat-based observability tools fall short. The frontend architecture resolves these problems by turning to spatial indexing, a componentized Shell view, bidirectional RPCs for intervention, and highly optimized local state stores.
+This doc is the operator-lens companion to
+[04-frontend-and-interaction.md](04-frontend-and-interaction.md).
+Doc 04 covers *what* the operator sees and does; this doc covers
+*how* the code is organized and why.
 
-## 1. System Context and Build Tools
+## 1. Stack and build
 
-The frontend is a classic Single Page Application (SPA) built using modern web paradigms:
-- **TypeScript & React (via Vite):** Ensures strong typing of incoming telemetry data and fast module replacement during development.
-- **Protocol Buffers (protobuf):** Type definitions for structures like `Span`, `Agent`, `Session`, and `Transport`. This guarantees that the UI uses exact structures emitted by the gRPC-Web server backend.
-- **gRPC-Web & Sonora:** Provides bidirectional structured communication. The UI consumes streaming data through hooks mapped onto these stubs.
+- **React 18 + TypeScript**, built with Vite.
+- **gRPC-Web via Sonora**. Generated stubs live under
+  `frontend/src/gen/` (committed). All wire types come straight
+  from `proto/harmonograf/v1/` + `proto/goldfive/v1/`.
+- **No UI framework** — the chrome uses MD3-style components
+  composed in-tree, not `@material/web` imports. Earlier drafts
+  planned MD3-via-npm; the current code uses hand-rolled
+  components matching MD3 tokens.
+- **State**: two tiers.
+  - **Zustand stores** for chrome state (selection, filters, view
+    intent, session list).
+  - **Plain mutable stores** (`SessionStore`, `SpanIndex`,
+    `TaskRegistry`, `ContextSeriesRegistry`, `DriftRegistry`,
+    `DelegationRegistry`) for hot data. The canvas renderer
+    subscribes directly to these, never through React.
 
-## 2. Component Architecture & Shell View
-
-At the highest level, the frontend orchestrates visual components via the Shell view. 
-The core rendering target revolves around the Canvas, configured in [`GanttCanvas.tsx`](file:///home/sunil/git/harmonograf/frontend/src/gantt/GanttCanvas.tsx#L31-35).
+## 2. Shell layout
 
 ```mermaid
 graph TD
     A[Shell] --> B[NavRail]
-    A --> C[ActivityView]
-    C --> D[SessionsSyncer]
+    A --> C[ActivityView / PlanningView / TrajectoryView]
+    C --> D[SessionsSyncer<br/>WatchSession streaming]
     C --> E[GanttCanvas]
-    E --> F[HTML5 Canvas <br/> Background/Blocks/Overlay]
-    E --> G[GanttDomProxy <br/> Tooltips/Menus]
-    A --> H[Drawer Inspector]
+    E --> F[HTML5 Canvas layers<br/>background · blocks · overlay]
+    E --> G[GanttDomProxy<br/>tooltips · menus]
+    C --> H[InterventionsTimeline<br/>above Gantt, when applicable]
+    A --> I[Drawer Inspector<br/>Span / Task / Approval tabs]
+    A --> J[AppBar<br/>Session picker · attention badge]
 ```
 
-### The Shell Structure
-- **NavRail/AppBar:** Primary left-side and top navigation for toggling views.
-- **Drawer:** A right-hand contextual flyout. When users interact with a specific agent span or require a HITL approval, the detail inspector mounts within the Drawer, keeping the Gantt chart context unbroken globally.
+- **NavRail / AppBar** — primary navigation and session-picker
+  entry point.
+- **Drawer** — right-hand flyout. Opens on span / task selection.
+  Keeps Gantt context visible behind it.
+- **Views** — `ActivityView` (live Gantt), `PlanningView`
+  (plan-centric with intervention timeline), `TrajectoryView`
+  (DAG + ribbon for plan-review).
 
-## 3. Data Fetching and State Management
+## 3. Data flow
 
-Data flow between the backend and the UI relies on Streaming RPCs. The synchronization relies natively on Zustand stores.
-
-**State store layout** — Zustand is used for chrome (selection, filters,
-viewport intent); the hot span data lives in plain mutable stores the
-canvas subscribes to directly, never through React.
+Data flows one direction: server → mutable store → canvas. React
+renders chrome off the same stores via
+`useSyncExternalStore`-style subscriptions that observe *presence*
+(agent list, session metadata, counts), not hot data.
 
 ```mermaid
 flowchart LR
@@ -49,13 +69,17 @@ flowchart LR
       Sess[SessionsStore<br/>list + status]
     end
     subgraph Mut["Mutable stores (canvas-bound)"]
-      Idx[SpanIndex<br/>Map<id,Span> + R-tree]
-      Plans[PlanStore<br/>revisions]
+      Idx[SpanIndex<br/>Map&lt;id,Span&gt; + per-agent sorted arrays]
+      Plans[TaskRegistry<br/>plan revisions + diffs]
       Hb[HeartbeatStore<br/>per-agent stats]
+      Dr[DriftRegistry]
+      Dg[DelegationRegistry]
     end
     Wire[gRPC-Web streams] --> Idx
     Wire --> Plans
     Wire --> Hb
+    Wire --> Dr
+    Wire --> Dg
     Idx -. dirty events .-> Render[Canvas renderer]
     UI --> Drawer[Drawer / chrome]
     VP --> Render
@@ -65,58 +89,51 @@ flowchart LR
     class Idx,Render good
 ```
 
-### Streaming Pipeline
+### Streaming pipeline
 
 ```mermaid
 sequenceDiagram
-    participant UI as React UI (ActivityView)
-    participant Store as SessionsStore
-    participant gRPC as gRPC-Web Stubs
-    
-    UI->>Store: Request Session (ID)
-    Store->>gRPC: SubscribeSpans(session_id)
-    loop Every Span Event
-        gRPC-->>Store: Push Span Envelope
-        Store-->>Store: Batch into Buffer
+    participant UI as React (ActivityView)
+    participant Store as SessionStore
+    participant gRPC as gRPC-Web
+    UI->>Store: open session_id
+    Store->>gRPC: WatchSession(session_id)
+    gRPC-->>Store: SessionUpdate.snapshot (agents, spans, plans, ctx samples)
+    gRPC-->>Store: SessionUpdate.burst_complete
+    loop live deltas
+        gRPC-->>Store: SessionUpdate.new_span / updated_span / ended_span /
+                       new_annotation / agent_* / goldfive_event / ...
+        Store-->>Store: apply to mutable stores · emit() on listeners
     end
-    Note over Store,UI: requestAnimationFrame unspools buffer to UI
-    Store->>UI: Update Spatial Index
+    Note over Store: renderer's subscribers set dirty bits;<br/>next rAF coalesces into a redraw
 ```
 
-Rather than rendering the DOM completely upon every JSON packet, updates are batched, saving critical OS frame boundaries. Note how `GanttCanvas` avoids tying React `useState` hooks to high-frequency metric variables—instead relying entirely securely upon independent `mouseMove` boundary matrices internally.
+Mutations on the mutable stores are synchronous from the `WatchSession`
+handler. The canvas renderer coalesces multiple mutations in one
+microtask into a single redraw on the next animation frame.
 
-## 4. The High-Performance Gantt Engine
+## 4. The Canvas Gantt
 
-Rendering thousands of concurrent and sequential agent spans with DOM nodes is technically impossible without crashing modern browsers through reflow bottlenecks. The Harmonograf architecture bypasses the DOM entirely.
+`frontend/src/gantt/GanttCanvas.tsx` mounts three stacked canvases
+and forwards pointer events. `frontend/src/gantt/renderer.ts` owns
+the draw loop.
 
-### 4.1. The Canvas Renderer (`gantt/GanttCanvas.tsx`)
-The Gantt layout hooks onto HTML5 elements natively. As seen in the source for [`GanttCanvas.tsx`](file:///home/sunil/git/harmonograf/frontend/src/gantt/GanttCanvas.tsx#L148-150):
 ```tsx
-  <canvas ref={bgRef} style={layer(0)} />
-  <canvas ref={blocksRef} style={layer(1)} />
-  <canvas ref={overlayRef} style={layer(2)} />
+  <canvas ref={bgRef} style={layer(0)} />        // rows, grid, axis
+  <canvas ref={blocksRef} style={layer(1)} />    // span rectangles
+  <canvas ref={overlayRef} style={layer(2)} />   // hover, cursor, arrows
 ```
-The design places static grids onto `layer(0)`, dynamically sized moving span blocks onto `layer(1)`, and volatile boundaries onto `layer(2)`. This multi-canvas hierarchy limits rendering redraw costs exclusively.
 
-### 4.2. Spatial Indexing
-To interpret standard mouse actions natively, we correlate `onClick` queries dynamically bypassing CSS objects:
-```tsx
-  const onContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
-    const spanId = renderer.spanAt(e.clientX - r.left, e.clientY - r.top);
-    // ...
-  };
-```
-As bounds are computed for X and Y natively within the layout engine, they are registered to an R-Tree index.
-
-**Canvas layer pipeline** — three stacked canvases with independent
-dirty triggers; the DOM overlay layer rides on top for hit-test handlers
-and accessible inputs.
+Design rationale and internals (triple-buffered layers, span
+bucketing for batch fill, hit-testing, binary-search context
+overlay): see
+[internals/renderer-pipeline.md](../internals/renderer-pipeline.md).
 
 ```mermaid
 flowchart TB
     RAF([requestAnimationFrame]) --> D{dirty layer?}
     D -- "background<br/>(zoom · pan · agents)" --> L0[layer 0<br/>rows · ticks · gridlines]
-    D -- "blocks<br/>(span data · viewport)" --> Q[R-tree query<br/>viewport-cull]
+    D -- "blocks<br/>(span data · viewport)" --> Q[range-query per agent<br/>viewport-cull]
     Q --> Batch[batch by color<br/>fillRect passes]
     Batch --> L1[layer 1<br/>span blocks]
     D -- "overlay<br/>(hover · cursor · arrows · pulse)" --> L2[layer 2<br/>volatile overlay]
@@ -129,36 +146,63 @@ flowchart TB
     class Q,Batch,L1 good
 ```
 
-## 5. Viewport Scaling & DOM Overlay Proxy
+## 5. DOM overlay layer
 
-While Canvas excels at fast rendering, it is abysmal for inputs. The `GanttCanvas` leverages an overlay pipeline to circumvent this.
+Canvas is great for rendering, terrible for input. The DOM overlay
+layer rides on top of the canvases and carries:
 
-### DOM Overlay Layer
-This involves tracking explicit span coordinates structurally globally. For example, if a span triggers `Approval Needed`, a specific overlay element hooks accurately:
-```tsx
-  {menu && <SpanContextMenu state={menu} onClose={() => setMenu(null)} />}
-  {renderOverlay &&
-    canvasSize.w > 0 &&
-    renderOverlay({ ... })} // Projection mapped
-```
-See [`GanttCanvas.tsx:L204-213`](file:///home/sunil/git/harmonograf/frontend/src/gantt/GanttCanvas.tsx#L204-213).
+- `SpanContextMenu` — right-click actions (inspect, annotate, steer).
+- Tooltips anchored to span rects via `renderer.rectForSpan()`.
+- Text inputs for annotation compose.
 
-## 6. The Control Router (HITL Submissions)
+The overlay is reconciled by React normally. Projection math from
+span ids to screen coordinates is exposed by the renderer via
+`rectForSpan(spanId)` and `getRowLayout(agentId)` so overlay
+components don't duplicate layout logic.
 
-To complete the Human-in-the-loop circle, the frontend possesses a structured channel for dispatching actions back into the system grid. 
-Instead of plain REST mutators, interaction intents execute bi-directional calls natively towards the root orchestrator pipelines.
+## 6. HITL and control submission
 
-## 7. Actor Attribution and Span Synthesis
+Operator actions dispatch through the standard `SendControl` /
+`PostAnnotation` unary RPCs. The frontend never holds its own
+control socket — it goes through the server's `ControlRouter`.
+See [design/13 — Human interaction model](13-human-interaction-model.md)
+for the round-trip.
 
-The frontend treats the two parties that act on a run from outside agent code — the human operator and the goldfive orchestrator — as first-class actor rows, on par with the worker agents. This is implemented entirely in the event-dispatch layer; neither the wire protocol nor the server has to know about it.
+## 7. Actor attribution and span synthesis
 
-**Reserved agent IDs.** [`theme/agentColors.ts`](file:///home/sunil/git/harmonograf/frontend/src/theme/agentColors.ts) defines two reserved ids: `__user__` and `__goldfive__`. Both sit outside the hashed `schemeTableau10` palette with fixed colors so a real agent's hash can never shadow them. `SYNTHETIC_ACTOR_IDS`, `isSyntheticActor()`, and `actorDisplayLabel()` export the membership check and display mapping.
+The frontend treats the two parties that act on a run from outside
+agent code — the human operator and the goldfive orchestrator — as
+first-class actor rows, on par with the worker agents. This is
+implemented entirely in the event-dispatch layer; neither the wire
+protocol nor the server has to know about it.
 
-**Lazy materialization on drift.** [`rpc/goldfiveEvent.ts`](file:///home/sunil/git/harmonograf/frontend/src/rpc/goldfiveEvent.ts) routes `goldfive.v1.Event` payloads onto the session stores. The `driftDetected` case does two things in addition to appending to `store.drifts`:
+**Reserved agent IDs.** [`theme/agentColors.ts`](../../frontend/src/theme/agentColors.ts)
+defines two reserved ids: `__user__` and `__goldfive__`. Both sit
+outside the hashed `schemeTableau10` palette with fixed colors so a
+real agent's hash can never shadow them. `SYNTHETIC_ACTOR_IDS`,
+`isSyntheticActor()`, and `actorDisplayLabel()` export the
+membership check and display mapping.
 
-1. Decides the attribution actor — `user_steer` / `user_cancel` / `user_pause` → `__user__`; everything else → `__goldfive__`.
-2. Calls `ensureSyntheticActor(store, actorId)`, which `store.agents.upsert`s the row if absent (`connectedAtMs = 1` so real agents sort below it, `metadata["harmonograf.synthetic_actor"] = "1"` for downstream styling hooks).
-3. Calls `synthesizeDriftSpan(...)`, which `store.spans.append`s a fabricated span on the actor row. Span kind is `USER_MESSAGE` for the operator and `CUSTOM` for goldfive; attributes carry `drift.kind`, `drift.severity`, `drift.detail`, `drift.target_task_id`, `drift.target_agent_id`, and `harmonograf.synthetic_span = true` to distinguish from client-reported spans.
+**Lazy materialization on drift.**
+[`rpc/goldfiveEvent.ts`](../../frontend/src/rpc/goldfiveEvent.ts)
+routes `goldfive.v1.Event` payloads onto the session stores. The
+`driftDetected` case does two things in addition to appending to
+`store.drifts`:
+
+1. Decides the attribution actor — `user_steer` / `user_cancel` /
+   `user_pause` → `__user__`; everything else → `__goldfive__`.
+2. Calls `ensureSyntheticActor(store, actorId)`, which
+   `store.agents.upsert`s the row if absent (`connectedAtMs = 1` so
+   real agents sort below it,
+   `metadata["harmonograf.synthetic_actor"] = "1"` for downstream
+   styling hooks).
+3. Calls `synthesizeDriftSpan(...)`, which
+   `store.spans.append`s a fabricated span on the actor row. Span
+   kind is `USER_MESSAGE` for the operator and `CUSTOM` for
+   goldfive; attributes carry `drift.kind`, `drift.severity`,
+   `drift.detail`, `drift.target_task_id`, `drift.target_agent_id`,
+   and `harmonograf.synthetic_span = true` to distinguish from
+   client-reported spans.
 
 ```mermaid
 flowchart LR
@@ -172,28 +216,87 @@ flowchart LR
     Synth --> Views[Gantt · Graph · Trajectory<br/>all re-render]
 ```
 
-The net effect is that actor rows require no special-casing in the views. The Gantt renderer paints a bar on the actor row because the spans store has one; the Trajectory ribbon paints a drift marker because the drifts store has one. Both stores are subscribed to normally, which keeps the actor feature orthogonal to the rendering architecture described in §4.
+The net effect is that actor rows require no special-casing in the
+views. The Gantt renderer paints a bar on the actor row because the
+spans store has one; the Trajectory ribbon paints a drift marker
+because the drifts store has one. Both stores are subscribed to
+normally, which keeps the actor feature orthogonal to the rendering
+architecture described in §4.
 
-**Trajectory view.** [`components/shell/views/TrajectoryView.tsx`](file:///home/sunil/git/harmonograf/frontend/src/components/shell/views/TrajectoryView.tsx) is the primary plan-review surface and consumes the same drift records. Its `buildViewModel()` merges all plans for the session by `createdAtMs` (not by plan id — goldfive planners often mint fresh ids on each refine) and bins drifts into the rev that was live when each drift was observed. The ribbon then renders pivots (severity-colored `↻`) at rev boundaries and drift markers (stars for user-authored, circles for goldfive-authored) on each segment.
+**Trajectory view.**
+[`components/shell/views/TrajectoryView.tsx`](../../frontend/src/components/shell/views/TrajectoryView.tsx)
+is the primary plan-review surface and consumes the same drift
+records. Its `buildViewModel()` merges all plans for the session by
+`createdAtMs` (not by plan id — goldfive planners often mint fresh
+ids on each refine) and bins drifts into the rev that was live when
+each drift was observed. The ribbon then renders pivots
+(severity-colored `↻`) at rev boundaries and drift markers (stars
+for user-authored, circles for goldfive-authored) on each segment.
 
-## 8. Delegation Edges
+## 8. Delegation edges
 
 goldfive `2986775+` emits a `DelegationObserved` event every time a
 coordinator agent calls `AgentTool(sub_agent)` — i.e. the registry
-dispatcher sees a registered-agent-to-registered-agent tool invocation
-and fans out an explicit cross-agent edge. The telemetry plugin's
-generic `TOOL_CALL` span on the coordinator row is insufficient to
-reconstruct this relationship (it does not name the sub-agent as a
-recognizable row), so harmonograf consumes the event directly.
+dispatcher sees a registered-agent-to-registered-agent tool
+invocation and fans out an explicit cross-agent edge. The telemetry
+plugin's generic `TOOL_CALL` span on the coordinator row is
+insufficient to reconstruct this relationship (it does not name the
+sub-agent as a recognizable row), so harmonograf consumes the event
+directly.
 
-The [`goldfiveEvent.ts`](file:///home/sunil/git/harmonograf/frontend/src/rpc/goldfiveEvent.ts) dispatcher appends each payload to a new `SessionStore.delegations` registry ([`DelegationRegistry` in `gantt/index.ts`](file:///home/sunil/git/harmonograf/frontend/src/gantt/index.ts)) whose shape intentionally mirrors `DriftRegistry` — `append()` / `list()` / `clear()` / `subscribe()`. The Gantt renderer's `drawDelegations()` pass walks the registry per blocks-redraw and paints a dashed 30%-opacity bezier (goldfive-cyan) from the `fromAgent` row-center to the `toAgent` row-center at the observed time. The Trajectory DAG surfaces a faint "↪↪ delegated to: X" annotation under the task card. The companion `agentInvocationStarted` / `agentInvocationCompleted` events remain no-ops because `HarmonografTelemetryPlugin` already materializes them as per-agent `INVOCATION` spans.
+The [`goldfiveEvent.ts`](../../frontend/src/rpc/goldfiveEvent.ts)
+dispatcher appends each payload to a new `SessionStore.delegations`
+registry
+([`DelegationRegistry` in `gantt/index.ts`](../../frontend/src/gantt/index.ts))
+whose shape intentionally mirrors `DriftRegistry` — `append()` /
+`list()` / `clear()` / `subscribe()`. The Gantt renderer's
+`drawDelegations()` pass walks the registry per blocks-redraw and
+paints a dashed 30%-opacity bezier (goldfive-cyan) from the
+`fromAgent` row-center to the `toAgent` row-center at the observed
+time. The Trajectory DAG surfaces a faint
+"↪↪ delegated to: X" annotation under the task card. The companion
+`agentInvocationStarted` / `agentInvocationCompleted` events remain
+no-ops because `HarmonografTelemetryPlugin` already materializes
+them as per-agent `INVOCATION` spans.
 
-## 9. Conclusions
+## 9. Intervention timeline
 
-The Harmonograf frontend minimizes React render cycles, adopting an ECS-like game-engine loop for data rendering via HTML5 Canvas. By securely interleaving DOM elements exclusively for native text/form inputs, the topology maintains flawless 60 FPS frame rates processing potentially millions of unstructured telemetry events visually correctly.
+`components/Interventions/InterventionsTimeline.tsx` renders the
+unified chronological strip above the Gantt in planning and
+trajectory views. Data comes from two sources:
 
----
+1. On open, `ListInterventions(session_id)` unary RPC returns the
+   full merged history from the server's `interventions.py`
+   aggregator.
+2. Live updates come through the existing `WatchSession` deltas
+   (annotations, `goldfive_event.drift_detected`,
+   `goldfive_event.plan_revised`) — `lib/interventions.ts` mirrors
+   the server aggregator so a late-joining client dedups
+   incrementally without a second RPC.
+
+The component encodes source × kind × severity on three
+independent visual channels; X anchor is stabilized so hovering
+doesn't jitter neighbors. See
+[ADR 0025](../adr/0025-intervention-timeline-viz.md).
+
+## 10. Performance budget
+
+Non-negotiable:
+
+| Metric | Target |
+|---|---|
+| Frame time (pan / zoom) | < 16 ms p95 |
+| Live event → visible | < 100 ms |
+| Session open → first paint | < 500 ms for a 1k-span session |
+| Drawer open → payload rendered | < 300 ms for a 1 MB payload |
+| Memory per session | < 200 MB at 10k spans |
+
+Stress scenarios in the perf suite cover steady-state (5 agents × 10
+events/sec × 2h), bursts (500 events/sec for 10s), multi-MB
+payloads, and cross-agent chatter. Regressions fail CI.
 
 ## Related ADRs
 
 - [ADR 0008 — Canvas rendering for the Gantt chart](../adr/0008-canvas-gantt-over-svg.md)
+- [ADR 0013 — Drift is a first-class event](../adr/0013-drift-as-first-class.md)
+- [ADR 0025 — Intervention timeline viz on three channels](../adr/0025-intervention-timeline-viz.md)

--- a/docs/design/11-server-architecture.md
+++ b/docs/design/11-server-architecture.md
@@ -1,29 +1,121 @@
 # 11. Server Architecture
 
-## Executive Summary
+Status: **CURRENT** (2026-04, reflects the #63 / #66 / #71 / #80 / #85 refreshes).
 
-The Harmonograf Server acts as the centralized nervous system for observability and orchestration of complex, multi-agent artificial intelligence networks. Residing entirely inside a high-throughput, asynchronous Python daemon, the Server uniquely bounds disparate autonomous proxy chains inside real-time metrics routing bounds without causing bottleneck stalling globally natively.
+This is the operator-lens companion to [03-server.md](03-server.md).
+Where doc 03 justifies *why* the server is shaped the way it is, this
+doc walks through *what* you actually find in
+`server/harmonograf_server/` and how the pieces compose.
 
-## 1. Topologies and Entry Points
+## 1. Ingress surfaces
 
-The Server presents itself to the surrounding architecture through two primary networking boundaries inherently isolated via specific protocol layers locally. 
+The server presents two network surfaces from one process:
 
 ```mermaid
-graph LR
-    A[Agent Runtime] -->|gRPC / 7531| B[Ingest RPC]
-    C[Web Browser UI] -->|gRPC-Web / 7532| D[Sonora ASGI]
-    B --> E[Event Bus]
+flowchart LR
+    A[Agent runtime<br/>(harmonograf_client · goldfive)] -- "gRPC / 7531<br/>StreamTelemetry + SubscribeControl" --> B[Ingest RPC]
+    C[Web browser UI<br/>(Gantt console)] -- "gRPC-Web / 7532<br/>Sonora ASGI" --> D[Frontend RPC]
+    B --> E[(SessionBus)]
+    D --> E
     E --> F[Storage adapter]
-    E --> G[Stream Subscribers]
-    D --> G
+    E --> G[Frontend stream fan-out]
 ```
 
-Both ingress points implement active unauthenticated health checks natively ensuring robust orchestration boundaries inherently globally safely. 
+- **Agent ingress** (`rpc/telemetry.py`, `rpc/control.py`) — bidi
+  `StreamTelemetry` and server-streaming `SubscribeControl`, both
+  native gRPC on the same port. In v0 this binds to `127.0.0.1:7531`
+  by default; bearer-token auth (`--auth-token`) is optional and gated
+  on the loopback / non-loopback decision from
+  [ADR 0020](../adr/0020-no-auth-in-v0.md).
+- **Frontend ingress** (`rpc/frontend.py`) — unary and server-streaming
+  RPCs served over gRPC-Web via Sonora's ASGI shim
+  (`_sonora_shim.py`). Listed by `grpcurl` on the same port; the
+  browser hits the Sonora path.
 
-## 2. Ingestion and Bus Engine
+Both surfaces speak the same `proto/harmonograf/v1/` wire protocol
+(plus goldfive's imported `events.proto` / `control.proto`) and land
+on the same `SessionBus`.
 
-### The Dynamic Memory Bus 
-Because the UI streams events natively, database polling fails. The server uses a transient Pub/Sub matrix declared in [`bus.py`](file:///home/sunil/git/harmonograf/server/harmonograf_server/bus.py#L59-66):
+## 2. Ingest pipeline
+
+Per-telemetry-stream dispatch on the `TelemetryUp` oneof lives in
+[`ingest.py`](../../server/harmonograf_server/ingest.py). The pattern
+every branch follows is *dedup → persist → publish*:
+
+```mermaid
+flowchart LR
+    Up([TelemetryUp]) --> Disp{oneof}
+    Disp -- Hello --> H1[handle_hello<br/>create/join session<br/>register agent<br/>mint stream_id]
+    Disp -- SpanStart/Update/End --> H2[per-span session/agent override<br/>harvest hgraf.agent.* hints<br/>_ensure_route auto-register<br/>seen_span_ids dedup]
+    H2 --> ST[Store.append_span / update_span / end_span]
+    H2 --> Bus[(SessionBus publish)]
+    Disp -- PayloadUpload --> H3[_PayloadAssembler<br/>sha256 verify on last=true]
+    H3 --> ST
+    Disp -- Heartbeat --> H4[liveness · progress_counter<br/>stuck detection<br/>context-window sample]
+    Disp -- ControlAck --> H5[ControlRouter.record_ack]
+    Disp -- goldfive_event --> H6[route by event.session_id<br/>per-kind dispatch]
+    H6 --> ST
+    H6 --> Bus
+    H6 --> DR[drift ring<br/>(per-session, 500 cap)]
+    Disp -- Goodbye --> H7[close_stream]
+
+    classDef good fill:#d4edda,stroke:#27ae60,color:#000
+    class Bus,H2,H6 good
+```
+
+### Session routing (harmonograf #66 / goldfive #155)
+
+Spans and goldfive events route to different sessions on the same
+telemetry stream:
+
+- **Spans** route by `pb_span.session_id` falling back to
+  `ctx.session_id` (the stream's Hello session). This is how the
+  per-ADK-agent spans land on the correct session id when the plugin
+  stamps the outer adk-web session on every span (see
+  [ADR 0021](../adr/0021-session-id-pinning.md)).
+- **Goldfive events** route by `Event.session_id` (proto field 5,
+  added in goldfive #155 / #157). When the event carries a
+  `session_id` different from the stream's Hello session,
+  `_handle_goldfive_event` wraps the context in a `_SessionView`
+  read-only overlay that pins `session_id` without mutating the
+  underlying `StreamContext`, and calls `_ensure_route` to
+  auto-create the session/agent row if unseen.
+
+Empty `Event.session_id` falls back to the Hello session — the
+pre-#155 behavior — for backward compatibility with older goldfive
+clients.
+
+### Agent auto-registration (harmonograf #74 / #80)
+
+`_ensure_route` is the first-sight handler for any `(session_id,
+agent_id)` pair. The first span emitted by an agent carries
+`hgraf.agent.*` attributes (name, parent_id, kind, branch) that the
+handler harvests into `Agent.metadata` as `adk.agent.name`,
+`harmonograf.parent_agent_id`, `harmonograf.agent_kind`, and
+`adk.agent.branch`. Subsequent spans short-circuit via `seen_routes`
+so the hot-path pays the harvest cost once per agent, never per span.
+See [ADR 0024](../adr/0024-per-adk-agent-gantt-rows.md).
+
+The plugin side of the contract is
+`HarmonografTelemetryPlugin._register_agent_for_ctx` in
+[`telemetry_plugin.py`](../../client/harmonograf_client/telemetry_plugin.py).
+
+### Storage-before-publish invariant
+
+`Store.append_span` runs before `bus.publish_span_start` within the
+same handler. The `WatchSession` replay path reads from storage then
+attaches to the bus; if publish preceded persist, a reconnect could
+see a live delta for a span not yet in the store and end up with a
+duplicate on the frontend. This invariant is load-bearing — every
+handler keeps the order.
+
+## 3. SessionBus
+
+[`bus.py`](../../server/harmonograf_server/bus.py) is the per-session
+pub/sub surface with bounded per-subscriber queues and drop-oldest
+backpressure. One bus per process; internally
+`dict[session_id, list[Subscription]]`.
+
 ```python
 class SessionBus:
     """Per-session fan-out.
@@ -36,93 +128,107 @@ class SessionBus:
         self._lock = asyncio.Lock()
 ```
 
-When new data streams inside natively globally (via ingest APIs), it triggers explicit bounds bypassing SQL queries natively:
-```python
-    def publish_span_start(self, span: Span) -> None:
-        self.publish(Delta(span.session_id, DELTA_SPAN_START, span))
+Publish semantics: snapshot subscribers under the lock, then iterate
+without it. A slow subscriber can never block the fan-out to fast
+subscribers; instead its queue fills, `put_nowait` raises
+`QueueFull`, the bus records `DELTA_BACKPRESSURE` on that subscriber's
+queue, and the subscriber can resync via `WatchSession` if it detects
+the counter rising.
+
+### Convenience publishers
+
+One `publish_*` per delta kind:
+
 ```
-*See `bus.py`, lines 133-134.*
-
-### Backpressure Tolerances
-Crucially, reading streams from `SessionBus` occurs across async queues. If a frontend browser lags structurally natively, the bus catches `asyncio.QueueFull` limits and natively tracks `DELTA_BACKPRESSURE` bounds to notify developers without stalling upstream ingestion natively.
-*See [`bus.py` L101-112](file:///home/sunil/git/harmonograf/server/harmonograf_server/bus.py#L101-L112).*
-
-## 3. Storage Adapters and State
-
-The backend persistent layouts map exclusively into interchangeable data bindings organically natively.
-
-```mermaid
-classDiagram
-    BaseStorage <|-- MemoryStorage
-    BaseStorage <|-- SqliteStorage
-    class BaseStorage{
-      +upsert_span()
-      +list_sessions()
-      +ping()
-    }
+publish_span_start       publish_task_plan
+publish_span_update      publish_task_status
+publish_span_end         publish_agent_upsert
+publish_annotation       publish_agent_status
+publish_heartbeat        publish_task_report
+publish_context_window_sample
+publish_run_started / _run_completed / _run_aborted
+publish_plan_submitted / _plan_revised
+publish_drift_detected
+publish_delegation_observed / _agent_invocation_*
 ```
 
-### Memory and SQLite Bounds
-Memory instances are volatile topologies optimized for container integration boundaries natively. SQLite commits binary Protobuf traces via Write-Ahead Logs ensuring uncorrupted indexing structures reliably. SQLite persistence establishes explicit DAG variables tracking `Parent_Span` indices inherently defining cascade graphs organically natively globally. 
+The fan-out for goldfive events is substantially the same pattern as
+the legacy span deltas; the wire shape is passthrough via the
+`goldfive_event = 19` variant on `SessionUpdate`.
 
-## 4. Bi-Directional Event Routing
+## 4. ControlRouter
 
-A purely observable database is simply logging. Harmonograf acts as an intervention plane via the control routers inherently globally.
+[`control_router.py`](../../server/harmonograf_server/control_router.py)
+is the reverse direction:
 
-### Human-in-the-Loop Interventions
+- `subscribe(session_id, agent_id, stream_id)` registers a live
+  `SubscribeControl` stream with a bounded (256) event queue.
+- `deliver(agent_id, kind, payload, timeout, require_all_acks)` builds
+  a `goldfive.v1.ControlEvent`, fans it out to every live subscription
+  for the agent, awaits acks, and resolves via `_maybe_resolve`.
+- `record_ack(ack, stream_id)` is called from the telemetry ingest
+  path when `TelemetryUp.control_ack` arrives. The ack rides
+  telemetry, not the control stream itself, so happens-before is
+  preserved (see [ADR 0005](../adr/0005-acks-ride-telemetry.md)).
+- `register_alias(sub_agent_id, stream_agent_id)` maps an ADK
+  sub-agent name to the transport stream's registered agent_id so
+  control events addressed to a per-ADK-agent display name route to
+  the stream that actually owns it.
 
-```mermaid
-sequenceDiagram
-    participant UI as Frontend
-    participant Server as ControlRouter
-    participant Client as Harmonograf Client
-    participant ADK as Agent Runtime
-    
-    ADK->>Client: Blocked (Approval Needed)
-    Client->>Server: Span Update (Status=BLOCKED)
-    Server->>UI: Stream Event
-    UI->>Server: control_router.InjectPayload("approve", true)
-    Server->>Client: Unblock RPC Stream via UUID
-    Client->>ADK: Resume Context Logic
-```
+No queuing across reconnects: if `deliver` finds no live
+subscriptions, it returns `UNAVAILABLE` immediately and the frontend
+surfaces a snackbar. The exception is STEERING annotations, which
+persist as undelivered and replay on reconnect — but that's an
+annotation-layer concern, implemented in `rpc/frontend.py`, not in
+the router.
 
-The system inherently binds connection sockets across `identity.py` hashes securely. Resolving conflicts prevents autonomous networks stalling sequentially inherently locally safely. 
+## 5. Intervention aggregator
 
-**Ingest pipeline & bus subscribers** — every `TelemetryUp` variant routes
-through `IngestPipeline` and lands on `SessionBus`; subscribers (storage,
-WatchSession watchers, retention sweeper) read independently without
-contending on a SQL transaction.
+[`interventions.py`](../../server/harmonograf_server/interventions.py)
+is the chronological merge of three source streams:
 
-```mermaid
-flowchart LR
-    Up([TelemetryUp]) --> Disp{oneof}
-    Disp -- Hello --> Sess[SessionRegistry<br/>create / join]
-    Disp -- SpanStart/Update/End --> SP[span pipeline<br/>dedup + bind tasks]
-    Disp -- PayloadUpload --> PA[PayloadAssembler<br/>chunks → digest verify]
-    Disp -- Heartbeat --> HB[liveness + progress_counter]
-    Disp -- ControlAck --> CR[ControlRouter.deliver_ack]
-    SP --> Bus[(SessionBus<br/>per-session fan-out)]
-    PA --> Bus
-    HB --> Bus
-    Sess --> Bus
-    Bus --> Sub1[Storage adapter<br/>(SQLite / Memory)]
-    Bus --> Sub2[WatchSession queues<br/>(per frontend)]
-    Bus --> Sub3[Retention sweeper]
-    Bus --> Sub4[Stuck-detection<br/>heartbeat watcher]
+- `annotations` table — user STEER / HUMAN_RESPONSE / COMMENT.
+- Ingest pipeline drift ring (`_drifts_by_session`) — live
+  `drift_detected` events, per-session bounded at 500.
+- `task_plans.revision_kind` — plan revisions carrying a drift kind
+  or goldfive-autonomous kind (`cascade_cancel`, `refine_retry`,
+  `human_intervention_required`).
 
-    classDef good fill:#d4edda,stroke:#27ae60,color:#000
-    class Bus,SP good
-```
+The aggregator projects each source into a common
+`InterventionRecord` shape, runs outcome attribution (drift → plan
+revision within a 5-minute window for user-control kinds, 5s for
+autonomous drifts), and deduplicates by `annotation_id` so a single
+user STEER doesn't surface as three cards (see
+[ADR 0023](../adr/0023-intervention-dedup-by-annotation-id.md)).
 
-## 5. Drift Replay for Late Subscribers
+The `ListInterventions(session_id)` unary RPC (added in #87) exposes
+the merged list. Live updates arrive via the existing `WatchSession`
+deltas; the frontend deriver in `lib/interventions.ts` mirrors the
+aggregator so a late-joining client recomputes incrementally without
+a second subscribe.
 
-Goldfive `drift_detected` events are fanned out on the live bus the same way spans and plan events are. The catch is that drifts are also load-bearing for frontend-side features beyond the trajectory pane itself — the `__user__` and `__goldfive__` actor rows (see [frontend architecture §7](10-frontend-architecture.md#7-actor-attribution-and-span-synthesis)) are *lazily* materialized from drift events, so a frontend that subscribes after a drift has already fired would see only worker rows with no attribution for the existing pivots in the trajectory.
+## 6. Drift replay for late subscribers
 
-The fix is a bounded in-memory ring on `IngestPipeline` that retains recent drifts per-session and replays them in `WatchSession`'s initial burst.
+Drift events are load-bearing for frontend-side features beyond the
+trajectory pane — the `__user__` and `__goldfive__` actor rows are
+lazily materialized from drifts. A frontend that subscribes *after* a
+drift has fired would see only worker agent rows with no attribution
+for the existing pivots.
 
-**Ring structure** — [`ingest.py`](file:///home/sunil/git/harmonograf/server/harmonograf_server/ingest.py) holds `_drifts_by_session: dict[str, list[dict[str, Any]]]` with a per-session cap of `_drift_ring_max = 500`. The `_on_drift_detected` hook both publishes onto the bus *and* pushes a compact dict (kind, severity, detail, task_id, agent_id, emitted_at) onto the ring. `drifts_for_session(session_id)` exposes an iterable copy for replay.
+The fix is a bounded in-memory ring on `IngestPipeline`:
 
-**Replay step** — [`rpc/frontend.py`](file:///home/sunil/git/harmonograf/server/harmonograf_server/rpc/frontend.py) `WatchSession` handler runs an initial burst before attaching to the live tail. Step 4b.1 iterates `self._ingest.drifts_for_session(session_id)` and re-emits each as a synthesized `goldfive.v1.Event` with `drift_detected` populated and the cached `emitted_at` timestamp preserved. The client observes the replayed event on the same oneof dispatch it would observe a live one, so actor synthesis and trajectory ribbon population happen identically for reconnects.
+- `_drifts_by_session: dict[str, list[dict[str, Any]]]`, cap 500 per
+  session.
+- `_on_drift_detected` publishes onto the bus *and* pushes a compact
+  dict (kind, severity, detail, task_id, agent_id, emitted_at,
+  annotation_id) onto the ring.
+- `drifts_for_session(session_id)` returns an iterable copy for
+  replay.
+
+`rpc/frontend.py :: WatchSession` re-emits each ring entry as a
+synthesized `goldfive.v1.Event` with `drift_detected` populated and
+the cached `emitted_at` preserved, before attaching to the live bus.
+Client-side dispatch is identical for live vs replayed events.
 
 ```mermaid
 sequenceDiagram
@@ -134,7 +240,7 @@ sequenceDiagram
     participant Fe as Frontend
 
     Client->>Ingest: drift_detected
-    Ingest->>Ring: append compact dict
+    Ingest->>Ring: append compact dict<br/>(annotation_id included)
     Ingest->>Bus: publish live event
     Bus-->>Fe: live tail (if subscribed)
 
@@ -146,20 +252,60 @@ sequenceDiagram
     Watch-->>Fe: attach to live tail
 ```
 
-Retention is deliberately cheap: drifts are orders of magnitude less voluminous than spans (one event per plan pivot, not per LLM call), and the 500 cap bounds memory per session without losing the useful prefix for any reasonable run. SQLite persistence is not used for drifts at the moment — the ring is rebuilt from the live stream on server restart, at the cost of losing pre-restart drift history for long-lived sessions. Adding a drift table to the storage layer is tracked in [milestones.md](../milestones.md) but not load-bearing for v0.
+Retention is deliberately cheap: drifts are orders of magnitude less
+voluminous than spans (one per plan pivot, not one per LLM call), and
+the 500 cap bounds memory per session. SQLite persistence for drifts
+is on the roadmap but not load-bearing for v0 — the ring rebuilds
+from the live stream on server restart.
 
-## 6. System Health, Retention, and GC
+## 7. Storage adapter
 
-Large swarms of active autonomous agents flood bounding limitations frequently. The `retention.py` background chron process guarantees garbage collections natively:
-1. Validates timestamps dynamically globally.
-2. Removes inactive session records preserving database indexing arrays safely reliably natively.
-3. Automatically avoids quarantining loops mapping active processes explicitly structurally natively globally safely cleanly.
+Two backends, one interface (`storage/base.py`):
 
-## 7. Conclusion 
+- `storage/memory.py` — in-memory dicts + intervaltrees, lossy on
+  shutdown. Default for tests; selectable via `--store memory`.
+- `storage/sqlite.py` — `aiosqlite` + WAL, production default.
+  Payload bytes above a threshold live on disk under
+  `{data_dir}/payloads/{xx}/{digest}`; small payloads inline in the
+  `payloads` table.
 
-By splitting synchronous database persistence (`SqliteStorage`) away from transient volatile memory routings (`SessionBus`), the Harmonograf architecture achieves microsecond ingest latencies scaling massively linearly without inducing architectural blocks organically natively globally completely.
+Schema walkthrough lives in
+[internals/storage-sqlite.md](../internals/storage-sqlite.md). The
+header-level facts:
 
----
+- Every storage method is a coroutine that runs SQL on a thread
+  executor.
+- FK cascades are enforced only on `tasks.plan_id`; all other
+  cleanup in `delete_session` is explicit DELETE in FK order.
+- Migrations are additive `ALTER TABLE ADD COLUMN` checked via
+  `PRAGMA table_info`. No version table.
+
+## 8. Health and retention
+
+- `/healthz`, `/readyz` — unauthenticated probes from
+  [`health.py`](../../server/harmonograf_server/health.py).
+- `retention.py` — background sweeper that honors session-age limits
+  configured via CLI. v0 defaults to no auto-retention; operators
+  call `DeleteSession` explicitly.
+- `stress.py` — synthetic-load generator for benchmarks.
+
+## 9. What's NOT here anymore
+
+- **Orchestration.** Plan / task / drift / invariant / refine logic
+  moved to [goldfive](https://github.com/pedapudi/goldfive) in Phases
+  A–D. Harmonograf ingests `goldfive.v1.Event` envelopes via
+  `TelemetryUp.goldfive_event` and persists plan / task state, but
+  never decides any of it. See
+  [`../goldfive-integration.md`](../goldfive-integration.md).
+- **`ControlKind` / `ControlAck` / `ControlEvent` proto.** Control
+  wire types live in `goldfive/v1/control.proto` and harmonograf
+  imports them. Harmonograf's own `control.proto` is only the
+  `SubscribeControlRequest` envelope.
+- **`Task` / `TaskPlan` / `TaskEdge` / `UpdatedTaskStatus` proto.**
+  These moved to `goldfive/v1/types.proto`. Harmonograf's storage
+  schema still has a `task_plans` / `tasks` table because the server
+  *persists* plans derived from `PlanSubmitted` / `PlanRevised`
+  events, but the wire types are goldfive's.
 
 ## Related ADRs
 
@@ -170,3 +316,7 @@ By splitting synchronous database persistence (`SqliteStorage`) away from transi
 - [ADR 0017 — Task state is monotonic; terminal states absorb](../adr/0017-monotonic-task-state.md)
 - [ADR 0018 — Heartbeat + progress_counter for stuck detection](../adr/0018-heartbeat-stuck-detection.md)
 - [ADR 0020 — No authentication or multi-tenancy in v0](../adr/0020-no-auth-in-v0.md)
+- [ADR 0021 — Pin `goldfive.Session.id` to the outer adk-web session id](../adr/0021-session-id-pinning.md)
+- [ADR 0022 — Lazy Hello](../adr/0022-lazy-hello.md)
+- [ADR 0023 — Intervention dedup by `annotation_id`](../adr/0023-intervention-dedup-by-annotation-id.md)
+- [ADR 0024 — Per-ADK-agent Gantt rows with auto-registration](../adr/0024-per-adk-agent-gantt-rows.md)

--- a/docs/design/13-human-interaction-model.md
+++ b/docs/design/13-human-interaction-model.md
@@ -1,117 +1,236 @@
 # 13. Human Interaction Model
 
-> **Note (2026-04 goldfive migration).** Figures on this page still use the
-> pre-migration vocabulary (`TaskPlan`, `planner.refine`, `detect_drift` as
-> harmonograf-side concepts). Those behaviours now live in
-> [goldfive](https://github.com/pedapudi/goldfive) — planner / drift / refine /
-> `Plan`. Harmonograf still owns the control stream, the annotation lifecycle,
-> and the frontend rendering of whatever goldfive emits. Read the diagrams
-> with that substitution in mind, and consult
-> [../goldfive-integration.md](../goldfive-integration.md) for the current
-> terminology.
+Status: **CURRENT** (2026-04, reflects the STEER / intervention / viz refreshes).
 
-## Executive Summary
+> **Scope note.** Harmonograf's human-interaction surface covers
+> observation (Gantt / trajectory / drawer), capture (annotations,
+> STEER, HITL approvals), and the intervention timeline. The
+> *decisions* that a steer triggers — drift classification, planner
+> refine, task cancellation cascades — live in
+> [goldfive](https://github.com/pedapudi/goldfive). Harmonograf
+> captures, routes, records, and renders; goldfive decides.
 
-The paradigm of Human-Computer Interaction (HCI) with Large Language Models historically forces humans mapping vast topologies securely safely exclusively via linear chat lines intuitively organically inherently explicitly globally. 
-Harmonograf transforms supervision bounds mapping proxy actions spatially sequentially cleanly. 
+This doc covers what an operator does with the harmonograf UI and
+how each action traces through the protocol. For the RPC-level
+contract see [protocol/control-stream.md](../protocol/control-stream.md)
+and [protocol/frontend-rpcs.md](../protocol/frontend-rpcs.md). For
+the visualization of interventions see
+[ADR 0025](../adr/0025-intervention-timeline-viz.md).
 
-## 1. Time as the Context Axis
+## 1. The three classes of operator action
 
-Traditional structures cascade vertically inherently limiting relational intelligence natively intuitively intelligently inherently comprehensively. 
+Every operator action on the harmonograf console belongs to one of
+three classes, each with a different wire cost:
 
-### The Gantt Spatial Reality
+| Class | Examples | Cost | Reaches the agent? |
+|---|---|---|---|
+| **Observation** | hover, click, zoom, scroll, filter | Local only | No |
+| **Annotation** | add comment, open drawer, copy payload | `PostAnnotation` unary | Only for STEERING / HUMAN_RESPONSE |
+| **Control** | PAUSE, RESUME, CANCEL, STEER, APPROVE, STATUS_QUERY | `SendControl` unary | Yes — synchronous ack |
 
-```mermaid
-gantt
-    title Agent Topologies
-    dateFormat  s
-    axisFormat  %S
-    
-    section Coordinator
-    Analyze Problem       :a1, 0, 3s
-    Delegate Research     :a2, after a1, 1s
-    Compile Final Answer  :a3, 10, 2s
+Observation never goes on the wire. Annotation goes on the wire but
+usually doesn't reach the agent (COMMENT = UI-only). Control always
+reaches the agent if the agent is live.
 
-    section Researcher
-    Web Search           :r1, 4, 3s
-    Synthesize Results   :r2, after r1, 2s
-```
+## 2. The control round-trip
 
-Viewing swarms intuitively explicitly maps structural density limits natively cleanly organically securely safely reliably naturally comprehensively reliably. 
-
-## 2. Interactive Drill-Down Modalities
-
-### Collapsible Trace Contexts
-Harmonograf handles multi-million level traces leveraging `Level Of Detail (LOD)` transitions explicitly securely cleanly safely natively intelligently explicitly visually clearly correctly. 
-Top-level boxes mask internal HTTP requests explicitly natively intuitively elegantly systematically elegantly uniquely explicitly clearly correctly intrinsically reliably systematically properly organically securely flawlessly securely accurately seamlessly efficiently reliably correctly securely flawlessly uniquely perfectly reliably practically structurally functionally intelligently definitively universally holistically categorically categorically optimally practically effectively robustly natively intrinsically intrinsically phenomenologically. 
-
-When operators click a span (hooking logic structurally natively natively bounds natively specifically defined via React overlays), the contextual Right Drawer initializes natively specifically explicitly mapping internal memory queries reliably properly efficiently. 
-
-**Interaction → control → ack** — every operator action becomes a
-`ControlEvent` that the server fans out to the agent's
-`SubscribeControl`; the ack rides back upstream on `StreamTelemetry` so
-the UI's "delivered" badge respects happens-before.
+A PAUSE is the canonical worked example.
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant Op as Operator
     participant FE as Frontend
-    participant Srv as Server
+    participant Srv as Server (ControlRouter)
     participant Cl as Client lib
     participant Ag as Agent
+
     Op->>FE: click PAUSE on agent row
-    FE->>Srv: SendControl(PAUSE, target=agent_id)
-    Srv->>Cl: ControlEvent(PAUSE) [SubscribeControl]
+    FE->>Srv: SendControl(ControlEvent{kind=PAUSE, target.agent_id=A})
+    Note over Srv: router.deliver() fans out to every<br/>live SubscribeControl for A
+    Srv->>Cl: ControlEvent{id=ctl_1, kind=PAUSE} [SubscribeControl]
     Cl->>Ag: handler runs · sets pause flag
     Ag-->>Cl: handler returns
-    Cl->>Srv: ControlAck(id=PAUSE) [StreamTelemetry — after surrounding spans]
-    Srv->>FE: WatchSession delta · ack delivered
+    Cl->>Srv: ControlAck{control_id=ctl_1, result=SUCCESS} [StreamTelemetry — after in-flight spans]
+    Note over Srv: record_ack resolves _PendingDelivery.future
+    Srv-->>FE: SendControlResponse{control_id, result, acks[]}
     FE-->>Op: snackbar "Paused"
 ```
 
-**Annotation lifecycle** — comments are local; steering annotations
-double as `ControlEvent.STEER` and persist as undelivered when the
-target is offline, replaying on reconnect.
+Key points:
+
+- The ack rides the telemetry stream, not the control stream (see
+  [ADR 0005](../adr/0005-acks-ride-telemetry.md)). Every span the
+  agent emitted before issuing the ack is already on the wire ahead
+  of it — the UI can correctly say "paused at span X."
+- The server never queues control across reconnects. If no
+  subscription is live, `deliver` returns `UNAVAILABLE` immediately
+  and the snackbar surfaces it.
+- Multi-stream fan-out is first-success-wins by default; the
+  `require_all_acks` flag opts into full-quorum semantics.
+
+## 3. Annotation lifecycle
+
+Annotations are the UI's single compose surface. Three kinds
+distinguish wire behavior:
 
 ```mermaid
 flowchart TD
-    Click([right-click span]) --> Kind{annotation kind}
-    Kind -- COMMENT --> A1[PostAnnotation<br/>store-only]
-    Kind -- STEERING --> A2[PostAnnotation<br/>+ build ControlEvent.STEER]
-    A2 --> Live{target agent<br/>has live SubscribeControl?}
-    Live -- yes --> Send[ControlRouter.send → ack within timeout]
-    Send --> Mark[mark_annotation_delivered]
-    Live -- no --> Pend[store undelivered]
-    Pend --> RC[on Hello reconnect:<br/>replay pending steers]
-    Kind -- HUMAN_RESPONSE --> A3[APPROVE / REJECT / INJECT_MESSAGE]
+    Click([right-click span / add note]) --> Kind{annotation kind}
+    Kind -- COMMENT --> A1[PostAnnotation<br/>store-only · delivery=SUCCESS]
+    Kind -- STEERING --> A2[PostAnnotation<br/>synthesize ControlEvent.STEER]
+    A2 --> Stamp[stamp SteerPayload.author + annotation_id<br/>from stored annotation]
+    Stamp --> Live{target agent<br/>has live SubscribeControl?}
+    Live -- yes --> Send[ControlRouter.deliver → ack within timeout]
+    Send --> Mark[put_annotation with delivered_at]
+    Live -- no --> Fail[delivery=FAILURE<br/>detail="agent offline"]
+    Kind -- HUMAN_RESPONSE --> A3[synthesize ControlEvent.INJECT_MESSAGE<br/>or APPROVE/REJECT depending on shape]
     A3 --> Send
 
     classDef good fill:#d4edda,stroke:#27ae60,color:#000
-    class Send,Mark good
+    class Send,Mark,Stamp good
 ```
 
-**Steering → drift → refine** — a steer is a drift signal; the planner
-refines and the new `TaskPlan` revision diffs into the UI banner.
+### STEER — author + annotation_id stamping (goldfive #171)
 
-```mermaid
-flowchart LR
-    Steer[STEER ControlEvent] --> Detect[detect_drift<br/>kind=user_steer]
-    Detect --> Refine[planner.refine<br/>(LLM call)]
-    Refine --> NewPlan[new TaskPlan revision]
-    NewPlan --> Diff[computePlanDiff]
-    Diff --> Banner[frontend banner +<br/>side-by-side drawer]
+When a STEERING annotation synthesizes a `ControlEvent.STEER`, the
+server populates two fields on the `SteerPayload`:
 
-    classDef good fill:#d4edda,stroke:#27ae60,color:#000
-    class Refine,Diff good
-```
+- `author` — copied from the stored `Annotation.author` so
+  goldfive's drift record carries operator identity end-to-end.
+- `annotation_id` — the stored annotation's id. This is what
+  [ADR 0023](../adr/0023-intervention-dedup-by-annotation-id.md)
+  uses to collapse the annotation row, the synthesized `user_steer`
+  drift row, and the resulting `PlanRevised` row into a single
+  Intervention card.
 
-## 3. Human In The Loop Matrices
+### STEER — body validation (harmonograf #72)
 
-Supervision demands execution intervention intrinsically functionally explicitly securely practically rationally functionally definitively universally organically intrinsically definitively robustly automatically safely specifically safely logically directly intrinsically structurally dynamically appropriately seamlessly specifically specifically gracefully directly uniquely transparently exclusively securely systematically efficiently effectively cleanly rationally organically precisely carefully dynamically properly consistently rigorously safely intuitively transparently intelligently efficiently specifically accurately uniquely inherently optimally successfully robustly properly correctly reliably strictly safely explicitly properly correctly safely transparently definitively functionally cleanly appropriately comprehensively safely inherently structurally efficiently accurately intelligently flawlessly correctly adequately properly strictly cleanly flawlessly successfully explicitly fundamentally robustly reliably precisely effectively successfully organically intelligently correctly safely flawlessly seamlessly definitively automatically gracefully dynamically flawlessly optimally correctly correctly appropriately safely seamlessly safely explicitly precisely logically rigorously correctly dynamically automatically inherently seamlessly cleanly successfully optimally safely inherently securely optimally adequately explicitly properly safely successfully correctly robustly completely consistently cleanly smoothly natively intrinsically naturally exclusively holistically implicitly intrinsically accurately consistently completely transparently correctly optimally specifically accurately clearly uniquely perfectly comprehensively adequately reliably elegantly properly strictly successfully smoothly consistently rationally intelligently inherently successfully efficiently accurately elegantly strictly accurately securely efficiently elegantly dynamically correctly definitively smoothly completely perfectly correctly structurally rigorously seamlessly appropriately dynamically gracefully optimally properly intelligently automatically transparently automatically efficiently consistently cleanly accurately perfectly successfully naturally safely perfectly implicitly organically precisely structurally successfully gracefully cleanly accurately functionally seamlessly dynamically correctly safely appropriately strictly transparently rationally dynamically automatically comprehensively appropriately smoothly dynamically adequately efficiently comprehensively smoothly flawlessly successfully exclusively organically carefully smoothly safely accurately completely definitively accurately smoothly reliably perfectly flawlessly seamlessly adequately elegantly specifically completely successfully automatically cleanly safely comprehensively explicitly smoothly comprehensively efficiently perfectly organically successfully securely adequately successfully effectively robustly implicitly functionally seamlessly efficiently dynamically seamlessly rationally explicitly smoothly inherently implicitly carefully gracefully logically correctly dynamically automatically automatically strictly completely explicitly seamlessly reliably implicitly intrinsically efficiently successfully automatically correctly logically flawlessly perfectly successfully appropriately successfully rigorously correctly successfully transparently cleanly successfully smoothly dynamically completely definitively successfully perfectly efficiently effectively adequately comprehensively perfectly securely explicitly efficiently correctly correctly successfully correctly smoothly completely safely organically properly efficiently smoothly explicitly smoothly appropriately inherently perfectly naturally exclusively accurately correctly properly rigorously appropriately explicitly optimally smoothly functionally reliably confidently successfully fully explicitly functionally explicitly correctly fully properly rationally strictly properly transparently perfectly practically completely functionally accurately functionally adequately perfectly functionally thoroughly precisely fully fully gracefully confidently successfully robustly natively confidently flawlessly perfectly completely transparently properly perfectly correctly successfully implicitly definitively gracefully optimally effectively functionally effectively beautifully perfectly natively exactly effortlessly effortlessly gracefully accurately effortlessly smoothly intuitively perfectly robustly inherently properly confidently rigorously organically appropriately thoroughly systematically automatically flawlessly precisely precisely exactly transparently correctly properly functionally appropriately confidently explicitly confidently rigorously successfully flawlessly flawlessly cleanly dynamically intrinsically perfectly flawlessly logically successfully consistently effectively exactly completely smoothly successfully elegantly dynamically rigorously smoothly dynamically transparently effectively effortlessly uniquely structurally elegantly optimally flawlessly flawlessly smoothly efficiently perfectly naturally automatically effectively efficiently perfectly exactly seamlessly fully smoothly intrinsically thoroughly smoothly precisely reliably safely fully properly completely effectively perfectly optimally correctly smoothly reliably successfully fully smoothly intuitively successfully completely gracefully transparently properly rationally properly accurately flawlessly perfectly accurately appropriately thoroughly intuitively effectively safely exactly elegantly explicitly safely seamlessly efficiently intuitively successfully cleanly smoothly perfectly precisely exactly transparently effortlessly transparently automatically successfully smoothly accurately naturally accurately intelligently effortlessly structurally rationally completely reliably safely smoothly successfully dynamically comprehensively comprehensively correctly smoothly effectively seamlessly successfully reliably successfully completely perfectly cleanly efficiently successfully automatically safely successfully intuitively correctly effortlessly successfully exactly seamlessly securely gracefully naturally cleanly clearly perfectly exactly fully correctly confidently safely safely efficiently cleanly appropriately successfully seamlessly correctly confidently perfectly confidently functionally dynamically precisely securely exactly safely gracefully securely successfully organically efficiently perfectly smoothly intelligently beautifully naturally clearly smoothly successfully seamlessly effectively safely smoothly completely exactly natively properly appropriately effectively properly flawlessly efficiently safely safely natively fully securely naturally seamlessly beautifully flawlessly comfortably reliably reliably smoothly smoothly comfortably successfully safely properly accurately fully successfully confidently inherently properly natively thoroughly accurately effortlessly systematically effectively safely gracefully intuitively seamlessly successfully effectively appropriately fully beautifully carefully safely correctly securely successfully properly securely clearly correctly explicitly easily intelligently smartly smoothly cleanly seamlessly smoothly perfectly seamlessly confidently smoothly effectively effectively accurately natively properly exactly correctly precisely easily clearly seamlessly smartly brilliantly automatically smartly smoothly perfectly natively safely beautifully nicely elegantly efficiently smoothly effectively smartly safely appropriately perfectly fully confidently nicely explicitly easily precisely effortlessly explicitly smoothly appropriately completely effectively effectively reliably perfectly smartly efficiently gracefully cleanly cleanly exactly precisely nicely beautifully beautifully perfectly efficiently properly flawlessly successfully perfectly intelligently accurately cleanly cleanly precisely automatically brilliantly carefully properly carefully perfectly successfully beautifully efficiently beautifully properly smoothly effectively flawlessly smartly cleanly nicely smoothly beautifully effortlessly neatly successfully exactly elegantly fully smartly efficiently explicitly naturally completely effortlessly smartly intuitively ideally precisely perfectly natively implicitly organically effectively cleanly flawlessly brilliantly cleanly logically cleanly effectively safely securely brilliantly correctly clearly carefully simply simply smartly gracefully cleanly expertly simply correctly logically organically organically securely nicely efficiently securely purely completely smoothly easily beautifully elegantly safely implicitly properly carefully fully intelligently expertly flawlessly comfortably smartly purely precisely cleanly elegantly brilliantly optimally perfectly seamlessly automatically beautifully exactly excellently automatically simply easily carefully properly simply elegantly smartly effortlessly smoothly properly efficiently seamlessly elegantly perfectly clearly automatically effectively successfully purely intuitively nicely securely comfortably brilliantly carefully seamlessly simply accurately adequately explicitly neatly cleanly seamlessly successfully easily expertly smoothly carefully beautifully flawlessly cleanly ideally automatically magically appropriately optimally securely exactly optimally smoothly perfectly beautifully safely easily naturally brilliantly comfortably efficiently efficiently completely completely magically properly transparently easily naturally transparently carefully beautifully comfortably expertly magically elegantly flawlessly optimally cleanly confidently intuitively appropriately simply explicitly effectively successfully strictly successfully perfectly correctly elegantly wonderfully elegantly naturally purely exactly nicely cleanly brilliantly exactly easily perfectly automatically magically magically seamlessly beautifully safely automatically comfortably beautifully securely perfectly wonderfully magically elegantly miraculously correctly intuitively successfully strictly intuitively miraculously seamlessly securely magically simply instinctively simply excellently flawlessly effortlessly beautifully exactly effectively correctly gracefully cleanly naturally seamlessly beautifully seamlessly brilliantly efficiently automatically automatically cleanly nicely flawlessly automatically wonderfully perfectly simply successfully effortlessly comfortably seamlessly miraculously seamlessly miraculously effectively miraculously purely ideally flawlessly seamlessly ideally smoothly beautifully wonderfully comfortably magically natively smoothly amazingly brilliantly effortlessly miraculously flawlessly beautifully perfectly ideally seamlessly miraculously miraculously magically elegantly automatically perfectly wonderfully wonderfully brilliantly magically seamlessly beautifully flawlessly safely amazingly beautifully miraculously seamlessly effortlessly miraculously remarkably surprisingly efficiently efficiently beautifully safely magically seamlessly smoothly wonderfully flawlessly optimally wonderfully effectively surprisingly perfectly flawlessly safely harmoniously amazingly smoothly exactly remarkably flawlessly seamlessly.
+`ControlBridge._events_loop` in
+[`client/harmonograf_client/_control_bridge.py`](../../client/harmonograf_client/_control_bridge.py)
+validates every STEER body before forwarding to goldfive:
 
----
+- Empty / whitespace-only → `FAILURE` ack with `detail="body empty"`.
+  The outstanding `deliver` resolves via the ack instead of timing
+  out.
+- Over `STEER_BODY_MAX_BYTES` (8 KiB utf-8) → `FAILURE` ack with
+  `detail="body too long (N)"`.
+- ASCII control characters (ord < 32 except `\t` and `\n`) are
+  stripped from the body before forwarding, so a steer cannot
+  smuggle escape sequences into the downstream LLM prompt.
+
+## 4. Human-in-the-loop approvals
+
+When any span enters `SPAN_STATUS_AWAITING_HUMAN`:
+
+1. The block pulses with `error-container` color plus a glow outline
+   so it's visually urgent at any zoom level.
+2. An MD3 snackbar rises: "Agent X needs your input: approve
+   `search_web(query='...')`?" with inline Approve / Reject / Edit
+   buttons.
+3. The attention counter in the app bar increments; the entry is
+   added to the "Activity queue" page in the nav rail.
+4. Clicking the block opens the drawer to the Approval pane with
+   the full tool args, the rationale (linked parent `LLM_CALL`
+   completion), and Approve / Reject / Edit & Approve buttons.
+
+Resolution sends `APPROVE` or `REJECT` as a `ControlEvent`; the
+span transitions `AWAITING_HUMAN → RUNNING` on ack and the pulse
+stops. Goldfive's flows A (task-level) and B (ADK tool-level) both
+use the same control path; the distinguishing field is
+`ApprovePayload.target_id` (task id vs ADK function-call id) —
+details live in goldfive's `docs/design/APPROVAL.md`.
+
+## 5. The intervention timeline
+
+`InterventionsTimeline` sits above the Gantt in both planning and
+trajectory views, showing every point where the plan changed
+direction. One marker per `Intervention` row returned by
+`ListInterventions` (or derived live from `WatchSession` deltas).
+
+Three visual channels encode the row:
+
+| Channel | Dimension | Values |
+|---|---|---|
+| Color | Source | user=blue `#5b8def`, drift=amber `#f59e0b`, goldfive=grey `#8d9199` |
+| Glyph | Kind | diamond / circle / chevron / square (distinct per source) |
+| Ring | Severity | none=info, dashed amber=warning, solid red=critical |
+
+Stability contract:
+
+- Marker X is captured as a `spanEndMs` snapshot on mount and
+  advanced on a coarse 1s tick via `useStableSpanEnd`. Hovering a
+  marker never recomputes X from the outer `endMs`, so other
+  markers stay put. (Pre-#76 this was jittery and the popover
+  anchor drifted mid-hover.)
+- Density: markers within `max(14px, 2% of strip width)` of each
+  other collapse into a cluster badge whose popover lists the
+  group.
+- Popover anchor is deterministic — always the marker's center,
+  not the cursor.
+- Axis ticks auto-select from a fixed ladder (10s, 30s, 1m, 5m,
+  10m, 30m) based on the visible window.
+
+See [ADR 0025](../adr/0025-intervention-timeline-viz.md) for
+rationale.
+
+## 6. User vs goldfive actor attribution
+
+Beyond the intervention timeline, the Gantt itself treats the
+human operator and the goldfive orchestrator as first-class actor
+rows, distinct from worker agents. The implementation is purely in
+the frontend event-dispatch layer:
+
+- Reserved agent ids `__user__` and `__goldfive__` sit outside the
+  hashed palette with fixed colors (see
+  [`frontend/src/theme/agentColors.ts`](../../frontend/src/theme/agentColors.ts)).
+- On `DriftDetected`, `frontend/src/rpc/goldfiveEvent.ts` decides
+  attribution: `user_steer` / `user_cancel` / `user_pause` →
+  `__user__`; everything else → `__goldfive__`. The actor row is
+  lazily materialized the first time it's needed.
+- A synthesized span is appended to the actor row with attributes
+  carrying the drift kind / severity / detail. Standard rendering
+  applies — the Gantt paints a bar on the actor row because the
+  spans store has one.
+
+See [design/10-frontend-architecture.md §7](10-frontend-architecture.md#7-actor-attribution-and-span-synthesis).
+
+## 7. Keyboard shortcuts (current)
+
+| Key | Action |
+|---|---|
+| `⌘K` / `Ctrl+K` | Session picker |
+| `Space` | Toggle pause (all agents) |
+| `←` `→` | Pan 10% |
+| `+` `-` | Zoom in / out |
+| `F` | Fit session to viewport |
+| `L` | Jump to live / return to live |
+| `G` | Graph mode on selected span |
+| `A` | Annotate selected span |
+| `S` | Steer selected span |
+| `Esc` | Close drawer / clear selection |
+| `1`…`9` | Jump to agent row N |
+
+See
+[`frontend/src/lib/shortcuts.ts`](../../frontend/src/lib/shortcuts.ts)
+for the canonical mapping.
+
+## 8. What's explicitly NOT here
+
+- **Autonomous control.** Harmonograf never issues its own control
+  events. Every `SendControl` originates from a user action in the
+  frontend (or from an external client calling the RPC directly).
+- **Plan or task decisions.** Clicking "Rewind to here" on a span
+  issues a `REWIND_TO` control event; what goldfive's executor
+  actually does with it (revert task state, re-plan, cascade-cancel
+  downstream) is goldfive's decision.
+- **Drift detection logic.** Harmonograf receives `DriftDetected`
+  events and renders them. It does not classify, fire, or throttle
+  drifts.
 
 ## Related ADRs
 
+- [ADR 0005 — Control acks ride upstream on the telemetry stream](../adr/0005-acks-ride-telemetry.md)
 - [ADR 0013 — Drift is a first-class event](../adr/0013-drift-as-first-class.md)
+- [ADR 0023 — Intervention dedup by `annotation_id`](../adr/0023-intervention-dedup-by-annotation-id.md)
+- [ADR 0025 — Intervention timeline viz on three channels](../adr/0025-intervention-timeline-viz.md)

--- a/docs/design/14-information-flow.md
+++ b/docs/design/14-information-flow.md
@@ -1,50 +1,59 @@
-# 14. Information Flow & Telemetry Schema
+# 14. Information Flow — ADK callback to rendered pixel
 
-## Executive Summary
+Status: **CURRENT** (2026-04).
 
-To successfully operate complex multi-agent intelligence frameworks, an observability system must map discrete abstract tasks onto heavily structured topological grids dynamically. Harmonograf separates its Information Flow processing layer into strict schema validations managed primarily through custom Protobuf bounds integrating directly downstream into binary RPC endpoints. 
+End-to-end tour of one piece of telemetry — an LLM call — as it
+traverses the five tiers that carry it from the agent process to a
+rendered pixel in the Gantt. Every tier has its own docs; this one
+stitches them together so a reader can keep the whole pipeline in
+their head.
 
-## 1. Information Generation Boundary
-
-Data initiates solely at the Agent perimeter. When Python frameworks execute, telemetry bounds trigger explicitly natively. 
-
-```mermaid
-sequenceDiagram
-    participant Agent as App/Agent Code
-    participant Client as Client Library
-    participant Server as gRPC Ingest
-    
-    Agent->>Client: emit_span_start(LLM_CALL)
-    Client->>Client: Pack into SpanStart Protobuf
-    Client->>Client: RingBuffer enqueues
-    Client->>Server: Background HTTP/2 Push
-```
-**Tier 1 — agent → client lib (in-process)** — the agent calls a public
-emit method; the client packs a proto, computes any payload digest, and
-pushes onto the ring buffer. Nothing blocks the agent thread.
+## Tier 1 — ADK callback → plugin → client ring buffer
 
 ```mermaid
 flowchart LR
-    Code[agent code<br/>tool / LLM call] --> API[Client.start_span /<br/>attach_payload / end_span]
-    API --> Build[build proto envelope<br/>(SpanStart / Update / End)]
-    API --> Stage[PayloadStager<br/>sha256 + summary]
-    Build --> EB[(EventRing buffer)]
-    Stage --> PB[(Payload buffer)]
-    EB -. notify .-> Worker[TransportWorker thread]
-    PB -. notify .-> Worker
+    Callback[ADK lifecycle callback<br/>(before_model, after_tool, ...)]
+    Plugin[HarmonografTelemetryPlugin<br/>stamp agent_id + session_id]
+    Client[Client.emit_span_start/end/attach_payload]
+    Ring[(Event ring buffer<br/>~2000 entries)]
+    Stage[PayloadStager<br/>sha256 + summary]
+    Worker[TransportWorker thread]
+    Callback --> Plugin
+    Plugin --> Client
+    Client --> Ring
+    Client --> Stage
+    Ring -. notify .-> Worker
+    Stage -. notify .-> Worker
 
     classDef good fill:#d4edda,stroke:#27ae60,color:#000
-    class EB,PB,Worker good
+    class Ring,Stage good
 ```
 
-**Tier 2 — client lib → server (over the wire)** — the worker drains the
-ring buffer onto `StreamTelemetry`, interleaving payload chunks; control
-events arrive on `SubscribeControl`; acks ride back upstream.
+What happens on the agent thread:
+
+1. ADK invokes a lifecycle callback on
+   `HarmonografTelemetryPlugin` (e.g. `before_model_callback`).
+2. The plugin derives the **per-agent id**
+   `{client_agent_id}:{adk_agent_name}` from its invocation-id
+   stack (see [ADR 0024](../adr/0024-per-adk-agent-gantt-rows.md))
+   and stamps it as the span's `agent_id`.
+3. The plugin derives the **session id** — the outer adk-web
+   `ctx.session.id` cached on the ROOT `before_run_callback` (see
+   [ADR 0021](../adr/0021-session-id-pinning.md)) — and stamps it
+   as the span's `session_id`.
+4. On first-sight for this `(session_id, per_agent_id)` pair, the
+   plugin adds the `hgraf.agent.*` hint attributes so the server
+   can auto-register the agent row.
+5. `Client.emit_span_start(...)` builds the protobuf envelope,
+   pushes onto the ring buffer, and returns. No network I/O on the
+   agent thread.
+
+## Tier 2 — client → server over `StreamTelemetry`
 
 ```mermaid
 flowchart LR
     subgraph Client["Client process"]
-      W[TransportWorker]
+      W[TransportWorker<br/>drain · interleave · backoff]
       Sub[ControlSubscriber]
     end
     subgraph Srv["Server"]
@@ -52,93 +61,166 @@ flowchart LR
       SC[SubscribeControl handler]
       CR[ControlRouter]
     end
-    W -- "SpanStart / Update / End ·<br/>PayloadUpload chunks ·<br/>Heartbeat · ControlAck" --> Tel
-    SC -- "ControlEvent push" --> Sub
+    W -. "lazy Hello (harmonograf#85)<br/>session_id = outer adk-web id" .-> Tel
+    W -- "SpanStart / Update / End ·<br/>PayloadUpload chunks ·<br/>Heartbeat · ControlAck ·<br/>goldfive_event" --> Tel
+    SC -- "goldfive.v1.ControlEvent" --> Sub
     Sub -. handler ack .-> W
-    Tel -. ack delivery .- CR
+    Tel -. "record_ack" .- CR
     CR --> SC
 
     classDef good fill:#d4edda,stroke:#27ae60,color:#000
     class W,Tel good
 ```
 
-**Tier 3 — ingest → bus → store** — the ingest pipeline dedups by span id,
-mirrors into the live session, persists via the store ABC, and publishes
-on `SessionBus` for any number of subscribers.
+Highlights:
+
+- **Lazy Hello** (harmonograf #83 / #85). The first
+  `TelemetryUp` on the stream is the Hello, but it's not sent at
+  stream open — the transport defers until the first real envelope
+  is ready. Hello's `session_id` is the session id of that first
+  envelope, so the home session starts with the right id from the
+  very first write. See [ADR 0022](../adr/0022-lazy-hello.md).
+- **Per-envelope session routing** (harmonograf #66). Individual
+  spans and goldfive events may carry a `session_id` different
+  from the Hello's, and the server routes each one to the
+  declared session. This is how one client process can emit on
+  behalf of multiple adk-web invocations that land on different
+  sessions.
+- **Control acks ride upstream on telemetry** (ADR 0005). A
+  separate `SubscribeControl` RPC delivers events; their acks fold
+  into `TelemetryUp.control_ack` on the telemetry stream so
+  happens-before is free.
+
+## Tier 3 — ingest → bus → store
 
 ```mermaid
 flowchart TB
-    In([TelemetryUp from any client]) --> Ing[IngestPipeline<br/>dedup by span.id]
-    Ing --> LM[LiveSession mirror<br/>(in-memory)]
+    In([TelemetryUp from any client]) --> Ing[IngestPipeline<br/>dedup span.id]
+    Ing --> Route[_ensure_route<br/>auto-register session/agent<br/>harvest hgraf.agent.* hints]
+    Route --> LM[LiveSession state<br/>(in-memory mirror)]
     Ing --> Asm[PayloadAssembler<br/>(per digest)]
-    Ing --> HB[heartbeat / liveness tracker]
+    Ing --> HB[heartbeat · progress_counter<br/>stuck detection]
+    Ing --> GE[goldfive_event dispatch<br/>route by event.session_id<br/>drift ring append]
     LM -. write-behind .-> Store[(Store ABC)]
-    Asm -. on last=true .-> Store
+    Asm -. on last=true + sha256 match .-> Store
+    GE --> Store
     Store --> Mem[InMemoryStore]
-    Store --> SQ[SQLiteStore + payloads/]
+    Store --> SQ[SQLiteStore + payloads/{xx}/{digest}]
     LM --> Bus[(SessionBus<br/>per-session fan-out)]
     HB --> Bus
     Asm --> Bus
+    GE --> Bus
     Bus --> Sub1[WatchSession queues]
     Bus --> Sub2[stuck-detector watcher]
-    Bus --> Sub3[retention sweeper]
 
     classDef good fill:#d4edda,stroke:#27ae60,color:#000
-    class Bus,LM,Ing good
+    class Bus,LM,Ing,Route good
 ```
 
-**Tier 4 — server → frontend (over gRPC-Web)** — `WatchSession` opens with
-a snapshot then drains deltas; `GetPayload` is lazy and only fires when
-the drawer demands bytes; backpressure on a slow watcher coalesces into
-a snapshot pointer instead of stalling ingest.
+Highlights:
+
+- **Storage-before-publish** is an invariant. `Store.append_span`
+  runs before `bus.publish_span_start` so a reconnecting
+  `WatchSession` that reads from storage then attaches to the bus
+  never sees a delta for a span not yet persisted.
+- **Auto-register agents** from span hints on first-sight. The
+  first span a new agent emits pays the hint cost; subsequent
+  spans short-circuit via `seen_routes`. See
+  [ADR 0024](../adr/0024-per-adk-agent-gantt-rows.md).
+- **Goldfive event routing** dispatches on
+  `TelemetryUp.goldfive_event.session_id` (field 5), falling back
+  to the stream's Hello session when empty. One transport stream
+  can carry events for multiple sessions.
+- **Drift ring** (500 per session) captures every
+  `DriftDetected` for late-subscribe replay. See
+  [design/11 §6](11-server-architecture.md#6-drift-replay-for-late-subscribers).
+
+## Tier 4 — server → frontend over gRPC-Web
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant FE as Frontend
-    participant Srv as Server
-    participant LM as LiveSession mirror
+    participant Srv as Server (WatchSession)
+    participant Ring as drift ring
+    participant Store
     participant Bus as SessionBus
     FE->>Srv: WatchSession(session_id)
-    Srv->>LM: snapshot
-    LM-->>Srv: full state
-    Srv-->>FE: SessionUpdate.Snapshot
-    Srv->>Bus: subscribe (per-watcher queue)
-    loop live updates
-        Bus-->>Srv: Delta (span / heartbeat / ack)
-        Srv-->>FE: SessionUpdate.Delta
+    Srv->>Bus: subscribe(session_id) [live tail buffers]
+    Srv->>Store: list_agents / list_spans / list_task_plans / list_ctx_samples
+    Store-->>Srv: rows
+    Srv->>Ring: drifts_for_session(session_id)
+    Ring-->>Srv: iterable of drift dicts
+    Srv-->>FE: SessionUpdate{ session }
+    Srv-->>FE: SessionUpdate{ agent } ×N
+    Srv-->>FE: SessionUpdate{ initial_span } ×M
+    Srv-->>FE: SessionUpdate{ initial_annotation } ×K
+    Srv-->>FE: SessionUpdate{ goldfive_event(drift_detected) } ×D  (replay)
+    Srv-->>FE: SessionUpdate{ burst_complete }
+    loop live phase
+        Bus-->>Srv: Delta from queue
+        Srv-->>FE: SessionUpdate{ new_span / updated_span / ...<br/>goldfive_event passthrough }
     end
-    Note over Srv,FE: queue full → coalesce to SnapshotPointer<br/>frontend re-fetches via GetSpanTree
+    Note over Srv,FE: queue full → coalesce to snapshot pointer;<br/>frontend re-fetches via GetSpanTree
     FE->>Srv: GetPayload(digest) [drawer open]
-    Srv-->>FE: bytes (or evicted marker)
+    Srv-->>FE: PayloadChunk ×N
 ```
 
-**Tier 5 — frontend → user (canvas + overlay)** — proto deltas land in the
-mutable span index; the renderer's RAF loop coalesces dirty rects into
-canvas redraws; React touches only the chrome and the inspector drawer.
+Highlights:
+
+- **Initial burst + live tail** with an explicit `burst_complete`
+  marker. Clients flip from "loading..." to "live" on the marker,
+  not on the first delta.
+- **Drift replay** happens during the burst so a late-joining
+  frontend sees the existing `__user__` / `__goldfive__` actor
+  rows materialized correctly.
+- **goldfive_event passthrough** (field 19). Plan / task / drift /
+  run lifecycle all ride the one oneof variant; the frontend
+  dispatches on the inner payload kind.
+
+## Tier 5 — frontend state → canvas render
 
 ```mermaid
 flowchart LR
-    Wire[WatchSession deltas] --> Idx[(span index<br/>Map + R-tree)]
+    Wire[WatchSession deltas<br/>+ ListInterventions] --> Idx[(SessionStore<br/>AgentRegistry · SpanIndex ·<br/>TaskRegistry · ContextSeriesRegistry ·<br/>DriftRegistry · DelegationRegistry)]
     Idx -. dirty rects .-> RAF[requestAnimationFrame]
     RAF --> Bg[layer 0 · background]
     RAF --> Bl[layer 1 · blocks<br/>(viewport-cull, color batch)]
-    RAF --> Ov[layer 2 · overlay<br/>(hover · cursor · arrows)]
+    RAF --> Ov[layer 2 · overlay<br/>(hover · cursor · arrows · pulse)]
     Bg --> Cv[(stacked canvas)]
     Bl --> Cv
     Ov --> Cv
     Cv --- Dom[DOM overlay<br/>SpanContextMenu · tooltips]
+    Idx --> Iv[lib/interventions.ts<br/>live deriver]
+    Iv --> IT[InterventionsTimeline<br/>stable X · 3-channel encoding]
     Idx --> Dr[Drawer (React)<br/>Inspector tabs]
     Dr -. lazy .-> Pay[GetPayload]
 
     classDef good fill:#d4edda,stroke:#27ae60,color:#000
-    class Idx,RAF,Cv good
+    class Idx,RAF,Cv,Iv good
 ```
 
-### Schemas
-Defining specific relationships inherently establishes spatial contexts natively securely logically flawlessly seamlessly cleanly perfectly clearly intuitively systematically smartly ideally organically properly safely robustly explicitly cleanly logically elegantly successfully practically structurally accurately dynamically completely perfectly correctly natively rationally perfectly rationally functionally comprehensively cleanly seamlessly precisely carefully carefully accurately seamlessly functionally dynamically organically perfectly flawlessly accurately smoothly rationally gracefully intuitively effortlessly cleanly seamlessly effortlessly rigorously perfectly flawlessly successfully dynamically exactly magically effortlessly accurately rationally securely carefully completely exactly strictly securely reliably successfully properly flawlessly safely logically appropriately correctly safely comprehensively effectively precisely smartly efficiently transparently comfortably explicitly safely dynamically explicitly effortlessly smoothly strictly implicitly cleanly perfectly natively automatically efficiently cleanly gracefully appropriately carefully successfully exactly organically cleanly smoothly automatically transparently cleanly purely implicitly nicely intelligently natively successfully intelligently optimally comfortably perfectly functionally gracefully securely seamlessly explicitly successfully appropriately perfectly smartly automatically completely properly brilliantly cleanly accurately smoothly reliably rationally smoothly smartly organically cleanly seamlessly exactly safely smoothly securely adequately successfully perfectly smoothly brilliantly exactly properly ideally expertly nicely logically gracefully cleanly gracefully properly perfectly exactly correctly effectively automatically intuitively perfectly efficiently reliably successfully nicely exactly seamlessly comfortably completely accurately smoothly smartly nicely effectively brilliantly automatically seamlessly successfully expertly successfully explicitly correctly flawlessly gracefully magically beautifully smoothly perfectly effortlessly smoothly correctly safely exactly nicely cleanly safely elegantly elegantly logically precisely gracefully perfectly purely confidently correctly confidently carefully logically explicitly smartly effectively precisely simply seamlessly seamlessly securely properly seamlessly automatically magically successfully clearly magically safely perfectly logically exactly efficiently completely simply accurately naturally confidently brilliantly safely gracefully optimally securely simply beautifully successfully securely naturally precisely perfectly efficiently comfortably exactly smoothly smartly cleanly intuitively explicitly seamlessly optimally perfectly completely properly cleanly smartly safely smoothly effortlessly naturally reliably gracefully effortlessly wonderfully brilliantly dynamically beautifully safely seamlessly brilliantly cleanly seamlessly carefully correctly functionally cleanly efficiently beautifully easily completely cleanly nicely beautifully transparently cleanly beautifully intuitively flawlessly flawlessly cleanly safely perfectly automatically naturally dynamically successfully nicely completely smoothly easily beautifully adequately effortlessly perfectly comfortably seamlessly effectively automatically seamlessly flawlessly cleanly elegantly wonderfully securely nicely reliably exactly smoothly effortlessly effectively intelligently dynamically efficiently beautifully correctly neatly automatically flawlessly dynamically purely automatically efficiently rationally seamlessly seamlessly seamlessly miraculously beautifully organically effortlessly beautifully miraculously perfectly practically successfully beautifully properly successfully automatically automatically seamlessly accurately nicely automatically magically perfectly safely naturally effectively transparently logically seamlessly flawlessly smoothly harmoniously gracefully perfectly miraculously fully harmoniously miraculously seamlessly fully seamlessly beautifully.
+Highlights:
 
----
+- **Mutable store, not Zustand** for the hot path. The renderer
+  reads field-directly from `SessionStore.spans.range(...)` on
+  every frame. React never re-renders the Gantt on data changes.
+- **Three canvas layers** (background / blocks / overlay) each
+  with independent dirty triggers. Layer separation lets
+  pan-without-data-change skip the overlay cost.
+- **Intervention deriver mirrors the server aggregator** so live
+  updates dedup by `annotation_id` the same way server-side does.
+  A steer that arrives as annotation → drift → plan revision all
+  collapses into one timeline row incrementally. See
+  [ADR 0023](../adr/0023-intervention-dedup-by-annotation-id.md).
+
+## Where to look in source
+
+- Tier 1: [`client/harmonograf_client/telemetry_plugin.py`](../../client/harmonograf_client/telemetry_plugin.py)
+- Tier 2: [`client/harmonograf_client/transport.py`](../../client/harmonograf_client/transport.py)
+- Tier 3: [`server/harmonograf_server/ingest.py`](../../server/harmonograf_server/ingest.py), [`server/harmonograf_server/bus.py`](../../server/harmonograf_server/bus.py), [`server/harmonograf_server/storage/sqlite.py`](../../server/harmonograf_server/storage/sqlite.py)
+- Tier 4: [`server/harmonograf_server/rpc/frontend.py`](../../server/harmonograf_server/rpc/frontend.py), [`server/harmonograf_server/interventions.py`](../../server/harmonograf_server/interventions.py)
+- Tier 5: [`frontend/src/gantt/renderer.ts`](../../frontend/src/gantt/renderer.ts), [`frontend/src/gantt/index.ts`](../../frontend/src/gantt/index.ts), [`frontend/src/lib/interventions.ts`](../../frontend/src/lib/interventions.ts), [`frontend/src/components/Interventions/InterventionsTimeline.tsx`](../../frontend/src/components/Interventions/InterventionsTimeline.tsx)
 
 ## Related ADRs
 
@@ -146,3 +228,6 @@ Defining specific relationships inherently establishes spatial contexts natively
 - [ADR 0005 — Control acks ride upstream on the telemetry stream](../adr/0005-acks-ride-telemetry.md)
 - [ADR 0016 — Content-addressed payloads with eviction](../adr/0016-content-addressed-payloads.md)
 - [ADR 0018 — Heartbeat + progress_counter for stuck detection](../adr/0018-heartbeat-stuck-detection.md)
+- [ADR 0021 — Pin `goldfive.Session.id` to the outer adk-web session id](../adr/0021-session-id-pinning.md)
+- [ADR 0022 — Lazy Hello](../adr/0022-lazy-hello.md)
+- [ADR 0024 — Per-ADK-agent Gantt rows with auto-registration](../adr/0024-per-adk-agent-gantt-rows.md)

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -39,23 +39,27 @@ flowchart LR
 ## Reading order
 
 1. [`server-ingest-bus.md`](server-ingest-bus.md) — the server fan-in for all
-   telemetry, the pub/sub bus with drop-oldest backpressure, and the
-   control-router that correlates acks from multiple live streams per agent.
+   telemetry, the pub/sub bus with drop-oldest backpressure, the
+   control-router that correlates acks from multiple live streams per agent,
+   the per-session drift ring used for late-subscribe replay, and the
+   intervention aggregator that merges annotations + drifts + plan
+   revisions into one chronological list.
 2. [`storage-sqlite.md`](storage-sqlite.md) — the SQLite backing store.
    Schema with inline commentary, the idempotent migration pattern, PRAGMAs,
    and the cascade-delete paths.
 3. [`session-store-task-registry.md`](session-store-task-registry.md) — the
-   mutable frontend hot path. `SessionStore` / `TaskRegistry` deliberately
-   sidestep React/Zustand and run direct subscriptions into the canvas
-   renderer. Read before adding any new field to the frontend data model.
+   mutable frontend hot path. `SessionStore` with `AgentRegistry`,
+   `SpanIndex`, `TaskRegistry`, `ContextSeriesRegistry`, `DriftRegistry`,
+   and `DelegationRegistry` deliberately sidestep React/Zustand and run
+   direct subscriptions into the canvas renderer. Read before adding any new
+   field to the frontend data model.
 4. [`renderer-pipeline.md`](renderer-pipeline.md) — how the Gantt canvas
    actually draws. Triple-buffered canvas layers, span bucketing for batch
    fill, binary-searched context-window overlay, and the hit-test path that
    powers selection.
-5. [`drift-taxonomy-catalog.md`](drift-taxonomy-catalog.md) — historical
-   drift taxonomy; superseded by goldfive's `DriftKind` (see goldfive's own
-   docs). Kept here for reference while the frontend still maps the same
-   string values onto badges.
+5. [`drift-taxonomy-catalog.md`](drift-taxonomy-catalog.md) — pointer
+   into goldfive's `DriftKind` taxonomy. The mapping of drift strings to
+   UI badges lives in `frontend/src/gantt/driftKinds.ts`.
 
 ## When to read which doc
 

--- a/docs/internals/renderer-pipeline.md
+++ b/docs/internals/renderer-pipeline.md
@@ -345,6 +345,40 @@ Task selection reconciliation at `GanttCanvas.tsx:149-167` subscribes to
 whenever the task registry mutates. This is how the Drawer and the
 Canvas stay in sync.
 
+## InterventionsTimeline insertion
+
+The strip is not part of the canvas renderer's draw loop — it's a
+separate React component
+(`components/Interventions/InterventionsTimeline.tsx`) that mounts
+above the Gantt in the planning and trajectory views. Data flow:
+
+- `ListInterventions(session_id)` unary RPC on view open returns the
+  full merged history.
+- Live updates come through the existing `WatchSession` deltas.
+  `lib/interventions.ts` mirrors the server aggregator (dedup by
+  `annotation_id`, outcome attribution) so rows reconcile without
+  a second RPC.
+
+Stability contract (harmonograf #76): the component captures
+`endMs` as an internal `spanEndMs` snapshot on mount and advances
+it on a coarse 1s tick via `useStableSpanEnd`. Hovering a marker
+never recomputes X positions from the outer `endMs`, so markers
+don't jitter mid-hover.
+
+Three visual channels encode the row (see
+[ADR 0025](../adr/0025-intervention-timeline-viz.md)):
+
+- Source (user / drift / goldfive) → color from `SOURCE_COLOR` in
+  `lib/interventions.ts`.
+- Kind → glyph (diamond / circle / chevron / square; distinct per
+  source).
+- Severity (warning / critical) → dashed amber or solid red ring.
+
+Density clustering kicks in at
+`max(14px, 2% of strip width)`; popover anchors deterministically
+to the marker center. Axis ticks auto-select from a fixed ladder
+(10s / 30s / 1m / 5m / 10m / 30m).
+
 ## Gotchas that bit prior iterations
 
 - **Do not fold bucketing into the subscription callbacks.** Bucketing

--- a/docs/internals/server-ingest-bus.md
+++ b/docs/internals/server-ingest-bus.md
@@ -1,18 +1,22 @@
 # Server ingest, bus, and control router
 
-The server's fan-in surface is split across three files:
+The server's fan-in surface is split across four files:
 
-- `server/harmonograf_server/ingest.py` (~770 lines) — the telemetry
+- `server/harmonograf_server/ingest.py` (~1000 lines) — the telemetry
   envelope pipeline. Receives every message from every client's
-  `StreamTelemetry` RPC, deduplicates, persists, and publishes.
-- `server/harmonograf_server/bus.py` (~230 lines) — the per-session
+  `StreamTelemetry` RPC, deduplicates, persists, publishes, and
+  maintains the per-session drift ring for late-subscribe replay.
+- `server/harmonograf_server/bus.py` (~260 lines) — the per-session
   pub/sub bus with bounded per-subscriber queues and drop-oldest
   backpressure.
 - `server/harmonograf_server/control_router.py` (~350 lines) — the
   reverse direction. Frontend sends control, server routes to live
   client streams, correlates acks back to pending requests.
+- `server/harmonograf_server/interventions.py` (~550 lines) — the
+  intervention aggregator. Merges annotations + drift ring + plan
+  revisions into one chronological list; dedups by `annotation_id`.
 
-All three are single-process, in-memory. Persistence is delegated to
+All four are single-process, in-memory. Persistence is delegated to
 the storage layer (see [`storage-sqlite.md`](storage-sqlite.md)); the
 bus only fans out the live stream to subscribers currently watching.
 
@@ -112,11 +116,16 @@ The dispatcher. Branches on message kind:
 - `payload` → `_handle_payload`
 - `heartbeat` → `_handle_heartbeat`
 - `control_ack` → forwarded to `ControlRouter.record_ack`
-- `task_plan` → `_handle_task_plan`
-- `task_status_update` → `_handle_task_status_update`
-- `context_window_sample` → `_handle_context_window_sample`
-- `task_report` → `_handle_task_report`
+- `goldfive_event` → `_handle_goldfive_event` (dispatches on the
+  `Event.payload` oneof — `run_started`, `plan_submitted`,
+  `plan_revised`, `task_started/progress/completed/failed/blocked/
+  cancelled`, `drift_detected`, `run_completed/aborted`,
+  `agent_invocation_*`, `delegation_observed`, ...)
 - `goodbye` → mark stream shut
+
+`task_plan = 9` and `task_status_update = 10` are **reserved** in the
+proto — pre-goldfive-migration they were their own oneof variants;
+plan / task state now rides inside `goldfive_event`.
 
 Every branch follows the same three-phase pattern: *dedup if
 applicable → persist → publish*.
@@ -150,6 +159,54 @@ subscribes to the bus for the live stream. If publishing preceded
 storage, the watcher could see a live span that the replay hadn't
 yet observed and end up with a duplicate. By persisting first, the
 storage state is always at least as fresh as what's on the bus.
+
+### Session routing (harmonograf #63 / #66 / #85)
+
+Spans and goldfive events route to different session ids on the same
+telemetry stream:
+
+- **Spans** route by `pb_span.session_id` (falling back to
+  `ctx.session_id`). A `HarmonografTelemetryPlugin` configured with
+  the outer adk-web session id stamps it on every span, so spans
+  land on the correct session row even when ADK's `AgentTool`
+  sub-Runner minted its own id. See
+  [ADR 0021](../adr/0021-session-id-pinning.md).
+- **Goldfive events** route by `Event.session_id` (goldfive field
+  5, added in goldfive #155). When an event carries a session id
+  different from the stream's Hello session,
+  `_handle_goldfive_event` wraps the context in a read-only
+  `_SessionView` that pins `session_id` without mutating the
+  shared `StreamContext`, then calls `_ensure_route` to
+  auto-create the session / agent row if unseen.
+
+Both paths preserve back-compat: empty `session_id` on a span or
+goldfive event falls back to the Hello session.
+
+### Agent auto-registration (harmonograf #74 / #80)
+
+`_ensure_route` is the first-sight handler. On a fresh
+`(session_id, agent_id)` pair it:
+
+1. Creates the session row if missing.
+2. Reads `hgraf.agent.name` / `hgraf.agent.parent_id` /
+   `hgraf.agent.kind` / `hgraf.agent.branch` attributes off the
+   span and writes them as `adk.agent.name`,
+   `harmonograf.parent_agent_id`, `harmonograf.agent_kind`,
+   `adk.agent.branch` in the agent's `metadata`.
+3. Prefers `hgraf.agent.name` over the bare `span.name` for the
+   display name (LLM/tool span names are the model/tool name, not
+   the agent name).
+4. Registers the Agent row with `Framework.ADK` when a name hint
+   is present, and publishes an `agent_upsert` delta.
+
+`seen_routes` on the `StreamContext` short-circuits subsequent
+spans so the hot path pays the harvest cost once per agent, never
+per span. See
+[ADR 0024](../adr/0024-per-adk-agent-gantt-rows.md).
+
+The plugin side of the contract is in
+[`client/harmonograf_client/telemetry_plugin.py`](../../client/harmonograf_client/telemetry_plugin.py)
+(`_register_agent_for_ctx`, `_stamp_agent_attrs`).
 
 ### Stream lifecycle
 
@@ -445,6 +502,68 @@ SUCCESS. This is how the "refresh status" button in the frontend
 gets its delayed response — the ack payload carries the agent's
 state_delta snapshot, which the router forwards to registered
 listeners.
+
+## Drift ring and late-subscribe replay
+
+`IngestPipeline._drifts_by_session: dict[str, list[dict]]` is a
+per-session bounded ring (`_drift_ring_max = 500`) that captures
+every `drift_detected` event the ingest pipeline observed.
+`_on_drift_detected` both publishes onto the bus *and* pushes a
+compact dict (kind, severity, detail, task_id, agent_id,
+emitted_at, annotation_id) onto the ring.
+
+The `WatchSession` handler in `rpc/frontend.py` re-emits each ring
+entry as a synthesized `goldfive.v1.Event` with `drift_detected`
+populated (and `annotation_id` / `emitted_at` preserved) during the
+initial burst, before attaching to the live bus. Client-side
+dispatch is identical for live vs replayed events, so actor
+synthesis (`__user__` / `__goldfive__` row materialization) and
+trajectory ribbon population happen correctly for reconnects.
+
+The ring is rebuilt from the live stream on server restart — no
+SQLite persistence for drifts yet. Per-session cap of 500 bounds
+memory without losing the useful prefix of any reasonable run.
+
+## Intervention aggregator (`interventions.py`)
+
+`list_interventions(store, session_id, ingest)` is the
+chronologically merged view of every point where the plan changed
+direction. Three source projections:
+
+- **Annotations** (`_project_annotations`) — STEER / HUMAN_RESPONSE
+  rows from the `annotations` table become user-sourced
+  interventions with `annotation_id` populated.
+- **Drift ring** (`_project_drifts`) — every drift in
+  `IngestPipeline.drifts_for_session(...)` becomes a row; user-source
+  drift kinds (`user_steer` / `user_cancel`) get `source="user"` with
+  the annotation id carried through; autonomous drifts get
+  `source="drift"`.
+- **Plan revisions** (`_project_plans`) — `task_plans` rows whose
+  `revision_kind` matches a known drift kind or goldfive-autonomous
+  kind become an intervention row; when a matching drift carries an
+  `annotation_id`, it's propagated onto the plan row so the final
+  dedup pass can fold the plan outcome back onto the annotation.
+
+The projected rows pass through two passes:
+
+1. `_attribute_outcomes(records)` — walks rows in time order,
+   attributing a drift/plan row to its successor within the
+   attribution window. Window is **5 minutes for user-control
+   kinds** (`user_steer` / `user_cancel`) — the refine LLM
+   roundtrip routinely takes tens of seconds — and **5 seconds for
+   autonomous drifts**. The narrow default keeps unrelated late
+   events from stealing attribution.
+2. `_merge_by_annotation_id(records)` — collapses rows that share an
+   `annotation_id` into a single user-authored card, merging
+   outcome / severity / plan_revision_index onto the surviving
+   annotation row. Rows without an `annotation_id` pass through
+   unchanged (that's how autonomous drifts keep their own cards).
+
+See [ADR 0023](../adr/0023-intervention-dedup-by-annotation-id.md).
+
+The frontend deriver (`frontend/src/lib/interventions.ts`) mirrors
+the same projection + attribution + dedup so live deltas from
+`WatchSession` reconcile incrementally without a second RPC.
 
 ## Backpressure semantics summary
 

--- a/docs/internals/session-store-task-registry.md
+++ b/docs/internals/session-store-task-registry.md
@@ -1,11 +1,18 @@
 # SessionStore and TaskRegistry
 
-`frontend/src/gantt/index.ts` (~600 lines) owns the frontend data model
-for a live session. It exposes four registries — `AgentRegistry`,
-`SpanIndex`, `TaskRegistry`, `ContextSeriesRegistry` — bundled together
-under a `SessionStore` class, and it is deliberately *not* a Zustand /
-Redux / signals store. The hot rendering path reads directly from these
-objects on every frame with zero React in the middle.
+`frontend/src/gantt/index.ts` (~900 lines) owns the frontend data model
+for a live session. It exposes a set of registries bundled under a
+`SessionStore` class — `AgentRegistry`, `SpanIndex`, `TaskRegistry`,
+`ContextSeriesRegistry`, `DriftRegistry`, `DelegationRegistry` — and
+it is deliberately *not* a Zustand / Redux / signals store. The hot
+rendering path reads directly from these objects on every frame with
+zero React in the middle.
+
+The `DriftRegistry` and `DelegationRegistry` were added after the
+goldfive migration (harmonograf #60 / #62 family). They mirror the
+pattern of the earlier registries — append / list / clear / subscribe —
+and back actor synthesis and cross-agent edge rendering respectively.
+See [design/10 §7–8](../design/10-frontend-architecture.md#7-actor-attribution-and-span-synthesis).
 
 ## Why not Zustand
 
@@ -88,18 +95,30 @@ classDiagram
 
 
 
-`SessionStore` is defined at `index.ts:455-593`. It owns:
+`SessionStore` is defined near the end of `index.ts`. It owns:
 
 - `agents: AgentRegistry` — active agents, status, metadata.
-- `spans: SpanIndex` — the time-indexed span store.
+  Includes reserved synthetic actor ids (`__user__`,
+  `__goldfive__`) when drift events have materialized them.
+- `spans: SpanIndex` — the time-indexed span store. Includes
+  synthesized drift spans on the synthetic actor rows.
 - `tasks: TaskRegistry` — plans, tasks, revisions.
 - `contextSeries: ContextSeriesRegistry` — per-agent context-window
   samples.
-- `wallClockStartMs: number` (`index.ts:580`) — session start on the
-  wall clock, used to convert absolute timestamps from the server into
+- `drifts: DriftRegistry` — `DriftRecord` ring per session; drives
+  actor attribution and the trajectory ribbon. Live `driftDetected`
+  events append here; the `WatchSession` initial burst replays the
+  ring. See [`design/10 §7`](../design/10-frontend-architecture.md#7-actor-attribution-and-span-synthesis).
+- `delegations: DelegationRegistry` — `DelegationObserved` entries.
+  Drives cross-agent dashed edges in the Gantt
+  (`drawDelegations()` in `renderer.ts`) and faint
+  "↪↪ delegated to: X" annotations in the trajectory DAG. See
+  [`design/10 §8`](../design/10-frontend-architecture.md#8-delegation-edges).
+- `wallClockStartMs: number` — session start on the wall clock, used
+  to convert absolute timestamps from the server into
   session-relative `tMs` values the renderer uses.
-- `nowMs: number` (`index.ts:584`) — current session-relative now,
-  advanced by the renderer each frame.
+- `nowMs: number` — current session-relative now, advanced by the
+  renderer each frame.
 
 Two higher-level helpers also live here:
 

--- a/docs/protocol/control-stream.md
+++ b/docs/protocol/control-stream.md
@@ -1,14 +1,24 @@
 # `SubscribeControl` reference
 
 ```proto
-rpc SubscribeControl(SubscribeControlRequest) returns (stream ControlEvent);
+rpc SubscribeControl(SubscribeControlRequest) returns (stream goldfive.v1.ControlEvent);
 ```
 
 `SubscribeControl` is a server-streaming RPC opened by the agent right
 after its `StreamTelemetry` handshake (`Welcome`) completes. The server
-pushes `ControlEvent`s that the agent should honor; the agent's
-responses (`ControlAck`) travel **back upstream on
+pushes `goldfive.v1.ControlEvent`s that the agent should honor; the
+agent's responses (`goldfive.v1.ControlAck`) travel **back upstream on
 `StreamTelemetry`**, not on this stream.
+
+> **Wire type ownership.** Since harmonograf #34 / goldfive #83 /
+> harmonograf migration issue #37, `ControlKind`, `ControlEvent`,
+> `ControlAck`, `ControlAckResult`, `ControlTarget`, and every
+> per-kind payload (`SteerPayload`, `RewindPayload`, `ApprovePayload`,
+> `RejectPayload`, `InjectMessagePayload`) live in
+> [`goldfive/v1/control.proto`](https://github.com/pedapudi/goldfive/blob/main/proto/goldfive/v1/control.proto).
+> Harmonograf imports them — there is no parallel harmonograf
+> ControlEvent any more. The shapes below are therefore summaries of
+> the goldfive protos; their canonical definitions are in goldfive.
 
 ## Why acks ride telemetry
 
@@ -49,24 +59,47 @@ returned in that `Welcome`.
 
 ## Response
 
-The response stream is a sequence of `ControlEvent`s. `ControlEvent`
-lives in [`types.proto`](../../proto/harmonograf/v1/types.proto) so
-`SendControl` (in `frontend.proto`) can also reference it.
+The response stream is a sequence of `goldfive.v1.ControlEvent`s.
+`ControlEvent` lives in goldfive's control proto; `SendControl` (in
+`harmonograf/v1/frontend.proto`) also references it directly.
 
 ```proto
+// goldfive/v1/control.proto
 message ControlEvent {
   string id = 1;
   google.protobuf.Timestamp issued_at = 2;
   ControlTarget target = 3;
   ControlKind kind = 4;
-  bytes payload = 5;
+
+  oneof payload {
+    SteerPayload steer = 10;         // note, suggested_action, author, annotation_id
+    RewindPayload rewind = 11;       // task_id
+    ApprovePayload approve = 12;     // target_id, detail
+    RejectPayload reject = 13;       // target_id, detail
+    InjectMessagePayload inject_message = 14;  // role, text
+  }
 }
 
 message ControlTarget {
   string agent_id = 1;
-  string span_id = 2;  // optional, kind-dependent
+  string task_id = 2;      // goldfive task-level approval (Flow A)
+  string tool_call_id = 3; // ADK tool-confirmation (Flow B)
 }
 ```
+
+The `payload` is a **typed oneof** rather than `bytes`. Earlier
+revisions used `bytes payload` and each consumer invented its own
+JSON schema; that caused the schema drift that triggered the move
+to goldfive-owned protos in the first place.
+
+`SteerPayload` gained two fields in goldfive #171:
+
+- `author` — operator identity, populated from the originating
+  `Annotation.author` by `PostAnnotation`.
+- `annotation_id` — source annotation id, used by goldfive for
+  STEER idempotency and by harmonograf's intervention aggregator
+  for row dedup (see
+  [ADR 0023](../adr/0023-intervention-dedup-by-annotation-id.md)).
 
 ### Control kinds
 
@@ -216,6 +249,27 @@ The alias map is:
 - **Per-process** (no cross-server persistence).
 - **Cleared when the underlying stream disconnects** — aliases pointing
   at a dropped stream are removed in `ControlRouter.unsubscribe`.
+
+## STEER body validation (harmonograf #72 / goldfive #171)
+
+The client-side `ControlBridge` validates every `STEER` body before
+forwarding to goldfive's `ControlChannel`. The validation is local to
+the client — the server's outstanding `deliver` future still resolves
+via the `FAILURE` ack, not a timeout.
+
+```
+body empty / whitespace-only              → ack FAILURE, detail="body empty"
+body > STEER_BODY_MAX_BYTES (8192 utf-8)  → ack FAILURE, detail="body too long (N)"
+ASCII control chars (ord < 32, not \t/\n) → stripped; body forwarded
+```
+
+Implemented in
+[`client/harmonograf_client/_control_bridge.py`](../../client/harmonograf_client/_control_bridge.py)
+(`_validate_steer_body`, `_sanitise_steer_body`,
+`ControlBridge._events_loop`). The scrub step prevents smuggling
+escape sequences into the downstream LLM prompt; the cap prevents a
+pathological UI / scripted caller from bloating every subsequent
+model call and storage write.
 
 ## Reject / failure modes
 

--- a/docs/protocol/data-model.md
+++ b/docs/protocol/data-model.md
@@ -1,9 +1,19 @@
 # Data model
 
-Every shared entity on the wire. All definitions live in
+Every shared entity on the wire. Definitions live in
 [`types.proto`](../../proto/harmonograf/v1/types.proto). Messages
 specific to one RPC (`Hello`, `Welcome`, `SessionUpdate`, etc.) live in
 the channel-specific protos and are covered in the channel docs.
+
+> **Scope note (post-goldfive migration).** Orchestration types
+> (`Plan` / `Task` / `TaskEdge` / `UpdatedTaskStatus` / `TaskStatus`)
+> and control types (`ControlKind` / `ControlEvent` / `ControlAck` /
+> `SteerPayload` / `RewindPayload` / `ApprovePayload` /
+> `RejectPayload` / `InjectMessagePayload` / `ControlTarget` /
+> `ControlAckResult`) now live in
+> `goldfive/v1/types.proto` and `goldfive/v1/control.proto`.
+> Harmonograf imports them wherever they cross the wire. See
+> [../goldfive-integration.md](../goldfive-integration.md).
 
 ## Entity map
 
@@ -15,24 +25,22 @@ classDiagram
     Span "1" --> "*" PayloadRef : payload_refs
     Span "1" --> "*" SpanLink : links
     Span "1" ..> Span : parent_span_id / links.target_span_id
-    TaskPlan "1" --> "*" Task : tasks
-    TaskPlan "1" --> "*" TaskEdge : edges
-    Task "1" ..> Span : bound_span_id
     Annotation --> AnnotationTarget
     AnnotationTarget "1" ..> Span : span_id
     AnnotationTarget "1" ..> AgentTimePoint : agent_time
-    ControlEvent --> ControlTarget
-    ControlEvent "1" ..> ControlAck : by control_id
+    Intervention "1" ..> Annotation : annotation_id (dedup)
+    GoldfiveEvent "1" ..> Session : session_id (field 5)
+    GoldfiveControlEvent "1" ..> GoldfiveControlAck : control_id
 
     class Session { id; title; created_at; ended_at; status; agent_ids[]; metadata }
     class Agent { id; session_id; name; framework; framework_version; capabilities[]; metadata; connected_at; last_heartbeat; status }
     class Span { id; session_id; agent_id; parent_span_id; kind; kind_string; status; name; start_time; end_time; attributes; payload_refs[]; links[]; error }
     class PayloadRef { digest; size; mime; summary; role; evicted }
-    class TaskPlan { id; session_id; invocation_span_id; planner_agent_id; created_at; summary; tasks[]; edges[]; revision_* }
-    class Task { id; title; description; assignee_agent_id; status; predicted_start_ms; predicted_duration_ms; bound_span_id }
     class Annotation { id; session_id; target; author; created_at; kind; body; delivered_at }
-    class ControlEvent { id; issued_at; target; kind; payload }
-    class ControlAck { control_id; result; detail; acked_at }
+    class Intervention { at; source; kind; body_or_reason; author; outcome; plan_revision_index; severity; annotation_id; drift_kind }
+    class GoldfiveEvent { event_id; run_id; sequence; emitted_at; session_id; payload (oneof) }
+    class GoldfiveControlEvent { id; issued_at; target; kind; payload (typed oneof) }
+    class GoldfiveControlAck { control_id; result; detail; acked_at }
 ```
 
 ## `Session`
@@ -50,8 +58,10 @@ message Session {
 ```
 
 - **`id`** — human-readable. Regex `^[a-zA-Z0-9_-]{1,128}$`. Either
-  user-supplied (`Hello.session_id`) or server-generated as
-  `sess_YYYY-MM-DD_NNNN`.
+  user-supplied (`Hello.session_id`), derived from the outer adk-web
+  `ctx.session.id` (see
+  [ADR 0021](../adr/0021-session-id-pinning.md)), or server-generated
+  as `sess_YYYY-MM-DD_NNNN`.
 - **`title`** — defaults to `id` if empty. Set by the first Hello via
   `Hello.session_title`; later Hellos **cannot change it**.
 - **`created_at`** — server wall-clock at session creation.
@@ -66,7 +76,8 @@ message Session {
   | `SESSION_STATUS_ABORTED` | Session was force-terminated |
 
 - **`agent_ids`** — denormalized for fast listing. Populated as agents
-  Hello in.
+  Hello in (or auto-register on first span — see
+  [ADR 0024](../adr/0024-per-adk-agent-gantt-rows.md)).
 - **`metadata`** — free-form; deep-merged from each Hello.
 
 ## `Agent`
@@ -86,16 +97,29 @@ message Agent {
 }
 ```
 
-- **`id`** — client-chosen, persisted to disk so a restarted agent
-  reclaims its row in the Gantt chart. Multiple concurrent telemetry
-  streams may exist under one `id` — each gets its own `stream_id`
-  from `Welcome`.
+- **`id`** — client-chosen and persisted to disk so a restarted
+  agent reclaims its row in the Gantt. Under the
+  `HarmonografTelemetryPlugin`, per-ADK-agent ids have the form
+  `{client_id}:{adk_name}` — the plugin stacks them per ADK agent
+  in the tree (see
+  [ADR 0024](../adr/0024-per-adk-agent-gantt-rows.md)).
 - **`framework`** — `FRAMEWORK_ADK`, `FRAMEWORK_CUSTOM`, or
   `FRAMEWORK_UNSPECIFIED`.
 - **`capabilities`** — what the agent will honor on `SubscribeControl`:
   `PAUSE_RESUME`, `CANCEL`, `REWIND`, `STEERING`, `HUMAN_IN_LOOP`,
   `INTERCEPT_TRANSFER`. Frontend uses these to grey out control
   buttons.
+- **`metadata`** — free-form. Reserved keys populated by the server
+  on auto-register when `hgraf.agent.*` hints arrive on the first
+  span from an agent:
+
+  | Key | Source attribute | Meaning |
+  |---|---|---|
+  | `adk.agent.name` | `hgraf.agent.name` | ADK-level agent name (e.g. `research_agent`) |
+  | `harmonograf.parent_agent_id` | `hgraf.agent.parent_id` | Parent per-agent id in the ADK tree |
+  | `harmonograf.agent_kind` | `hgraf.agent.kind` | `coordinator` / `specialist` / `agent_tool` / `sequential_container` / etc. |
+  | `adk.agent.branch` | `hgraf.agent.branch` | ADK's dotted ancestry string |
+
 - **`status`** — one of:
 
   | Enum | Meaning |
@@ -132,8 +156,10 @@ message Span {
   server dedups by `id` when a client replays buffered spans.
 - **`session_id`** / **`agent_id`** — may differ from the owning
   telemetry stream's Hello defaults. Per-span overrides let one
-  client emit on behalf of multiple sub-agents / sessions on a single
-  stream (see `ingest._ensure_route`).
+  client emit on behalf of multiple sub-agents / sessions on a
+  single stream (see `ingest._ensure_route`). This is how the
+  `HarmonografTelemetryPlugin` lands per-ADK-agent spans on
+  per-agent rows under one Client.
 - **`parent_span_id`** — intra-agent parent. Empty for roots.
 - **`kind`** — categorical type:
 
@@ -170,9 +196,12 @@ message Span {
   | Key | Meaning |
   |---|---|
   | `hgraf.task_id` | Task binding stamp (see [`span-lifecycle.md#task-binding`](span-lifecycle.md#task-binding)) |
+  | `hgraf.agent.name` / `.parent_id` / `.kind` / `.branch` | First-span agent-hint attributes (harvested into `Agent.metadata`; see [ADR 0024](../adr/0024-per-adk-agent-gantt-rows.md)) |
   | `task_report` | Proactive status report; broadcast as a `TaskReport` delta |
   | `drift_kind`, `drift_severity`, `drift_detail`, `error` | Stamped on the active INVOCATION span by critical drifts |
   | `finish_reason` | LLM finish reason (`MAX_TOKENS`, `LENGTH`, etc.) — used for context-pressure drift |
+  | `llm.reasoning` / `llm.has_thinking` | Reasoning / thinking content extracted by the plugin from provider-specific fields |
+  | `adk.session_id` | Per-ctx ADK session id kept for forensic debugging when session id is pinned to the outer adk-web session |
 
 - **`payload_refs`** — zero or more payloads, distinguished by `role`.
 - **`links`** — cross-span edges. See [`SpanLink`](#spanlink).
@@ -251,8 +280,6 @@ is intra-agent.
 | `LINK_RELATION_FOLLOWS` | Sequential dependency across agents |
 | `LINK_RELATION_REPLACES` | This span supersedes a prior one (e.g. after rewind) |
 
-The five `LinkRelation` values shown as the cross-span edges they produce — INVOKED and TRIGGERED_BY are inverses of each other, REPLACES is rewind-only:
-
 ```mermaid
 flowchart LR
     A["Span A<br/>(orchestrator)"]
@@ -283,80 +310,6 @@ message ErrorInfo {
 
 Attached to failed spans. `stack` is free-form; clients may truncate
 or omit.
-
-## `TaskPlan` / `Task` / `TaskEdge`
-
-```proto
-message TaskPlan {
-  string id = 1;
-  string session_id = 2;
-  string invocation_span_id = 3;
-  string planner_agent_id = 4;
-  google.protobuf.Timestamp created_at = 5;
-  string summary = 6;
-  repeated Task tasks = 7;
-  repeated TaskEdge edges = 8;
-  string revision_reason = 9;
-  string revision_kind = 10;
-  string revision_severity = 11;
-  int64 revision_index = 12;
-}
-
-message Task {
-  string id = 1;
-  string title = 2;
-  string description = 3;
-  string assignee_agent_id = 4;
-  TaskStatus status = 5;
-  int64 predicted_start_ms = 6;
-  int64 predicted_duration_ms = 7;
-  string bound_span_id = 8;
-}
-
-message TaskEdge {
-  string from_task_id = 1;
-  string to_task_id = 2;
-}
-```
-
-- **`TaskPlan.id`** is stable across revisions. Re-submitting a plan
-  with the same id replaces it; `revision_index` increments.
-- **`revision_kind`** is the structured drift tag that triggered the
-  revision (e.g. `"tool_error"`, `"new_work_discovered"`). Empty on
-  initial plans. See [`task-state-machine.md#drift-taxonomy`](task-state-machine.md#drift-taxonomy).
-- **`revision_severity`** is `"info"` / `"warning"` / `"critical"`.
-- **`Task.status`** transitions are **monotonic** — see
-  [`task-state-machine.md#state-machine`](task-state-machine.md#state-machine).
-- **`Task.bound_span_id`** is set when a span carrying
-  `hgraf.task_id = <task.id>` begins running, or by explicit
-  `UpdatedTaskStatus.bound_span_id`.
-- **`predicted_start_ms` / `predicted_duration_ms`** are session-relative
-  hints from the planner. Both zero → the frontend falls back to t=0
-  stacking.
-
-| `TaskStatus` | Meaning |
-|---|---|
-| `TASK_STATUS_PENDING` | Queued, deps not yet satisfied |
-| `TASK_STATUS_RUNNING` | Bound to a live span |
-| `TASK_STATUS_COMPLETED` | Terminal, success |
-| `TASK_STATUS_FAILED` | Terminal, failure |
-| `TASK_STATUS_CANCELLED` | Terminal, cascaded from an unrecoverable upstream failure |
-
-## `UpdatedTaskStatus`
-
-```proto
-message UpdatedTaskStatus {
-  string plan_id = 1;
-  string task_id = 2;
-  TaskStatus status = 3;
-  string bound_span_id = 4;
-  google.protobuf.Timestamp updated_at = 5;
-}
-```
-
-Escape hatch for task state changes not tied to a span. Rides
-`TelemetryUp.task_status_update` upstream and fans out on
-`WatchSession.updated_task_status` downstream.
 
 ## `Annotation`
 
@@ -395,41 +348,106 @@ message Annotation {
 - `target` is a `oneof`: either a concrete `span_id` or an
   `(agent_id, timestamp)` point on the timeline.
 - `COMMENT` is UI-only.
-- `STEERING` is routed as a synthesized `CONTROL_KIND_STEER` event; the
-  agent ack fills in `delivered_at`.
-- `HUMAN_RESPONSE` is routed as `CONTROL_KIND_APPROVE` and is expected
+- `STEERING` is routed as a synthesized `goldfive.v1.ControlEvent`
+  with `kind=STEER`. The server populates `SteerPayload.author`
+  and `SteerPayload.annotation_id` from the stored annotation so
+  goldfive can dedup retries and propagate operator identity
+  (goldfive #171; see
+  [ADR 0023](../adr/0023-intervention-dedup-by-annotation-id.md)).
+- `HUMAN_RESPONSE` is routed as `CONTROL_KIND_INJECT_MESSAGE` or
+  `CONTROL_KIND_APPROVE` depending on the response shape; expected
   to target a `SPAN_STATUS_AWAITING_HUMAN` span.
 
-## `ControlEvent` / `ControlTarget` / `ControlAck`
+`delivered_at` is stamped by `PostAnnotation` after a successful
+ack.
+
+## `Intervention`
+
+Added in harmonograf #71 / #81. A chronologically merged view of
+every point where the plan changed direction.
 
 ```proto
-message ControlTarget {
-  string agent_id = 1;
-  string span_id = 2;
-}
-
-message ControlEvent {
-  string id = 1;
-  google.protobuf.Timestamp issued_at = 2;
-  ControlTarget target = 3;
-  ControlKind kind = 4;
-  bytes payload = 5;
-}
-
-message ControlAck {
-  string control_id = 1;
-  ControlAckResult result = 2;
-  string detail = 3;
-  google.protobuf.Timestamp acked_at = 4;
+message Intervention {
+  google.protobuf.Timestamp at = 1;
+  string source = 2;
+  string kind = 3;
+  string body_or_reason = 4;
+  string author = 5;
+  string outcome = 6;
+  int32 plan_revision_index = 7;
+  string severity = 8;
+  string annotation_id = 9;
+  string drift_kind = 10;
 }
 ```
 
-- `ControlEvent.id` is the correlation token. The agent must echo it
-  verbatim in `ControlAck.control_id`.
-- `span_id` on `ControlTarget` is meaningful for some kinds only
-  (`REWIND_TO`, `APPROVE`/`REJECT`, `STEER` when targeting a specific
-  span).
-- `payload` interpretation is `ControlKind`-specific — see
-  [`control-stream.md#control-kinds`](control-stream.md#control-kinds).
+- **`source`** — `"user"` | `"drift"` | `"goldfive"`.
+- **`kind`** — source-specific label:
+  - User: `"STEER"` / `"CANCEL"` / `"PAUSE"` / `"RESUME"`.
+  - Drift: upper-case drift kind (e.g. `"LOOPING_REASONING"`).
+  - Goldfive: `"CASCADE_CANCEL"` / `"REFINE_RETRY"` /
+    `"HUMAN_INTERVENTION_REQUIRED"`.
+- **`body_or_reason`** — user text, drift detail, or cascade/goldfive
+  reason.
+- **`author`** — populated for user-sourced rows; empty otherwise.
+- **`outcome`** — attribution string: `"plan_revised:rN"`,
+  `"cascade_cancel:N_tasks"`, `"paused"`, `"run_cancelled"`, or
+  `"recorded"` when no follow-up event was observed within the
+  attribution window.
+- **`plan_revision_index`** — set when the outcome produced a new
+  revision.
+- **`severity`** — for drift-sourced rows, drives timeline ring
+  (see [ADR 0025](../adr/0025-intervention-timeline-viz.md)).
+- **`annotation_id`** — populated for annotation-backed rows. Used by
+  the aggregator (and the frontend deriver) to deduplicate rows that
+  share a source annotation (see
+  [ADR 0023](../adr/0023-intervention-dedup-by-annotation-id.md)).
+- **`drift_kind`** — raw lowercase drift kind name, kept separate
+  from `kind` so the renderer stays tree-agnostic.
 
-See [`control-stream.md`](control-stream.md) for the full lifecycle.
+Exposed via `ListInterventions(session_id)` on
+`frontend.proto` and re-derived live from `WatchSession` deltas by
+`frontend/src/lib/interventions.ts`.
+
+## Types imported from goldfive
+
+Harmonograf no longer declares its own control or orchestration
+types. Everything on the wire that crosses the agent / server
+boundary for plan / task / drift / control flows comes from
+goldfive's protos, imported where they appear:
+
+| Message | Lives in | Used by harmonograf |
+|---|---|---|
+| `goldfive.v1.ControlEvent` | `goldfive/v1/control.proto` | `SubscribeControl` stream, `SendControl` request |
+| `goldfive.v1.ControlAck` | `goldfive/v1/control.proto` | `TelemetryUp.control_ack` (field 7) |
+| `goldfive.v1.ControlKind` | `goldfive/v1/control.proto` | `ControlEvent.kind` |
+| `goldfive.v1.ControlAckResult` | `goldfive/v1/control.proto` | `ControlAck.result`, `SendControlResponse.result`, `PostAnnotationResponse.delivery` |
+| `goldfive.v1.ControlTarget` | `goldfive/v1/control.proto` | `ControlEvent.target` |
+| `goldfive.v1.SteerPayload` / `RewindPayload` / `ApprovePayload` / `RejectPayload` / `InjectMessagePayload` | `goldfive/v1/control.proto` | Typed oneof on `ControlEvent` |
+| `goldfive.v1.Event` | `goldfive/v1/events.proto` | `TelemetryUp.goldfive_event` (field 11), `SessionUpdate.goldfive_event` (field 19) |
+| `goldfive.v1.Plan` / `Task` / `TaskEdge` / `TaskStatus` / `DriftKind` / `DriftSeverity` | `goldfive/v1/types.proto` + `events.proto` | Carried inside `goldfive.v1.Event` payload variants |
+
+See `goldfive/v1/events.proto` for the full set of Event payload
+variants (RunStarted / GoalDerived / PlanSubmitted / PlanRevised /
+TaskStarted / TaskProgress / TaskCompleted / TaskFailed / TaskBlocked
+/ TaskCancelled / DriftDetected / RunCompleted / RunAborted /
+ConversationStarted / ConversationEnded / ApprovalRequested /
+ApprovalGranted / ApprovalRejected / AgentInvocationStarted /
+AgentInvocationCompleted / DelegationObserved).
+
+### New fields flagged (2026-04)
+
+- `goldfive.v1.Event.session_id` (field 5) — added in goldfive #155 /
+  PR #157. The Runner / Steerer / Executors stamp it on every
+  emitted event so one transport stream can multiplex events across
+  sessions. Empty = fall back to the Hello session.
+- `goldfive.v1.SteerPayload.author` (field 3) — operator identity,
+  propagated from `Annotation.author` (goldfive #171).
+- `goldfive.v1.SteerPayload.annotation_id` (field 4) — source
+  annotation id; used by goldfive for STEER idempotency and by
+  harmonograf's intervention aggregator for dedup
+  (goldfive #171 / harmonograf #75).
+- `goldfive.v1.DriftDetected.annotation_id` (field 6) — propagated
+  through to drift records so the server-side aggregator can
+  collapse annotation + drift + plan-revision rows into one card
+  (goldfive #176 / #177, harmonograf #75).

--- a/docs/protocol/frontend-rpcs.md
+++ b/docs/protocol/frontend-rpcs.md
@@ -16,6 +16,7 @@ service declaration is in
 | [`PostAnnotation`](#postannotation) | unary | User note / steering / HITL response |
 | [`SendControl`](#sendcontrol) | unary | PAUSE / RESUME / STEER / STATUS_QUERY / etc. |
 | [`DeleteSession`](#deletesession) | unary | Purge a session |
+| [`ListInterventions`](#listinterventions) | unary | Merged chronological intervention history |
 | [`GetStats`](#getstats) | unary | Retention / storage stats |
 
 ## `ListSessions`
@@ -392,6 +393,57 @@ message DeleteSessionResponse {
 Refuses LIVE sessions unless `force=true`. Payloads are garbage-
 collected by digest: only the bytes that no other session still
 references are freed.
+
+## `ListInterventions`
+
+```proto
+rpc ListInterventions(ListInterventionsRequest) returns (ListInterventionsResponse);
+```
+
+```proto
+message ListInterventionsRequest {
+  string session_id = 1;
+}
+
+message ListInterventionsResponse {
+  repeated Intervention interventions = 1;
+}
+```
+
+Returns the chronologically merged view of user-initiated,
+drift-triggered, and goldfive-autonomous interventions for one
+session. Derived on the server by
+`server/harmonograf_server/interventions.py` from three sources that
+already exist on the wire:
+
+- the `annotations` table (STEERING / HUMAN_RESPONSE / COMMENT),
+- the in-memory drift ring (`_drifts_by_session`, bounded at 500 per
+  session),
+- `task_plans.revision_kind` / `revision_index` for plan revisions
+  carrying a drift kind or a goldfive autonomous kind
+  (`cascade_cancel`, `refine_retry`, `human_intervention_required`).
+
+Outcome attribution uses a per-kind window:
+- **5 minutes** for user-control drift kinds (`user_steer`,
+  `user_cancel`) — the LLM refine round-trip can take tens of seconds
+  on larger models.
+- **5 seconds** for autonomous drifts — those are fast-path
+  heuristics with no LLM round-trip to wait for.
+
+Dedup by `annotation_id`: rows that share an annotation id (the
+original STEER annotation, the `user_steer` drift goldfive emitted,
+and the subsequent `plan_revised`) collapse into one card. See
+[ADR 0023](../adr/0023-intervention-dedup-by-annotation-id.md).
+
+Live updates: the frontend mirrors the aggregator in
+`lib/interventions.ts`, consuming the `initial_annotation` /
+`new_annotation` / `goldfive_event.drift_detected` /
+`goldfive_event.plan_revised` deltas on `WatchSession`. A late-joining
+frontend reconciles by calling `ListInterventions` once at open time
+and relying on live deltas thereafter.
+
+See [`data-model.md#intervention`](data-model.md#intervention) for the
+`Intervention` message shape.
 
 ## `GetStats`
 

--- a/docs/protocol/index.md
+++ b/docs/protocol/index.md
@@ -43,8 +43,8 @@ flowchart LR
 | [`overview.md`](overview.md) | The five RPC-level concerns, why telemetry / control / frontend split three ways, how a new client first attaches. |
 | [`telemetry-stream.md`](telemetry-stream.md) | `StreamTelemetry` upstream (`TelemetryUp`) and downstream (`TelemetryDown`) variants, Hello/Welcome, resume_token, Goodbye. |
 | [`control-stream.md`](control-stream.md) | `SubscribeControl`, `ControlEvent` → `ControlAck` lifecycle, capability negotiation, multi-stream fan-out, `require_all_acks`. |
-| [`frontend-rpcs.md`](frontend-rpcs.md) | UI-facing RPCs: `ListSessions`, `WatchSession`, `GetPayload`, `GetSpanTree`, `PostAnnotation`, `SendControl`, `DeleteSession`, `GetStats`. |
-| [`data-model.md`](data-model.md) | Every shared `types.proto` message: `Session`, `Agent`, `Span`, `AttributeValue`, `PayloadRef`, `ErrorInfo`, `TaskPlan`, `Task`, `TaskEdge`, `UpdatedTaskStatus`, `Annotation`, `ControlEvent`, `ControlAck`. |
+| [`frontend-rpcs.md`](frontend-rpcs.md) | UI-facing RPCs: `ListSessions`, `WatchSession`, `GetPayload`, `GetSpanTree`, `PostAnnotation`, `SendControl`, `DeleteSession`, `ListInterventions`, `GetStats`. |
+| [`data-model.md`](data-model.md) | Every shared `types.proto` message: `Session`, `Agent`, `Span`, `AttributeValue`, `PayloadRef`, `ErrorInfo`, `Annotation`, `Intervention`; plus the `goldfive.v1.*` types imported for control + events. |
 | [`task-state-machine.md`](task-state-machine.md) | Plan execution protocol: `session.state` schema, reporting tools, orchestration modes, monotonic transitions, 26-kind drift taxonomy, refine pipeline, invariant validator. |
 | [`span-lifecycle.md`](span-lifecycle.md) | `SpanStart` / `SpanUpdate` / `SpanEnd`, attribute merging, the `hgraf.task_id` binding attribute, cross-agent links. |
 | [`payload-flow.md`](payload-flow.md) | Content-addressed `PayloadRef`s, chunked `PayloadUpload`, client-side eviction, server-side `PayloadRequest` re-requests, the `PayloadAvailable` delta. |
@@ -68,12 +68,16 @@ matches what you're implementing:
   original architectural rationale for the split. Whenever a "why" in
   this reference gets long, the answer usually lives there.
 - [`docs/design/12-client-library-and-adk.md`](../design/12-client-library-and-adk.md)
-  — design of the Python ADK adapter; see for the rationale behind the
-  reporting tools and the walker.
-- **Task #7 — Developer guide** — how to build and run the stack, plus
-  internal module layout. This reference does not cover local dev setup.
-- **Task #6 — User guide** — how the Gantt UI renders what lands on the
-  wire. The semantics here become pixels there.
+  — design of the Python ADK integration (observability plugin). The
+  bulk of this doc is superseded by the goldfive migration; see
+  [`../goldfive-integration.md`](../goldfive-integration.md) for the
+  current integration story.
+- **Dev guide** (`docs/dev-guide/`) — how to build and run the stack,
+  plus internal module layout. This reference does not cover local
+  dev setup.
+- **User guide** (`docs/user-guide/`) — how the Gantt UI renders what
+  lands on the wire. The semantics here become pixels there.
 - [`docs/reporting-tools.md`](../reporting-tools.md) — agent-facing
-  quick reference for the seven `report_*` tools. See
-  [`task-state-machine.md`](task-state-machine.md) for the full contract.
+  quick reference for goldfive's reporting tools. The task state
+  machine itself now lives in goldfive (see
+  [`task-state-machine.md`](task-state-machine.md) for the redirect).

--- a/docs/protocol/telemetry-stream.md
+++ b/docs/protocol/telemetry-stream.md
@@ -29,6 +29,10 @@ From [`telemetry.proto`](../../proto/harmonograf/v1/telemetry.proto):
 
 ```proto
 message TelemetryUp {
+  // Reserved: were TaskPlan task_plan = 9 / UpdatedTaskStatus
+  // task_status_update = 10 before the goldfive migration (issue #2).
+  // Plan + task state now ride inside goldfive_event.
+  reserved 9, 10;
   oneof msg {
     Hello hello = 1;
     SpanStart span_start = 2;
@@ -36,21 +40,37 @@ message TelemetryUp {
     SpanEnd span_end = 4;
     PayloadUpload payload = 5;
     Heartbeat heartbeat = 6;
-    ControlAck control_ack = 7;
+    goldfive.v1.ControlAck control_ack = 7;
     Goodbye goodbye = 8;
-    TaskPlan task_plan = 9;
-    UpdatedTaskStatus task_status_update = 10;
+    goldfive.v1.Event goldfive_event = 11;
   }
 }
 ```
 
 Every `TelemetryUp` carries exactly one oneof variant.
 
+> **Wire type ownership.** `control_ack` carries `goldfive.v1.ControlAck`
+> (not a harmonograf type — see
+> [`control-stream.md`](control-stream.md)). Fields 9 / 10 are
+> **reserved** — they were `TaskPlan` / `UpdatedTaskStatus` before
+> the goldfive migration; plan / task state now rides inside
+> `goldfive_event = 11`.
+
 ### `Hello` (oneof tag 1)
 
 First message on every telemetry stream. Exactly one `Hello` per stream.
 A second `Hello` is rejected by ingest (`ingest.handle_message` raises
 `ValueError`).
+
+**Lazy Hello** (harmonograf #83 / #85): the reference client transport
+defers sending `Hello` until the first real `TelemetryUp` is queued.
+The `session_id` stamped on Hello is derived from the first envelope
+(so the home session stamps with the correct id from the start). This
+eliminates ghost `sess_*` rows that used to appear for processes that
+opened a Client but never emitted. See
+[ADR 0022](../adr/0022-lazy-hello.md). New clients implementing the
+wire do not have to defer Hello, but doing so gives them the same
+ghost-session guarantee for free.
 
 ```proto
 message Hello {
@@ -314,38 +334,36 @@ sequenceDiagram
     Note over I,C2: v0 server ignores resume_token; client<br/>resends any unconfirmed spans (dedup by id)
 ```
 
-### `TaskPlan` (oneof tag 9)
+### `goldfive_event` (oneof tag 11)
 
-The planner-helper agent's plan, emitted once before normal execution
-begins. See [`data-model.md#taskplan`](data-model.md#taskplan) for
-field-by-field semantics and [`task-state-machine.md`](task-state-machine.md)
-for how plans are revised in flight.
+Goldfive orchestration event envelope. Carries a
+`goldfive.v1.Event` with a typed `payload` oneof:
 
-A plan may also be **re-submitted** at any time to replace a prior
-revision (that's how refine delivers a revised plan). The server
-canonicalizes by `(session_id, plan_id)`; the new plan supersedes the
-old one and a `TaskPlan` delta fans out on `WatchSession`.
+| Payload | Meaning |
+|---|---|
+| `run_started` / `run_completed` / `run_aborted` | Run lifecycle |
+| `goal_derived` | Goal list and success predicates |
+| `plan_submitted` / `plan_revised` | Task plan (first submission or refine) |
+| `task_started` / `task_progress` / `task_completed` / `task_failed` / `task_blocked` / `task_cancelled` | Task lifecycle |
+| `drift_detected` | Observer-detected drift (plan divergence, loop, refusal, user_steer, user_cancel, etc.) |
+| `conversation_started` / `conversation_ended` | Cross-turn chat context |
+| `approval_requested` / `approval_granted` / `approval_rejected` | HITL approval flow |
+| `agent_invocation_started` / `agent_invocation_completed` | Per-agent invocation boundaries |
+| `delegation_observed` | `AgentTool(sub_agent)` call surfaces as a cross-agent edge |
 
-### `UpdatedTaskStatus` (oneof tag 10)
+**Per-event session routing** (goldfive #155 / PR #157):
+`Event.session_id` (field 5) is stamped by the Runner / Steerer /
+Executors on every event so one transport stream can multiplex events
+across sessions (e.g. ADK's `AgentTool` mints sub-Runner sessions
+inside a single adk-web run). Ingest routes on this field, falling
+back to the stream's Hello session when empty. See
+[`../design/14-information-flow.md`](../design/14-information-flow.md)
+§Tier 3.
 
-Explicit task status delta. Use this when no span carries the task's
-`hgraf.task_id` stamp (e.g. the task completes in a code path the
-client does not span around).
-
-```proto
-message UpdatedTaskStatus {
-  string plan_id = 1;
-  string task_id = 2;
-  TaskStatus status = 3;
-  string bound_span_id = 4;
-  google.protobuf.Timestamp updated_at = 5;
-}
-```
-
-Most of the time, task state derives automatically from spans carrying
-the `hgraf.task_id` attribute (see
-[`span-lifecycle.md#task-binding`](span-lifecycle.md#task-binding)).
-`UpdatedTaskStatus` is an escape hatch.
+Fields 9 and 10 are **reserved** (were `TaskPlan` / `UpdatedTaskStatus`
+pre-migration). Plan and task state updates now ride inside
+`goldfive_event` via `plan_submitted` / `plan_revised` /
+`task_started` / `task_completed` / etc.
 
 ## Downstream — `TelemetryDown`
 

--- a/docs/research/hci-orchestration-paper.md
+++ b/docs/research/hci-orchestration-paper.md
@@ -1,80 +1,214 @@
-# Orchestrating Autonomy: The Case for Visual Understandability and Drill-Down Observability in Complex Multi-Agent Systems
+# Orchestrating Autonomy: Visual Understandability and Drill-Down Observability in Multi-Agent Systems
 
-**Abstract**  
-The rapid evolution of Large Language Models (LLMs) has catalyzed a paradigm shift from solitary conversational agents to complex, asynchronous, and collaborative multi-agent systems (MAS). While these networks exhibit remarkable emergent problem-solving capabilities, they fundamentally challenge historical human-computer interaction (HCI) models. This paper argues that traditional chat-based interfaces inherently fail to support the supervision, debugging, and orchestration of distributed AI systems due to catastrophic cognitive load accumulation. By examining recent literature in the HCI community regarding human-in-the-loop (HITL) system observability, we synthesize a theoretical foundation demonstrating why spatial, time-based visualization topologies—specifically interactive Gantt charts featuring drill-down observability—are computationally and psychosocially critical for fostering human trust, steering capability, and comprehensive orchestrative interoperability within complex MAS.  
+**Abstract**
 
----
+Large language model agents are increasingly deployed as distributed,
+asynchronous, multi-party systems — coordinators that hand off work to
+specialists, tool-call chains that span agent processes, and parallel
+task execution with cross-agent handoffs. Conventional chat-style
+observability collapses these structures onto a single conversational
+thread and scales poorly with the number of concurrent agents and
+the depth of their call graphs. This paper argues that a spatial,
+time-based visualization surface — specifically an interactive Gantt
+chart with lazy drill-down, first-class intervention markers, and
+bidirectional control primitives — is better matched to the
+supervision task for multi-agent systems. We describe the harmonograf
+system as an existence proof and report on design decisions made
+during its 2025–2026 development.
 
 ## 1. Introduction
 
-The integration of artificial intelligence into complex workflows has transitioned from simple query-response modalities to autonomous orchestration networks. These multi-agent systems typically deploy localized proxy nodes interacting recursively natively—compiling code, executing search behaviors, resolving internal logic conflicts, and handing off context horizontally (e.g., LangGraph, AutoGen, or ADK) [1]. 
+Single-agent observability has good defaults: a chat transcript, a
+trace viewer for tool calls, and a log stream for errors. Three
+transitions break these defaults:
 
-However, as systems scale in autonomy, they exponentially obfuscate their reasoning trajectories natively. Historically, AI observability relied uniformly upon reading linear log transcripts.
+1. **Concurrency.** Several agents run at the same time, overlapping
+   in wall-clock time but independent in causal structure.
+2. **Delegation.** One agent invokes another as a tool, creating
+   cross-process call graphs that a single transcript cannot render
+   coherently.
+3. **Plan-directedness.** Agents pursue an explicit plan with
+   revisions triggered by drift detection or user intervention; the
+   mental model the operator needs is "what plan is running, and
+   what made it change."
 
-```mermaid
-graph TD
-    A[Linear Output] --> B[Text Wall]
-    B --> C[Loss of Context]
-    C --> D[Operator Overload]
-    D --> E[System Distrust]
-```
+These shifts mean the operator is no longer reading a single
+conversation; they are supervising a small concurrent system. The
+HCI question becomes: what visualization surface scales with
+concurrency, makes causal structure legible, and exposes the
+intervention primitives the operator needs to steer?
 
-## 2. Theoretical Background and Related Work
+## 2. The chat-transcript failure modes
 
-### 2.1 The Crisis of "Black-Box" Orchestration
-Recent research across CHI and UIST domains highlights the erosion of human trust regarding localized "black-box" agent operations globally. Evaluative studies studying operator confidence in deterministic outputs explicitly demonstrate that trust correlates not just with output accuracy, but with the transparency of the intermediate verification logic natively [3].
+A linear chat interface fails for multi-agent runs in predictable
+ways:
 
-### 2.2 Cognitive Load in Linear Parsing 
-Cognitive Load Theory (CLT) predicts system failures natively when intrinsic variables overwhelm working memory bounds natively. Parsing text lines evaluating asynchronous logical transitions involves high cognitive overhead globally natively.
+- **Interleaved output.** Two agents emitting concurrently produce a
+  transcript that has to be reassembled mentally. The structure is
+  "who said what when"; a sequential text stream erases two of the
+  three axes.
+- **Tool call depth.** When a tool call invokes another agent that
+  invokes another tool, the chat flattens that stack into a linear
+  sequence of messages, losing the call-graph topology.
+- **Plan invisibility.** The plan the agent is pursuing, and the
+  pivots the plan has taken, are derivable from the transcript only
+  by reconstructing the planner's reasoning — expensive and
+  error-prone under time pressure.
+- **No control surface.** Text interfaces are optimized for dialog,
+  not for pause / rewind / cancel / steer. Injecting a control
+  primitive into a chat interface reduces to "send a message telling
+  the agent to stop" — high-latency, unreliable, and stateless.
 
-## 3. The Harmonograf Paradigm: Temporal Spatial Modeling 
+The HCI literature on system-trace visualization shows consistent
+gains over pure chat on trust, debugging speed, and intervention
+accuracy [1, 2, 3]. Harmonograf takes these findings as the starting
+premise.
 
-To resolve the disjoint bounds separating logical hierarchies from latency metrics natively globally, advanced interaction interfaces (such as the Harmonograf topology) leverage spatial temporal grids structurally mapping X/Y axis matrices globally. 
+## 3. Visualization surface
 
-```mermaid
-gantt
-    title Cognitive Load Reduction via Topology
-    dateFormat  s
-    axisFormat  %S
-    
-    section Human Supervisor
-    Assess Output       :a1, 0, 3s
-    Identify Failure Point :a2, after a1, 1s
-    Inject Correction :a3, 10, 2s
+Harmonograf's Gantt has three invariant dimensions:
 
-    section Agent Swarm
-    Process Logic           :r1, 4, 3s
-    Resume Generation  :r2, 12, 5s
-```
+- **X-axis: time.** Monotonic session wall-clock; the same block
+  always renders at the same X regardless of viewport state.
+- **Y-axis: agent identity.** One row per agent; join-time stable
+  ordering so agents never shuffle. In multi-ADK-agent runs
+  (coordinator + specialists + `AgentTool` wrappers), harmonograf
+  renders one row per ADK agent in the tree rather than collapsing
+  everything onto a single client-process row
+  ([ADR 0024](../adr/0024-per-adk-agent-gantt-rows.md)).
+- **Color / glyph: kind and status.** LLM calls, tool calls,
+  transfers, waiting-on-human have distinct visual encodings that
+  remain legible at the full zoom range.
 
-### 3.1 Mapping Intelligence to Canvas Renderers
-By treating system span execution lengths globally natively as rectangles traversing Cartesian coordinates structurally globally, the operator transforms from a reader into a visual analyst natively globally. 
+A separate intervention timeline strip sits above the Gantt,
+rendering every point where the plan changed direction — user
+steers, drift detections, plan revisions, cascade cancels. The
+timeline uses three independent visual channels (source × kind ×
+severity) so the operator can answer "who changed this?" at a
+glance, before drilling into *what* was changed
+([ADR 0025](../adr/0025-intervention-timeline-viz.md)).
 
-## 4. Human-In-The-Loop Steering (HITL)
+Drill-down is lazy: hover tooltips read from small in-memory
+summaries; full payload bytes (LLM prompts and completions, tool
+arguments and results) load on demand via a content-addressed
+payload fetch [8].
 
-Observability without control is inherently passive telemetry uniquely globally natively. HCI studies universally correlate human operational satisfaction with active interruption bounds inherently globally natively [4]. 
+## 4. Intervention primitives
 
-```mermaid
-journey
-    title HITL Experience Metrics
-    section Observation
-      Identify bug: 5: Supervisor
-      Locate source agent: 4: Supervisor
-    section Action
-      Pause Execution: 6: Supervisor
-      Edit Context: 7: Supervisor
-      Resume Flow: 6: Supervisor
-```
+Passive observation is valuable but insufficient. Harmonograf
+provides four first-class intervention primitives:
 
-## 5. Conclusion 
+- **STEER.** The operator attaches a steering note to a span or
+  agent row; harmonograf routes it as a control event carrying the
+  body text. Body validation rejects empty, over-cap, or
+  control-character payloads so the steer cannot smuggle escape
+  sequences into the downstream LLM prompt [9].
+- **PAUSE / RESUME / CANCEL.** Traditional execution-control verbs,
+  implemented by delivering a control event on a dedicated RPC
+  stream and awaiting ack. Acks ride back on the telemetry stream
+  to preserve happens-before ordering — the operator can read
+  "paused at span X" correctly [4].
+- **APPROVE / REJECT.** For human-in-the-loop tool calls that
+  require explicit authorization, the span enters an
+  `AWAITING_HUMAN` state that the UI renders with maximum
+  visual urgency; the operator clicks through to approve, reject,
+  or edit-and-approve.
+- **REWIND_TO.** The operator can rewind execution to before a
+  target span; new spans emitted after the rewind carry a
+  `REPLACES` link back to the discarded ones, preserving history
+  for review.
 
-As artificial intelligence rapidly devolves singular execution monolithic pipelines into federated swarm topologies natively globally, the imperative shifts from generative capacity uniquely toward human orchestration metrics natively. Linear text interfaces inherently fracture mental models globally natively. Adopting highly concurrent, time-based geometric visualizations equipped with bidirectional data control limits actively transforms the HCI paradigm globally natively, providing indispensable understandability matrices allowing scalable proxy operations across limitless autonomous horizons natively globally intuitively. 
+Every intervention surfaces on the intervention timeline and is
+available via `ListInterventions` for post-hoc analysis.
 
----
+## 5. Plan-aware observability
 
-**References**
+Multi-agent systems built on plan-executor architectures (goldfive's
+orchestration model being one example) have an explicit plan object
+with typed tasks and dependency edges. Harmonograf persists every
+plan revision and renders a plan-diff view that shows what
+specifically changed: which tasks were added, removed, or modified;
+which edges flipped. The drift taxonomy — looping reasoning, goal
+drift, plan divergence, context pressure, refusal, tool error,
+user_steer, user_cancel — maps each revision to a typed cause.
 
-[1] Shneiderman, B. (2020). Human-Centered Artificial Intelligence: Reliable, Safe & Trustworthy. *International Journal of Human–Computer Interaction*, 36(6), 495-504.  
-[2] Amershi, S., et al. (2019). Guidelines for Human-AI Interaction. In *Proceedings of the 2019 CHI Conference on Human Factors in Computing Systems* (pp. 1-13).  
-[3] Lai, P., & Glass, B. (2022). Towards Trustworthy AI: Analyzing System Trace Visualizations vs Chat. *Journal of interactive systems*.  
-[4] Kim, Y., et al. (2023). AGDebugger: Providing Steerable Interventions within Multi-Agent Workflows. *UIST 2023 Symposium*.  
+The design decision is that the plan is a first-class wire event,
+not a transcript derivation. Harmonograf ingests
+`goldfive.v1.Event` envelopes — `plan_submitted`, `plan_revised`,
+`drift_detected`, `task_*` — and persists them into a query surface
+the frontend reads directly.
+
+## 6. Implementation notes
+
+As of 2026-04, harmonograf runs on:
+
+- **Client:** A Python library (`harmonograf_client`) with an ADK
+  plugin for Google's Agent Development Kit. The plugin stamps a
+  per-ADK-agent id on every span so multi-agent ADK trees render
+  per-agent rows [5].
+- **Server:** A Python gRPC service that terminates telemetry,
+  persists to SQLite, fans out to frontends via a pub/sub bus, and
+  routes control in both directions.
+- **Frontend:** A React + TypeScript SPA with a canvas-based Gantt
+  that bypasses React entirely for the hot draw path [6]. Three
+  stacked canvas layers with independent dirty triggers sustain 60
+  Hz on sessions of 10k+ spans.
+
+Session identity: one adk-web run is pinned to one harmonograf
+session via the outer `ctx.session.id` stamped on every span
+[7]. A lazy-Hello transport deferral
+[10] eliminates ghost session rows from long-lived client processes
+that never emit. Agent registration is transparent: the first span
+an agent emits carries `hgraf.agent.*` hint attributes that the
+server harvests into metadata on the auto-registered agent row.
+
+## 7. Conclusion
+
+Chat-style observability is insufficient for supervising multi-agent
+systems at scale. Spatial, time-based visualizations paired with
+first-class intervention primitives produce a surface matched to
+the task: the operator sees concurrent structure, navigates causal
+graphs via drill-down, and intervenes through typed control verbs
+whose acks preserve happens-before semantics.
+
+Harmonograf is one specific answer to the design question; the
+general claim — that concurrent, plan-directed multi-agent systems
+need a visualization surface shaped by their structure, not by the
+conventions of single-agent chat — is the durable point.
+
+## References
+
+[1] Shneiderman, B. (2020). Human-Centered Artificial Intelligence:
+Reliable, Safe & Trustworthy. *International Journal of
+Human–Computer Interaction*, 36(6), 495–504.
+
+[2] Amershi, S., et al. (2019). Guidelines for Human-AI Interaction.
+In *Proceedings of the 2019 CHI Conference on Human Factors in
+Computing Systems*, 1–13.
+
+[3] Lai, P., & Glass, B. (2022). Towards Trustworthy AI: Analyzing
+System Trace Visualizations vs Chat. *Journal of Interactive
+Systems*.
+
+[4] Kim, Y., et al. (2023). AGDebugger: Providing Steerable
+Interventions within Multi-Agent Workflows. In *Proceedings of
+UIST 2023*.
+
+[5] Harmonograf ADR 0024 — Per-ADK-agent Gantt rows with
+auto-registration. See `docs/adr/0024-per-adk-agent-gantt-rows.md`.
+
+[6] Harmonograf ADR 0008 — Canvas rendering for the Gantt chart.
+See `docs/adr/0008-canvas-gantt-over-svg.md`.
+
+[7] Harmonograf ADR 0021 — Pin `goldfive.Session.id` to the outer
+adk-web session id. See `docs/adr/0021-session-id-pinning.md`.
+
+[8] Harmonograf ADR 0016 — Content-addressed payloads with eviction.
+See `docs/adr/0016-content-addressed-payloads.md`.
+
+[9] Harmonograf `ControlBridge` STEER body validation — see
+`docs/protocol/control-stream.md` (STEER body validation section)
+and `client/harmonograf_client/_control_bridge.py`.
+
+[10] Harmonograf ADR 0022 — Lazy Hello. See
+`docs/adr/0022-lazy-hello.md`.


### PR DESCRIPTION
## Summary

Sweep design / protocol / ADR / internals docs to match current state after the goldfive migration and the #63 / #66 / #71 / #76 / #80 / #85 refreshes.

- 5 new ADRs (0021–0025) covering session-id pinning, lazy Hello, intervention dedup by `annotation_id`, per-ADK-agent Gantt rows, and intervention timeline viz encoding.
- Three design docs (10 / 11 / 13 / 14) fully rewritten: the previous prose had LLM-generated filler ("natively globally", etc.) and referenced pre-migration internals.
- Protocol docs updated to reflect goldfive-owned wire types (`ControlEvent`, `ControlAck`, `Plan` / `Task` / `TaskEdge`), the `goldfive_event = 11` telemetry oneof variant (with fields 9/10 reserved), and the new `ListInterventions` RPC.
- Internals docs freshened for session routing, agent auto-registration, drift ring replay, and the intervention aggregator + deriver pattern.
- Research paper rewritten, grounded against real implementation state, cites ADRs as evidence.

## Files touched (docs/ only — no code changes)

- `docs/adr/0021-session-id-pinning.md` (new)
- `docs/adr/0022-lazy-hello.md` (new)
- `docs/adr/0023-intervention-dedup-by-annotation-id.md` (new)
- `docs/adr/0024-per-adk-agent-gantt-rows.md` (new)
- `docs/adr/0025-intervention-timeline-viz.md` (new)
- `docs/adr/index.md`
- `docs/design/01-data-model-and-rpc.md`
- `docs/design/03-server.md`
- `docs/design/04-frontend-and-interaction.md`
- `docs/design/10-frontend-architecture.md` (rewritten)
- `docs/design/11-server-architecture.md` (rewritten)
- `docs/design/13-human-interaction-model.md` (rewritten)
- `docs/design/14-information-flow.md` (rewritten)
- `docs/internals/{index,server-ingest-bus,session-store-task-registry,renderer-pipeline}.md`
- `docs/protocol/{index,data-model,telemetry-stream,control-stream,frontend-rpcs}.md`
- `docs/research/hci-orchestration-paper.md` (rewritten)

## Test plan

- [ ] CI passes on all 4 jobs (no code changes; docs-only).
- [ ] ADR index lists 0021–0025 with correct titles.
- [ ] Cross-links between design docs, ADRs, and protocol docs resolve.
- [ ] Protocol docs match `proto/harmonograf/v1/*.proto` for reserved fields, goldfive imports, `Intervention` message, and `ListInterventions` RPC.