### PR TITLE
docs: refresh dev-guide + user-guide + runbooks + skills for current state

### DIFF
--- a/.agents/skills/hgraf-add-annotation-kind/SKILL.md
+++ b/.agents/skills/hgraf-add-annotation-kind/SKILL.md
@@ -57,13 +57,28 @@ The `annotations` table in `sqlite.py:105` stores `kind TEXT NOT NULL`. Existing
 
 ```python
 if kind == ANNOTATION_KIND_STEERING:
-    await control_router.deliver(... CONTROL_KIND_STEER ...)
+    event.kind = CONTROL_KIND_STEER
+    event.steer.note = request.body
+    event.steer.author = ann.author                # goldfive#171
+    event.steer.annotation_id = ann.id             # goldfive#171
+    await control_router.deliver(event)
 elif kind == ANNOTATION_KIND_HUMAN_RESPONSE:
-    # resolve the awaiting span
-    ...
+    event.kind = CONTROL_KIND_INJECT_MESSAGE
+    event.inject_message.text = request.body
+    await control_router.deliver(event)
 ```
 
-Add a branch for your new kind. If the semantics map to a control event, issue it through `control_router.deliver(...)` and set `annotation.delivered_at` when the ack arrives (see `types.proto:336`). If semantics are UI-only, just store and broadcast — no control event.
+Add a branch for your new kind. If the semantics map to a control event:
+
+- Propagate `author` and `annotation_id` onto the event payload so
+  goldfive can attribute the drift back to the source annotation and
+  dedupe retries (mirrors goldfive#171 for STEER).
+- Issue it through `control_router.deliver(...)` and set
+  `annotation.delivered_at` when the ack arrives.
+- If the kind represents user control, goldfive should also emit a
+  matching drift kind so the intervention aggregator picks it up.
+
+If semantics are UI-only, just store and broadcast — no control event.
 
 ### 6. Watch delta
 

--- a/.agents/skills/hgraf-add-capability/SKILL.md
+++ b/.agents/skills/hgraf-add-capability/SKILL.md
@@ -47,7 +47,11 @@ grep -rn "CAPABILITY_\|capabilities=" client/harmonograf_client/
 
 Typical path: `client/harmonograf_client/identity.py` or the `HarmonografClient` constructor in `client/harmonograf_client/client.py` takes a `capabilities=[...]` arg and forwards it into `Hello.capabilities` via `client/harmonograf_client/transport.py :: _build_hello`.
 
-For the ADK plugin, `client/harmonograf_client/adk.py :: make_adk_plugin` decides the default capabilities list. Add the new capability there only if every ADK-backed agent supports the matching control kind; otherwise leave it opt-in.
+With `HarmonografTelemetryPlugin` installed on an ADK `App`, the
+plugin does not touch capabilities directly — the embedding code
+decides what to advertise. If you want every ADK-backed client to
+advertise a new capability by default, that's a downstream pattern
+(e.g. wrap `Client()` in a helper), not a harmonograf change.
 
 ### 4. Server ingest → storage
 

--- a/.agents/skills/hgraf-add-control-kind/SKILL.md
+++ b/.agents/skills/hgraf-add-control-kind/SKILL.md
@@ -59,9 +59,24 @@ Verify `git status` shows updated `*_pb2.py`, `*_pb2.pyi`, and `frontend/src/pb/
 
 Control dispatch in the client lives in `client/harmonograf_client/transport.py:649 _dispatch_control`. It resolves the enum name via `_control_kind_name` (`transport.py:700`) which strips the `CONTROL_KIND_` prefix — so your new kind dispatches under the key `"RETRY_LAST_TOOL"`.
 
-Handlers are registered via `HarmonografClient.register_control_handler(kind, cb)` — see `client/harmonograf_client/client.py:204` and the `on_control("STATUS_QUERY", ...)` precedent in `client/harmonograf_client/adk.py:1558`. The callback receives the `ControlEvent` and returns an optional `ControlAckSpec(result="success"|"failure"|"unsupported", detail="...")`.
+Handlers are registered via `Client.on_control(kind, cb)` — see
+`client/harmonograf_client/client.py :: on_control`. The callback
+receives a `ControlEvent` and returns an optional
+`ControlAckSpec(result="success"|"failure"|"unsupported", detail="...")`.
 
-For the ADK plugin, wire a default handler inside `make_adk_plugin` — follow the `_handle_status_query` template in `adk.py:1471`:
+For STEER / CANCEL / PAUSE-like kinds, goldfive's control bridge
+(`client/harmonograf_client/_control_bridge.py`) takes over via
+`Client.set_control_forward(...)` and handles dispatch through to
+goldfive's steerer. When adding a new user-control kind, make sure:
+
+- The server's `PostAnnotation` fan-out (rpc/frontend.py) propagates
+  the annotation's `author` and `id` onto the control event — STEER
+  does this via `event.steer.author` / `event.steer.annotation_id`
+  (goldfive#171).
+- Goldfive emits a matching drift kind so the intervention
+  aggregator surfaces it on the timeline. See `hgraf-add-drift-kind`.
+
+Example callback body (for non-STEER/CANCEL kinds handled directly):
 
 ```python
 def _handle_retry_last_tool(event):

--- a/.agents/skills/hgraf-add-drift-kind/SKILL.md
+++ b/.agents/skills/hgraf-add-drift-kind/SKILL.md
@@ -1,122 +1,148 @@
 ---
 name: hgraf-add-drift-kind
-description: End-to-end checklist for introducing a new drift kind across client detection, throttling, frontend metadata, banner rendering, and regression tests.
+description: Add a new drift kind end-to-end. Goldfive owns the detector + enum; harmonograf reflects the kind through the intervention aggregator and the UI timeline.
 ---
 
 # hgraf-add-drift-kind
 
 ## When to use
 
-You are expanding the drift taxonomy that drives dynamic replanning. A new drift kind is warranted when there is a distinct *cause* the planner should see in its `refine()` prompt, distinct from all existing kinds in `client/harmonograf_client/adk.py:352-368`. Examples of valid new kinds: "tool took longer than predicted duration", "agent returned a disallowed mime type", "LLM emitted malformed function-call args that fell back to text". Examples of things that are **not** a new drift kind: a slight variation of an existing one (add a `detail` field instead), or a UI-only badge (add it in `driftKinds.ts` without touching the client).
+You're adding a new *cause* the planner should see as a distinct
+drift: a new tool-level detector, a new plan-coherence check, a new
+user-control surface. The drift kind is a wire-visible string that
+flows through goldfive into harmonograf and onto the intervention
+timeline.
 
-## Prerequisites
+Examples of valid new kinds: "agent called a tool with stale args"
+(new detector), "planner emitted a contradictory edge" (new validator
+drift), "external signal X" (user-control variant). Not a new kind:
+a slight variation of an existing detail (add a `detail` field to
+an existing drift instead).
 
-1. Read the existing taxonomy end to end:
-   - `client/harmonograf_client/adk.py:326-378` — `DriftReason` dataclass + all `DRIFT_KIND_*` constants + throttling constants.
-   - `frontend/src/gantt/driftKinds.ts:30-58` — `DRIFT_KIND_META` record (category, icon, severity, human label).
-   - `client/tests/test_drift_taxonomy.py` — the duck-typed unit tests that cover every kind.
-2. Skim [`docs/design/10-frontend-architecture.md`](../../../docs/design/10-frontend-architecture.md) and `AGENTS.md` → *Plan execution protocol* section to confirm the new kind fits the "callback-driven drift → refine → computePlanDiff → banner" pipeline.
+## Primary location: goldfive
 
-## Step-by-step
+Drift detection, the `DriftKind` enum, severity, and the classifier
+all live in [goldfive](https://github.com/pedapudi/goldfive). Follow
+goldfive's `how-to-add-a-drift-kind` guide first. The relevant
+goldfive touchpoints:
 
-### 1. Client: declare the kind constant
+- `proto/goldfive/v1/types.proto` — `DriftKind` enum.
+- `proto/goldfive/v1/events.proto` — `DriftDetected` event shape;
+  note `annotation_id` (#177) for user-control drifts.
+- `goldfive.detectors.*` — the detector classes. `ToolLoopTracker`
+  (#181/#186) for loops, the three-stage function_call gate (#178)
+  for PLAN_DIVERGENCE / CONFABULATION_RISK.
+- `goldfive.steerer` — user-control drift synthesis from incoming
+  STEER / CANCEL controls.
 
-Edit `client/harmonograf_client/adk.py`. Add a new constant alongside the existing `DRIFT_KIND_*` block (around line 352-368). Use the same naming shape — snake-case, no prefix, stable for wire compatibility:
+Goldfive is the source of truth. If you only add the enum on the
+goldfive side and ship, harmonograf will pick it up automatically
+via `goldfive_event.drift_detected` ingest. The UI renders unknown
+kinds generically; to make them first-class, continue with this
+skill.
 
-```python
-DRIFT_KIND_TASK_DURATION_EXCEEDED = "task_duration_exceeded"
-```
+## Harmonograf-side steps
 
-Decide **severity** (info | warn | error) and **recoverable** (True for most — only False when the planner cannot meaningfully refine, like hard tool failures). These live in the `DriftReason` instance you construct at the detection site, not on the constant.
+### 1. Server: intervention aggregator
 
-### 2. Client: add the detection path
+`server/harmonograf_server/interventions.py` derives interventions
+from annotations + drifts + plan revisions. Most of it is
+tree-agnostic — any kind name renders. The exceptions:
 
-There are three detection paths. Pick the one that matches the signal's origin:
+- `_USER_DRIFT_KINDS` — the set of lowercase drift kinds that flag
+  `source="user"` on the intervention row. If your new kind is a
+  *user-control* drift emitted by goldfive from a STEER-like
+  control, add its lowercase name here.
+- `_GOLDFIVE_REVISION_KINDS` — the set of lowercase *revision* kinds
+  (not drift kinds) that flag `source="goldfive"` autonomous
+  intervention. Add if relevant.
 
-- **Inside `detect_drift()`** (`adk.py:2917-3050`) — for drifts derived from span/event scanning. Append a new branch that appends `DriftReason(kind=DRIFT_KIND_..., detail=..., severity=..., recoverable=...)` to the returned list.
-- **Inside `after_model_callback()`** (`adk.py:1227-1276`) — for drifts the LLM expressed in prose (refusal, merge, split, reorder patterns).
-- **Inside `before_tool_callback()`** (`adk.py:1299-1316`) or a reporting-tool interceptor — for drifts raised by the agent via a reporting tool (e.g. `report_task_failed` → `task_failed_*`, `report_plan_divergence` → `plan_divergence`).
+### 2. Server: attribution window
 
-**Critical:** route every drift through the same exit point — the function that eventually calls `refine_plan_on_drift()` (`adk.py:3256-3350`). Do not call `planner.refine()` directly from your detection code; you will miss throttling and unrecoverable cascade logic.
+`_outcome_window_for(kind)` returns 300 s for user-control kinds
+(planner refine latency; #86) and 5 s for autonomous kinds. If your
+new kind can block on an LLM call in goldfive — like a STEER waits
+on the planner — route it through the user-control window path so
+its attribution doesn't strand.
 
-### 3. Client: respect throttling
+### 3. Frontend: deriver mirror
 
-`adk.py:373-378` defines:
-```python
-_STAMP_MISMATCH_THRESHOLD = 3
-_DRIFT_REFINE_THROTTLE_SECONDS = 2.0
-```
+`frontend/src/lib/interventions.ts` mirrors the server aggregator.
+Keep the two in lockstep:
 
-The refine loop coalesces repeated drifts within `_DRIFT_REFINE_THROTTLE_SECONDS`. If your new drift is noisy (fires many times per turn — e.g. repeated `failed_span` on retries), follow the `multiple_stamp_mismatches` pattern: count occurrences, only promote to a `DriftReason` once a threshold is crossed. Do **not** lower the global throttle; add a kind-local threshold constant next to `_STAMP_MISMATCH_THRESHOLD`.
+- `USER_DRIFT_KINDS` — must match `_USER_DRIFT_KINDS` on the server.
+- `GOLDFIVE_REVISION_KINDS` — must match `_GOLDFIVE_REVISION_KINDS`.
+- `outcomeWindowFor(driftKind)` — mirrors the server's
+  `_outcome_window_for`.
+- `normalizeDriftKind(raw)` — lowercase kind → display label. Only
+  the user-control kinds get pretty labels (`STEER`, `CANCEL`);
+  drift and goldfive kinds are upper-cased verbatim.
 
-### 4. Client: unit test in test_drift_taxonomy
+### 4. Frontend: intervention timeline glyph
 
-Add a test case to `client/tests/test_drift_taxonomy.py` following the existing pattern (duck-typed fakes; no real ADK import). The fixtures at the top of the file (`FakeClient`, `FakeFunctionCall`, `RecordingPlanner`, roughly lines 41-80) are reusable — construct whatever event sequence triggers your new kind, feed it through `detect_drift` (or the relevant callback), and assert:
-- The returned list contains exactly one `DriftReason` with your new `kind` string.
-- `severity` and `recoverable` match your design.
-- `detail` includes the span/event id that triggered it.
+`frontend/src/components/Interventions/InterventionsTimeline.tsx`'s
+`glyphFor(row)` picks marker shapes by source + kind. The default:
 
-Run:
-```bash
-cd client && uv run --with pytest --with pytest-asyncio python -m pytest tests/test_drift_taxonomy.py -q
-```
+- user → diamond / diamond-x
+- drift → circle or chevron (chevron when `outcome` is
+  `plan_revised:*`)
+- goldfive → square
 
-### 5. Client: end-to-end test in test_llm_agency_scenarios
+If your kind deserves a new glyph (rare — the source trichotomy is
+usually enough), extend the `Glyph` union and add a `<path>` branch
+to the `Marker` component.
 
-If the drift is LLM-agency-driven (callback path), add a second test to `client/tests/test_llm_agency_scenarios.py`. This file imports real `google.adk.Event` and `google.genai.types` payloads (see the skip guard at lines 29-37) and exercises `detect_drift → refine_plan_on_drift` through the real seam. Use the existing agency scenarios as templates.
+### 5. Tests
 
-### 6. Frontend: drift kind metadata
-
-Edit `frontend/src/gantt/driftKinds.ts:30-58`. Add an entry to the `DRIFT_KIND_META` record keyed by your `"task_duration_exceeded"` string (must match the client constant value exactly — this is the wire key):
-
-```ts
-task_duration_exceeded: {
-  label: "Task overran predicted duration",
-  category: "schedule",         // or: tool | plan | agency | user | system
-  icon: "clock-alert",          // MDI icon name, matches existing convention
-  severity: "warn",             // info | warn | error
-},
-```
-
-`parseRevisionReason()` at `driftKinds.ts:60-87` parses `"{kind}: {detail}"` format from `TaskPlan.revisionReason`, and `getDriftKindMeta()` at lines 89-92 does the lookup. Both will pick up your new entry automatically — no wiring required.
-
-### 7. Frontend: verify banner preview
-
-The `PlanRevisionBanner` component (`frontend/src/components/shell/PlanRevisionBanner.tsx`) reads from `TaskRegistry` revisions and renders using `getDriftKindMeta()`. After step 6, run:
-```bash
-cd frontend && pnpm lint && pnpm build
-```
-Then `make demo` and drive a scenario that actually emits the new drift. Visually confirm:
-- Banner shows your icon + label.
-- Banner category colour matches the rest of your category (see `driftKinds.ts` category → colour).
-- The diff drawer shows the added/removed/modified tasks that the planner returned in its `refine()` response.
-
-### 8. Plan diff integration (usually no-op)
-
-`computePlanDiff()` at `frontend/src/gantt/index.ts:129-181` is drift-kind-agnostic — it diffs task sets and edge sets. You do **not** need to touch it unless your drift kind changes the diff semantics (e.g. a "renamed task" drift that should match by semantic id not task id). That is a much larger change — open a design doc first.
+- `server/tests/test_interventions_aggregator.py` — add a case
+  covering the new kind's source classification, outcome attribution,
+  and dedup by annotation_id.
+- `frontend/src/__tests__/interventions.test.ts` — add the mirror
+  test for the client-side deriver.
+- If you extended `glyphFor`, add a render-snapshot test for the new
+  glyph.
 
 ## Verification
 
 ```bash
-# 1. client unit tests
-cd client && uv run --with pytest --with pytest-asyncio python -m pytest tests/test_drift_taxonomy.py tests/test_llm_agency_scenarios.py tests/test_invariants.py -q
+# Server unit
+cd server && uv run pytest tests/test_interventions_aggregator.py -q
 
-# 2. full client suite
-cd client && uv run --with pytest --with pytest-asyncio python -m pytest -q
+# Full server + client
+make test
 
-# 3. frontend type + lint
-cd frontend && pnpm lint && pnpm build
+# Frontend
+cd frontend && pnpm test -- --run intervention
 
-# 4. live smoke
+# Live smoke
 make demo
-# Drive a scenario that triggers the new drift; confirm banner renders.
+# Drive a scenario that emits the new drift; confirm marker renders
+# on the InterventionsTimeline strip with correct source + glyph.
 ```
 
 ## Common pitfalls
 
-- **Wire-key drift.** The client constant value (`"task_duration_exceeded"`) is the wire key. Changing it later breaks any persisted sqlite TaskPlan rows and any frontend that cached `DRIFT_KIND_META`. Pick a good name once.
-- **Forgetting throttling.** A new drift kind that fires on every span end will hammer the planner. `_DRIFT_REFINE_THROTTLE_SECONDS = 2.0` gives you coarse global protection but you still want per-kind thresholds for noisy signals.
-- **Routing around `refine_plan_on_drift`.** The function at `adk.py:3256-3350` applies the unrecoverable-cascade logic — if your drift is `recoverable=False` and you bypass it, child tasks stay RUNNING forever and the invariant checker (`client/harmonograf_client/invariants.py:78-100`) will complain on the next sweep.
-- **Skipping `driftKinds.ts`.** If you add the client constant but forget the frontend entry, `getDriftKindMeta()` returns `UNKNOWN_DRIFT_KIND_META` and the banner shows a generic icon. Lint will not catch this — it is a string lookup.
-- **Mutating state from detection code.** Detection returns `DriftReason` objects. Do not flip task status in `detect_drift()`. All state transitions go through `_set_task_status()` at `adk.py:242-280` — see `hgraf-safely-modify-adk-py`.
-- **Duplicate-constant naming collision.** If you pick a name already used in `DRIFT_KIND_META` (frontend) or `DRIFT_KIND_*` (client) but with different semantics, the type system will not catch it — the strings will silently merge. Grep both files first.
+- **Drift kind wire key drift.** The goldfive enum name (uppercased)
+  is the wire value. Lowercase-compare across tables. Don't change
+  it after ship — persisted sqlite `task_plans.revision_kind` rows
+  hold the string.
+- **Aggregator window mismatch.** Server and frontend both compute
+  attribution windows. If you add a user-control kind and only
+  update one side, the intervention dedup will be asymmetric and
+  produce bonus cards.
+- **annotation_id propagation.** User-control drifts must carry
+  `annotation_id` (goldfive#177) so the aggregator folds the drift
+  onto the source annotation. If a drift should be user-control but
+  doesn't surface its annotation id, the intervention timeline will
+  show duplicate cards.
+- **Routing through goldfive.** Don't add detectors to harmonograf.
+  Every drift path lives in goldfive post-migration.
+
+## Cross-links
+
+- `docs/user-guide/tasks-and-plans.md#drift-kinds` — user-facing
+  taxonomy; update when adding a new kind.
+- `docs/user-guide/trajectory-view.md` — how drifts surface on the
+  intervention timeline.
+- `docs/dev-guide/server.md#listinterventions-71` — aggregator
+  internals.

--- a/.agents/skills/hgraf-add-fake-llm-scenario/SKILL.md
+++ b/.agents/skills/hgraf-add-fake-llm-scenario/SKILL.md
@@ -7,16 +7,29 @@ description: Script a complex multi-turn FakeLlm scenario — function calls, to
 
 ## When to use
 
-You are writing a test that needs a deterministic sequence of LLM turns, possibly interleaved with tool-call replies, transfers, drift triggers, or control events. The client already has a basic `FakeLlm` harness (`client/tests/test_dynamic_plans_real_adk.py:129`); this skill is for the next-level scenarios beyond single-turn replies.
+You are writing a test that needs a deterministic sequence of LLM turns, possibly interleaved with tool-call replies, transfers, drift triggers, or control events.
 
-For simple single-turn fakes and the general `FakeLlm` + StaticPlanner + InMemoryRunner fixture choice, see `hgraf-write-e2e-scenario.md` in batch 1. This skill goes deeper into scripting complex turn sequences.
+## Post-goldfive-migration scope
 
-## Prerequisites
+Harmonograf's dedicated FakeLlm harnesses moved out with the rest of
+the orchestration code. The current places to look for reusable
+FakeLlm patterns:
 
-1. Read `client/tests/test_dynamic_plans_real_adk.py:120-166` — the `_build_fake_llm` factory with `responses`, `cursor`, and the callable-hook trick for mid-invocation side effects.
-2. Read `client/tests/test_dynamic_plans_real_adk.py:169-183` — the `_text(...)` and `_fc(...)` builders for `LlmResponse` objects.
-3. Read `client/tests/test_orchestration_modes.py:109` for a second FakeLlm scaffold used in parallel/sequential orchestration tests.
-4. Know ADK's `LlmResponse`, `Content`, and `FunctionCall` shapes — they come from `google.adk.models.llm_response` and `google.genai.types`.
+- `tests/e2e/` — harmonograf's own end-to-end tests. Look for a
+  `FakeLlm` or similar fixture colocated with the scenario.
+- `third_party/goldfive/tests/` — goldfive's FakeLlm scaffolding,
+  which is what you actually want for scripted-turn tests that
+  exercise the planner / steerer / drift detectors.
+
+The two building blocks are the same:
+
+- `LlmResponse(content=Content(parts=[Part(text=...)]))` for plain
+  text turns.
+- `LlmResponse(content=Content(parts=[Part(function_call=FunctionCall(...))]))`
+  for tool calls.
+
+Both types come from `google.adk.models.llm_response` and
+`google.genai.types`.
 
 ## Scenario-building primitives
 

--- a/.agents/skills/hgraf-add-proto-field/SKILL.md
+++ b/.agents/skills/hgraf-add-proto-field/SKILL.md
@@ -14,11 +14,19 @@ You are extending the wire format between client library, server, and frontend. 
 1. `make install` has been run at least once.
 2. Proto toolchain available: `grpcio-tools`, `mypy-protobuf` (`Makefile:proto-python`) and `frontend/buf.gen.yaml` + `@bufbuild/protoc-gen-es` (`Makefile:proto-ts`).
 3. You know which `.proto` file owns the message — see `proto/harmonograf/v1/`:
-   - `types.proto` — shared enums + core messages (Span, Task, TaskPlan, Agent, ContextWindowSample, etc.)
-   - `telemetry.proto` — client→server stream (Hello, SpanStart, SpanEnd, Heartbeat, etc.)
-   - `control.proto` — server→client control channel
-   - `frontend.proto` — server→frontend (SessionUpdate, NewSpan, TaskReport, etc.)
-   - `service.proto` — RPC definitions only
+   - `types.proto` — shared enums + core messages (`Span`, `Agent`, `Session`, `Annotation`, `Intervention`, `PayloadRef`). Task / Plan / Drift / Control moved to goldfive.
+   - `telemetry.proto` — client→server stream (`Hello`, `SpanStart`, `SpanEnd`, `Heartbeat`, `TelemetryUp.goldfive_event`).
+   - `control.proto` — `SubscribeControlRequest` (ControlEvent / Ack live in `goldfive/v1/`).
+   - `frontend.proto` — frontend RPCs (`SessionUpdate`, `NewSpan`, `TaskReport`, `ListInterventionsRequest`, `ContextWindowSample`, etc.)
+   - `service.proto` — RPC definitions only.
+
+Recent additions to know about when picking numbers:
+
+- `SubscribeControlRequest.session_id = 1` — per-session sub.
+- `SteerPayload.author`, `SteerPayload.annotation_id` — goldfive#171.
+- `DriftDetected.annotation_id` — goldfive#177.
+- `Heartbeat.context_window_tokens = 10`, `limit_tokens = 11`.
+- `TelemetryUp.goldfive_event = 11`; fields 9 + 10 reserved.
 
 ## Step-by-step
 

--- a/.agents/skills/hgraf-add-reporting-tool/SKILL.md
+++ b/.agents/skills/hgraf-add-reporting-tool/SKILL.md
@@ -1,133 +1,86 @@
 ---
 name: hgraf-add-reporting-tool
-description: Add a new reporting tool end-to-end — tools.py definition, before_tool_callback interception, state_protocol key, frontend OrchestrationTimeline icon, and instruction appendix update.
+description: Add a new reporting tool. Reporting tools moved to goldfive post-migration; harmonograf no longer owns `client/harmonograf_client/tools.py`. This skill redirects to goldfive and covers the harmonograf-side touchpoints.
 ---
 
 # hgraf-add-reporting-tool
 
-## When to use
+## Post-goldfive-migration scope
 
-The existing reporting tools (`report_task_started`, `report_task_progress`, `report_task_completed`, `report_task_failed`, `report_task_blocked`, `report_new_work_discovered`, `report_plan_divergence` — defined in `client/harmonograf_client/tools.py:77-165`) cover the standard task lifecycle + divergence signals. You need a new tool when:
-- A new *kind of report* the agent should volunteer (not a drift the server infers).
-- A new shared-state field the agent should push (e.g. "I am waiting on external human approval").
-- A new hook for the Gantt timeline (e.g. "begin experiment phase" checkpoint).
+Reporting-tool definitions, interception, and the task-state side
+effects moved to [goldfive](https://github.com/pedapudi/goldfive)
+under issue #2. Harmonograf does NOT own any of:
 
-Do **not** add a reporting tool when the equivalent can be done via an existing `harmonograf.*` state key. The reporting tools should remain a small, curated surface — every one of them is injected into every sub-agent and eats tokens in system instructions.
+- `client/harmonograf_client/tools.py` (deleted)
+- `REPORTING_TOOL_FUNCTIONS`, `build_reporting_function_tools`,
+  `SUB_AGENT_INSTRUCTION_APPENDIX` (moved to `goldfive.reporting`)
+- The interception logic (lives in
+  `goldfive.adapters.adk.ADKAdapter` /
+  `goldfive.DefaultSteerer`)
 
-## Prerequisites
+If you want a new reporting tool, follow goldfive's
+`add-reporting-tool` guide. When goldfive ships the new tool, it
+emits an `Event` variant (e.g. `TaskStarted`, `TaskProgress`) that
+already rides on the wire via `TelemetryUp.goldfive_event` — no
+harmonograf wire change needed.
 
-1. Read the full reporting-tools reference at [`docs/reporting-tools.md`](../../../docs/reporting-tools.md) and the protocol section of `AGENTS.md`.
-2. Read `client/harmonograf_client/tools.py` end-to-end (it is only ~200 lines) so you understand the `REPORTING_TOOL_FUNCTIONS` tuple, `build_reporting_function_tools()`, and `SUB_AGENT_INSTRUCTION_APPENDIX`.
-3. Read `client/harmonograf_client/state_protocol.py` — specifically the constants at lines 89-103 and the ALL_KEYS tuple at 112-126.
+## Harmonograf-side touchpoints
 
-## Step-by-step
+If the new tool surfaces a fresh UI concept (new event kind, new
+drawer tab, new intervention source), you have work on the harmonograf
+side too:
 
-### 1. Define the tool function in tools.py
+### 1. A new `Event` variant
 
-Add a new function to `client/harmonograf_client/tools.py` matching the pattern of the existing tools (lines 77-165). The body **must** return `{"acknowledged": True}` — the real work happens in `before_tool_callback` interception. Example:
+If goldfive defines a new event on
+`proto/goldfive/v1/events.proto`:
 
-```python
-def report_awaiting_human_approval(
-    task_id: str,
-    reason: str,
-    expected_resolver: str = "",
-) -> dict:
-    """Signal that the current task is blocked on out-of-band human approval.
+- Update `server/harmonograf_server/ingest.py`'s
+  `_handle_goldfive_event` dispatch to match on the new variant.
+- Convert to storage if durable state is needed. Usually the new
+  event is just a delta the bus can fan out unchanged.
+- Add `SessionUpdate` oneof handling if the frontend consumes it
+  (`proto/harmonograf/v1/frontend.proto`).
+- Extend `frontend/src/rpc/goldfiveEvent.ts` to typed-convert.
 
-    Harmonograf intercepts this call in before_tool_callback and transitions
-    the task to BLOCKED with a structured reason. Returns {"acknowledged": True}.
-    """
-    return {"acknowledged": True}
-```
+### 2. A new intervention source
 
-Docstring is critical — ADK surfaces it to the model as part of the tool schema.
+If the tool surfaces a new kind of user or goldfive-autonomous
+intervention (e.g. "ask-human" becomes a visible intervention,
+not just a span), update the aggregator:
 
-### 2. Register in the tuples
+- `server/harmonograf_server/interventions.py` — extend
+  `_project_drifts` / `_project_plans` if needed.
+- `frontend/src/lib/interventions.ts` — mirror any classification
+  change.
 
-Same file, around lines 168-180:
+See `hgraf-add-drift-kind` for the aggregator-side specifics.
 
-```python
-REPORTING_TOOL_FUNCTIONS = (
-    report_task_started,
-    ...
-    report_awaiting_human_approval,   # new
-)
+### 3. A new span attribute
 
-REPORTING_TOOL_NAMES = tuple(f.__name__ for f in REPORTING_TOOL_FUNCTIONS)
-```
+If the tool stamps a span attribute you want the UI to surface,
+update:
 
-`build_reporting_function_tools()` at lines 183-190 wraps each into a `google.adk.tools.FunctionTool` — no edits needed.
-
-### 3. Update the instruction appendix
-
-`SUB_AGENT_INSTRUCTION_APPENDIX` at `tools.py:193-202` is appended to every sub-agent's instruction (via `HarmonografAgent._auto_register_reporting_tools` at `agent.py:335-355`). Add a one-sentence bullet describing when to call your tool. Keep it terse — every word here is replicated across every agent and multiplies token cost.
-
-### 4. Add the interception in before_tool_callback
-
-`client/harmonograf_client/adk.py:1299-1316` is `async def before_tool_callback`. The existing pattern dispatches on tool name via `_dispatch_reporting_tool`. Find that function (grep for `_dispatch_reporting_tool`) and add a branch for your new tool name.
-
-Inside the branch:
-- Parse arguments out of the `args` dict.
-- Apply state via `_AdkState` — **always** through `_set_task_status()` at `adk.py:242-280` for status transitions, never by mutating `task.status` directly. See `hgraf-safely-modify-adk-py`.
-- If the tool should produce a `DriftReason`, construct one and route it through the same refine path `report_task_failed` and `report_plan_divergence` use.
-
-### 5. Add a state_protocol key (if applicable)
-
-If your tool writes a new field readable by other agents, add a `KEY_*` constant to `client/harmonograf_client/state_protocol.py` (alongside lines 99-103 for Agents→Harmonograf keys):
-
-```python
-KEY_AWAITING_HUMAN = HARMONOGRAF_PREFIX + "awaiting_human"
-```
-
-Add it to the `ALL_KEYS` tuple at lines 112-126. Wire the interception in step 4 to write this key into `session.state` so other sub-agents can read it. Use `_safe_get()` / `_safe_str()` at lines 129-144 for reads — they never raise.
-
-### 6. Add unit tests
-
-Tests live in `client/tests/test_reporting_tools.py` and `client/tests/test_reporting_registration.py`. Follow the existing patterns:
-
-- `test_reporting_registration.py` — assert your new function is in `REPORTING_TOOL_FUNCTIONS`, that `REPORTING_TOOL_NAMES` includes it, and that `build_reporting_function_tools()` produces a FunctionTool for it.
-- `test_reporting_tools.py` — construct a fake ADK event stream invoking the tool, assert `_AdkState` applies the expected transition and state keys.
-- `test_state_protocol.py` — if you added a new KEY_*, assert it round-trips through the safe getters.
-
-```bash
-cd client && uv run --with pytest --with pytest-asyncio python -m pytest \
-  tests/test_reporting_tools.py tests/test_reporting_registration.py tests/test_state_protocol.py -q
-```
-
-### 7. Frontend: OrchestrationTimeline icon
-
-The orchestration timeline in the drawer (`frontend/src/components/shell/OrchestrationTimeline.tsx:7-87`) renders reporting-tool invocations as timeline entries. Find `KIND_LABEL` and `ALL_KINDS` near the top of that file — add a new entry for your tool name, pick a label and icon.
-
-The tool name flows from span attributes (set by `before_tool_callback`) through the ingest pipeline into the frontend `TOOL_CALL` span renderer. If you picked a brand new name, the timeline will show `Unknown` until you add the mapping here.
-
-### 8. Documentation
-
-Update [`docs/reporting-tools.md`](../../../docs/reporting-tools.md) with a reference entry for the new tool. Keep the structure consistent with the existing entries (signature, when to call, state it writes, example).
+- `frontend/src/rpc/convert.ts` — pass the attribute through to
+  the frontend `Span` type.
+- Drawer Summary tab — already renders arbitrary attributes via
+  the attribute table; no wiring needed unless you want pretty
+  rendering.
 
 ## Verification
 
 ```bash
-# 1. client tests
-cd client && uv run --with pytest --with pytest-asyncio python -m pytest tests/test_reporting_tools.py tests/test_reporting_registration.py tests/test_state_protocol.py tests/test_tool_callbacks.py -q
+# Server: goldfive_event ingest
+cd server && uv run pytest tests/test_ingest_goldfive_event.py -q
 
-# 2. full client suite
-cd client && uv run --with pytest --with pytest-asyncio python -m pytest -q
-
-# 3. frontend
-cd frontend && pnpm lint && pnpm build
-
-# 4. live smoke — drive a scenario where an agent calls the new tool
-make demo
+# Frontend: event converter
+cd frontend && pnpm test -- --run goldfiveEvent
 ```
 
-In the demo UI: open the Drawer → Orchestration Timeline → confirm the new tool appears with your label and icon, and the task row reflects the expected state transition.
+## Cross-links
 
-## Common pitfalls
-
-- **Tool body does real work.** The body **must** return `{"acknowledged": True}` only. The real effect happens in `before_tool_callback` interception so that `_AdkState` is the single writer to task status. If you do work in the tool body, you bypass the state-machine lock and create race conditions under `parallel_mode=True`.
-- **Auto-registration is subtree-wide.** `agent.py:335-355` walks the full sub-agent tree at `HarmonografAgent` construction and appends your tool to every `LlmAgent`. Every agent pays the system-prompt cost of your new tool. Be parsimonious with the tools you add and with the instruction appendix prose.
-- **Instruction appendix bloat.** Each new bullet multiplies across every agent's instruction. Aim for ≤15 words per bullet. Prefer examples in [`docs/reporting-tools.md`](../../../docs/reporting-tools.md) over verbose in-prompt instructions.
-- **Not going through `_set_task_status`.** Direct `task.status = ...` assignments skip the monotonic-transition guard at `adk.py:242-280`. The invariant checker (`invariants.py`) will flag the resulting state on the next sweep and log a violation, but by then you've already written wrong state to the server.
-- **Forgetting ALL_KEYS.** If you add a `KEY_*` constant but don't add it to `ALL_KEYS` at `state_protocol.py:112-126`, the diff helper will silently not pick it up, and the delta stream to the server will miss writes.
-- **Frontend mapping lag.** You can ship client-only and the tool will still work — the timeline just shows a generic `Unknown` entry. Many new tools get stuck in that state because nobody goes back and adds the mapping. Do both sides in the same PR.
-- **Wire name ≠ function name.** `REPORTING_TOOL_NAMES` is derived from `__name__`. Renaming the function renames the wire key and breaks any persisted sqlite rows or replayed traces referencing the old name. Pick the name once.
+- [goldfive's reporting-tool guide](https://github.com/pedapudi/goldfive/blob/main/docs/how-to/add-reporting-tool.md)
+  (authoritative).
+- `hgraf-add-drift-kind` — when the new tool's side effects should
+  surface as a drift on the intervention timeline.
+- `dev-guide/server.md` — goldfive_event ingest.

--- a/.agents/skills/hgraf-debug-frontend-state/SKILL.md
+++ b/.agents/skills/hgraf-debug-frontend-state/SKILL.md
@@ -14,8 +14,9 @@ The server shows one thing in sqlite or on `WatchSession`, but the frontend show
 1. Dev server running: `pnpm -C frontend dev` (usually `http://localhost:5173`). Backend running locally: `uv run harmonograf-server`.
 2. Chrome/Firefox DevTools open on the tab.
 3. Read `frontend/src/gantt/index.ts:1-120` to understand the `SessionStore` shape: `agents`, `spans`, `tasks`, `plans`, `annotations`, each a subscribe-able collection.
-4. Read `frontend/src/state/uiStore.ts` for the zustand store that owns UI-only state (drawer open, selected span, viewport, focused agent).
+4. Read `frontend/src/state/uiStore.ts` for the zustand store that owns UI-only state (drawer open, selected span, viewport, focused agent). Sibling stores: `sessionsStore.ts` (picker state), `annotationStore.ts` (annotations synced from WatchSession), `approvalsStore.ts` (pending approvals), `popoverStore.ts` (popover position).
 5. Read `frontend/src/rpc/hooks.ts` — `getSessionStore`, `useSessionWatch`, `useHarmonografClient` are the top-level access points.
+6. For the InterventionsTimeline: `frontend/src/lib/interventions.ts` derives the merged intervention list from `annotationStore` + `store.drifts` + `store.tasks` (plans). Mirrors `server/harmonograf_server/interventions.py`. Debug by dumping each input slice.
 
 ## Step-by-step
 

--- a/.agents/skills/hgraf-debug-task-stuck/SKILL.md
+++ b/.agents/skills/hgraf-debug-task-stuck/SKILL.md
@@ -1,135 +1,70 @@
 ---
 name: hgraf-debug-task-stuck
-description: Diagnostic playbook when a task appears stuck — invariants, sweep log, reporting-tool interception, drift throttling, walker budget exhaustion, heartbeat timeouts.
+description: Diagnostic playbook when a task appears stuck. Post-overlay-era: PENDING → NOT_NEEDED at invocation end is expected.
 ---
 
 # hgraf-debug-task-stuck
 
 ## When to use
 
-- A task in the Gantt is wearing its "stuck" stripe (the server marked the agent STUCK after `STUCK_THRESHOLD_BEATS` missed heartbeats; see `ingest.py:62-65`).
-- A task stays RUNNING long past its predicted duration and never transitions.
-- A task is PENDING and never starts even though its dependencies are COMPLETED.
-- The frontend shows a drift banner but the planner never issues a refine.
-- Parallel mode "appears to hang" — the walker runs out of budget and stops without reporting.
+- A task in the Gantt sits at `PENDING` or `RUNNING` long past
+  when you expected it to resolve.
+- The intervention timeline shows no drift firing despite the
+  obvious stall.
+- The agent's `⚠ stuck` stripe is lit in the Graph view header.
 
-## Prerequisites
+Under the overlay model (goldfive#141-144), a task that sits at
+`PENDING` throughout a finished run and then flips to
+`NOT_NEEDED` at the end is **working as intended**. Only worry if
+the agent is actively running and the task still doesn't move.
 
-- A reproducing session (live or persisted trace).
-- Access to server stdout (or sqlite file for offline analysis).
-- Know the session id and task id you are debugging (from the UI drawer, the `sessions` table, or the `tasks` table in `data/harmonograf.sqlite`).
+## Entry points
 
-## Diagnostic playbook
+This skill is a short index. For depth, go to the runbooks:
 
-Work the list top-down. Each step has a concrete command or log pattern to look for.
+| Situation | Runbook |
+|---|---|
+| Task stuck at PENDING while agent runs | [runbooks/task-stuck-in-pending.md](../../../docs/runbooks/task-stuck-in-pending.md) |
+| Task stuck at RUNNING | [runbooks/task-stuck-in-running.md](../../../docs/runbooks/task-stuck-in-running.md) |
+| Drift should've fired but didn't | [runbooks/drift-not-firing.md](../../../docs/runbooks/drift-not-firing.md) |
+| LLM or tool call hung | [runbooks/high-latency-callbacks.md](../../../docs/runbooks/high-latency-callbacks.md) |
+| Context window near limit | [runbooks/context-window-exceeded.md](../../../docs/runbooks/context-window-exceeded.md) |
 
-### 1. Check invariant violations
+## 30-second triage
 
-The invariant checker (`client/harmonograf_client/invariants.py:78-100`) runs as a read-only validator after walker turns. It logs `InvariantViolation` records at WARN or ERROR level depending on severity. Grep the server log:
+1. **Is the run still active?** If not, a PENDING task flipping to
+   NOT_NEEDED at invocation end is fine.
+2. **Open spans?** SQL:
+   ```sql
+   SELECT id, kind, name, start_time FROM spans
+   WHERE agent_id='<AID>' AND end_time IS NULL
+   ORDER BY start_time DESC;
+   ```
+   A long-open `LLM_CALL` → slow LLM / hung provider.
+   A long-open `TOOL_CALL` → tool hung.
+   Only an open `INVOCATION` → agent-code loop.
+3. **What's `goldfive.llm.duration_ms` on the newest LLM call?**
+   Values > 60 000 flag a wedged model.
+4. **What do the drift and intervention RPCs say?**
+   ```bash
+   grpcurl -plaintext -d '{"session_id":"<SID>"}' \
+     localhost:7531 harmonograf.v1.Harmonograf/ListInterventions | jq .
+   ```
+5. **Duplicate plugin?** `grep 'duplicate HarmonografTelemetryPlugin' agent.log`.
+   Silent duplicates don't break span emission but DO break the
+   `on_cancellation` sweep, leaving RUNNING spans after CANCEL.
 
-```
-grep -i "invariantviolation\|invariant.*violat" <server.log>
-```
+## What to send upstream
 
-If you see a violation like `task X in RUNNING with no active span` or `task completed out of dependency order`, you have a state-machine bug — not a stuck task. Jump to `hgraf-safely-modify-adk-py` for root-cause analysis.
+If you file a bug:
 
-The allowed transitions are enumerated at `invariants.py:41-55` (`_VALID_STATUSES`, `_TERMINAL_STATUSES`, `_ALLOWED_TRANSITIONS`). Any transition not in that dict is a violation by definition.
+- The session id.
+- Output of `ListInterventions`.
+- Newest few rows from `task_plans` for the session.
+- Goldfive log excerpt containing `DriftDetected` lines.
+- py-spy dump of the agent process if it's still running.
 
-### 2. Check the sweep log
+## Cross-links
 
-`classify_and_sweep_running_tasks()` at `client/harmonograf_client/adk.py:2608-2720` is the periodic sweeper: it classifies every RUNNING task against recent events and applies COMPLETED/FAILED/partial transitions. If a task is stuck, either:
-- The sweeper is not running (bug — check the timer loop).
-- The sweeper is running but classifying the task as "still in progress" (normal — wait longer, or check whether the classifier criteria are met).
-- The sweeper is running but `_set_task_status` is refusing the transition (monotonic guard — `adk.py:242-280`).
-
-Enable DEBUG logging and grep:
-```
-HARMONOGRAF_LOG_LEVEL=DEBUG make server-run 2>&1 | grep -i "sweep\|classify_and_sweep"
-```
-
-### 3. Check reporting-tool interception
-
-If the agent is calling `report_task_completed` but the status never changes, the `before_tool_callback` dispatch may be failing silently. Add a breakpoint or log at `client/harmonograf_client/adk.py:1299-1316` (`before_tool_callback`). Verify:
-- The dispatch function receives your tool name.
-- Argument parsing does not raise (reporting tool dispatchers catch exceptions — look for `try/except` wrapping).
-- `_set_task_status` returns truthy (the transition was allowed).
-
-Run:
-```bash
-cd client && uv run --with pytest --with pytest-asyncio python -m pytest tests/test_reporting_tools.py tests/test_tool_callbacks.py -q
-```
-
-A failing test here points at the interception layer; a passing suite exonerates it.
-
-### 4. Check drift throttling
-
-`_DRIFT_REFINE_THROTTLE_SECONDS = 2.0` at `adk.py:378` coalesces refines. If your drift fires at 10Hz, only the first refine in each 2s window runs. If the first refine was a no-op and subsequent ones would have fixed things, you will see "drift detected but task not moving."
-
-Grep for `refine throttled` or the refine call site at `adk.py:3256-3350`. Look at `_STAMP_MISMATCH_THRESHOLD = 3` at `adk.py:373` — some drifts need to fire 3 times before they even become `DriftReason` objects. If the condition flickers (fires twice then stops), no refine ever runs.
-
-### 5. Check walker budget exhaustion (parallel mode only)
-
-In `parallel_mode=True`, the rigid DAG batch walker at `agent.py:1061-1071` drives sub-agents directly. It has a per-turn budget; if the budget is exhausted, the walker stops and waits for the next invocation. Symptoms:
-- A task is PENDING with all dependencies COMPLETED.
-- The walker log shows "budget exhausted" or "batch size 0".
-- `report_task_started` for that task never fires.
-
-Fix: bump the budget in the walker's config, or split the plan into smaller batches. Be cautious — raising the budget unbounded causes token cost explosions.
-
-### 6. Check heartbeat timeouts (client-side hang)
-
-`ingest.py:62-65` defines `HEARTBEAT_TIMEOUT_S = 15.0` and `STUCK_THRESHOLD_BEATS = 3`. A client that stops sending heartbeats (because it is blocked in a synchronous tool call, a long network I/O, or a debugger breakpoint) will have its agent marked STUCK after ~45s. The task stays RUNNING because the client never reported a transition.
-
-Confirm by querying the sqlite store:
-```bash
-sqlite3 data/harmonograf.sqlite \
-  "SELECT id, name, status, last_heartbeat FROM agents WHERE session_id = '<sid>';"
-```
-
-If `last_heartbeat` is stale vs. wall clock, the client is blocked. Attach a debugger to the agent process and inspect its stack — look for synchronous `requests`, `subprocess.run`, or `time.sleep` in a tool body. The fix is usually to make the tool async or to move the blocking call off the event loop.
-
-### 7. Check ContextVar inheritance (parallel / sub-agent cases)
-
-`adk.py` uses two ContextVars: `_forced_task_id_var` (lines 320-322) and `_current_root_hsession_var` (lines 1656-1659 on `_AdkState`). ContextVars are automatically inherited by `asyncio.create_task()` descendants but **not** by threads or by tasks scheduled from a different `contextvars.copy_context()`. If a sub-agent is running under the wrong forced task id, its spans bind to the wrong task and the correct task stays empty / stuck.
-
-Look for cases where:
-- The agent tool is executed via `run_in_executor` (thread pool) without `contextvars.copy_context()` wrapping.
-- A manually constructed `asyncio.Task` was spawned from a lambda that captured the wrong context.
-
-The hygienic pattern is `_forced_task_id_var.set(...)` immediately before the await, with a `_route_tokens` reset token stored for LIFO reset (see `adk.py:1661-1663`).
-
-### 8. Check the server fan-out
-
-If the client is transitioning tasks correctly but the UI doesn't reflect it, the bug is downstream. Verify:
-- `convert.py` maps the updated task status (see `pb_task_status_from_pb` imports at `ingest.py:28-49`).
-- The `SessionBus` publishes a `DELTA_TASK_STATUS` (`bus.py:25-36`).
-- The `WatchSession` RPC is streaming to the frontend (check the `StreamAck` counter, or `make stats`).
-- The frontend `TaskRegistry` receives the delta (`frontend/src/gantt/index.ts:183`+) — add a `console.log` inside `upsertPlan`.
-
-## Verification
-
-After applying a fix:
-
-```bash
-# Invariant suite
-cd client && uv run --with pytest --with pytest-asyncio python -m pytest tests/test_invariants.py tests/test_task_lifecycle.py tests/test_walker_completion_timing.py -q
-
-# End-to-end scenario that exercises the stuck path
-cd /home/sunil/git/harmonograf && uv run --extra e2e pytest tests/e2e/test_scenarios.py -q
-
-# Live repro with sqlite persistence, then inspect
-make demo
-# trigger the scenario, then:
-sqlite3 data/harmonograf.sqlite \
-  "SELECT id, title, status, started_at, updated_at FROM tasks \
-   WHERE session_id = '<sid>' ORDER BY started_at;"
-```
-
-## Common pitfalls
-
-- **Confusing STUCK (agent) with stuck (task).** Agent-level STUCK is a heartbeat timeout; task-level stuck is a state transition that isn't happening. Different causes, different fixes. The UI stripe pattern is different too.
-- **Adding logs inside `_set_task_status` without scope.** It is called on every transition attempt including rejected ones. Logging at INFO floods the log. Use DEBUG.
-- **"Just unblock it" by direct mutation.** Never `task.status = COMPLETED` from a debugger to "unstick" a test. The invariant checker will not flag it at write time, but the next sweep will detect the violation and your bug report becomes bimodal. Always go through `_set_task_status`.
-- **Trusting the wall-clock.** Sweep intervals and heartbeat timeouts use monotonic clocks under the hood. A laptop sleeping mid-session can trigger false STUCK on wake. Reproduce on a non-suspended machine.
-- **Blaming the planner.** The refine loop is well-tested. If the planner returns `None`, the task genuinely has no fix; if it returns a revised plan that still doesn't unblock, the drift kind you detected was wrong. Work backwards from the drift detection, not forwards from the plan.
-- **Missing `--store sqlite`.** The in-memory store forgets on restart. If your "stuck task" is cleared by a reboot you only proved you restarted. Use sqlite for any debugging that spans a process lifetime.
+- `dev-guide/debugging.md` for SQL snippets.
+- `user-guide/tasks-and-plans.md` for the overlay-era state machine.

--- a/.agents/skills/hgraf-interpret-invariant-violations/SKILL.md
+++ b/.agents/skills/hgraf-interpret-invariant-violations/SKILL.md
@@ -1,196 +1,41 @@
 ---
 name: hgraf-interpret-invariant-violations
-description: Read InvariantViolation log lines, map them to the specific rule in invariants.py, and decide whether to fix the bug or silence the check.
+description: Retained for history. Plan-state invariants moved to goldfive. This skill redirects.
 ---
 
 # hgraf-interpret-invariant-violations
 
-## When to use
+## Historical scope
 
-You see log lines like `invariant monotonic_state: task draft illegal transition COMPLETED → PENDING` or pytest is failing on `_run_invariants` output and you need to understand what is going wrong and what to do about it.
+`client/harmonograf_client/invariants.py` was removed during the
+goldfive migration (issue #2). Plan-state invariants (monotonic
+task transitions, terminal-status preservation, assignee validity)
+now live in goldfive's `DefaultSteerer` / task-state code.
 
-For general adk.py safety, see `hgraf-safely-modify-adk-py.md` in batch 1. This skill specializes on reading violation records and mapping them to root causes.
+Harmonograf no longer validates plan-state invariants on its own.
+Whatever goldfive emits over `TelemetryUp.goldfive_event` is the
+truth from harmonograf's perspective.
 
-## Prerequisites
+## If you see violation-shaped log lines
 
-1. Read `client/harmonograf_client/invariants.py:58-76 InvariantViolation` — fields `rule`, `severity`, `detail`, and `log_level()`.
-2. Read `invariants.py:41-55` — the `_VALID_STATUSES`, `_TERMINAL_STATUSES`, and `_ALLOWED_TRANSITIONS` tables.
-3. Read `invariants.py:93-118 InvariantChecker.check` — the top-level dispatcher that runs every individual check and returns the list in a stable order.
-4. Know where violations are surfaced: `_AdkState._run_invariants` in `adk.py`, called at the end of each walker turn. Errors assert in tests; warnings log and continue.
+They're coming from goldfive, not harmonograf. The log namespace
+starts with `goldfive.*`. Inspect goldfive's invariant code and
+open a goldfive issue if a genuine bug.
 
-## The eight invariants and what they mean
+Harmonograf-side validations that remain (unrelated to plan state):
 
-### 1. `monotonic_state` (error)
+- **Payload digest mismatch** — `ingest.py` rejects an upload whose
+  recomputed sha256 doesn't match the declared digest. This is
+  about integrity, not plan state.
+- **Hello frame shape** — `ingest.py` rejects malformed Hello frames
+  (empty `agent_id`, etc.).
+- **Wire proto enum validity** — the generated protobuf stubs
+  refuse unknown enum values on decode.
 
-Source: `invariants.py:124 _check_monotonic`.
+For any of those, look at the message in the server log and trace
+to the relevant handler.
 
-A task's status went backwards through an illegal transition, or is not one of `PENDING | RUNNING | COMPLETED | FAILED | CANCELLED`.
+## Cross-links
 
-Allowed transitions (`invariants.py:49-55`):
-- `PENDING → PENDING | RUNNING | CANCELLED | FAILED`
-- `RUNNING → RUNNING | COMPLETED | FAILED | CANCELLED`
-- `COMPLETED`, `FAILED`, `CANCELLED` — terminal, no outgoing edges.
-
-Typical root causes:
-- A callback directly wrote `task.status = "PENDING"` after a COMPLETED. The guard in `_set_task_status` prevents this; bypassing the guard (mutating `task.status` on a raw object) is the usual culprit.
-- A refine path rebuilt tasks from the LLM response without preserving terminal statuses (see `_apply_refined_plan` preservation loop at `adk.py:3494`).
-- A test fixture with a hand-crafted plan used an invalid status string.
-
-Action: fix the offending write path. **Never silence this error** — it means the state machine is corrupt.
-
-### 2. `dependency_consistency` (warning)
-
-Source: `invariants.py:158 _check_dependency_consistency`.
-
-`dst` is COMPLETED but `src` (its dependency) is still PENDING.
-
-Typical root causes:
-- A parallel walker completed a task before its dependency started (walker bug — very rare).
-- The LLM in refine-mode reordered tasks without rewiring edges.
-- `dropout` scenarios where the LLM omitted the dependency from the refined plan entirely.
-
-Action: usually fix in the plan-building code. For edge cases, a warning is acceptable — the UI shows it but execution proceeds.
-
-### 3. `assignee_validity` (warning)
-
-Source: `invariants.py:187 _check_assignee_validity`.
-
-A task's `assignee_agent_id` is not in `plan_state.available_agents`.
-
-Typical root causes:
-- LLM hallucinated an agent id.
-- Plan refresh changed `available_agents` but preserved old tasks with stale assignees.
-- Initial plan from `PlannerHelper.generate` bypassed `_canonicalize_plan_assignees`.
-
-Action: ensure `_canonicalize_plan_assignees` runs on every plan insertion (`adk.py:3478` is the canonical site for refine). For initial plans, confirm the call also happens in the generate path.
-
-### 4. `plan_id_uniqueness` (error likely)
-
-Source: `invariants.py:210 _check_plan_id_uniqueness`.
-
-Two different `hsession_id`s share the same `plan_id` in `state._active_plan_by_session`.
-
-Typical root causes:
-- Using a hardcoded plan_id in tests that run in parallel.
-- A UUID generator misfiring (collision probability is negligible — check for a default value like `"plan_0"`).
-
-Action: always generate plan_ids with `uuid.uuid4().hex` or equivalent. Fix the source.
-
-### 5. `forced_task` (error)
-
-Source: `invariants.py :: _check_forced_task`.
-
-The forced `task_id` ContextVar (parallel walker) points at a task that isn't in the current plan_state, or at a task in a terminal status.
-
-Typical root causes:
-- Walker logic left a stale ContextVar value after a refine superseded the old plan.
-- A test manually set the ContextVar without restoring it.
-
-Action: check the walker's ContextVar lifecycle. `reset()` on every task boundary.
-
-### 6. `task_results_keys` (warning)
-
-Source: `invariants.py :: _check_task_results_keys`.
-
-`session.state['harmonograf.completed_task_results']` has keys that don't correspond to any task in the current plan.
-
-Typical root causes:
-- Stale entries from a superseded plan that weren't garbage-collected.
-- Testing harnesses that pre-populate the state without syncing with the plan.
-
-Action: usually fine to silence in tests (pre-populate results matching a real plan). In production, clean up on plan supersession.
-
-### 7. `revision_history_monotone` (error)
-
-Source: `invariants.py :: _check_revision_history_monotone`.
-
-The `revision_history` list inside `PlanState` has non-monotonic `revision_index` values.
-
-Typical root causes:
-- Concurrent refine paths racing without the lock (very rare — the lock at `adk.py:3493` exists for this).
-- A test that manually appended a revision without bumping the index.
-
-Action: always go through `_apply_refined_plan` — never mutate `plan_state.plan.revision_index` by hand.
-
-### 8. `span_bindings` (warning)
-
-Source: `invariants.py :: _check_span_bindings`.
-
-A task's `bound_span_id` points at a span that doesn't exist in the client's local span tracker, OR the span's `hgraf.task_id` attribute doesn't match.
-
-Typical root causes:
-- A forced `task_id` ContextVar drove a binding that the client didn't actually stamp.
-- A span was emitted and discarded before the binding was written.
-- A test emits spans out-of-order relative to task reports.
-
-Action: confirm the order of operations is `emit_span_start → (bind task) → emit_span_update` in the adapter path. Read `adk.py :: _bind_span_to_task`.
-
-## Step-by-step diagnosis
-
-### 1. Capture the full violation list
-
-Violations arrive as a `list[InvariantViolation]` — **read all of them**, not just the first. The checker returns them in stable order and a single bug often triggers two or three different rules.
-
-```python
-violations = check_plan_state(state, hsession_id)
-for v in violations:
-    log.log(v.log_level(), "invariant %s (%s): %s", v.rule, v.severity, v.detail)
-```
-
-The same `rule` appearing N times usually means N tasks caught by the same bug, not N different bugs.
-
-### 2. Reproduce deterministically
-
-Convert the violation into a failing unit test. Pattern:
-
-```python
-def test_reproduces_monotonic_regression():
-    state = _AdkState(...)
-    plan_state = _build_plan_state(...)
-    state._active_plan_by_session["s1"] = plan_state
-    # Simulate the exact mutation path
-    plan_state.tasks["draft"].status = "COMPLETED"
-    plan_state.tasks["draft"].status = "PENDING"  # illegal
-    violations = check_plan_state(state, "s1")
-    assert any(v.rule == "monotonic_state" for v in violations)
-```
-
-Then fix the underlying write path and assert the violation disappears.
-
-### 3. Decide fix-or-silence
-
-| Severity | Default action |
-|---|---|
-| `error` | Always fix. Silencing an error means the state machine is lying. |
-| `warning` | Fix if cheap; silence if the check is incorrect for a specific legitimate case. |
-
-To silence a warning for a specific known-safe path, add a guard *inside the check*, not a try/except around it. Silencing by catching exceptions hides real bugs.
-
-### 4. When the check itself is wrong
-
-If the check is producing false positives on a legitimate plan shape:
-
-1. Add a test case in `client/tests/test_invariants.py` that demonstrates the false positive.
-2. Refine the check. Prefer narrowing (adding a precondition) over widening the allowed set.
-3. Document the new precondition in the check's docstring.
-
-### 5. Performance note
-
-`_run_invariants` runs on every walker turn. If the plan is large (100+ tasks), the check budget matters — each rule is O(n) or O(n²) for edges. Profile with the pattern in `hgraf-profile-callback-perf.md`.
-
-## Verification
-
-```bash
-uv run pytest client/tests/test_invariants.py -x -q
-uv run pytest client/tests/test_protocol_callbacks.py -x -q -k invariant
-uv run pytest client/tests -x -q -k "invariant or monotonic"
-```
-
-## Common pitfalls
-
-- **Silencing in tests with an assert filter**: `assert not any(v.severity == "error")` in tests is the right call — errors are bugs. `assert not violations` is too strict because warnings are informational.
-- **Testing after the bug is gone**: if your fix removes the violation, also add a regression test that re-triggers it so a future rewrite can't reintroduce the bug.
-- **Reading `_last_status` across tests**: the module-level `InvariantChecker` carries state across calls. Construct a fresh `InvariantChecker()` per test to avoid cross-test pollution.
-- **Confusing rule name with detail**: the `rule` field is a stable tag (e.g. `"monotonic_state"`); the `detail` is a human-readable string. Aggregations and filters should key on `rule`, never on the detail.
-- **Firing invariants during refine**: `_run_invariants` is called *after* the walker turn settles. If you add a mid-refine check, you'll see transient violations that aren't real — don't.
-- **Assuming log-level matches severity**: `log_level()` returns `ERROR` for `"error"` and `WARNING` for anything else (`invariants.py:74`). "Silence" = filter at the logger, not at the severity label.
+- goldfive repo for plan-state invariants.
+- `dev-guide/debugging.md` for harmonograf-side integrity checks.

--- a/.agents/skills/hgraf-profile-callback-perf/SKILL.md
+++ b/.agents/skills/hgraf-profile-callback-perf/SKILL.md
@@ -1,99 +1,82 @@
 ---
 name: hgraf-profile-callback-perf
-description: Profile ADK callback overhead using the existing client/tests/test_callback_perf.py harness + ProtocolMetrics counters + pytest --durations.
+description: Profile ADK callback overhead on the current telemetry plugin + goldfive per-LLM-call metrics.
 ---
 
 # hgraf-profile-callback-perf
 
 ## When to use
 
-You changed something in `client/harmonograf_client/adk.py` (callback path, walker, invariant check, state writer) and want to confirm you didn't regress per-callback latency. Harmonograf doesn't have a real profiler framework — it uses a scripted plan + `time.perf_counter_ns` harness and a lightweight `ProtocolMetrics` counter struct.
+You changed something in the client's ADK plugin
+(`client/harmonograf_client/telemetry_plugin.py`), in the ring buffer
+or transport (`buffer.py` / `transport.py`), or in the server's
+ingest pipeline, and you want to confirm you didn't regress per-call
+latency.
 
-## Prerequisites
+## Where the hot paths are now
 
-1. `make client-install` done.
-2. Read `client/harmonograf_client/metrics.py` — the `ProtocolMetrics` dataclass is the entire "perf observability" surface on the client. It tracks callback fire counts, task transitions, refine fires, reporting tool invocations, walker iterations, and invariant violations. No timings, no histograms — just counters.
-3. Read `client/tests/test_callback_perf.py` — the reference harness for measuring callback latency without spinning up real ADK or gRPC.
+With goldfive owning orchestration, the client's remaining hot paths
+are short:
 
-## Step-by-step
+| Hot path | Location | Dominant cost |
+|---|---|---|
+| ADK callback → span enqueue | `telemetry_plugin.py` | `emit_span_*` marshal + ring push |
+| Ring buffer push | `buffer.py` | One deque append under `threading.Lock` |
+| Transport drain | `transport.py::_send_loop` | `pop_batch` + proto marshal + gRPC queue put |
+| Server ingest | `server/ingest.py::handle_message` | `pb_span_to_storage` + `store.upsert_span` + `bus.publish_*` |
+| Sqlite write | `storage/sqlite.py::append_span` | aiosqlite INSERT under process-wide asyncio.Lock |
+| Bus fan-out | `bus.py::publish` | One `put_nowait` per subscriber |
 
-### 1. Run the existing harness first
+See `dev-guide/performance-tuning.md` for the full map.
 
-```bash
-uv run pytest client/tests/test_callback_perf.py -q --durations=10
-```
+## The three metrics that matter most
 
-Note the p50/p95 it logs to stdout. The harness budget is ~5ms p95 per callback (`test_callback_perf.py:10`) and logs-but-doesn't-assert on breach so CI stays green on slow runners.
+1. **`goldfive.llm.duration_ms`** (goldfive#172) — wall-clock time of
+   each LLM call. Almost always the dominant cost in a "slow agent"
+   complaint.
+2. **`goldfive.llm.request.chars`** — request prompt size. Balloons
+   post-STEER when the steerer injects drift body + task state.
+3. **`buffered_events`** (from `Heartbeat`) — if this climbs, the
+   client can't drain fast enough. Usually the signal is network,
+   not local CPU.
 
-### 2. Identify which callback you suspect
+Log these via goldfive at INFO to see trends.
 
-The ADK callback paths all funnel through `_AdkState` in `client/harmonograf_client/adk.py`. The common hot spots:
-
-- `_AdkState._on_before_model_callback` — runs on every model call, writes plan context into `session.state`.
-- `_AdkState._on_after_model_callback` — parses the response for reporting-tool function_calls, task markers, state_delta writes.
-- `_AdkState._on_event_callback` — checks transfer / escalate / state_delta events.
-- `_AdkState._on_tool_callback` — dispatches the `report_task_*` tool intercepts.
-- `_AdkState._run_invariants` — the post-walker turn safety net (`client/harmonograf_client/invariants.py`).
-
-### 3. Write a scoped micro-harness
-
-Copy `test_callback_perf.py` wholesale, trim the plan to just the callback you care about, and add direct `perf_counter_ns()` timing around that one callback:
-
-```python
-import time, statistics
-durations = []
-for _ in range(1000):
-    t0 = time.perf_counter_ns()
-    state._on_before_model_callback(ctx, llm_request)
-    durations.append(time.perf_counter_ns() - t0)
-print("p50", statistics.median(durations) / 1_000_000, "ms")
-print("p95", sorted(durations)[int(0.95 * len(durations))] / 1_000_000, "ms")
-```
-
-The existing harness uses `FakeClient` (`test_callback_perf.py:45`) so you don't pay gRPC costs. Reuse that fixture — anything else is a different benchmark.
-
-### 4. Check metrics counters
-
-`state._metrics` is a `ProtocolMetrics`. After the hot loop:
-
-```python
-from harmonograf_client.metrics import format_protocol_metrics
-print(format_protocol_metrics(state._metrics))
-```
-
-Use this to catch cases where a callback quietly started firing 10x as often — that's frequently the real cause of a "slow" run rather than any single call getting slower.
-
-### 5. Use `pytest --durations` for full-suite regressions
+## Sampling the plugin
 
 ```bash
-uv run pytest client/tests --durations=25 -q
+# Attach py-spy to a running agent:
+py-spy top --pid $(pgrep -f my_agent)
+py-spy dump --pid $(pgrep -f my_agent) | head -60
 ```
 
-This gives you the slowest 25 test cases. If your change made `test_callback_perf.py` jump from 120ms to 400ms, it will float to the top immediately.
+Hot frames to expect on a healthy agent:
 
-### 6. Check for invariant-driven slowdown
+- `google.adk.*` (ADK machinery)
+- `goldfive.*` (planner, steerer, detectors)
+- `litellm.*` or the model provider's client
+- Minimal time in `harmonograf_client.*`
 
-`_run_invariants` iterates over every task in the plan on every walker turn. It is O(plan_size × history_depth). For a 50-task plan it's already ~30ms on a cold laptop; a doubled plan is 4x. Grep `check_plan_state` in `client/harmonograf_client/invariants.py` and confirm no new rule is doing an O(n²) scan.
+Hot frames on `harmonograf_client.telemetry_plugin` or
+`harmonograf_client.transport` that exceed single-digit percentage
+of CPU point at a regression in the plugin or the transport.
 
-### 7. Check for state-dict bloat
+## Common regression shapes
 
-`_AdkState._write_plan_context_to_session_state` serializes the plan context into `session.state`. If your change added a large field (e.g. full payload bodies), every callback now pays a JSON copy. Look for this first — it's the most common regression mode.
+1. **Large payload hashing.** A tool or LLM output in the tens of MB
+   pays a `hashlib.sha256` + chunking cost on every emit. Look for
+   hot frames in `client.py::_attach_payload` or
+   `transport.py::_drain_payloads`.
+2. **Attribute dict copies.** The `_stamp_agent_attrs` path copies
+   the attrs dict on first sight of each agent. That cost is bounded
+   (once per `(session_id, agent_id)` pair) but if your change
+   invalidates the cache more aggressively, it multiplies.
+3. **Duplicate plugin (#68).** Silent duplicates don't cost much on
+   callbacks (they short-circuit early), but the initial dedup walk
+   is O(plugins). Not an issue in practice but worth a glance.
 
-### 8. Verification
+## Cross-links
 
-After profiling:
-
-```bash
-uv run pytest client/tests/test_callback_perf.py -x -q
-uv run pytest client/tests --durations=10 -q
-```
-
-Both must still pass. Compare the `--durations` output against a run on `main` to spot regressions.
-
-## Common pitfalls
-
-- **`time.time()` instead of `time.perf_counter_ns()`**: wall clock has millisecond-level jitter that swamps the signal. Always use `perf_counter_ns` for ns-precision timing.
-- **Benchmarking with real gRPC**: the transport loop has its own overhead (~1–5ms per round trip). Profile with `FakeClient` unless you specifically want the end-to-end number.
-- **Counter amnesia**: `ProtocolMetrics` counters are per-`_AdkState` instance. If your test creates a new state each iteration, counters reset. Create it once outside the loop.
-- **Assuming `--durations` catches everything**: `--durations` measures whole test cases, not individual callbacks. A callback that got 10x slower inside a loop of 1000 will still look fine if the whole test takes <1s.
-- **No CI budget enforcement**: the callback-perf test logs but does not assert. If you want to catch regressions in CI, add an explicit assert on `p95` inside your scoped harness. Pick a forgiving number (2x current p95) to avoid flakes.
+- `dev-guide/performance-tuning.md` — the complete hot-path map.
+- `runbooks/high-latency-callbacks.md` — operator-level diagnosis.
+- goldfive docs for planner / detector profiling.

--- a/.agents/skills/hgraf-read-memory-bank/SKILL.md
+++ b/.agents/skills/hgraf-read-memory-bank/SKILL.md
@@ -1,91 +1,110 @@
 ---
 name: hgraf-read-memory-bank
-description: Navigating docs/, AGENTS.md, and the iter16 doc set to get context on any harmonograf subsystem before making changes.
+description: Orient on harmonograf before making changes. Read AGENTS.md, the dev guide, design docs, and key source files in the right order.
 ---
 
 # hgraf-read-memory-bank
 
 ## When to use
 
-You are starting work on a harmonograf task and need orientation on a subsystem you haven't touched. Instead of grep-walking the code from scratch, read the curated documents in the right order. This skill is an index to the "memory bank" — the human-written docs that explain *why* the code looks the way it does.
+You're starting work on a harmonograf task and need orientation on a
+subsystem you haven't touched. This is the "first 10 minutes of any
+non-trivial task" skill.
 
-Use this as the first 5-10 minutes of any non-trivial task.
+## Reading order
 
-## Prerequisites
+### Layer 1 — project-level (always read first)
 
-None. All files referenced are in-repo.
+1. **`AGENTS.md`** — project vision + high-level architecture.
+2. **`README.md`** — external framing and quickstart.
+3. **`docs/dev-guide/index.md`** — map of the developer documentation.
 
-## The reading order
+### Layer 2 — dev-guide chapters (pick based on task)
 
-### Layer 1 — project-level (always read first, < 5 minutes)
+- **`dev-guide/setup.md`** — boot the stack locally.
+- **`dev-guide/architecture.md`** — the three-component (client /
+  server / frontend) map.
+- **`dev-guide/client-library.md`** — `HarmonografTelemetryPlugin`,
+  `HarmonografSink`, lazy Hello, per-agent attribution, plugin
+  dedup, cancellation sweep.
+- **`dev-guide/server.md`** — ingest pipeline, bus, storage,
+  auto-register agents, intervention aggregator, RPC surface
+  (`WatchSession`, `ListInterventions`, `PostAnnotation`, …).
+- **`dev-guide/frontend.md`** — stores, views, InterventionsTimeline,
+  per-agent Gantt rows.
+- **`dev-guide/working-with-protos.md`** — proto layout,
+  forward-compat rules, codegen.
+- **`dev-guide/storage-backends.md`** — Store ABC + SQLite schema.
+- **`dev-guide/migration.md`** — goldfive migration, overlay era,
+  lazy Hello era, per-agent rows era.
 
-1. **`AGENTS.md`** — project vision + high-level architecture + the *Plan execution protocol* section. The protocol section is load-bearing: it explains the three coordinated channels (session.state / reporting tools / ADK callback inspection) and the three orchestration modes (Sequential / Parallel / Delegated). If you skip this you will end up fighting the state machine.
-2. **`README.md`** — external framing. Usually less useful than AGENTS.md but occasionally has setup quirks that the dev docs omit.
-3. **[`docs/operator-quickstart.md`](../../../docs/operator-quickstart.md)** — how to boot the stack, the prompt you drive, what you should see. Complement to the `hgraf-run-demo` skill.
-4. **[`docs/reporting-tools.md`](../../../docs/reporting-tools.md)** — full reference for the reporting tools (see `hgraf-add-reporting-tool`). Read this before touching anything in `client/harmonograf_client/tools.py` or `before_tool_callback`.
+### Layer 3 — user-guide (for UX context)
 
-### Layer 2 — subsystem docs (pick based on task)
+- **`user-guide/trajectory-view.md`** — the plan review and
+  intervention history surface. Read before touching intervention-
+  related code.
+- **`user-guide/gantt-view.md`** — per-agent rows, cross-agent edges,
+  cross-links to controls.
+- **`user-guide/tasks-and-plans.md`** — the overlay-era task state
+  machine and the drift kind taxonomy.
+- **`user-guide/control-actions.md`** — STEER / CANCEL / PAUSE
+  semantics, body validation, idempotency.
 
-`docs/design/` contains numbered design documents. Start with the one closest to your task area:
+### Layer 4 — design docs
 
-- **[`01-data-model-and-rpc.md`](../../../docs/design/01-data-model-and-rpc.md)** — the shared data model (agent/span/task/plan/annotation) and the proto-level RPC shape. Required reading before `hgraf-add-proto-field`.
-- **[`02-client-library.md`](../../../docs/design/02-client-library.md)** — the pre-ADK design of the client library. Historical but still accurate for the transport layer.
-- **[`03-server.md`](../../../docs/design/03-server.md)** — server architecture intent (pre-ingest refactor). Read alongside [`11-server-architecture.md`](../../../docs/design/11-server-architecture.md).
-- **[`04-frontend-and-interaction.md`](../../../docs/design/04-frontend-and-interaction.md)** — early UX intent. Read alongside [`10-frontend-architecture.md`](../../../docs/design/10-frontend-architecture.md) and [`13-human-interaction-model.md`](../../../docs/design/13-human-interaction-model.md).
-- **[`10-frontend-architecture.md`](../../../docs/design/10-frontend-architecture.md)** — the **current** Gantt + shell architecture. This is the authoritative reference for frontend changes. Cross-reference with `hgraf-update-frontend-component` and `hgraf-add-gantt-overlay`.
-- **[`11-server-architecture.md`](../../../docs/design/11-server-architecture.md)** — the **current** server architecture (ingest / bus / storage / control router). Authoritative for `server/harmonograf_server/` edits.
-- **[`12-client-library-and-adk.md`](../../../docs/design/12-client-library-and-adk.md)** — the **current** client architecture including the ADK adapter, the `_AdkState` design, and why `adk.py` is 5700 lines. **Mandatory reading** before touching `adk.py` — see `hgraf-safely-modify-adk-py`.
-- **[`13-human-interaction-model.md`](../../../docs/design/13-human-interaction-model.md)** — the "what does a user actually do with this console" document. Read when designing new UI affordances.
-- **[`14-information-flow.md`](../../../docs/design/14-information-flow.md)** — the end-to-end data path: agent emits → client buffers → server ingests → bus fans out → frontend renders. Best single document for understanding a bug that crosses component boundaries.
+`docs/design/` numbered ADRs and architecture notes. Look up by
+topic (data model, protocol, internals). Often older than the
+dev-guide — cross-check.
 
-### Layer 3 — research + rationale
+### Layer 5 — runbooks
 
-- **[`docs/research/hci-orchestration-paper.md`](../../../docs/research/hci-orchestration-paper.md)** — the HCI paper that informs the console's interaction model. Read when deciding whether a new feature is aligned with the project's theoretical grounding (e.g. "should this be pull-based or push-based").
+`docs/runbooks/*.md` — operator-oriented symptom → cause → fix.
+Useful even when writing code because they enumerate real failure
+modes.
 
-### Layer 4 — milestones + changelog
+## Key source anchors
 
-- **[`docs/milestones.md`](../../../docs/milestones.md)** — the sequence of iteration goals. Useful to understand "why was X merged in iter12 with a rough edge that iter14 cleaned up." Check this before rewriting something — the history is often why it is what it is.
+When the docs and the code disagree, **the code is the ground truth**.
+Anchor your reading with these files:
 
-## What to read for common tasks
+- Client plugin: `client/harmonograf_client/telemetry_plugin.py`
+  (~1150 lines).
+- Client sink: `client/harmonograf_client/sink.py`.
+- Client control bridge: `client/harmonograf_client/_control_bridge.py`.
+- Server ingest: `server/harmonograf_server/ingest.py`.
+- Server intervention aggregator: `server/harmonograf_server/interventions.py`.
+- Server storage: `server/harmonograf_server/storage/sqlite.py`.
+- Proto: `proto/harmonograf/v1/{types,telemetry,frontend,control,service}.proto`.
+- Frontend session store: `frontend/src/gantt/index.ts`.
+- Frontend intervention deriver: `frontend/src/lib/interventions.ts`.
+- Frontend InterventionsTimeline: `frontend/src/components/Interventions/InterventionsTimeline.tsx`.
+- Keyboard shortcuts: `frontend/src/lib/shortcuts.ts`.
+
+## Task → recommended reading
 
 | Task | Read in this order |
 |---|---|
-| Add drift kind | AGENTS.md (protocol section) → `12-client-library-and-adk.md` → `10-frontend-architecture.md` → `driftKinds.ts` |
-| Add proto field | `01-data-model-and-rpc.md` → `11-server-architecture.md` → `12-client-library-and-adk.md` |
-| Modify ingest path | `11-server-architecture.md` → `14-information-flow.md` → `server/harmonograf_server/ingest.py` |
-| Add Gantt overlay | `10-frontend-architecture.md` → `14-information-flow.md` → existing ContextWindowSample implementation |
-| Modify orchestration | AGENTS.md (protocol section) → `12-client-library-and-adk.md` → `adk.py` (see `hgraf-safely-modify-adk-py`) |
-| Debug stuck task | AGENTS.md → `hgraf-debug-task-stuck` skill → `invariants.py` |
-| Design new UX | [`13-human-interaction-model.md`](../../../docs/design/13-human-interaction-model.md) → [`docs/research/hci-orchestration-paper.md`](../../../docs/research/hci-orchestration-paper.md) |
-
-## Cross-references to code ground truth
-
-When the docs and the code disagree, **the code is the ground truth** (docs drift between iterations). Anchor your reading with these key files:
-
-- Protocol constants: `client/harmonograf_client/state_protocol.py:86-126` (KEY_ names + ALL_KEYS)
-- Orchestration modes: `client/harmonograf_client/agent.py:207-470` (HarmonografAgent class)
-- State machine: `client/harmonograf_client/adk.py:242-280` (_set_task_status) + `invariants.py:41-55` (allowed transitions)
-- Drift taxonomy: `client/harmonograf_client/adk.py:326-378` + `frontend/src/gantt/driftKinds.ts:30-58`
-- Bus deltas: `server/harmonograf_server/bus.py:25-65`
-- SQLite schema: `server/harmonograf_server/storage/sqlite.py:45-170`
-- Gantt renderer: `frontend/src/gantt/renderer.ts:1-97`
+| Add a drift kind | goldfive docs first → `user-guide/tasks-and-plans.md` → `dev-guide/server.md#listinterventions-71` → `frontend/src/lib/interventions.ts` |
+| Add a proto field | `dev-guide/working-with-protos.md` → relevant `.proto` file → `convert.py` → frontend `rpc/convert.ts` |
+| Modify ingest | `dev-guide/server.md` → `server/harmonograf_server/ingest.py` |
+| Add a Gantt overlay | `dev-guide/frontend.md` → `frontend/src/gantt/renderer.ts` → `ContextWindowBadgeStrip` as a reference |
+| Debug stuck task | `runbooks/task-stuck-in-{pending,running}.md` → `dev-guide/debugging.md` |
+| Understand the intervention timeline | `user-guide/trajectory-view.md` → `server/harmonograf_server/interventions.py` → `frontend/src/lib/interventions.ts` + `InterventionsTimeline.tsx` |
 
 ## Verification
 
-You know you have read enough when you can answer:
-1. Which of the three orchestration modes does your task apply to?
-2. Which of the three drift detection paths (detect_drift / after_model_callback / before_tool_callback) does your signal route through?
-3. Which `DELTA_*` kind does your change emit, if any?
-4. Which sqlite table does your change read or write, if any?
-5. Which frontend store subscribes to the resulting update?
+You've read enough when you can answer:
 
-If any answer is "I don't know," re-read the relevant design doc before writing code.
-
-## Common pitfalls
-
-- **Skipping AGENTS.md because "I already read it."** The protocol section changes with iterations. Re-skim it if you haven't touched the project in a month.
-- **Trusting `02-client-library.md` over `12-client-library-and-adk.md`.** The early design docs describe intent; the later ones describe reality. When they disagree, the higher-numbered one wins.
-- **Reading `milestones.md` as authoritative.** It is a log, not a spec. Useful for archaeology, not for deciding current behavior.
-- **Ignoring code when docs are clear.** Even the current design docs lag the code by ~1 iteration. Always cross-check against the files listed above before making assumptions.
-- **Leaving the memory bank unchanged after a large PR.** If you land something that invalidates a doc, fix the doc in the same PR. Otherwise the next agent reads stale context and repeats your investigation. See task #5-#8 in the original milestone docs for how the docs have been maintained historically.
-- **Expecting skills to replace docs.** The skills in `.claude/skills/` are task recipes. The docs in `docs/design/` are architecture. Read docs for "why," read skills for "how."
+1. Which harmonograf surface does my change cross (proto, client,
+   server, frontend, storage)?
+2. Which goldfive surface does my change interact with (events,
+   detectors, planner, steerer)? Is this actually a goldfive change?
+3. Does my change affect the intervention aggregator? If yes, do
+   both the server (`interventions.py`) and the frontend
+   (`lib/interventions.ts`) need updates?
+4. Does my change require a sqlite migration? If yes, update
+   `SCHEMA` + the backfill block in `SqliteStore.start()`.
+5. Does my change affect the InterventionsTimeline's render? If
+   yes, eyeball the dev-guide/frontend.md "InterventionsTimeline"
+   section and verify the component's invariants (stable X anchor,
+   clustering, deterministic popover).

--- a/.agents/skills/hgraf-refine-plan-lineage/SKILL.md
+++ b/.agents/skills/hgraf-refine-plan-lineage/SKILL.md
@@ -1,131 +1,92 @@
 ---
 name: hgraf-refine-plan-lineage
-description: Understand revision_index, supersession, drift throttling, and terminal-status preservation when refining plans; how to test refine chains end-to-end.
+description: Understand revision_index and plan lineage. Plan refine logic moved to goldfive; harmonograf only stores + renders the revisions.
 ---
 
 # hgraf-refine-plan-lineage
 
 ## When to use
 
-You are touching the refine path — the code that rewrites a live `Plan` in response to drift. This is one of the most intricate subsystems in harmonograf because every refine must preserve history, increment lineage, re-canonicalize assignees, and keep the Gantt's plan-revision banner coherent.
+You're touching how harmonograf reads or renders plan-revision
+history — revision banners, the trajectory view's rev chips, the
+intervention aggregator's outcome attribution, or the SQLite
+`task_plans.revision_*` columns.
 
-## Prerequisites
-
-1. Read the proto fields that encode lineage: `proto/harmonograf/v1/types.proto:258-287`:
-   - `TaskPlan.revision_reason` — free-text human summary (set at `adk.py:3483`).
-   - `TaskPlan.revision_kind` — structured drift kind (`tool_error`, `new_work_discovered`, `wrong_agent`, …) used by the frontend for icons/filters.
-   - `TaskPlan.revision_severity` — `"info" | "warning" | "critical"`.
-   - `TaskPlan.revision_index` — monotonic counter within a lineage, 0 for initial, +1 each refine.
-2. Read `client/harmonograf_client/adk.py :: _apply_refined_plan` at `adk.py:3461-3540` — the canonical swap-in path.
-3. Read `client/harmonograf_client/adk.py :: refine_plan_on_drift` around `adk.py:3283-3430` — the throttle, the drift-kind dispatch, the call into `_apply_refined_plan`.
-4. Read `_DRIFT_REFINE_THROTTLE_SECONDS` at `adk.py:378` — currently 2.0s per (session, drift kind).
-5. Read the frontend diff computation: `frontend/src/gantt/index.ts :: computePlanDiff`. This is the code the UI uses to render "added / removed / changed" in the revision banner.
+The *refine decision logic* (when to refine, what drift kind to
+attribute, how to compose the LLM prompt) is in goldfive — see
+`goldfive.planner.*` and `goldfive.DefaultSteerer`. This skill
+covers the harmonograf side only.
 
 ## Conceptual model
 
-A **lineage** is a sequence of `TaskPlan` snapshots that share the same `plan_id`. Each snapshot has a `revision_index`:
+A **lineage** is a sequence of `TaskPlan` rows sharing the same
+`plan_id`. Each row has a `revision_index`:
 
-- `revision_index = 0` — initial plan from `PlannerHelper.generate()`.
-- `revision_index = N` — Nth refine.
+- `revision_index = 0` — initial plan (goldfive's first
+  `PlanSubmitted`).
+- `revision_index = N` — Nth refine (goldfive's Nth `PlanRevised`).
 
-The **server stores every revision** (see `server/harmonograf_server/storage/sqlite.py:121-149 task_plans` table). The `revision_index` column means we can query historical revisions for a given plan and rebuild lineage offline.
+Four columns encode lineage:
 
-The **client only holds the latest revision** in `PlanState.plan`; the server fans out the wire `TaskPlan` message on each upsert.
+| Column | Role |
+|---|---|
+| `revision_index` | Monotonic within a `plan_id`. |
+| `revision_kind` | Lowercase drift kind that caused the revise (`user_steer`, `tool_error`, `looping_reasoning`, `cascade_cancel`, …). Empty for `revision_index=0`. |
+| `revision_severity` | `info` / `warning` / `critical`. |
+| `revision_reason` | Free-text human summary from the planner. |
 
-**Supersession**: when `refine_plan_on_drift` decides to replace the plan, the old `PlanState` instance is logged as "superseded stale PlanState" (`adk.py:1822`). A fresh instance carries the same `plan_id` but a new `revision_index`. The wire message is a full `TaskPlan`, not a delta — the server treats it as upsert-by-id.
+See `server/harmonograf_server/storage/sqlite.py` for the SCHEMA
+and the backfill `ALTER TABLE` block.
 
-## Step-by-step recipes
+## Wire path
 
-### Adding a new drift kind that refines
+1. Goldfive emits `PlanSubmitted` (initial) or `PlanRevised` events.
+2. The client sends them as `TelemetryUp.goldfive_event` envelopes.
+3. `server/harmonograf_server/ingest.py` dispatches to
+   `_handle_plan_submitted` / `_handle_plan_revised`.
+4. The handler stores the new `TaskPlan` row (new `revision_index`)
+   and publishes a delta on the bus.
+5. Frontend's `TaskRegistry.upsert(plan)` runs `computePlanDiff`
+   against the previous revision and stores a `PlanRevision`.
 
-1. Add the drift kind to `DriftReason` enum in `adk.py`. Grep `class DriftReason` to find it.
-2. Add a throttle entry in `_DRIFT_REFINE_THROTTLE_SECONDS` or leave the default 2.0s.
-3. Decide severity: `"info"` / `"warning"` / `"critical"`. Critical bypasses the throttle (see `refine_plan_on_drift`).
-4. Emit the drift from wherever the new drift is detected (tool callback, after-model-callback, walker) via `self.refine_plan_on_drift(hsession_id, DriftReason(kind=..., severity=..., reason_text=...))`.
-5. The rest is automatic: `_apply_refined_plan` stamps `revision_reason`, `revision_kind`, `revision_severity`, bumps `revision_index`, preserves terminal statuses, and publishes the upsert.
+## Intervention aggregator interplay
 
-See the companion skill `hgraf-add-drift-kind.md` in batch 1 for the full DriftReason plumbing.
+`server/harmonograf_server/interventions.py` joins revisions with
+drifts + annotations. Two important mechanics:
 
-### Changing how terminal statuses are preserved
+- **Attribution.** A drift that fired within `_OUTCOME_WINDOW_S`
+  (5 s) before a `PlanRevised` gets the `plan_revised:rN` outcome
+  label. User-control drifts use `_USER_OUTCOME_WINDOW_S` (300 s)
+  because the planner's refine LLM takes tens of seconds on local
+  models.
+- **Dedup by annotation_id.** When a user STEER causes a revise,
+  three rows land (annotation, USER_STEER drift, PlanRevised
+  row). They collapse onto the annotation row via `_merge_by_annotation_id`.
 
-`_apply_refined_plan` reads `plan_state.tasks` and carries `RUNNING/COMPLETED/FAILED/CANCELLED` statuses forward into the new plan regardless of what the LLM returned. Code at `adk.py:3494-3520`.
+## UI path
 
-- **Do not remove this preservation.** A refine that forgets a COMPLETED task is a regression the UI cannot heal — the Gantt loses the historical bar.
-- The set of preserved statuses is `_TERMINAL_TASK_STATUSES` (grep for it). `RUNNING` is also preserved so the frontend doesn't flash-back to PENDING when the refine arrives mid-execution.
-- If you need a status that should NOT be preserved (e.g. a new "PAUSED"), add it to the mutable set explicitly.
+- `docs/user-guide/trajectory-view.md` describes the ribbon + rev
+  chips the Trajectory view renders from the lineage.
+- `frontend/src/gantt/index.ts :: computePlanDiff` computes the
+  diff between successive revisions. Updates to `Task` shape must
+  keep this in sync.
 
-### Testing refine lineage end-to-end
+## Pitfalls
 
-The reference tests are in `client/tests/test_dynamic_plans_real_adk.py` using scripted `FakeLlm`. Minimal pattern:
+- **Don't rewrite history.** `revision_index` is monotonic. If you
+  re-ingest an event with a lower index, the UI will just ignore
+  it. The server does not overwrite higher-indexed revisions.
+- **Empty `revision_kind` on revisions.** Goldfive should stamp a
+  kind on every revision beyond 0. An empty kind on a non-zero
+  revision surfaces as an unattributed intervention in the
+  aggregator; chase it upstream.
+- **Plan id collisions across sessions.** Plans are scoped by
+  `session_id`; `plan_id` is unique per session but not globally.
+  When joining for cross-session analytics, include both keys.
 
-```python
-# 1. Arrange: fake LLM with two plan responses
-fake = FakeLlm()
-fake.responses = [plan_v0_response, plan_v1_response]
+## Cross-links
 
-# 2. Generate initial plan (revision_index=0)
-ps = planner_helper.generate(...)
-assert ps.revision_index == 0
-
-# 3. Fire a drift
-_adk_state.refine_plan_on_drift(hsession_id, DriftReason(kind="tool_error", ...))
-
-# 4. Assert lineage bumped
-ps2 = _adk_state.get_plan_state(hsession_id)
-assert ps2.plan.revision_index == 1
-assert ps2.plan.revision_kind == "tool_error"
-assert all(t.id in ps2.tasks for t in ps.tasks if t.status == "COMPLETED")  # preservation
-```
-
-For multi-step refine chains, enqueue more responses and fire drifts in sequence. The assertion is always: `revision_index` is strictly monotonic, terminal statuses preserved, `plan_id` stable.
-
-### Testing the throttle
-
-Fire the same drift kind twice within 2 seconds:
-
-```python
-_adk_state.refine_plan_on_drift(hsession_id, DriftReason(kind="tool_error"))
-_adk_state.refine_plan_on_drift(hsession_id, DriftReason(kind="tool_error"))
-# Only one refine should have happened; revision_index bumped by 1, not 2.
-```
-
-Then wait past the throttle window (use a `now_fn` injection or monkeypatch `time.monotonic`) and fire again — this time it should refine.
-
-### Visualizing lineage in the UI
-
-`frontend/src/components/shell/PlanRevisionBanner.tsx` reads the current `PlanRevision` list from the session store. Each revision has `revisionIndex`, `revisionKind`, `revisionSeverity`, `revisionReason`. Clicking a revision in the banner opens a diff via `computePlanDiff(current, previous)` in `frontend/src/gantt/index.ts`.
-
-To add a new banner field (e.g. a timestamp), follow the chain:
-1. Proto field on `TaskPlan`.
-2. Store column in `sqlite.py task_plans`.
-3. Convert in `server/harmonograf_server/convert.py`.
-4. UI type in `frontend/src/gantt/types.ts` (or wherever `PlanRevision` is defined).
-5. Render in `PlanRevisionBanner.tsx`.
-
-### Throttling retune
-
-If a drift kind is firing too often:
-- Increase the per-kind throttle seconds.
-- Or upgrade the severity to `critical` to bypass throttle — be careful, that's the opposite of quieting.
-
-If a drift kind is firing too rarely:
-- Confirm it isn't being suppressed by an upstream detector that runs before `detect_drift` (e.g. a callback that already consumed the response).
-- Lower the throttle.
-
-## Verification
-
-```bash
-uv run pytest client/tests/test_dynamic_plans_real_adk.py -x -q
-uv run pytest client/tests/test_drift_taxonomy.py -x -q
-uv run pytest client/tests/test_adk_adapter.py -x -q -k refine
-cd frontend && pnpm test -- --run PlanRevisionBanner
-```
-
-## Common pitfalls
-
-- **Forgetting to bump `revision_index`**: a refine that leaves the index unchanged gets deduped by the server-side upsert and the UI never shows it.
-- **Dropping terminal preservation**: breaks history. Never short-circuit the `preserved_statuses` loop.
-- **Replacing `plan_id`**: creates a new lineage rather than refining the existing one. The UI shows a disconnected second plan — usually wrong. Always reuse the `plan_id` from the existing `PlanState`.
-- **Drift firing inside the refine**: if `_apply_refined_plan` mutates state that a callback watches, you can recursively fire refine. Critical drifts bypass the throttle, so a bug here is an infinite loop. The lock at `adk.py:3493` serializes refines, but cross-session loops still happen — test with two concurrent sessions.
-- **Ignoring the `revision_severity` contract**: the frontend assumes exactly `"info" | "warning" | "critical"`. An empty string (the default) means "initial plan". Any other string silently renders with the default icon — easy to miss in review.
-- **Refusing to canonicalize**: `_canonicalize_plan_assignees` at `adk.py:3478` rewrites bad assignee ids to the host agent. If you skip it, the LLM's hallucinated agent ids appear in the Gantt as missing rows.
+- `dev-guide/server.md#listinterventions-71` — aggregator internals.
+- `dev-guide/storage-backends.md#task-plans` — schema columns.
+- `user-guide/trajectory-view.md` — user-facing render.
+- goldfive docs for the decision logic.

--- a/.agents/skills/hgraf-review-pr/SKILL.md
+++ b/.agents/skills/hgraf-review-pr/SKILL.md
@@ -11,9 +11,17 @@ You've been asked to review a PR on the harmonograf repo, or you're self-reviewi
 
 ## Prerequisites
 
-1. Read `AGENTS.md` at the repo root — the project vision, the three-component architecture, the plan execution protocol (`session.state` + reporting tools + callback inspection).
-2. Know which batch-1 / batch-2 skill applies to the area being changed. For example: a proto field change should be reviewed against `hgraf-add-proto-field.md`; a drift kind change against `hgraf-add-drift-kind.md`. This review skill is the meta layer — it asks whether the right sub-skill was followed.
-3. Have the PR checked out locally. Don't review from the web UI alone — you'll miss generated-file drift and cross-layer incoherence.
+1. Read `AGENTS.md` at the repo root — the project vision, the
+   three-component architecture.
+2. Know which sibling skill applies to the area being changed
+   (`hgraf-add-proto-field`, `hgraf-add-drift-kind`,
+   `hgraf-migrate-sqlite-schema`, etc.). This review skill is the
+   meta layer — it asks whether the right sub-skill was followed.
+3. Have the PR checked out locally. Don't review from the web UI
+   alone — you'll miss generated-file drift and cross-layer
+   incoherence.
+4. No Claude / AI co-author trailer. Maintainer scrubs them; flag
+   any that slipped in.
 
 ## The review passes
 

--- a/.agents/skills/hgraf-run-demo/SKILL.md
+++ b/.agents/skills/hgraf-run-demo/SKILL.md
@@ -28,12 +28,21 @@ Do **not** use this skill for unit-level work. Prefer `tests/e2e/test_scenarios.
    ```
    See `Makefile` targets `proto-python` and `proto-ts`. `proto-ts` requires `frontend/buf.gen.yaml`; if missing it silently skips.
 
-3. An OpenAI API key in the environment. The demo reads `OPENAI_API_KEY`; if unset, the Makefile falls back to the literal string `"dummy"` which will fail on the first model call. Export a real key:
+3. An LLM endpoint in the environment. The demo uses an
+   OpenAI-compatible endpoint (kikuchi, vLLM, Ollama gateway):
    ```bash
-   export OPENAI_API_KEY=sk-...
+   export KIKUCHI_LLM_URL=http://localhost:18000
+   export USER_MODEL_NAME=openai/qwen3.5-35b          # default
+   export GOLDFIVE_EXAMPLE_PLANNER_MODEL=openai/qwen3.5-35b  # optional override for planner
    ```
+   For Gemini-backed demos, set `GOOGLE_API_KEY` or `GEMINI_API_KEY`
+   instead.
 
-4. Ports free: **7531** (gRPC server), **5173** (Vite), **8080** (adk web). Override with `SERVER_PORT=`, `FRONTEND_PORT=`, `ADK_WEB_PORT=` (see `Makefile:demo`).
+4. Ports free: **7531** (native gRPC), **5174** (gRPC-Web for the
+   browser), **5173** (Vite dev server), **8080** (adk web).
+   Override with `SERVER_PORT=`, `FRONTEND_PORT=`, `ADK_WEB_PORT=`
+   (see `Makefile:demo`). Do not confuse 5173 (Vite) with 5174
+   (gRPC-Web); the Vite server talks to 5174 over the network.
 
 ## Step-by-step
 
@@ -66,7 +75,23 @@ You should see:
 - Open the **Harmonograf UI** at `http://127.0.0.1:5173` in a second tab. You should see a new session appear in the session list within ~1s of the first span.
 - Click the session to open the Gantt. Spans stream in live.
 
-The presentation agent itself is defined in `tests/reference_agents/presentation_agent/agent.py`. It is instrumented through `HarmonografAgent` which auto-registers reporting tools into every `LlmAgent` in its sub-tree (`client/harmonograf_client/agent.py:335-355` — `_auto_register_reporting_tools`).
+The presentation agent itself is defined in
+`tests/reference_agents/presentation_agent/agent.py`. It's a plain
+ADK agent tree wrapped via `goldfive.wrap(...)` plus
+`HarmonografTelemetryPlugin` for span telemetry. Goldfive's
+`ADKAdapter` auto-injects its reporting tools (`report_task_started`,
+`report_task_completed`, …) into every sub-agent; harmonograf's
+plugin observes and emits spans.
+
+Two variants appear in ADK web's agent picker:
+
+- `presentation_agent` — observation mode (plain ADK tree with
+  `HarmonografTelemetryPlugin`, no goldfive wrap).
+- `presentation_agent_orchestrated` — orchestration mode (same tree
+  wrapped with `goldfive.wrap(...)`). This is where you see plans,
+  drifts, STEERs, and the full intervention history. Per-agent
+  Gantt rows (#80) render here — coordinator + specialists each on
+  their own row.
 
 ### 3. Tail logs
 
@@ -106,7 +131,13 @@ sqlite3 data/harmonograf.sqlite "SELECT id, title, status, started_at FROM sessi
 
 ## Common pitfalls
 
-- **`OPENAI_API_KEY=dummy` is the default fallback.** The Makefile uses `$${OPENAI_API_KEY:-dummy}`. If your first call fails with `401 Unauthorized` you forgot to export a real key.
+- **`KIKUCHI_LLM_URL` unset.** If your first call errors with a
+  connection refusal, you forgot to export the URL or the local
+  kikuchi / vLLM / Ollama process isn't running. `curl
+  "$KIKUCHI_LLM_URL/v1/models"` confirms reachability.
+- **Lazy Hello (#85) means the session doesn't appear until the
+  first span emits.** Send a turn to the agent before panicking
+  that the picker is empty.
 - **Port collisions.** `pnpm dev --strictPort` will refuse to start if 5173 is taken; the trap in `make demo` will then kill the server and adk web too because `bash -eu` exits. Either free the port or set `FRONTEND_PORT=5174`.
 - **`.demo-agents/` is regenerated every run.** Do not edit files under `.demo-agents/` — your changes are wiped. Edit `tests/reference_agents/presentation_agent/agent.py` instead; the passthrough loads it by absolute file path (see `Makefile:.demo-agents-stage`).
 - **Symlinks under `.demo-agents/` will break ADK.** ADK's `_resolve_agent_dir` calls `Path.resolve()` and refuses paths that escape the agents root. The passthrough pattern in the Makefile is load-bearing — do not "simplify" it to a symlink.

--- a/.agents/skills/hgraf-safely-modify-adk-py/SKILL.md
+++ b/.agents/skills/hgraf-safely-modify-adk-py/SKILL.md
@@ -1,158 +1,73 @@
 ---
 name: hgraf-safely-modify-adk-py
-description: Survival guide for editing client/harmonograf_client/adk.py — the 5700-line ADK adapter. Covers _AdkState invariants, state transition discipline, the Aclosing wrapper, ContextVars, and happens-before constraints.
+description: Retained for history. `client/harmonograf_client/adk.py` is gone — the ADK adapter logic moved to goldfive. For ADK plugin work today, see the small `telemetry_plugin.py`.
 ---
 
 # hgraf-safely-modify-adk-py
 
-## When to use
+## This skill is historical
 
-You are about to touch `client/harmonograf_client/adk.py`. This file is ~5900 lines, coordinates 20+ ADK callbacks, owns the in-memory task state for every session, and is the single point where drift detection, plan refinement, task classification, and telemetry emission come together. Mistakes here are the most expensive class of bug in the whole project because they break state monotonicity without obvious symptoms at the edit site.
+`client/harmonograf_client/adk.py` (the 5900-line ADK adapter that
+owned drift detection, plan walker, reporting-tool interception, and
+the task state machine) was deleted during the goldfive migration
+(issue #2, mid-2025). That surface is gone.
 
-Read this skill *before* you open the file. If it's too long, the minimum version is: **every status change goes through `_set_task_status`, every task_id routing goes through ContextVars, never directly mutate `_AdkState` fields from outside the class, and never call `planner.refine()` directly.**
+The current harmonograf client has:
 
-## Prerequisites
+- `client/harmonograf_client/telemetry_plugin.py` (~1150 lines) —
+  an ADK `BasePlugin` that emits spans from ADK lifecycle callbacks.
+  Pure observability, no orchestration, no invariants.
+- `client/harmonograf_client/sink.py` — `HarmonografSink`, a
+  `goldfive.EventSink` that passes `goldfive.v1.Event`s through the
+  transport as `TelemetryUp.goldfive_event`.
+- `client/harmonograf_client/_control_bridge.py` — the bridge between
+  harmonograf's control channel and goldfive's steerer. Does STEER
+  body validation (#72) and forwards controls.
 
-1. Read `AGENTS.md` → *Plan execution protocol* section.
-2. Read [`docs/design/12-client-library-and-adk.md`](../../../docs/design/12-client-library-and-adk.md) end-to-end.
-3. Read `client/harmonograf_client/invariants.py` (short, ~100 lines) — that is the validator that will catch you if you break monotonicity.
-4. Have the file open at these anchor points so you can jump between them:
+## If you were reaching for this skill today
 
-| Line range | Symbol | What it does |
-|---|---|---|
-| 242-280 | `_set_task_status(task, new_status)` | Monotonic state machine guard. All transitions go through here. |
-| 294-313 | `class PlanState` | Session-keyed plan storage holding tasks, edges, available_agents. |
-| 320-322 | `_forced_task_id_var: ContextVar` | Task-local forced task id for parallel walker. |
-| 326-378 | `DriftReason` + `DRIFT_KIND_*` + throttle constants | The drift taxonomy. |
-| 1227-1276 | `after_model_callback` | LLM response parsing + agency drift detection. |
-| 1299-1316 | `before_tool_callback` | Reporting-tool interception. |
-| 1391-1409 | `on_event_callback` | Session delta router + harmonograf-agent inner substitution. |
-| 1591-1705 | `class _AdkState` | In-flight span tracker, session→plan map, span→task map, lock, pending mutations. |
-| 1656-1659 | `_current_root_hsession_var` | Per-instance ContextVar for root session id. |
-| 1661-1663 | `_route_tokens` | invocation_id → ContextVar token (for LIFO reset). |
-| 1863-1920 | `maybe_run_planner` | Planner entrypoint. |
-| 2608-2720 | `classify_and_sweep_running_tasks` | Periodic classifier sweeper. |
-| 2917-3050 | `detect_drift` | Span/event-driven drift detection. |
-| 3256-3350 | `refine_plan_on_drift` | Refine entry — the only place planner.refine() is called. |
+Pick the right one:
 
-## The invariants that matter
+- **Editing `telemetry_plugin.py`** — read the inline docstring at
+  the top of the file and the "Per-agent attribution (#80)" section
+  in `dev-guide/client-library.md`. Invariants to preserve:
+  per-invocation FIFO for model-call pairing; dedup guard
+  (`_maybe_disable_as_duplicate`); root-session rollup; cancellation
+  sweep (`on_cancellation`); `hgraf.agent.*` first-sight stamp.
 
-These are not enforced by the compiler. Break them and you get silent state corruption that surfaces as "stuck task" or "wrong lane" hours later.
+- **Editing `_control_bridge.py`** — preserve STEER body validation
+  (`STEER_BODY_MAX_BYTES = 8192`), control-character sanitation, and
+  `author` / `annotation_id` propagation.
 
-### I1. Monotonic status transitions
+- **Orchestration logic** — goldfive repo. Look at
+  `goldfive.adapters.adk.ADKAdapter`, `goldfive.DefaultSteerer`,
+  `goldfive.planner.*`, `goldfive.detectors.*`.
 
-Status flows are: `PENDING → RUNNING → (COMPLETED | FAILED | CANCELLED)`. Once terminal, no further transitions. `_set_task_status` at lines 242-280 enforces this. Everywhere that changes a task's status **must** go through it. Never write `task.status = X` from outside `_AdkState`.
+- **Task state machine / invariants** — goldfive. Harmonograf has
+  no invariant validator for task state post-migration.
 
-The allowed-transition table lives in `invariants.py:41-55` (`_ALLOWED_TRANSITIONS`); the runtime validator at `invariants.py:78-100` checks it after walker turns. A violation logs a warning but does not roll back — by then you've already polluted the state.
+## Still-applicable general discipline
 
-### I2. Lock discipline
+A few discipline items that apply to any ADK-side Python code in
+this repo:
 
-`_AdkState._lock` is an `asyncio.Lock`. All reads and writes to `_active_plan_by_session`, `_span_to_task`, `_invocations`, `_llm_by_invocation`, `_tools`, `_long_running`, `_pending_mutations` must happen under the lock. The class methods acquire it; external callers should go through class methods, not poke fields directly.
+1. **Telemetry must not raise.** Every callback in
+   `telemetry_plugin.py` swallows exceptions with a DEBUG log.
+   Breaking this makes a telemetry bug break the user's agent.
+2. **Don't block in callbacks.** ADK callbacks run on the event
+   loop. Anything longer than a ring-buffer push belongs behind a
+   queue.
+3. **Context handoff between Context objects is fragile.** ADK
+   rebuilds `CallbackContext` between before/after hooks. Use
+   `invocation_id` as the key, not `id(ctx)`. The plugin does this;
+   preserve it.
+4. **Duplicate-install guard.** The plugin can be installed twice
+   under `goldfive.wrap` + `adk web`. Don't route any state through
+   a side channel that the dedup guard wouldn't silence. See #68.
 
-Under `parallel_mode=True`, the walker spawns concurrent sub-invocations that race on these fields. Without the lock you get lost updates.
+## Cross-links
 
-### I3. Happens-before on `pending_mutations`
-
-`_pending_mutations` is a deferred-write queue: mutations prepared under one callback apply during the next one. This lets the state machine be consistent at callback boundaries without holding the lock across an await. Do not add an immediate-apply path that bypasses the queue — you will race with whatever is draining it.
-
-### I4. ContextVar inheritance
-
-`_forced_task_id_var` (line 320) and `_current_root_hsession_var` (line 1656) are the two ContextVars that make routing work. `asyncio.create_task()` descendants inherit them automatically. **Threads do not.** `run_in_executor()` does not. If you spawn work off the event loop, wrap it in `contextvars.copy_context().run(fn)` and set the vars explicitly.
-
-The `_route_tokens` dict at line 1661 stores the LIFO reset token for each invocation. Reset tokens **must** be popped in reverse order of set — otherwise ContextVar raises. The existing code handles this via a try/finally around the invocation lifetime; do not break that structure.
-
-### I5. Aclosing on async generators
-
-ADK's event stream is an async generator. The Aclosing wrapper (grep for `aclosing` or `AsyncClosing` in `adk.py`) ensures that if the consumer aborts mid-iteration (exception, cancel), the generator's `aclose()` runs and cleans up ContextVar tokens + in-flight span state. If you rewrap the generator without aclosing, a cancel will leak route tokens and corrupt `_route_tokens`.
-
-### I6. Single-writer to `planner.refine`
-
-`refine_plan_on_drift` at lines 3256-3350 is the **only** function that calls `planner.refine()`. All drift paths (detect_drift, after_model_callback, before_tool_callback, sweeper) funnel through it. Do not call the planner directly from a new detection site — you will miss:
-- Throttling (`_DRIFT_REFINE_THROTTLE_SECONDS = 2.0`, line 378)
-- Severity thresholds (`_STAMP_MISMATCH_THRESHOLD = 3`, line 373)
-- Unrecoverable cascade (cancels child tasks on non-recoverable drifts)
-- Invariant check around the refine result
-
-### I7. The sweeper is the fallback, not the primary
-
-`classify_and_sweep_running_tasks` at lines 2608-2720 exists for the "model described its work in prose instead of calling a reporting tool" case. It is best-effort and should not be your first-choice way to transition a task. If you find yourself extending the sweeper to handle a new signal, first ask whether a reporting tool call would be cleaner (see `hgraf-add-reporting-tool`).
-
-## Where to add state
-
-If you need new state:
-
-1. **Per-task state** → add a field to the Task or TaskPlan proto (see `hgraf-add-proto-field`).
-2. **Per-session ephemeral state** → add a field to `_AdkState` initialized in `__init__`, mutated only through a new method on the class, guarded by `_lock`.
-3. **Per-invocation routing state** → add a new ContextVar. Document its inheritance rules at the declaration site.
-4. **Per-tool call state** → usually lives in the `_tools` dict on `_AdkState`, keyed by tool call id.
-
-Do **not** add module-level mutable state. `adk.py` is imported once but run against multiple `_AdkState` instances (one per client), and module-level state is shared across all of them.
-
-## Where to add callback logic
-
-Know your callback surface:
-
-- `before_agent_callback` / `after_agent_callback` — coarse agent-level hooks. Fire once per agent invocation.
-- `before_model_callback` / `after_model_callback` — around every LLM call. Best place to read/write session.state for protocol keys.
-- `before_tool_callback` / `after_tool_callback` — around every tool call. Reporting tool interception lives here (before).
-- `on_event_callback` — every ADK event including session deltas and transfers. Observer for drift detection.
-
-Pick the least-specific callback that has the information you need. Work done in `on_event_callback` runs on every event including chat turns — heavy work there is expensive.
-
-## Workflow for editing adk.py
-
-1. **Read the target function + 50 lines of context.** State flows through parameter threading and ContextVar reads — the 20 lines around the site are rarely enough to understand cause and effect.
-2. **Grep for every caller of the function** before you change its signature or semantics. `adk.py` is not modular; one function can have 15 callers across the file.
-3. **Add your change behind the lock** if it touches `_AdkState` fields, through `_set_task_status` if it changes status.
-4. **Add or extend a unit test in `client/tests/test_*.py`** that exercises your new code path. Look for the closest existing file:
-   - Drift: `test_drift_taxonomy.py`, `test_llm_agency_scenarios.py`
-   - Callbacks: `test_model_callbacks.py`, `test_tool_callbacks.py`, `test_protocol_callbacks.py`
-   - Reporting tools: `test_reporting_tools.py`, `test_reporting_registration.py`
-   - Walker: `test_walker_completion_timing.py`, `test_walker_simplification.py`
-   - State: `test_invariants.py`, `test_task_lifecycle.py`, `test_state_protocol.py`
-5. **Run the full client test suite.** adk.py changes have non-local effects; only the full suite catches regressions.
-   ```bash
-   cd client && uv run --with pytest --with pytest-asyncio python -m pytest -q
-   ```
-6. **Run the e2e suite.** Real ADK + real server smoke catches ContextVar bugs that unit tests miss.
-   ```bash
-   cd /home/sunil/git/harmonograf && uv run --extra e2e pytest tests/e2e -q
-   ```
-7. **Smoke with `make demo`.** Some bugs only surface with real streaming (e.g. `_route_tokens` leaks on cancel).
-
-## Verification
-
-```bash
-cd client && uv run --with pytest --with pytest-asyncio python -m pytest \
-  tests/test_invariants.py \
-  tests/test_task_lifecycle.py \
-  tests/test_walker_completion_timing.py \
-  tests/test_walker_simplification.py \
-  tests/test_drift_taxonomy.py \
-  tests/test_llm_agency_scenarios.py \
-  tests/test_reporting_tools.py \
-  tests/test_model_callbacks.py \
-  tests/test_tool_callbacks.py \
-  tests/test_protocol_callbacks.py \
-  tests/test_orchestration_modes.py \
-  -q
-
-# And the full suite
-cd client && uv run --with pytest --with pytest-asyncio python -m pytest -q
-
-# And the e2e suite
-cd /home/sunil/git/harmonograf && make e2e
-```
-
-## Common pitfalls (in order of frequency)
-
-1. **Direct status mutation.** Writing `task.status = TaskStatus.COMPLETED` somewhere new. It slips past `_set_task_status`, invariant checker flags it on next sweep, you spend an hour blaming the sweeper. Always go through `_set_task_status`.
-2. **Calling `planner.refine()` from a new detection site.** Skips throttling + severity + cascade. The symptom is "refines fire too often" or "non-recoverable drift didn't cascel children." Always funnel through `refine_plan_on_drift`.
-3. **ContextVar not inherited by threadpool.** Symptom: parallel mode binds spans to the wrong task. Fix: wrap `run_in_executor` with `contextvars.copy_context()`.
-4. **Token reset out of order.** Symptom: `LookupError` or ContextVar state inconsistencies under heavy concurrency. Fix: use try/finally with LIFO discipline on `_route_tokens`.
-5. **Holding `_lock` across an await.** Symptom: deadlock or serialized parallelism that defeats parallel_mode. Prefer `_pending_mutations` for deferred work.
-6. **Adding logic in `on_event_callback` that should be in a more specific callback.** Symptom: the logic runs on every chat turn and tanks latency. Move to `before_tool_callback` / `after_model_callback`.
-7. **Bypassing `_AdkState` methods.** Symptom: races, lost updates, or invariant violations. Always go through class methods.
-8. **Forgetting the sweeper runs on a timer.** Symptom: "my test passes but the live system flips the task status seconds later." The sweeper will reclassify if your state lacks the markers it expects.
-9. **Monkey-patching `_AdkState` in tests.** Symptom: tests pass, prod breaks because the monkey patch hid a real bug. Use real `_AdkState` instances in unit tests via the existing fixtures in `client/tests/_fixtures.py`.
-10. **Changing the meaning of an existing `DRIFT_KIND_*` constant.** Symptom: replayed traces or frontend caches render the wrong icon. Never reassign; always add new constants.
+- `dev-guide/client-library.md` — the small modern client surface.
+- `hgraf-update-frontend-component` — the skill for harmonograf UI
+  changes.
+- goldfive repo — everything orchestration-shaped.

--- a/.agents/skills/hgraf-update-planner-prompt/SKILL.md
+++ b/.agents/skills/hgraf-update-planner-prompt/SKILL.md
@@ -1,129 +1,66 @@
 ---
 name: hgraf-update-planner-prompt
-description: Change the planner/refine system prompts in planner.py safely — schema contract, test against real LLM, regression guards.
+description: Planner prompts live in goldfive. This skill redirects and describes the harmonograf-side touchpoints for planner output changes.
 ---
 
 # hgraf-update-planner-prompt
 
-## When to use
+## Post-migration scope
 
-You want to change how harmonograf's PlannerHelper decomposes a request into a task DAG, or how the Refine path rewrites a plan in response to drift. The prompts are the LLM's *entire* contract — changing a word can shift schema adherence, task granularity, or drift-response behavior.
+The planner is in
+[goldfive](https://github.com/pedapudi/goldfive). Harmonograf no
+longer owns `client/harmonograf_client/planner.py`. Prompt changes,
+schema tweaks, and refine-path logic all belong in goldfive.
 
-## Prerequisites
+If you want to change:
 
-1. Read the full planner module: `client/harmonograf_client/planner.py`. The two prompts you will edit:
-   - `_DEFAULT_SYSTEM_PROMPT` at `planner.py:164` — initial plan generation.
-   - `_REFINE_SYSTEM_PROMPT` at `planner.py:408` — live refine path.
-2. Read the JSON schema both prompts reference. The response shape is parsed in `planner.py :: _plan_from_json` (around `planner.py:230-290`). The prompt MUST match what the parser expects, or every refine returns `None` and the drift triggers silently.
-3. Read `client/harmonograf_client/adk.py :: _refine_plan_async` and follow `plan_state.plan.revision_index` bumping around `adk.py:3372` and `adk.py:3486` — those are the insertion points where a new refined plan is stored.
-4. Read the existing planner tests: `client/tests/test_planner.py` for the generate path and `client/tests/test_dynamic_plans_real_adk.py` for the end-to-end refine path with a real ADK runner and scripted `FakeLlm`.
+- How plans are initially generated → goldfive's planner prompt.
+- How refines are structured → goldfive's steerer + planner.
+- The `PlanSubmitted` / `PlanRevised` event schema →
+  `proto/goldfive/v1/events.proto`.
 
-## Step-by-step
+## Harmonograf-side touchpoints
 
-### 1. Identify which prompt you're changing
+You only come back here if the output shape of a goldfive event
+changes in a way that harmonograf's ingest or frontend needs to
+learn about:
 
-- **Initial plan**: edit `_DEFAULT_SYSTEM_PROMPT`. This runs once at session start via `PlannerHelper.generate()`.
-- **Refine**: edit `_REFINE_SYSTEM_PROMPT`. This runs every time a drift kind fires (`adk.py :: DriftReason`) inside `PlannerHelper.refine()` (`planner.py:394`).
-- **Override from the application**: don't edit the module at all. `PlannerHelper(system_prompt=...)` at `planner.py:310` accepts a custom string. If you're experimenting, pass a test prompt rather than committing to the repo prompt.
+### 1. Ingest dispatch
 
-### 2. Preserve the JSON schema contract
+`server/harmonograf_server/ingest.py`'s `_handle_goldfive_event`
+fan-out covers `run_started` / `goal_derived` / `plan_submitted` /
+`plan_revised` / `task_*` / `drift_detected` / `run_completed` /
+`run_aborted`. New variants need a case; new field on an existing
+variant usually just rides through in `convert.py`.
 
-Every prompt ends with a literal schema block. Don't change field names. The parser looks for exactly these keys:
+### 2. Storage columns
 
-Initial plan:
-```json
-{"summary": "...", "tasks": [{"id","title","description","assignee_agent_id"}], "edges": [{"from_task_id","to_task_id"}]}
-```
+If the planner starts emitting a new field we want to persist
+(e.g. a confidence score or plan digest), add it to
+`storage/base.py`'s `TaskPlan` dataclass and `sqlite.py`'s CREATE
+TABLE + conditional ALTER TABLE. See `hgraf-migrate-sqlite-schema`.
 
-Refine plan (adds a `status` field per task):
-```json
-{"summary": "...", "tasks": [{"id","title","description","assignee_agent_id","status"}], "edges": [{"from_task_id","to_task_id"}]}
-```
+### 3. Frontend rendering
 
-`_plan_from_json` will drop the response if any required key is missing. Since it returns `None`, the refine path silently keeps the old plan. Add a unit test that asserts your new prompt still parses.
+The frontend consumes plan shape via
+`frontend/src/rpc/goldfiveEvent.ts` and `TaskRegistry`. If the new
+field affects rendering — revision severity colour, banner text,
+DAG layout hints — you'll need to thread it through.
 
-### 3. Keep the stability rules intact
+## Testing
 
-The refine prompt has seven numbered rules at `planner.py:417-448` — `PRESERVE HISTORY`, `UPDATE STATUSES`, `ADD NEW TASKS`, `DROP OBSOLETE PENDING`, `REASSIGN`, `KEEP IDS STABLE`, `RETURN A COMPLETE PLAN`. These are load-bearing.
+Harmonograf-side planner changes are exercised by:
 
-- Dropping `PRESERVE HISTORY` makes the Gantt lose completed tasks — the UI shows a broken timeline.
-- Dropping `KEEP IDS STABLE` breaks the revision diff (`frontend/src/gantt/index.ts :: computePlanDiff`) which depends on id-based matching.
-- Dropping `RETURN A COMPLETE PLAN` breaks `adk.py :: _upsert_refined_plan` which does a wholesale replace, not a merge.
+- `server/tests/test_ingest_goldfive_event.py` — conversion round-trip.
+- `server/tests/test_task_plans.py` — storage CRUD.
+- Frontend: `frontend/src/__tests__/interventions.test.ts` if the
+  aggregator cares.
 
-If you need to weaken one of these, change the parser and the adapter atomically — not just the prompt.
+Planner prompt regression goes in goldfive's test suite. Harmonograf
+CI does not gate on planner output quality.
 
-### 4. Keep the "no prose, no markdown fences" instruction
+## Cross-links
 
-Both prompts end with "Respond with a single JSON object and NOTHING ELSE — no prose, no markdown fences". `_strip_code_fences` at `planner.py:227` handles fenced JSON as a fallback, but leading prose breaks the parser. If you remove this instruction, LLMs will preface with "Here is the plan:" and everything silently fails.
-
-### 5. Test with a scripted FakeLlm
-
-The repeatable path: scripted `FakeLlm` replay. See `client/tests/test_dynamic_plans_real_adk.py:129` for the pattern:
-
-```python
-class FakeLlm(BaseLlm):
-    model: str = "fake-llm"
-    responses: list = []
-    cursor: int = -1
-    @classmethod
-    def supported_models(cls): return ["fake-llm"]
-    async def generate_content_async(self, llm_request, stream=False):
-        self.cursor += 1
-        yield self.responses[min(self.cursor, len(self.responses)-1)]
-```
-
-Enqueue a sequence that exercises every rule you changed: an initial plan, then a drift event, then the refined plan. Assert:
-
-- The returned `Plan` parses (`_plan_from_json` returns non-None).
-- `revision_index` incremented by 1.
-- Completed tasks still appear in the refined plan.
-- New tasks have fresh ids.
-
-### 6. Test with a real LLM
-
-For prompt changes, unit tests aren't enough — you need the actual model's behavior. Two options:
-
-**Option A — Integration test with API key**:
-
-```bash
-GOOGLE_API_KEY=... uv run pytest client/tests/test_dynamic_plans_real_adk.py::test_real_llm -m real_llm -x
-```
-
-(If `-m real_llm` marker doesn't exist, grep the tests for the actual marker name. The suite uses skip markers to keep API-key-gated tests out of CI.)
-
-**Option B — Manual REPL**:
-
-```python
-from harmonograf_client.planner import PlannerHelper, make_default_adk_call_llm
-ph = PlannerHelper(call_llm=make_default_adk_call_llm(), model="gemini-2.5-flash")
-plan = ph.generate(user_request="...", available_agents=[{"id": "researcher", "name": "..."}])
-print(plan)
-```
-
-Run 5-10 prompt variants against it. Count how many produce a parseable `Plan`. A drop from 95% to 80% is a prompt regression, even if unit tests pass.
-
-### 7. Measure DAG shape regressions
-
-After a prompt change, refined plans may become too small (the LLM dropped rules), too large (LLM over-decomposes), or too linear (LLM stopped producing parallel branches). Spot-check by running the planner on three representative requests and comparing task count, edge count, and max DAG width against the baseline.
-
-### 8. Update refine throttling if behavior changes
-
-The refine path is throttled per drift kind at `adk.py:3283` — "Recoverable drifts within the throttle window don't re-fire refine". If your prompt change makes refine much cheaper or much more expensive, retune `_REFINE_THROTTLE_BY_KIND` in `adk.py:375` (the table above `_last_refine_by_kind`).
-
-### 9. Verification
-
-```bash
-uv run pytest client/tests/test_planner.py -x -q
-uv run pytest client/tests/test_dynamic_plans_real_adk.py -x -q
-# Only if you have API access:
-GOOGLE_API_KEY=... uv run pytest client/tests/test_dynamic_plans_real_adk.py -x -q -k real_llm
-```
-
-## Common pitfalls
-
-- **Adding a required field to the schema**: the parser silently drops the plan, the refine silently no-ops, and the only symptom is a stuck Gantt chart. Always update `_plan_from_json` atomically with the prompt.
-- **Quoting drift**: copy-pasting JSON from a Markdown editor introduces curly quotes (`"` instead of `"`). LLMs mirror them back and the parser rejects the response. Hand-type or use a plain editor.
-- **"Respond with only JSON" without the "no markdown fences"**: Gemini and Claude will still wrap responses in ```json```. `_strip_code_fences` handles it; don't remove the guard.
-- **Changing the prompt without changing the tests**: the old scripted `FakeLlm` responses will keep passing because the LLM is fake. Add a new test case that specifically exercises the changed behavior.
-- **Forgetting that refine has state**: the refine prompt receives the current plan AS JSON. If your prompt change also changes how the plan is serialized into the request, that's a second edit — search `adk.py` for the `current plan` serialization path.
-- **Dropping "complete plan, not a delta"**: one-word removal breaks the upsert — the plan-replacement path expects the whole thing. Never hint the model to "return only changes".
+- goldfive's planner docs (authoritative).
+- `hgraf-migrate-sqlite-schema` for persistence.
+- `dev-guide/server.md` for the ingest dispatch.

--- a/.agents/skills/hgraf-write-e2e-scenario/SKILL.md
+++ b/.agents/skills/hgraf-write-e2e-scenario/SKILL.md
@@ -1,150 +1,119 @@
 ---
 name: hgraf-write-e2e-scenario
-description: Pattern for writing a new tests/e2e/test_scenarios.py scenario using scripted FakeLlm, StaticPlanner, and real ADK + real harmonograf server.
+description: Pattern for writing a new end-to-end test in tests/e2e/ — real ADK + real harmonograf server, scripted FakeLlm for determinism.
 ---
 
 # hgraf-write-e2e-scenario
 
 ## When to use
 
-You need a hermetic end-to-end test that exercises the full stack — real `google.adk` runtime, real `harmonograf_client`, real `harmonograf_server` (in-process) — but with deterministic, scripted LLM output. Use this for:
-- Regression tests on drift detection + refine flow.
-- Plan-diff rendering correctness (client→bus→frontend-fixtures).
-- Reporting tool lifecycle coverage.
-- Walker/walker-completion-timing scenarios that unit tests can't catch.
+You need a hermetic end-to-end test that exercises the full stack —
+real `google.adk` runtime, real `harmonograf_client`, real
+`harmonograf_server` (in-process) — but with deterministic, scripted
+LLM output. Use this for:
 
-Do **not** use this skill for tests that don't need ADK at all — prefer the duck-typed unit tests under `client/tests/test_drift_taxonomy.py` or `test_invariants.py`. They run 10-100× faster.
+- Regression tests that cross the client / server / storage boundary.
+- Plan-diff rendering correctness (client → bus → frontend-fixtures).
+- Intervention aggregator flows with real ingest.
+- Cancellation sweep, lazy Hello, per-agent row auto-registration.
 
-## Prerequisites
+Do **not** use this skill for tests that don't need ADK at all —
+prefer pytest unit tests under `client/tests/` or `server/tests/`.
+They run 10-100× faster.
 
-1. `make install` has run (needs the ADK submodule). See `Makefile:install` which calls `git submodule update --init --recursive`.
-2. Read the existing test file top to bottom: `tests/e2e/test_scenarios.py` (module docstring at lines 1-34 explains the whole approach).
-3. Read the fixtures in `tests/e2e/conftest.py` — specifically:
-   - `harmonograf_server` at lines 32-57 (in-memory store, ephemeral ports)
-   - `real_harmonograf_server` at lines 60-94 (sqlite-backed, tmp_path)
-4. Understand `FakeLlm` — built via `_build_fake_llm_class()` at `test_scenarios.py:42-79`. It takes a list of `LlmResponse` objects and a cursor; each call consumes one response. Exhausting the list raises.
+## Scope
+
+Harmonograf's e2e suite is in `tests/e2e/`. It composes:
+
+- A real `harmonograf_server` started in-process on an ephemeral
+  port with either an in-memory or sqlite-backed store.
+- A real `harmonograf_client.Client(...)` pointing at that server.
+- A real ADK runner + `HarmonografTelemetryPlugin`.
+- Optionally a real `goldfive.wrap(...)` for orchestration flows.
+- A scripted `FakeLlm` so the model never goes off-script.
 
 ## Step-by-step
 
-### 1. Pick your fixture
+### 1. Pick your server fixture
 
-Use `harmonograf_server` for speed (in-memory store, dict-backed). Use `real_harmonograf_server` only when the test verifies sqlite persistence or schema migrations — it is slower but exercises the real storage path.
+The conftest under `tests/e2e/` exposes server fixtures. Prefer the
+in-memory store for speed and the sqlite-backed one only when the
+test verifies persistence / migration.
 
-```python
-async def test_my_scenario(harmonograf_server):
-    app = harmonograf_server["app"]
-    addr = harmonograf_server["addr"]
-    bus = harmonograf_server["bus"]
-    store = harmonograf_server["store"]
-    ...
-```
+### 2. Build a FakeLlm
 
-### 2. Build the FakeLlm response script
-
-`_build_fake_llm_class()` at `test_scenarios.py:42-79` returns a `(FakeLlm, LlmResponse, genai_types)` triple. Use the helpers at lines 82-102:
-
-- `_text_response("assistant text")` — a plain text turn.
-- `_function_call_response(name="report_task_started", args={"task_id": "t1"})` — a tool call.
-
-Script the exact sequence the agent should produce. Each LLM turn pops one response. If the agent produces more turns than you scripted, `FakeLlm` raises — that is often the bug you want to see.
+Construct a list of `LlmResponse` objects using ADK's own types:
 
 ```python
-from google.adk.models import LlmResponse  # via _build_fake_llm_class
+from google.adk.models.llm_response import LlmResponse
+from google.genai.types import Content, Part, FunctionCall
+
 responses = [
-    _function_call_response("report_task_started", {"task_id": "t1"}),
-    _text_response("Working on t1..."),
-    _function_call_response("report_task_completed", {"task_id": "t1", "summary": "ok"}),
-    _function_call_response("report_task_started", {"task_id": "t2"}),
-    _function_call_response("report_task_completed", {"task_id": "t2", "summary": "ok"}),
+    LlmResponse(content=Content(parts=[Part(text="I'll call the search tool.")])),
+    LlmResponse(content=Content(parts=[Part(function_call=FunctionCall(
+        name="web_search", args={"query": "..."}))])),
+    # ...
 ]
-fake_llm = FakeLlm(responses=responses, cursor=0, sleep_ms=0)
 ```
 
-Set `sleep_ms` >0 only if you are testing throttling (the fake LLM sleeps that many milliseconds per turn, simulating real latency).
+Wrap them in a FakeLlm class that advances a cursor each call.
 
-### 3. Build a StaticPlanner
+### 3. Drive the agent
 
-`class StaticPlanner(PlannerHelper)` at `test_scenarios.py:110-129` is the deterministic planner: `generate()` returns `self._plan`, `refine()` returns `self._refined`. It counts calls via `generate_calls` and `refine_calls` so you can assert exactly one refine fired.
+With the client configured against the local server, run the agent.
+Spans, heartbeats, and goldfive events flow through the real wire
+into the in-process server.
 
-```python
-planner = StaticPlanner(
-    _plan=Plan(tasks=[Task(id="t1", title="do first", ...), ...], edges=[]),
-    _refined=None,  # no refine on drift
-)
-```
+### 4. Assert
 
-Feed your planner to `HarmonografAgent(planner=planner, ...)`.
+- Query the server's store directly for spans, agents, plans,
+  annotations, interventions.
+- Call the server's RPCs (`ListInterventions`, `WatchSession`,
+  `GetSpanTree`) to verify end-user-facing shape.
+- Compare against expected structure — task state machine
+  transitions, intervention dedup, plan revisions, per-agent row
+  shape (#80), etc.
 
-### 4. Build the agent tree
+### 5. Scenarios worth covering
 
-`_make_agent()` at `test_scenarios.py:137-148` shows the pattern: construct an `LlmAgent` with `model=fake_llm`, an instruction, and `sub_agents=[]`. Wrap in `HarmonografAgent(inner_agent=agent, harmonograf_client=client, ...)`. Pick the orchestration mode explicitly:
-
-- `orchestrator_mode=True, parallel_mode=False` — sequential (default).
-- `orchestrator_mode=True, parallel_mode=True` — parallel DAG walker.
-- `orchestrator_mode=False` — delegated (agent is in charge of its own sequencing; observer scans afterwards).
-
-See `AGENTS.md` → *Plan execution protocol* for when each is appropriate.
-
-### 5. Run under InMemoryRunner
-
-Use `google.adk.runners.InMemoryRunner` (imported in the existing test file — grep for it). It provides an in-memory session service and a synchronous `run_async` driver:
-
-```python
-runner = InMemoryRunner(agent=harmonograf_agent)
-async for event in runner.run_async(user_id="u", session_id="s", new_message=...):
-    pass
-```
-
-Drive until the agent emits its terminal event.
-
-### 6. Assert on server-observed state
-
-The `harmonograf_server` fixture exposes `store` and `bus` — you can assert on the persisted state directly:
-
-```python
-session = await store.get_session(session_id)
-tasks = await store.list_tasks(session_id)
-assert [t.status for t in tasks] == [TaskStatus.COMPLETED, TaskStatus.COMPLETED]
-assert planner.generate_calls == 1
-assert planner.refine_calls == 0
-```
-
-If you need to assert on the streaming delta path (not just final state), subscribe to the bus before driving the agent:
-
-```python
-sub = bus.subscribe(session_id)
-# drive agent
-deltas = []
-while not sub.queue.empty():
-    deltas.append(await sub.queue.get())
-assert any(d.kind == DELTA_TASK_STATUS for d in deltas)
-```
-
-### 7. Clean up
-
-The async fixtures in `conftest.py` handle server teardown. If you subscribed to the bus, call `sub.close()` before the test ends or you will leak an unsubscribed queue.
+- **Lazy Hello (#85)**: construct a `Client`, assert the server sees
+  nothing; emit the first envelope, assert `Hello` lands.
+- **Per-agent rows (#80)**: run a tree of ADK agents, assert the
+  server has one `Agent` row per ADK agent with `hgraf.agent.*`
+  metadata populated.
+- **Plugin dedup (#68)**: install `HarmonografTelemetryPlugin`
+  twice; assert spans don't double-emit.
+- **STEER idempotency (#72)**: post the same STEER annotation twice
+  in quick succession; assert only one drift fires.
+- **Cancellation sweep**: cancel the ADK task mid-run; assert any
+  open spans close with `status=CANCELLED`.
+- **Intervention dedup (#81, #87)**: trigger a STEER → USER_STEER
+  drift → PlanRevised chain; assert `ListInterventions` returns one
+  card, not three.
 
 ## Verification
 
 ```bash
-# Run just your new scenario
-cd /home/sunil/git/harmonograf && uv run --extra e2e pytest tests/e2e/test_scenarios.py::test_my_scenario -q -xvs
-
-# Full e2e suite
 make e2e
-
-# And the client suite (to catch regressions in detection logic)
-cd client && uv run --with pytest --with pytest-asyncio python -m pytest -q
+# or for one file:
+cd tests/e2e && uv run pytest test_<scenario>.py -q
 ```
+
+Some e2e tests need `KIKUCHI_LLM_URL` for real-LLM scenarios; those
+are gated and skipped by default.
 
 ## Common pitfalls
 
-- **Exhausted FakeLlm.** Scripting too few responses raises a cryptic IndexError inside ADK. Err on the side of an extra no-op `_text_response("done")` at the end.
-- **Scripting too many responses.** If the agent stops early (e.g. completes on `report_task_completed`), trailing scripted responses are never consumed — that is fine, but if your test also asserts `fake_llm.cursor == len(responses)`, it will fail. Drop the assertion or match the exact count.
-- **`InMemoryRunner` + `parallel_mode=True`.** The parallel walker spawns concurrent sub-invocations. `InMemoryRunner` is single-threaded but async-safe; do not mix in any synchronous blocking. Use asyncio primitives throughout.
-- **Ephemeral port collision.** `_free_port()` at `conftest.py:26-29` grabs a port and releases it immediately before the server binds — there is a tiny TOCTOU window on busy CI boxes. If you see occasional `Address already in use`, retry the fixture (do not expand the port range; that just pushes the flake elsewhere).
-- **SQLite fixture + file leakage.** `real_harmonograf_server` writes to `tmp_path`. Pytest cleans it up. Do not `rm` it yourself; do not copy the file out of `tmp_path` and assume it survives the fixture scope.
-- **Reporting tool body mismatch.** The reporting tool function bodies return `{"acknowledged": True}` — the *state change* happens in `before_tool_callback`. If your FakeLlm script calls a tool but nothing transitions, the interception isn't running — check that `HarmonografAgent._auto_register_reporting_tools` found your inner agent (it walks the subtree at construction).
-- **StaticPlanner returning `Plan(tasks=[], edges=[])`.** An empty plan trips the invariant checker ("no tasks in plan"). Always return at least one PENDING task.
-- **ContextVar leakage between tests.** `_forced_task_id_var` is reset via LIFO tokens; if an earlier test crashes mid-walker, the token may not be reset and the next test inherits stale state. The fixture should construct a fresh client and harmonograf state per test — do not share.
-- **Assuming wall-clock in assertions.** Tasks have `started_at` timestamps from the server's clock. Assertions like `started_at == <fixed value>` will flake. Use relative ordering (`t1.started_at < t2.started_at`) or epsilon windows.
+- **Lazy Hello silences emit-less tests.** A test that constructs a
+  `Client` and never emits will not connect at all. That's correct
+  per #85 — emit something before asserting server-side state.
+- **Per-agent rows change assertions.** If you assert "session has
+  exactly one `Agent`", a goldfive.wrap run will now have N agents.
+  Update assertions to match the per-agent shape.
+- **Don't hard-code agent ids.** Use the `<client>:<name>` shape or
+  query the server for the registered ids.
+
+## Cross-links
+
+- `dev-guide/testing.md` — the four-tier test hierarchy.
+- `hgraf-add-fake-llm-scenario` — complex turn scripting.

--- a/docs/dev-guide/client-library.md
+++ b/docs/dev-guide/client-library.md
@@ -9,6 +9,29 @@ the steerer — is in [goldfive](https://github.com/pedapudi/goldfive). See
 [../goldfive-integration.md](../goldfive-integration.md) for how the two
 compose.
 
+## Recent shape changes (what this doc assumes)
+
+- **Lazy Hello (#85).** The transport defers the `Hello` RPC until the
+  first envelope arrives on the ring buffer. Construction no longer
+  opens a stream; ghost sessions from importing the library are gone.
+- **Per-agent Gantt rows (#80).** `HarmonografTelemetryPlugin` stamps a
+  per-ADK-agent id on every span via `before_agent_callback` /
+  `after_agent_callback`. A single `goldfive.wrap` run with a
+  coordinator + specialists + AgentTool wrappers renders one row per
+  ADK agent — not one collapsed row for the whole tree.
+- **Plugin dedup (#68).** If two `HarmonografTelemetryPlugin` instances
+  end up on the same ADK `PluginManager` (easy under `goldfive.wrap` +
+  `adk web` + `App(plugins=[...])`), the later instance detects the
+  earlier one on its first callback and silently disables itself.
+- **STEER body validation (#72).** The `_control_bridge` between
+  harmonograf's control delivery and goldfive rejects empty bodies and
+  bodies > 8 KiB (`STEER_BODY_MAX_BYTES = 8192`) and strips ASCII
+  control characters before forwarding (`_sanitise_steer_body`).
+  `author` and `annotation_id` are stamped onto every STEER
+  ControlEvent the server synthesises in `PostAnnotation`
+  (`rpc/frontend.py:508-515`), so the goldfive-side steerer can
+  attribute + dedupe.
+
 ## Anatomy
 
 ```
@@ -127,17 +150,103 @@ app = App(
 )
 ```
 
-The plugin maps:
+The plugin maps ADK lifecycle callbacks to span kinds:
 
-| ADK callback | Span |
+| ADK callback | Span kind |
 |---|---|
 | `before_run_callback` / `after_run_callback` | `INVOCATION` |
+| `before_agent_callback` / `after_agent_callback` | *no span — pushes per-agent id onto the invocation's agent stack* |
 | `before_model_callback` / `after_model_callback` | `LLM_CALL` |
 | `before_tool_callback` / `after_tool_callback` / `on_tool_error_callback` | `TOOL_CALL` |
-| `on_event_callback` (transfer / escalate) | `TRANSFER`, `WAIT_FOR_HUMAN` |
+| `on_cancellation(invocation_id)` (goldfive#167) | *closes stale RUNNING spans with `status=CANCELLED`* |
 
 It never reads or writes plan state. Orchestration decisions are
 goldfive's; the plugin is pure observability.
+
+#### Per-agent attribution (#80)
+
+A single `goldfive.wrap` run typically drives a tree of ADK agents —
+coordinator, specialists, AgentTool wrappers, workflow containers
+(`SequentialAgent` / `ParallelAgent` / `LoopAgent`). Without attribution
+every span would collapse onto the client's root `agent_id` and the
+Gantt would render one row for the whole tree.
+
+The plugin derives a stable per-ADK-agent id from the client root and
+the ADK agent's `name`:
+
+```text
+agent_id = f"{client.agent_id}:{adk_agent.name}"
+```
+
+On `before_agent_callback` the plugin pushes this id onto an
+invocation-keyed stack (`_agent_stash[invocation_id]`). Subsequent
+spans (LLM, tool, child invocations) read the top-of-stack and stamp
+the id into `Span.agent_id`. `after_agent_callback` pops.
+
+On the FIRST span the plugin sees for a given `(session_id,
+per_agent_id)` pair it also stamps four `hgraf.agent.*` attributes:
+
+- `hgraf.agent.name` — the raw ADK agent name.
+- `hgraf.agent.kind` — a coarse hint (`llm`, `workflow`, `tool_wrapped`,
+  `unknown`) derived by walking the MRO of the agent class.
+- `hgraf.agent.parent_id` — the derived id of the parent ADK agent, or
+  the last-but-one segment of `ctx.branch` as a fallback.
+- `hgraf.agent.branch` — the ADK dot-delimited ancestry (forensic).
+
+The server harvests these into `Agent.metadata` on first-sight via the
+auto-register path in `ingest.py` (see `server.md`). The client never
+stamps these attributes on subsequent spans from the same agent — the
+cost is paid exactly once per `(session_id, agent_id)` pair.
+
+#### Lazy Hello (#84, #85)
+
+Constructing a `Client` no longer opens a stream. The transport waits
+for the first envelope on the ring buffer and opens `StreamTelemetry` +
+`SubscribeControl` on demand. This matters for ADK flows: importing
+`harmonograf_client` to configure an `App(plugins=[...])` no longer
+mints an empty session visible in the picker. Ghost sessions caused by
+module-level instantiation are gone as of 2026-04.
+
+Two corollaries:
+
+1. The `session_id` the server assigns is not known until the first
+   emit. `Client.session_id` returns `""` until then.
+2. Every callback in `HarmonografTelemetryPlugin` wakes the transport
+   via `_client.emit_span_*` → `transport.notify()`, so the very first
+   callback on a run is what flushes the handshake.
+
+#### Plugin dedup (#68)
+
+Under `goldfive.wrap` + `adk web` + `App(plugins=[HarmonografTelemetryPlugin(c)])`
+it is easy to end up with two plugin instances on the same
+`PluginManager`: one from `App.plugins`, another propagated via
+`observe()` or an adapter's `add_plugin` call. Without dedup every
+span is emitted twice.
+
+On the first callback the plugin walks
+`invocation_context.plugin_manager.plugins` and checks whether another
+plugin with `name="harmonograf-telemetry"` appears *earlier* in the
+list than `self`. If so, it flips `_disabled_as_duplicate = True` and
+short-circuits every subsequent callback. An INFO log is emitted
+exactly once per deduped instance so operators can see what happened.
+
+#### Cancellation sweep
+
+When a `goldfive.ADKAdapter.invoke()` asyncio task catches
+`CancelledError` (USER_STEER / USER_CANCEL / upstream cancel),
+`after_run_callback` and any in-flight `after_model_callback` /
+`after_tool_callback` do NOT fire — ADK places those hooks after the
+`async with Aclosing(...)` block, not inside a `finally`. Without
+cleanup, spans the plugin already `emit_span_start`-ed would stay
+`status=RUNNING` forever.
+
+The adapter calls `plugin.on_cancellation(invocation_id)` on every
+plugin that exposes the hook; `HarmonografTelemetryPlugin` delegates
+to `_close_stale_spans_for_invocation`, which flushes leftover run /
+LLM / tool spans scoped to the cancelled invocation with
+`status=CANCELLED`. Tool spans for concurrent sibling invocations are
+preserved — the plugin tracks `id(tool_context) → invocation_id` in a
+parallel dict so cleanup filters precisely.
 
 ## Envelope kinds
 
@@ -173,6 +282,33 @@ Reconnect is exponential-backoff with a circuit breaker after consecutive
 failures. On reconnect, the client sends a `Hello` carrying the resume
 token from the last `Welcome`; the server replays any post-token deltas
 before accepting new input.
+
+## Root-session rollup for AgentTool sub-Runners
+
+ADK's `AgentTool` spawns a sub-`Runner` whose root agent's
+`before_run_callback` fires against the same plugin (ADK propagates
+the plugin manager into sub-Runners). Each sub-Runner mints its own
+`InMemorySessionService` session id, so if we stamped the per-ctx id
+on every span, a single `adk web` run would fan out across N
+harmonograf sessions — the plan view (pinned to the outer adk-web
+session per goldfive#161) would sit alone and the span view would be
+scattered.
+
+The plugin caches the ROOT `ctx.session.id` on the first
+`before_run_callback` (`_root_session_id`) and stamps it on every
+subsequent span. Sub-Runners use the cached root; the `adk.session_id`
+attribute still carries the per-ctx id for forensic debugging. The
+root is cleared by the matching `after_run_callback` (matching on
+`_root_invocation_id` so sub-Runner teardowns don't release it early).
+
+On root-invocation start, the plugin also opens an additional
+server-side control subscription scoped to the cached session id via
+`Client.open_additional_control_subscription(session_id)`. This makes
+the server's router prefer this sub when a STEER arrives with
+`session_id=<outer adk-web session>` — fixing the goldfive#162 /
+harmonograf#54 flakiness where STEER ack-timed-out because the
+router's fall-back fan-out to every live sub is unreliable under
+some topologies. One extra sub per run, not per sub-Runner.
 
 ## Control handlers
 

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -57,6 +57,10 @@ flowchart LR
 - **One logical change per commit.** If you can split it, split it.
 - **Reference issues** in the body, not the title: `Closes #42` or
   `Refs #123`.
+- **No Claude / AI co-author trailers.** Maintainers scrub them from
+  history, so don't add `Co-Authored-By: Claude …` to commits here
+  even when the commit was AI-assisted. If a tool adds one
+  automatically, amend it out before pushing.
 
 ## PR expectations
 

--- a/docs/dev-guide/debugging.md
+++ b/docs/dev-guide/debugging.md
@@ -265,9 +265,32 @@ Useful one-liners:
 SELECT COUNT(*) FROM spans;
 SELECT id, kind, status, name, start_time, end_time FROM spans ORDER BY start_time DESC LIMIT 20;
 SELECT * FROM agents WHERE status='CONNECTED';
-SELECT plan_id, revision_index, revision_kind, summary FROM task_plans ORDER BY revision_index DESC LIMIT 10;
+
+-- Per-ADK-agent rows in one session (#80). Metadata holds the
+-- hgraf.agent.* hints harvested from the first span.
+SELECT id, name, metadata FROM agents WHERE session_id='<SID>' ORDER BY connected_at;
+
+-- Plan revision lineage with the drift kind that triggered each refine.
+SELECT id, revision_index, revision_kind, revision_severity, revision_reason, summary
+  FROM task_plans
+  WHERE session_id='<SID>'
+  ORDER BY created_at;
+
+-- Annotations (STEER / HUMAN_RESPONSE / COMMENT) posted on a session,
+-- newest first. `author` now carries the poster identity (#72).
+SELECT id, kind, author, body, created_at, delivered_at
+  FROM annotations
+  WHERE session_id='<SID>'
+  ORDER BY created_at DESC;
+
 SELECT digest, size, mime, evicted FROM payloads ORDER BY created_at DESC LIMIT 10;
 ```
+
+To inspect the intervention history the frontend sees for a session,
+either call `ListInterventions` directly against the server or read
+the three source tables (`annotations`, `task_plans` with
+`revision_kind != ''`, drift ring in the server's log) and merge them
+by hand. `docs/runbooks/drift-not-firing.md` has the full checklist.
 
 If the sqlite file is corrupted (power loss, aborted write), delete it and
 restart the server. Data retention is not authoritative — agents will

--- a/docs/dev-guide/deployment.md
+++ b/docs/dev-guide/deployment.md
@@ -43,10 +43,13 @@ The server is built by `Harmonograf.from_config()` at
 `server/harmonograf_server/main.py:74`. It runs two listeners
 concurrently (`main.py:107-183`):
 
-| Listener | Default port | Transport | Audience |
-|---|---|---|---|
-| native gRPC | `cfg.grpc_port` = `7531` | grpc.aio | Agent clients (Python) |
-| gRPC-Web + health | `cfg.web_port` = `7532` | hypercorn + sonora | Browsers, health probes |
+| Listener | Default port | Env | Transport | Audience |
+|---|---|---|---|---|
+| native gRPC | `7531` | `SERVER_PORT`, `HARMONOGRAF_SERVER` | grpc.aio | Agent clients (Python) |
+| gRPC-Web + health | `5174` | `FRONTEND_PORT` | hypercorn + sonora | Browsers, health probes |
+
+The Vite dev server (`pnpm dev`) listens on `5173` and talks to the
+gRPC-Web listener on `5174` — do not confuse the two.
 
 Both listeners share the same `TelemetryServicer` instance, so
 sessions are visible from either side. The port numbers are

--- a/docs/dev-guide/frontend.md
+++ b/docs/dev-guide/frontend.md
@@ -31,13 +31,21 @@ frontend/src/
 │   ├── hooks.ts              #   React hooks wrapping each RPC
 │   ├── convert.ts            #   proto ↔ frontend types
 ├── state/
-│   └── uiStore.ts            # Zustand store for UI state (selection, drawer, viewport)
+│   ├── uiStore.ts            # Zustand store for UI state (selection, drawer, viewport)
+│   ├── sessionsStore.ts      # Zustand store for session list / picker state
+│   ├── annotationStore.ts    # Zustand store for annotations (synced from WatchSession)
+│   ├── approvalsStore.ts     # Zustand store for pending human-response approvals
+│   └── popoverStore.ts       # Zustand store for popover position/visibility
 ├── lib/
-│   └── shortcuts.ts          # Keyboard shortcuts
+│   ├── shortcuts.ts          # Keyboard shortcuts
+│   └── interventions.ts      # Client-side intervention deriver mirroring server aggregator
 ├── components/
 │   ├── shell/                # Shell, AppBar, NavRail, Drawer
-│   ├── Gantt/                # Minimap, in-chart overlays
+│   ├── Gantt/                # Minimap, in-chart overlays, context-window badges
+│   ├── Interactions/         # (legacy) span interaction bits
 │   ├── Interaction/          # SpanPopover, steering controls
+│   ├── Interventions/        # InterventionsTimeline (unified timeline strip, #71 / #76)
+│   ├── DelegationTooltip/    # Delegation edge tooltips
 │   ├── TransportBar/         # Transport state indicator
 │   ├── LiveActivity/         # "What is the agent doing right now"
 │   ├── OrchestrationTimeline/# Task-stage timeline (secondary view)
@@ -161,6 +169,26 @@ flowchart LR
     canvas -. reads .-> spans
 ```
 
+### Per-agent Gantt rows (#80)
+
+The Gantt draws one row per harmonograf `Agent`. With the per-agent
+attribution shipped in the client (#80), a single `goldfive.wrap` run
+drives a tree of ADK agents — coordinator, specialists, AgentTool
+wrappers — and each gets its own row.
+
+From the frontend's perspective this is transparent: `agent_joined`
+deltas land in `AgentRegistry` with ids shaped like
+`<client.agent_id>:<adk_agent_name>` and `Agent.metadata` populated
+with `hgraf.agent.*` hints the server harvested from the first span.
+The renderer uses `metadata["hgraf.agent.name"]` for the row label
+when present; otherwise it falls back to the name the client set.
+
+`AgentRegistry` receives one `agent_joined` per sub-agent the server
+auto-registered, so the renderer does not need to parse the id shape.
+The parent relationship in `metadata["hgraf.agent.parent_id"]` is
+available for future tree-shaped renderings but is not used by the
+default flat Gantt.
+
 ### Mutation entry points
 
 Everything that changes the store funnels through mutator methods:
@@ -251,14 +279,15 @@ The transport is gRPC-Web under the hood. It connects to
 
 `frontend/src/rpc/hooks.ts` wraps each RPC in a React hook:
 
-| Hook | Line | Purpose | RPC |
-|---|---|---|---|
-| `useSessions` | 87 | Poll `ListSessions` with a configurable interval | `ListSessions` (unary) |
-| `useAgentLive` | 162 | Subscribe to an agent's heartbeat + activity deltas | Via `useSessionWatch` |
-| `useSessionWatch` | 173 | Stream session deltas, push into `SessionStore` | `WatchSession` (server-stream) |
-| `usePayload` | 452 | Lazy fetch a payload by digest | `GetPayload` (unary) |
-| `useSendControl` | 531 | Send a control event; await ack | `SendControl` (unary) |
-| `usePostAnnotation` | 570 | Post an annotation; await ack | `PostAnnotation` (unary) |
+| Hook | Purpose | RPC |
+|---|---|---|
+| `useSessions` | Poll `ListSessions` with a configurable interval | `ListSessions` (unary) |
+| `useAgentLive` | Subscribe to an agent's heartbeat + activity deltas | Via `useSessionWatch` |
+| `useSessionWatch` | Stream session deltas, push into `SessionStore` | `WatchSession` (server-stream) |
+| `usePayload` | Lazy fetch a payload by digest | `GetPayload` (unary) |
+| `useSendControl` | Send a control event; await ack | `SendControl` (unary) |
+| `usePostAnnotation` | Post an annotation; await ack | `PostAnnotation` (unary) |
+| `useListInterventions` | Fetch merged intervention history once on session open; the `lib/interventions.ts` deriver keeps it live from `WatchSession` deltas | `ListInterventions` (unary) |
 
 Helper functions in the same file:
 
@@ -366,6 +395,48 @@ in production builds.
 `components/Gantt/Minimap.tsx`. Overview strip under the main canvas; drag
 to navigate the viewport. Reads directly from `SessionStore` so it stays
 in sync with the main canvas without a separate subscription.
+
+### `Gantt/ContextWindowBadge` + `ContextWindowBadgeStrip`
+
+Display the LLM context-window fill for each agent, fed by
+`ContextWindowSample` messages delivered via `WatchSession`. The badge
+shows `tokens / limit_tokens` and trips a warning color when the fill
+approaches the limit.
+
+### `Interventions/InterventionsTimeline` (#71 / #76)
+
+The unified intervention timeline strip that sits above the Gantt in
+planning view. It's the centerpiece of the Trajectory view and the
+intervention drawer tab. Core properties:
+
+- **Stable X anchor.** Marker X positions are captured on mount via
+  `useStableSpanEnd` and only advance on a coarse 1 s tick — not on
+  every re-render. Fixes the "markers jump on hover" pathology where
+  the parent's `endMs` recomputed each frame on a live session.
+- **Glyph/color/ring tri-channel.** `source` (`user` / `drift` /
+  `goldfive`) drives the fill color; `kind` drives the glyph (diamond /
+  diamond-x / chevron / circle / square); `severity ≥ warning` draws a
+  ring around the glyph. No taxonomy knowledge is baked into rendering —
+  new drift kinds work without a frontend change.
+- **Density clustering.** Markers whose centers land within ~2 % of
+  the strip width collapse into a single badge; the badge's popover
+  enumerates the group. Threshold is `max(14 px, width * 0.02)`.
+- **Deterministic popover.** Anchored to the marker's x position in
+  strip coordinates, not the cursor. Pinning (click) survives
+  re-renders; hover-only shows while the cursor is over the marker.
+- **Axis ticks.** 4-8 evenly spaced session-relative time labels
+  (`10s` / `30s` / `1m` / `5m` / `10m` / `30m` steps depending on the
+  span).
+- **Fade-only entrance.** Newly arrived rows fade in once via
+  `useSeenKeys`; the seen-set only grows, never shrinks, so subsequent
+  renders don't replay the entrance.
+- **Intervention cards dedup by annotation_id.** The server's
+  `list_interventions` + `lib/interventions.ts` deriver collapse
+  annotation + USER_STEER drift + plan_revised:rN into one card.
+
+The deriver in `lib/interventions.ts` mirrors the server's
+`interventions.py` aggregator so the frontend doesn't need a fresh RPC
+on every `WatchSession` delta.
 
 ## Keyboard shortcuts
 

--- a/docs/dev-guide/index.md
+++ b/docs/dev-guide/index.md
@@ -7,20 +7,31 @@ you are trying to *use* harmonograf to observe your own agents, see
 
 ## How to use this guide
 
-The guide is organized into ten files. Read them in the order below on your first
-pass; afterwards they work as reference.
+The guide is organized into fifteen files. Read the first nine in the order below on
+your first pass; the remaining six (`storage-backends`, `migration`, `deployment`,
+`security-model`, `performance-tuning`, `debugging`) are topical reference you grab
+when the situation demands.
 
 | # | File | When to read |
 |---|---|---|
 | 1 | [`setup.md`](setup.md) | First day. Clone, install, run `make demo`, smoke-test. |
 | 2 | [`architecture.md`](architecture.md) | Before touching anything that crosses a component boundary. |
-| 3 | [`client-library.md`](client-library.md) | Anything under `client/`. Orchestration modes, reporting tools, invariants. |
-| 4 | [`server.md`](server.md) | Anything under `server/`. Ingest pipeline, bus, storage, RPC surface. |
-| 5 | [`frontend.md`](frontend.md) | Anything under `frontend/`. SessionStore, renderer, uiStore, Connect-RPC. |
+| 3 | [`client-library.md`](client-library.md) | Anything under `client/`. Lazy Hello, per-agent callbacks, plugin dedup. |
+| 4 | [`server.md`](server.md) | Anything under `server/`. Ingest pipeline, bus, storage, intervention aggregator, RPC surface. |
+| 5 | [`frontend.md`](frontend.md) | Anything under `frontend/`. Stores, views, `InterventionsTimeline`, per-agent Gantt rows. |
 | 6 | [`working-with-protos.md`](working-with-protos.md) | Any `.proto` change. Codegen + forward-compat rules. |
-| 7 | [`testing.md`](testing.md) | Before writing a test or debugging a flake. Covers pytest + vitest + e2e. |
-| 8 | [`debugging.md`](debugging.md) | When something is broken. Logging, invariants, common failure modes. |
-| 9 | [`contributing.md`](contributing.md) | Before opening a PR. Commit style, CI expectations, AGENTS.md rules. |
+| 7 | [`storage-backends.md`](storage-backends.md) | SQLite schema, PostgreSQL adapter, session-relative times, agent metadata. |
+| 8 | [`testing.md`](testing.md) | Before writing a test or debugging a flake. Covers pytest + vitest + e2e. |
+| 9 | [`debugging.md`](debugging.md) | When something is broken. Logging, invariants, common failure modes. |
+| 10 | [`performance-tuning.md`](performance-tuning.md) | Per-LLM-call metrics, heartbeat cadence, aggregator cost. |
+| 11 | [`security-model.md`](security-model.md) | v0 posture (no auth, STEER body validation, local-only). |
+| 12 | [`migration.md`](migration.md) | Upgrade paths across the overlay / lazy-Hello / per-agent-row eras. |
+| 13 | [`deployment.md`](deployment.md) | Local + single-host deployment shape. |
+| 14 | [`contributing.md`](contributing.md) | Before opening a PR. Commit style, CI expectations, AGENTS.md rules. |
+
+The guide does not duplicate the wire-protocol reference or the ADR set — those
+live under [`docs/protocol/`](../protocol/) and [`docs/design/`](../design/).
+Cross-link wherever appropriate but do not rewrite.
 
 The map below shows how the chapters depend on each other on a first read:
 

--- a/docs/dev-guide/migration.md
+++ b/docs/dev-guide/migration.md
@@ -398,6 +398,72 @@ harmonograf no longer owns the `harmonograf.*` key schema. Evolution
 of that schema is a goldfive concern. See goldfive's docs for the
 current reader/writer contract.
 
+## Era migrations
+
+Harmonograf has gone through a handful of cross-cutting reshapes. If
+you're upgrading an old client or database, here's the map:
+
+### The goldfive migration (issue #2, mid-2025)
+
+Plans, tasks, drift kinds, control events, steering, and the
+reinvocation loop moved out of harmonograf into `goldfive`. Harmonograf
+became observability-only. Concrete markers:
+
+- `TelemetryUp.task_plan` (field 9) and `updated_task_status`
+  (field 10) reserved — all plan + task state rides inside
+  `goldfive_event = 11` now.
+- `types.proto` stopped declaring `Task`, `TaskEdge`, `TaskPlan`,
+  `DriftKind`, `ControlEvent`, `ControlAck`. Those types are imported
+  from `goldfive/v1/`.
+- `HarmonografAgent`, `HarmonografRunner`, `attach_adk`,
+  `make_adk_plugin` deleted from the client. Replaced by
+  `HarmonografSink` (for goldfive `EventSink`) and
+  `HarmonografTelemetryPlugin` (for ADK `BasePlugin`).
+
+Old sqlite files pre-migration still carry the `task_plans` table —
+schema is forward-compatible, goldfive_event ingest fills the same
+columns.
+
+### The overlay era (goldfive#141-144, early 2026)
+
+Goldfive replaced per-task driving with observation-driven overlay +
+soft follow-up + intervention ladder. User-visible effect on
+harmonograf:
+
+- Tasks can transition `PENDING → NOT_NEEDED` at invocation end, not
+  just terminal states. A PENDING task stuck indefinitely while the
+  agent is running is still a bug; see
+  [`runbooks/task-stuck-in-pending.md`](../runbooks/task-stuck-in-pending.md).
+- Plan revisions (`PlanRevised`) can fire without a backing drift when
+  the overlay folds in follow-ups autonomously. The intervention
+  aggregator surfaces these as `source="goldfive"` with kinds like
+  `cascade_cancel`, `refine_retry`, `human_intervention_required`.
+
+### Lazy Hello (harmonograf#84 / #85, 2026-04)
+
+`Client` construction no longer opens a `StreamTelemetry`. The
+transport defers `Hello` until the first envelope arrives on the ring
+buffer. Migration impact:
+
+- Library consumers that relied on `Client.session_id` being
+  populated immediately after construction must now emit at least
+  one span before reading it.
+- Old sessions created by mere library imports are gone — if your
+  session picker is suddenly missing a row, check whether the agent
+  actually emitted anything.
+
+### Per-agent Gantt rows (harmonograf#80, 2026-04)
+
+`HarmonografTelemetryPlugin` now stamps a per-ADK-agent id on every
+span via `before_agent_callback` / `after_agent_callback`. Historical
+sessions recorded pre-#80 show every agent collapsed onto the client
+root row — that's fine, they predate the fix. Fresh sessions on a
+newer client render one row per ADK agent.
+
+No database migration is required: per-agent rows are auto-registered
+on ingest via the existing `agents` table; old sessions retain their
+single row.
+
 ## Checklist for a proto change
 
 Before you open the PR:

--- a/docs/dev-guide/performance-tuning.md
+++ b/docs/dev-guide/performance-tuning.md
@@ -470,6 +470,46 @@ order — do not skip steps.
 
 ---
 
+## Per-LLM-call metrics (goldfive#172)
+
+Goldfive emits per-LLM-call metrics as log events and observation
+metadata every time it invokes a model. The fields you care about when
+hunting latency:
+
+| Metric | Source | What it measures |
+|---|---|---|
+| `goldfive.llm.duration_ms` | log event | Wall-clock time the LLM call took, incl. network. Consistent >60 s points at a stuck provider or a runaway prompt. |
+| `goldfive.llm.request.chars` | log event | Total chars in the request. Balloons post-STEER when the steerer injects the drift body + task state. Pair with `context_window_tokens` in the Gantt header. |
+| `goldfive.llm.request.messages` | log event | Number of messages in the request. Sudden jumps flag loop accumulation. |
+| `goldfive.llm.usage.*_tokens` | log event | Provider-reported prompt / completion / total token counts. |
+
+When a STEER seems to "take 30-70 s to apply", inspect the planner's
+refine call in the Gantt and read `goldfive.llm.duration_ms` off the
+span — almost always the LLM, not harmonograf, that's slow.
+
+## Intervention aggregator cost
+
+`list_interventions` joins annotations + drifts + plan revisions in
+memory and runs a dedup pass keyed on `annotation_id`. Cost is
+O((A + D + P) log (A + D + P)) in the sort plus O((A + D) * P) for the
+attribution window scan.
+
+Expected bounds:
+
+- A (annotations) rarely exceeds a few hundred per session.
+- D (drifts) scales with drift detector sensitivity; most sessions run
+  at < 50.
+- P (plan revisions) scales with the number of refines; 10-30 is
+  typical even on a heavily-steered run.
+
+So even a pathological session is a fraction of a millisecond. The
+heavy lifting is on the frontend side (`lib/interventions.ts`) which
+re-derives on every WatchSession delta — that's still cheap but if
+your session grows unbounded, add a reactive cache keyed on
+`(annotations.length, drifts.length, plans.length)`.
+
+---
+
 ## Cross-links
 
 - [`architecture.md`](architecture.md) — the end-to-end walk-through

--- a/docs/dev-guide/security-model.md
+++ b/docs/dev-guide/security-model.md
@@ -113,6 +113,15 @@ The only thing the server actively validates beyond syntax:
 - **Payload size ceiling** (`ingest.py:65, 99-102`) —
   `PAYLOAD_MAX_BYTES = 64 * 1024 * 1024` per digest. This is a DoS
   bound, not authentication.
+- **STEER body validation** (`client/harmonograf_client/_control_bridge.py`) —
+  the client-side bridge between harmonograf control delivery and
+  goldfive rejects empty bodies and bodies larger than
+  `STEER_BODY_MAX_BYTES = 8 * 1024` before forwarding, and strips
+  ASCII control characters (`_sanitise_steer_body`). This defends
+  against a pathological UI / scripted caller submitting a multi-MB
+  "body" or smuggling escape sequences into an LLM prompt via
+  control codes. Not authentication — it's input hygiene. Harmonograf
+  #72 / goldfive #171.
 
 ### What the optional bearer token actually does
 

--- a/docs/dev-guide/server.md
+++ b/docs/dev-guide/server.md
@@ -7,30 +7,32 @@ it, so read this chapter before touching anything under `server/`.
 
 ## Anatomy
 
-| File | Lines | Purpose |
-|---|---|---|
-| `main.py` | ~237 | Composition root. `Harmonograf.from_config()` + `Harmonograf.start()`. Wires everything and runs two listeners. |
-| `cli.py` | ~132 | CLI entry point; parses flags and calls `Harmonograf.from_config()`. Exposed via the `harmonograf-server` script. |
-| `config.py` | ~25 | `ServerConfig` dataclass. |
-| `ingest.py` | ~752 | `IngestPipeline` — consumes telemetry and drives store + bus + router. |
-| `bus.py` | ~205 | `SessionBus` — in-process pub/sub for WatchSession fan-out. |
-| `control_router.py` | ~349 | `ControlRouter` — routes control events, collects acks. |
-| `convert.py` | ~454 | Proto ↔ storage dataclass converters. |
-| `storage/base.py` | ~396 | `Storage` ABC + domain dataclasses + enums. |
-| `storage/sqlite.py` | ~1,066 | Default backend (aiosqlite + WAL). |
-| `storage/memory.py` | ~431 | In-memory backend (tests only). |
-| `storage/factory.py` | ~18 | `make_store(kind, …)` helper. |
-| `rpc/telemetry.py` | — | `TelemetryServicer` implementing `StreamTelemetry` + mixins. |
-| `rpc/control.py` | — | `SubscribeControl` handler (mixin). |
-| `rpc/frontend.py` | — | Frontend RPCs (mixin): `ListSessions`, `WatchSession`, `GetPayload`, `GetSpanTree`, `PostAnnotation`, `SendControl`, `DeleteSession`, `GetStats`. |
-| `auth.py` | ~119 | Bearer-token auth for gRPC channels (optional). |
-| `health.py` | ~64 | `grpc.health.v1.Health` implementation. |
-| `_cors.py` | ~98 | CORS allow list for the gRPC-Web listener. |
-| `_sonora_shim.py` | ~76 | Shim over sonora's ASGI app to attach the servicer. |
-| `logging_setup.py` | ~57 | Rich-backed structured logger. |
-| `metrics.py` | ~60 | In-process counters. |
-| `retention.py` | ~72 | Background sweeper for old sessions. |
-| `stress.py` | ~371 | Synthetic load generator (not wired into production). |
+| File | Purpose |
+|---|---|
+| `main.py` | Composition root. `Harmonograf.from_config()` + `Harmonograf.start()`. Wires everything and runs two listeners. |
+| `cli.py` | CLI entry point; parses flags and calls `Harmonograf.from_config()`. Exposed via the `harmonograf-server` script. |
+| `config.py` | `ServerConfig` dataclass. |
+| `ingest.py` | `IngestPipeline` — consumes telemetry and drives store + bus + router. Auto-registers per-ADK-agent rows on span ingest. |
+| `bus.py` | `SessionBus` — in-process pub/sub for WatchSession fan-out. |
+| `control_router.py` | `ControlRouter` — routes control events, collects acks; prefers per-session subs when present. |
+| `convert.py` | Proto ↔ storage dataclass converters. |
+| `interventions.py` | Intervention history aggregator — joins annotations, drifts, plan revisions into a unified chronological list. |
+| `storage/base.py` | `Storage` ABC + domain dataclasses + enums. |
+| `storage/sqlite.py` | Default backend (aiosqlite + WAL). |
+| `storage/memory.py` | In-memory backend (tests only). |
+| `storage/postgres.py` | Experimental PostgreSQL backend. |
+| `storage/factory.py` | `make_store(kind, …)` helper. |
+| `rpc/telemetry.py` | `TelemetryServicer` implementing `StreamTelemetry` + mixins. |
+| `rpc/control.py` | `SubscribeControl` handler (mixin). |
+| `rpc/frontend.py` | Frontend RPCs (mixin): `ListSessions`, `WatchSession`, `GetPayload`, `GetSpanTree`, `PostAnnotation`, `SendControl`, `DeleteSession`, `GetStats`, `ListInterventions`. |
+| `auth.py` | Bearer-token auth for gRPC channels (optional; off by default). |
+| `health.py` | `grpc.health.v1.Health` implementation. |
+| `_cors.py` | CORS allow list for the gRPC-Web listener. |
+| `_sonora_shim.py` | Shim over sonora's ASGI app to attach the servicer. |
+| `logging_setup.py` | Rich-backed structured logger. |
+| `metrics.py` | In-process counters. |
+| `retention.py` | Background sweeper for old sessions. |
+| `stress.py` | Synthetic load generator (not wired into production). |
 
 ## Composition root
 
@@ -124,15 +126,40 @@ main entry. It inspects the oneof and dispatches:
 | `TelemetryUp` variant | Handler | What happens |
 |---|---|---|
 | `hello` | `_handle_hello` | Validate, allocate session/stream IDs (or honor resume token), upsert `Agent`, send `Welcome` response. |
-| `span_start` | `_handle_span_start` | Convert via `pb_span_to_storage` (`convert.py:251`), `store.upsert_span`, `bus.publish_span`. |
+| `span_start` | `_handle_span_start` | Convert via `pb_span_to_storage`, auto-register any per-ADK-agent id seen on `Span.agent_id` that has no matching row yet (reads `hgraf.agent.*` attrs for the metadata payload), `store.upsert_span`, `bus.publish_span`. |
 | `span_update` | `_handle_span_update` | Fetch existing span, apply delta attributes + optional status, upsert, publish. |
 | `span_end` | `_handle_span_end` | Finalize span, upsert, publish (end delta marks span as terminal so renderer can stop watching). |
 | `payload_upload` | `_handle_payload_upload` | Append chunk to assembler; on `last=true`, digest-check and store. |
 | `heartbeat` | `_handle_heartbeat` | Update agent's `last_heartbeat`, `buffer stats`, `current_activity`, `progress_counter`, `context_window_*`; publish agent delta. |
 | `goodbye` | `_handle_goodbye` | Mark agent `DISCONNECTED`; do not close stream (client may reconnect with resume token). |
 | `control_ack` | `_handle_control_ack` | Forward to `ControlRouter` so the waiting frontend RPC can return. |
-| `task_plan` | `_handle_task_plan` | Upsert `TaskPlan`; publish `plan_delta` via the bus. |
-| `updated_task_status` | `_handle_updated_task_status` | Upsert `Task`; publish `task_delta`. |
+| `goldfive_event` | `_handle_goldfive_event` | Dispatch on the inner `payload` oneof: `run_started` / `goal_derived` / `plan_submitted` / `plan_revised` / `task_*` / `drift_detected` / `run_completed` / `run_aborted`. Plans and task state live here post-goldfive-migration (issue #2); the old `task_plan` / `updated_task_status` variants are gone. |
+
+The old `task_plan` (field 9) and `updated_task_status` (field 10)
+variants are reserved in `TelemetryUp` — plan + task state now ride
+inside `goldfive_event` so the wire matches whatever the orchestrator
+emitted byte-for-byte.
+
+### Per-agent row auto-registration (#80)
+
+A single client process often drives a tree of ADK agents
+(coordinator + specialists + AgentTool wrappers). The client-side
+plugin (`HarmonografTelemetryPlugin`) stamps a per-ADK-agent id on
+every span via `Span.agent_id`, and four `hgraf.agent.*` attributes on
+the first span each agent emits:
+
+- `hgraf.agent.name`
+- `hgraf.agent.kind` (`llm` / `workflow` / `tool_wrapped` / `unknown`)
+- `hgraf.agent.parent_id`
+- `hgraf.agent.branch` (forensic ADK ancestry)
+
+`_handle_span_start` checks whether the span's `agent_id` has a row in
+`agents`. If not, it synthesises an `Agent` record using the client's
+framework/version, stamps the `hgraf.agent.*` attrs into the
+`Agent.metadata` map, and publishes an `agent_joined` delta. Subsequent
+spans from the same agent skip the attrs (the client tracks first-sight
+locally), so the cost is paid exactly once per `(session_id, agent_id)`
+pair.
 
 Ingest fans each `TelemetryUp` variant into the store and the bus:
 
@@ -363,7 +390,7 @@ composes three mixins:
 |---|---|---|
 | Telemetry | `rpc/telemetry.py` | `StreamTelemetry` (bidi) |
 | Control | `rpc/control.py` | `SubscribeControl` (server-streaming) |
-| Frontend | `rpc/frontend.py` | `ListSessions`, `WatchSession`, `GetPayload`, `GetSpanTree`, `PostAnnotation`, `SendControl`, `DeleteSession`, `GetStats` |
+| Frontend | `rpc/frontend.py` | `ListSessions`, `WatchSession`, `GetPayload`, `GetSpanTree`, `PostAnnotation`, `SendControl`, `DeleteSession`, `GetStats`, `ListInterventions` |
 
 ### `StreamTelemetry`
 
@@ -423,6 +450,45 @@ return value includes the annotation ID.
 Unary wrapper around `ControlRouter.send_control()`. Used by the frontend
 for direct control events (pause, cancel, status query) that don't involve
 a body annotation.
+
+### `ListInterventions` (#71)
+
+Unary. Returns the chronological merge of user-initiated, drift-triggered,
+and goldfive-autonomous interventions for one session. Backed by
+`interventions.list_interventions()` which derives the list from three
+sources that already live in the store + ingest ring:
+
+- **annotations** (STEERING / HUMAN_RESPONSE) — user rows.
+- **drift ring** (goldfive `DriftDetected` events) — `user_steer` and
+  `user_cancel` kinds flag `source="user"`, everything else is
+  `source="drift"`.
+- **plan revisions** (`task_plans.revision_kind`) — when the revision
+  kind has no matching drift in the attribution window, goldfive
+  minted it autonomously (`cascade_cancel`, `refine_retry`,
+  `human_intervention_required`).
+
+The aggregator then runs a dedup pass
+(`_merge_by_annotation_id`, harmonograf#75, #86, #87): rows that share
+an `annotation_id` (propagated through STEER drifts via goldfive#176)
+collapse onto the annotation row — one card per operator intervention,
+even when the wire emits three events (annotation + USER_STEER drift +
+plan_revised).
+
+The attribution window is kind-dependent (`_outcome_window_for`):
+
+- Autonomous drifts use a tight 5 s window — looping-reasoning /
+  tool-error heuristics fire immediately, no LLM roundtrip.
+- User-control drifts (`user_steer`, `user_cancel`) use 300 s — a STEER
+  flows through the planner's LLM which routinely takes 30-70 s on a
+  local Qwen3.5-35B (issue #86). The narrow default stranded drift
+  rows outside the window and leaked a second card.
+
+Live updates: `WatchSession` still streams the underlying deltas
+(`initial_annotation`, `new_annotation`, `goldfive_event.drift_detected`,
+`goldfive_event.plan_revised`), so the frontend recomputes the merged
+list incrementally via `lib/interventions.ts` — no second subscribe.
+This RPC is used once on session open (late-joining frontend) and the
+deriver keeps it live from there.
 
 ## Reading the code
 

--- a/docs/dev-guide/setup.md
+++ b/docs/dev-guide/setup.md
@@ -298,8 +298,10 @@ are **checked into git**. Commit them alongside the `.proto` edit. See
 | `SERVER_PORT` | `7531` | Native gRPC listener |
 | `FRONTEND_PORT` | `5174` | gRPC-Web listener (sonora) — **not** the Vite dev server port |
 | `ADK_WEB_PORT` | `8080` | `make demo-presentation` |
-| `KIKUCHI_LLM_URL` | — | Shared LLM endpoint used by e2e suite (see `testing.md`) |
-| `GOOGLE_API_KEY` / `GEMINI_API_KEY` | — | For real-LLM tests; not required for unit tests |
+| `KIKUCHI_LLM_URL` | — | OpenAI-compatible LLM endpoint (e.g. local vLLM / Ollama gateway). Required for real-LLM demos and e2e. |
+| `USER_MODEL_NAME` | `openai/qwen3.5-35b` | Model string passed to goldfive's `ADKAdapter` for the primary user-facing agent. |
+| `GOLDFIVE_EXAMPLE_PLANNER_MODEL` | same as `USER_MODEL_NAME` | Overrides the planner model independently of the worker model. Useful for running a small planner against a larger worker. |
+| `GOOGLE_API_KEY` / `GEMINI_API_KEY` | — | For Gemini-backed demos; not required with `KIKUCHI_LLM_URL`. |
 
 The Vite dev server itself listens on port 5173 and proxies nothing — it
 reaches the backend via gRPC-Web on `FRONTEND_PORT`. If you see CORS errors in

--- a/docs/dev-guide/storage-backends.md
+++ b/docs/dev-guide/storage-backends.md
@@ -104,6 +104,20 @@ broken connection should override it; otherwise the default suffices.
 | `list_agents_for_session(session_id)` | All agents for a session, ordered by `connected_at`. |
 | `update_agent_status(session_id, agent_id, status, last_heartbeat=None)` | No-op if the agent doesn't exist (does *not* raise). |
 
+`Agent.metadata` is a free-form `dict[str, str]`. Ingest populates
+harmonograf-specific keys on first-sight auto-registration (#80):
+
+| Metadata key | Source | Meaning |
+|---|---|---|
+| `hgraf.agent.name` | `hgraf.agent.name` span attribute | Raw ADK agent name (`"research"`, `"writer"`). |
+| `hgraf.agent.kind` | `hgraf.agent.kind` span attribute | `llm` / `workflow` / `tool_wrapped` / `unknown`. |
+| `hgraf.agent.parent_id` | `hgraf.agent.parent_id` span attribute | Derived per-agent id of the parent ADK agent. |
+| `hgraf.agent.branch` | `hgraf.agent.branch` span attribute | Dot-delimited ADK ancestry for forensic debugging. |
+
+These are written by the server's ingest pipeline when it
+auto-registers a per-ADK-agent row on span ingest; the client only
+emits them on the FIRST span for each agent per session.
+
 ### Spans
 
 | Method | Semantics |
@@ -142,8 +156,21 @@ just keep the digest as the only stable identifier.
 |---|---|
 | `put_task_plan(plan)` | **Upsert by `plan.id`. Replaces the task list wholesale** so re-emitted plans cleanly drop tasks the planner removed. |
 | `get_task_plan(plan_id)` | `Optional[TaskPlan]`. |
-| `list_task_plans_for_session(session_id)` | Ordered by `created_at`. |
+| `list_task_plans_for_session(session_id)` | Ordered by `created_at`. Used by `ListInterventions` to surface revision history. |
 | `update_task_status(plan_id, task_id, status, bound_span_id=None)` | Returns the updated `Task`, or `None` if the plan/task doesn't exist. |
+
+`TaskPlan` carries four revision columns used by the intervention
+aggregator and the PlanRevisionBanner:
+
+| Column | Purpose |
+|---|---|
+| `revision_index` | `0` for the initial plan submission, `>= 1` for refines. |
+| `revision_kind` | Drift kind (`user_steer`, `looping_reasoning`, …) or autonomous kind (`cascade_cancel`, `refine_retry`, `human_intervention_required`). |
+| `revision_reason` | Human-readable narrative the planner attached. |
+| `revision_severity` | `info` / `warning` / `critical` — drives pivot-glyph color. |
+
+All four are backfilled on pre-existing databases via conditional
+`ALTER TABLE` in `SqliteStore.start()`.
 
 ### Context window samples
 

--- a/docs/dev-guide/testing.md
+++ b/docs/dev-guide/testing.md
@@ -47,30 +47,34 @@ flowchart TB
 
 ```bash
 # Python, one file
-cd client && uv run pytest tests/test_orchestration_modes.py -q
+cd client && uv run pytest tests/test_telemetry_plugin.py -q
 
 # Python, one test
-cd client && uv run pytest tests/test_orchestration_modes.py::test_parallel_mode_walker -q
+cd client && uv run pytest tests/test_telemetry_plugin_per_agent.py::test_per_agent_stamping -q
 
 # Python, match by substring
-cd client && uv run pytest -k "parallel_mode" -q
+cd client && uv run pytest -k "per_agent" -q
 
 # Frontend, one file
-cd frontend && pnpm test -- src/__tests__/computePlanDiff.test.ts
+cd frontend && pnpm test -- src/__tests__/interventions.test.ts
 ```
 
 ## Writing client-side unit tests
 
-Use `client/tests/test_orchestration_modes.py` as your reference. It shows:
+Use `client/tests/test_telemetry_plugin.py` and its siblings
+(`_cancel`, `_dedup`, `_per_agent`, `_session_id`) as reference.
+They show:
 
 - How to skip if `google-adk` isn't installed (`pytest.importorskip` at the
   top of the file).
-- The `FakeClient` pattern: duck-type the `Client` interface instead of
-  mocking the transport. Lets you assert exactly which envelopes would be
-  emitted without spinning up a gRPC server.
-- The scripted `FakeLlm` pattern: pre-bake a queue of `LlmResponse`s so
-  each model call returns a deterministic response. Crucial for testing
-  the callback dispatch path without real LLM nondeterminism.
+- The `FakeClient` pattern (in `_fixtures.py`): duck-type the
+  `Client` interface instead of mocking the transport. Lets you
+  assert exactly which envelopes would be emitted without spinning
+  up a gRPC server.
+- The scripted `FakeLlm` pattern: pre-bake a queue of `LlmResponse`s
+  so each model call returns a deterministic response. Crucial for
+  testing the callback dispatch path without real LLM
+  nondeterminism.
 
 ### Fake LLM
 
@@ -230,24 +234,27 @@ goldfive test suite is the place to add new plan-state checks.
 | Storage schema in `sqlite.py` | Server unit against `SqliteStore` | Only sqlite-specific behavior. |
 | `computePlanDiff` or `SessionStore` | Frontend vitest unit | Pure TS. |
 | A new RPC on the wire | Server unit via servicer + frontend mock | Both sides of the contract matter. |
-| Plan state machine | Integration (real ADK + scripted LLM) + invariant checker | Multiple channels to test. |
-| Drift taxonomy | `test_drift_taxonomy.py` unit | Table-driven. |
+| Plan state machine | Goldfive's tests; harmonograf no longer owns it | Plans / drift live in goldfive post-migration. |
+| Intervention aggregator | `server/tests/test_interventions*.py` + `frontend/src/__tests__/interventions.test.ts` | Mirror test — both sides need to agree. |
 | UI render | vitest component test (if no canvas) or Playwright (if canvas) | — |
 | Full pipeline regression | e2e scenario | Last-resort safety net. |
 
 ## Performance tests
 
-Two perf tools exist:
+One perf tool ships:
 
-1. **`client/tests/test_callback_perf.py`** — asserts that the ADK
-   callback hot path stays below a per-callback time budget. If this test
-   gets slower, the cost-to-observe ratio is slipping.
-2. **`server/harmonograf_server/stress.py`** — synthetic load generator.
+1. **`server/harmonograf_server/stress.py`** — synthetic load generator.
    Run manually:
    ```bash
    cd server && uv run python -m harmonograf_server.stress --agents 10 --spans-per-sec 100
    ```
    Not wired into CI.
+
+For callback-level profiling use `py-spy`; see
+[`performance-tuning.md`](performance-tuning.md) and
+[`runbooks/high-latency-callbacks.md`](../runbooks/high-latency-callbacks.md).
+The per-LLM-call metrics (`goldfive.llm.duration_ms` + friends from
+goldfive#172) are the primary latency telemetry.
 
 ## How a pytest invocation reaches CI
 

--- a/docs/dev-guide/working-with-protos.md
+++ b/docs/dev-guide/working-with-protos.md
@@ -22,14 +22,34 @@ proto/harmonograf/v1/
 | File | Top-level messages | When to edit |
 |---|---|---|
 | `service.proto` | `service Harmonograf { … }` (RPC definitions) | You are adding, removing, or renaming an RPC. Rare. |
-| `telemetry.proto` | `Hello`, `Welcome`, `SpanStart`, `SpanUpdate`, `SpanEnd`, `PayloadUpload`, `PayloadRequest`, `Heartbeat`, `Goodbye`, `ServerGoodbye`, `ControlAck`, `TaskPlan`, `UpdatedTaskStatus`, `TelemetryUp`, `TelemetryDown`, `FlowControl` | You are changing the agent wire protocol. Touching this affects every agent process. |
-| `control.proto` | `SubscribeControlRequest` | Rare; control event routing layer. |
-| `types.proto` | `Session`, `Agent`, `Span`, `SpanLink`, `AttributeValue`, `PayloadRef`, `ErrorInfo`, `Task`, `TaskEdge`, `TaskPlan`, `Annotation`, `ControlEvent`, `ControlAck`, plus enums (`SessionStatus`, `AgentStatus`, `Framework`, `Capability`, `SpanKind`, `SpanStatus`, `LinkRelation`, `AnnotationKind`, `TaskStatus`) | You are adding a field to a domain type. Most common place to edit. |
-| `frontend.proto` | `ListSessionsRequest/Response`, `WatchSessionRequest`, `SessionUpdate`, `GetPayloadRequest/Response`, `GetSpanTreeRequest/Response`, `PostAnnotationRequest/Response`, `SendControlRequest/Response`, `DeleteSessionRequest/Response`, `GetStatsRequest/Response` | Frontend needs a new RPC or new payload shape. |
+| `telemetry.proto` | `Hello`, `Welcome`, `SpanStart`, `SpanUpdate`, `SpanEnd`, `PayloadUpload`, `PayloadRequest`, `Heartbeat`, `Goodbye`, `ServerGoodbye`, `TelemetryUp` (carries `goldfive.v1.Event` via `goldfive_event = 11`), `TelemetryDown`, `FlowControl` | You are changing the agent wire protocol. Touching this affects every agent process. |
+| `control.proto` | `SubscribeControlRequest` (ControlEvent/Ack live in `goldfive/v1/control.proto`) | Rare; control event routing layer. |
+| `types.proto` | `Session`, `Agent`, `Span`, `SpanLink`, `AttributeValue`, `PayloadRef`, `ErrorInfo`, `Annotation`, `AnnotationTarget`, `AgentTimePoint`, `Intervention`, plus enums (`SessionStatus`, `AgentStatus`, `Framework`, `Capability`, `SpanKind`, `SpanStatus`, `LinkRelation`, `AnnotationKind`). Task/Plan/Drift/Control moved to goldfive per issue #2 / #37. | You are adding a field to a domain type. Most common place to edit. |
+| `frontend.proto` | `ListSessionsRequest/Response`, `WatchSessionRequest`, `SessionUpdate`, `GetPayloadRequest/Response`, `GetSpanTreeRequest/Response`, `PostAnnotationRequest/Response`, `SendControlRequest/Response`, `DeleteSessionRequest/Response`, `GetStatsRequest/Response`, `ListInterventionsRequest/Response`, `TaskReport`, `ContextWindowSample` | Frontend needs a new RPC or new payload shape. |
 
 The cleanest rule of thumb: if the type is shared between agent→server and
 server→frontend, it belongs in `types.proto`. If it's specific to one side
-of the wire, it belongs in `telemetry.proto` or `frontend.proto`.
+of the wire, it belongs in `telemetry.proto` or `frontend.proto`. Orchestration
+types (plans, tasks, drift kinds, control event payloads) live in goldfive
+and are imported with `import "goldfive/v1/…"` wherever needed.
+
+### Recent proto additions to know about
+
+- `SubscribeControlRequest.session_id = 1` — scoped subscription key so
+  multiple `SubscribeControl` calls under one agent can disambiguate by
+  session. Prefers per-session sub in the router.
+- `SteerPayload.author` / `SteerPayload.annotation_id` (goldfive#171) —
+  `PostAnnotation` stamps these onto the synthesised STEER ControlEvent
+  so goldfive can attribute the drift and dedup retries.
+- `DriftDetected.annotation_id` (goldfive#177) — present on user-control
+  drifts (`user_steer` / `user_cancel`) so the intervention aggregator
+  can fold the drift row onto its source annotation.
+- `Intervention` (types.proto) — unified intervention history row used
+  by `ListInterventions` and emitted by the server's aggregator. Fields:
+  `at`, `source`, `kind`, `body_or_reason`, `author`, `outcome`,
+  `plan_revision_index`, `severity`, `annotation_id`, `drift_kind`.
+- `Heartbeat.context_window_tokens` / `context_window_limit_tokens`
+  (fields 10/11) — carry the most recent LLM context-window sample.
 
 ## Codegen
 

--- a/docs/runbooks/agent-not-connecting.md
+++ b/docs/runbooks/agent-not-connecting.md
@@ -3,6 +3,19 @@
 The agent process is running but never appears in the session picker,
 or appears as "0 agents" and stays that way.
 
+## Lazy Hello is a real thing now (#84 / #85)
+
+As of 2026-04, constructing a `Client` does NOT open a stream — the
+transport waits for the first envelope on the ring buffer before
+sending `Hello`. If the agent imported `harmonograf_client` and even
+built a `Client(...)` but never emitted a span, there is nothing to
+register with the server.
+
+Quick test: if the agent process is alive but has never exercised an
+ADK callback or called `client.emit_span_start(...)` directly, the
+server will never see it. Send the agent a turn, or bypass lazy Hello
+by emitting a synthetic span during startup.
+
 **Triage decision tree** — symptom → check → most-likely cause → fix path.
 Walk top-to-bottom; the candidates are ordered by frequency.
 

--- a/docs/runbooks/context-window-exceeded.md
+++ b/docs/runbooks/context-window-exceeded.md
@@ -8,36 +8,42 @@ from "history bloat".
 
 ```mermaid
 flowchart TD
-    Start([context_window_tokens<br/>≥ limit_tokens]):::sym --> Q1{provider tokenizer ==<br/>client tokenizer?}
-    Q1 -- "no" --> F1[Tokenizer mismatch:<br/>swap to provider tokenizer]:::fix
-    Q1 -- "yes" --> Q2{Configured limit<br/>matches model docs?}
-    Q2 -- "no" --> F2[Wrong constant:<br/>fix context_window_limit]:::fix
-    Q2 -- "yes" --> Q3{session.state biggest<br/>key is task_results?}
-    Q3 -- "yes" --> F3[State bloat: only inject<br/>relevant completed results]:::fix
-    Q3 -- "no" --> Q4{Tool output payloads<br/>> 50KB?}
-    Q4 -- "yes" --> F4[Truncate tool outputs at<br/>emit; reference by URL]:::fix
-    Q4 -- "no" --> Q5{System prompt /<br/>retrieval bloated?}
-    Q5 -- "yes" --> F5[Compress / chunk retrieval]:::fix
-    Q5 -- "no" --> F6[Genuine long session —<br/>split via steer-restart<br/>with summary]:::fix
+    Start([context_window_tokens<br/>≥ limit_tokens]):::sym --> Q1{STEER was recently issued?}
+    Q1 -- "yes, several" --> F1[STEER-driven growth:<br/>truncate bodies, prune<br/>completed tasks from planner prompt]:::fix
+    Q1 -- "no" --> Q2{goldfive.llm.request.chars<br/>growing monotonically?}
+    Q2 -- "yes" --> F2[History bloat: summarise<br/>prior turns, drop stale state]:::fix
+    Q2 -- "no" --> Q3{Tool output payloads<br/>> 50 KB?}
+    Q3 -- "yes" --> F3[Truncate tool outputs at<br/>emit; reference by URL]:::fix
+    Q3 -- "no" --> Q4{System prompt /<br/>retrieval bloated?}
+    Q4 -- "yes" --> F4[Compress / chunk retrieval]:::fix
+    Q4 -- "no" --> F5[Genuine long session —<br/>split via steer-restart<br/>with summary]:::fix
 
     classDef sym fill:#fde2e4,stroke:#c0392b,color:#000
     classDef fix fill:#d4edda,stroke:#27ae60,color:#000
 ```
 
+**Post-STEER context growth is expected.** Every STEER the steerer
+applies adds the drift body + task-state snapshot into the planner's
+prompt. Several STEERs in a row grow the context predictably and
+observably — see
+[high-latency-callbacks.md](high-latency-callbacks.md) for the
+`goldfive.llm.request.chars` diagnostic.
+
 ## Symptoms
 
-- **UI**: drawer's context-window visualization shows
-  `tokens / limit_tokens` at or near 1.0; Gantt marks recent LLM_CALL
-  spans with errors.
-- **Client log**:
-  - `drift observed kind=context_pressure severity=... detail=...`
-    — drift detector fired the `context_pressure` drift kind.
-  - Possibly `plan refined: drift=context_pressure reason=... plan_id=...`
-    if the refine took effect.
-  - LLM client library errors, e.g. `google.api_core.exceptions.InvalidArgument:
-    prompt too long` or provider-specific equivalents.
+- **UI**: Gantt's per-agent context-window overlay renders red on the
+  agent rows that are near the limit; the per-agent header chip shows
+  `tokens / limit_tokens` at or near 1.0; recent LLM_CALL spans end
+  with errors.
+- **Goldfive log**:
+  - Per-LLM-call metrics (goldfive#172) —
+    `goldfive.llm.request.chars` climbing; `goldfive.llm.usage.*_tokens`
+    approaching `limit_tokens`.
+  - LLM client library errors, e.g. `openai.BadRequestError:
+    prompt too long`, `google.api_core.exceptions.InvalidArgument:
+    prompt too long`, or provider-specific equivalents.
 - **Heartbeat**: `context_window_tokens` ≥ `context_window_limit_tokens`
-  — see `ingest.py:587-609` for the sample publish path.
+  (published via `ingest.py`).
 
 ## Immediate checks
 

--- a/docs/runbooks/demo-wont-start.md
+++ b/docs/runbooks/demo-wont-start.md
@@ -49,17 +49,27 @@ pgrep -af 'pnpm dev\|vite'
 pgrep -af 'adk web'
 
 # Are the three default ports bound?
-lsof -nP -iTCP:7531 -sTCP:LISTEN
-lsof -nP -iTCP:5173 -sTCP:LISTEN
-lsof -nP -iTCP:8080 -sTCP:LISTEN
+lsof -nP -iTCP:7531 -sTCP:LISTEN         # harmonograf gRPC
+lsof -nP -iTCP:5174 -sTCP:LISTEN         # harmonograf gRPC-Web (for browsers)
+lsof -nP -iTCP:5173 -sTCP:LISTEN         # Vite dev server
+lsof -nP -iTCP:8080 -sTCP:LISTEN         # adk web
 
 # Is the LLM endpoint set and reachable?
-echo $OPENAI_API_BASE
-curl -s $OPENAI_API_BASE/models 2>/dev/null || echo "unreachable"
-
-# Vite logs (stdout of the `make demo` invocation — grep there)
-# ADK web logs
+echo "KIKUCHI_LLM_URL=$KIKUCHI_LLM_URL"
+echo "USER_MODEL_NAME=$USER_MODEL_NAME"
+echo "GOLDFIVE_EXAMPLE_PLANNER_MODEL=$GOLDFIVE_EXAMPLE_PLANNER_MODEL"
+curl -s "$KIKUCHI_LLM_URL/v1/models" | head 2>/dev/null || echo "unreachable"
 ```
+
+The demo uses:
+
+- `KIKUCHI_LLM_URL` — OpenAI-compatible endpoint (e.g. a local vLLM
+  or Ollama gateway).
+- `USER_MODEL_NAME` — model string for the primary user-facing agent
+  (defaults to `openai/qwen3.5-35b`).
+- `GOLDFIVE_EXAMPLE_PLANNER_MODEL` — model for the planner; defaults
+  to `USER_MODEL_NAME`. Override to run a smaller/faster model as the
+  planner.
 
 ## Root cause candidates (ranked)
 
@@ -68,9 +78,11 @@ curl -s $OPENAI_API_BASE/models 2>/dev/null || echo "unreachable"
    different project, etc.). Vite exits with `EADDRINUSE`; harmonograf
    server crashes; ADK web refuses to bind.
 2. **LLM endpoint missing / unreachable** — the presentation agent
-   needs a reachable LLM. If `OPENAI_API_BASE` (or `GOOGLE_API_KEY`) is
-   unset or points at a dead host, the agent either crashes at import
-   or responds with errors on the first turn.
+   needs a reachable LLM. If `KIKUCHI_LLM_URL` is unset or points at
+   a dead host, the agent either crashes at import (OpenAI client
+   initialisation) or responds with errors on the first turn. A
+   Gemini-backed demo uses `GOOGLE_API_KEY` / `GEMINI_API_KEY`
+   instead.
 3. **`HARMONOGRAF_SERVER` pointing at the wrong port** — the Makefile
    sets `HARMONOGRAF_SERVER=127.0.0.1:$(SERVER_PORT)` (Makefile ~line
    171); if you overrode it with something stale, the agent connects

--- a/docs/runbooks/drift-not-firing.md
+++ b/docs/runbooks/drift-not-firing.md
@@ -1,184 +1,165 @@
 # Runbook: Drift not firing
 
-> **Post-goldfive note.** Drift detection and the refine pipeline live
-> in [goldfive](https://github.com/pedapudi/goldfive) now
-> (`goldfive.DefaultSteerer`, `goldfive.drift`). Line numbers into
-> `adk.py` / `agent.py` are historical; look in goldfive for current
-> fire sites. Check goldfive logs for `drift observed` /
-> `refine: entry` lines rather than harmonograf-client loggers.
+A tool failed, the agent refused, the user sent a steer — and nothing
+happened. No drift marker appeared on the InterventionsTimeline, no
+plan revision fired, the planner looks idle.
 
-A tool failed, the agent refused, or the user sent a steer — and
-nothing happened. No `drift observed` log line, no refine, no plan
-revision.
-
-**Triage decision tree** — drift detection runs from ADK callbacks; if the
-right callback never fires for the event class, the detector is blind.
-
-```mermaid
-flowchart TD
-    Start([Expected drift,<br/>nothing detected]):::sym --> Q1{ADK callback fired<br/>at all? before/after_tool,<br/>on_event}
-    Q1 -- "no" --> F1[ADK version skipped<br/>callback for this event;<br/>upgrade ADK or add hook]:::fix
-    Q1 -- "yes" --> Q2{Tool actually raised<br/>or returned error obj?}
-    Q2 -- "returned obj" --> F2[Tool swallowed exception:<br/>let it propagate so<br/>on_tool_end sees error=]:::fix
-    Q2 -- "raised" --> Q3{detect_drift raised<br/>and was swallowed?<br/>(needs DEBUG log)}
-    Q3 -- "yes" --> F3[Fix detector exception,<br/>add unit test]:::fix
-    Q3 -- "no" --> Q4{task_plans count<br/>for session = 0?}
-    Q4 -- "yes" --> F4[Drift fired before<br/>first plan — submit plan<br/>first]:::fix
-    Q4 -- "no" --> Q5{LOG_LEVEL = DEBUG?}
-    Q5 -- "no" --> F5[severity=debug drifts hide<br/>at INFO; raise log level]:::fix
-    Q5 -- "yes" --> F6[Drift kind not on the<br/>scanner's path —<br/>add detector for it]:::fix
-
-    classDef sym fill:#fde2e4,stroke:#c0392b,color:#000
-    classDef fix fill:#d4edda,stroke:#27ae60,color:#000
-```
+All drift detection is in [goldfive](https://github.com/pedapudi/goldfive)
+now. This runbook is about diagnosing which detector didn't fire and
+why.
 
 ## Symptoms
 
-- **Client log**: absence of
-  - `WARN harmonograf_client.adk: drift observed kind=<k> severity=<s> detail=<d>`
-    (`adk.py:3311` for critical, `adk.py:3313` for info —
-    `sev_msg = "drift observed kind=%s severity=%s detail=%s"`).
-  - `INFO harmonograf_client.adk: refine: entry hsession=... drift_kind=...`
-    (`adk.py:3301`).
-- **Server log**: nothing unusual; the server only sees drift
-  indirectly via revised plans.
-- **UI**: amber pill never appears; drawer plan-revision history is
-  static.
+- **Intervention timeline strip**: empty or missing the event you
+  expected (`TOOL_ERROR`, `AGENT_REFUSAL`, `USER_STEER`,
+  `LOOPING_REASONING`, `PLAN_DIVERGENCE`, `CONFABULATION_RISK`).
+- **Drawer → Task → Plan revisions**: no new revision followed the
+  event.
+- **Goldfive log**: no line of the form
+  `goldfive.drift: DriftDetected kind=<K> severity=<S> detail=<D>`.
+- **Harmonograf server log**: nothing unusual. The server only sees
+  drift indirectly via `goldfive_event.drift_detected` ingested from
+  the agent.
+
+## Detector catalogue
+
+Goldfive runs a handful of detectors, each wired into a specific ADK
+callback. If the callback doesn't fire for the event kind you care
+about, the detector is blind.
+
+| Drift kind | Detector location | Callback hook |
+|---|---|---|
+| `USER_STEER`, `USER_CANCEL` | `goldfive.steerer` | Synthesised from incoming `STEER` / `CANCEL` control events. |
+| `TOOL_ERROR` | `goldfive.adapters.adk.plugin` | `on_tool_error_callback`. |
+| `AGENT_REFUSAL` | `goldfive.adapters.adk.plugin` | `after_model_callback` parses refusal patterns. |
+| `LOOPING_REASONING` | `goldfive.detectors.tool_loop_tracker` (#181/#186) | `after_tool_callback` — exact, name, and alternating modes. |
+| `PLAN_DIVERGENCE` (goldfive#178 stage 2) | `goldfive.detectors.function_call_gate` | `before_tool_callback` gate. |
+| `CONFABULATION_RISK` (goldfive#178 stage 3) | same gate | Hallucinated tool name. |
+| `GOAL_DRIFT` | `goldfive.planner.goal_aware` | Goal-aware refiner observation. |
+| `HUMAN_INTERVENTION_REQUIRED` | `goldfive.steerer` intervention ladder | Escalated when other drifts don't resolve. |
+| `REFINE_VALIDATION_FAILED` | `goldfive.planner` | Planner's own refine result validation. |
 
 ## Immediate checks
 
 ```bash
-# Did any detector scan run?
-grep -E 'detect_drift|drift observed|refine: entry' /path/to/agent.log | tail -30
+# Did any detector run?
+grep -E 'DriftDetected|drift observed' /path/to/agent.log | tail -30
 
-# Did callbacks run at all?
-grep -E 'after_model_callback|on_event_callback|before_tool_callback' /path/to/agent.log | tail -20
+# Did the relevant callback fire?
+grep -E 'after_tool_callback|on_tool_error_callback|after_model_callback|before_tool_callback' /path/to/agent.log | tail -30
 
-# Was a tool error visible?
-grep -E 'tool_error|on_tool_end|error=' /path/to/agent.log | tail -20
+# Did the steerer even see a control?
+grep -E 'STEER received|CANCEL received|control_ack' /path/to/agent.log | tail -20
+
+# Check harmonograf's intervention list via the server RPC:
+uv run --with grpcurl grpcurl -plaintext \
+  -d '{"session_id":"<SID>"}' \
+  localhost:7531 harmonograf.v1.Harmonograf/ListInterventions
 ```
 
-## Root cause candidates (ranked)
+## Root-cause candidates (ranked)
 
-1. **Detector wasn't on the callback path for this event kind** — e.g.
-   the error came from an async tool that the `after_tool_callback`
-   didn't observe. If `state.on_tool_end(..., error=...)`
-   (`adk.py:1369`) wasn't called, drift detection isn't scheduled.
-2. **Detect_drift raised and was swallowed** —
-   `DEBUG harmonograf_client.agent: HarmonografAgent: detect_drift raised: <exc>`
-   (`agent.py:562`, `agent.py:780`). If you're at INFO level, you
-   won't see this.
-3. **Callback path never fired** — `after_model_callback` /
-   `on_event_callback` is the belt-and-suspenders path; if neither
-   runs, no scan happens. Typically because the ADK version skipped
-   calling the callback for the event type you care about.
-4. **Tool reported success despite erroring** — the tool implementation
-   swallowed its exception and returned a value. The adapter has no
-   way to know the tool failed. Same symptom as (1).
-5. **Drift fired but throttled** — rare, because drift-not-firing
-   usually means zero entries in the log, but worth checking:
-   `refine: throttled kind=...`.
-6. **Plan was None when drift was evaluated** — `refine_plan_on_drift`
-   early-exits if there's no current plan; no log, no action. This
-   happens when a drift fires before the first plan was submitted.
-7. **Drift severity dropped to DEBUG** — info/warning severity is
-   logged at INFO or WARNING, but DEBUG-severity drifts are logged at
-   DEBUG (`adk.py:3315`). If your log level is INFO, you won't see
-   them.
+1. **Tool swallowed the exception** — a tool that does
+   `try: ... except: return {"error": "..."}` never trips
+   `on_tool_error_callback`. The tool returns "successfully" so
+   `TOOL_ERROR` doesn't fire. Same symptom: the agent clearly
+   failed, but harmonograf and goldfive see nothing.
+2. **Callback never fired** — the ADK version skipped the callback
+   for this event type. `after_tool_callback` coverage is the most
+   common gap.
+3. **Detector exception swallowed** — a detector raised and goldfive
+   logged at DEBUG. Run with `LOG_LEVEL=DEBUG` to see.
+4. **STEER annotation body was rejected** — empty body, body > 8 KiB,
+   or ASCII control characters. The client-side bridge rejects it
+   before goldfive's steerer sees it. Check the frontend for an
+   inline error.
+5. **STEER bypassed goldfive** — some clients don't install the
+   goldfive control bridge. Controls deliver but drift never synthesises.
+6. **Plan was None when drift was evaluated** — goldfive refuses to
+   refine against an empty plan. Check that `PlanSubmitted` fired
+   before the drift.
+7. **Duplicate `HarmonografTelemetryPlugin`** (#68) — if the plugin
+   was installed twice, the later instance silently disabled itself.
+   Span visibility may be intact but any drift inference that depended
+   on span-attribute hooks from the disabled instance is lost. Look
+   for `duplicate HarmonografTelemetryPlugin instance detected` at INFO.
+8. **Tool-loop threshold not reached** — `LOOPING_REASONING` needs a
+   minimum repetition count (configurable in goldfive). A two-step
+   loop won't trip it.
 
 ## Diagnostic steps
 
-### 1. Callback coverage
+### 1. Goldfive drift log
 
-Turn on `LOG_LEVEL=DEBUG` for `harmonograf_client.adk` and
-`harmonograf_client.agent`:
+Run with goldfive at INFO:
 
 ```bash
-grep -E 'before_tool_callback|after_tool_callback|on_tool_end|on_event_callback' /path/to/agent.log | tail -40
+GOLDFIVE_LOG_LEVEL=INFO ...
+grep -E 'DriftDetected' /path/to/agent.log
 ```
 
-You should see every ADK callback cross this log. If only some kinds
-appear, that is your gap.
+If you see drifts firing on unrelated events but not yours, the
+detector for your event class is blind.
 
-### 2. detect_drift exception
+### 2. Intervention RPC
 
 ```bash
-grep 'detect_drift raised' /path/to/agent.log
+grpcurl -plaintext \
+  -d '{"session_id":"sess_2026-04-21_0001"}' \
+  localhost:7531 harmonograf.v1.Harmonograf/ListInterventions | jq .
 ```
 
-Fix the underlying exception; it is usually a TypeError against a
-dict shape that changed.
+Empty `interventions` list for a session where you triggered a STEER
+means the annotation didn't make it to goldfive.
 
-### 3. Callback never fired
-
-Grep for the specific ADK event type:
+### 3. STEER annotation diagnostics
 
 ```bash
-grep -E 'invocation_id|event_type' /path/to/agent.log
-```
-
-If the ADK version doesn't fire `on_event_callback` for
-`StateDelta` events, the whole delegated-mode drift scanner is blind.
-You need to upgrade ADK, or add a pre-call hook.
-
-### 4. Tool swallowed error
-
-Read the tool's source. If it has `try: ... except: return {...}`,
-the adapter never sees the failure. No quick fix — audit the tool.
-
-### 5. Throttled
-
-```bash
-grep 'refine: throttled' /path/to/agent.log
-```
-
-### 6. Plan was None
-
-```bash
-grep 'apply_drift_from_control: no active sessions' /path/to/agent.log
-# and more generally:
 sqlite3 data/harmonograf.db \
-  "SELECT COUNT(*) FROM task_plans WHERE session_id='SESSION_ID';"
+  "SELECT id, kind, body, author, created_at, delivered_at
+   FROM annotations
+   WHERE session_id='<SID>' AND kind='STEERING'
+   ORDER BY created_at DESC LIMIT 5;"
 ```
 
-If zero, the drift fired before a plan existed. Submit a plan first.
+- `delivered_at IS NULL` → the STEER never made it to the agent. The
+  server dispatched a `STEER` ControlEvent but no ack came back.
+  Check `control_router` logs.
+- Body looks empty or malformed → validation rejected it on the
+  client bridge.
 
-### 7. DEBUG severity
+### 4. Duplicate plugin
 
 ```bash
-grep -i 'drift observed.*severity=debug' /path/to/agent.log
+grep 'duplicate HarmonografTelemetryPlugin' /path/to/agent.log
 ```
 
-If present, the detector *is* running; it's just quiet at INFO.
+If present, remove one of the installation points. The plugin is
+usually installed via `App(plugins=[HarmonografTelemetryPlugin(c)])`
+— make sure a downstream `observe()` or `add_plugin` isn't also
+installing it.
+
+### 5. Tool swallowing
+
+Audit the tool source. If it has broad `except`, let the exception
+propagate instead.
 
 ## Fixes
 
-1. **Missing callback path**: add the hook for the event kind you care
-   about. For tool errors, verify `after_tool_callback` is wired and
-   that tools raise exceptions instead of returning error objects.
-2. **detect_drift exception**: fix it and add a unit test.
-3. **Callback never fired**: upgrade ADK to a version that fires the
-   callback, or implement your own wrapper.
-4. **Tool swallowed error**: stop swallowing; let exceptions propagate
-   so `on_tool_end` sees `error=<exc>`.
-5. **Throttled**: not a bug; see goldfive's refine-throttle settings.
-6. **Plan missing**: ensure goldfive has submitted a plan for this run
-   (look for a `PlanSubmitted` event in the timeline).
-7. **Severity = DEBUG**: raise log level or change the detector to
-   emit at INFO.
-
-## Prevention
-
-- Audit every tool for swallowed exceptions on import — a tool that
-  returns `{"error": "..."}` is invisible to drift detection.
-- Unit-test each drift detector against a canned event log from the
-  ADK you support.
-- In CI, assert that a forced tool exception produces at least one
-  `drift observed kind=tool_error` log line.
+1. Stop swallowing tool exceptions.
+2. Upgrade ADK if a callback isn't firing.
+3. Fix the detector's exception, add a unit test.
+4. Post STEER annotations with non-empty, < 8 KiB bodies.
+5. Ensure only one `HarmonografTelemetryPlugin` lands on the
+   `PluginManager`.
+6. For loops, tune goldfive's `ToolLoopTracker` threshold or
+   instrument the tool to surface the ambiguity.
 
 ## Cross-links
 
-- [`dev-guide/debugging.md`](../dev-guide/debugging.md) §"A drift fires
-  repeatedly" — symmetric problem.
-- [`runbooks/frontend-shows-stale-data.md`](frontend-shows-stale-data.md)
-  — if the revision is happening but not reaching the UI.
+- [user-guide/control-actions.md](../user-guide/control-actions.md)
+  — STEER body constraints.
+- [user-guide/trajectory-view.md](../user-guide/trajectory-view.md) —
+  how drifts surface on the intervention timeline.
+- [dev-guide/debugging.md](../dev-guide/debugging.md) — server-side
+  SQL snippets for inspecting plans, annotations, agents.

--- a/docs/runbooks/high-latency-callbacks.md
+++ b/docs/runbooks/high-latency-callbacks.md
@@ -1,177 +1,139 @@
 # Runbook: High-latency callbacks
 
-> **Post-goldfive note.** The heavy callbacks that used to live in
-> `harmonograf_client.adk._AdkState.*` (planner refine, drift
-> detection, context-window accounting) now run in
-> [goldfive](https://github.com/pedapudi/goldfive). Profile goldfive's
-> `DefaultSteerer` / `LLMPlanner.refine` / drift classifiers when
-> chasing hot-path latency; the harmonograf side is span marshal +
-> ring-buffer push only.
-
 The agent's hot path is slow. Spans take a long time to end, the
-client buffer backs up, the UI feels laggy. Py-spy shows most time
-inside `harmonograf_client.adk` callbacks.
+client buffer backs up, the UI feels laggy, STEER acks take
+seconds.
 
-**Triage decision tree** — py-spy first; the dominant frame names the cause.
-
-```mermaid
-flowchart TD
-    Start([Hot path slow,<br/>buffered_events climbing]):::sym --> Q1{py-spy top: dominant<br/>frame?}
-    Q1 -- "tiktoken / tokenizer / encode" --> F1[Tokenizer-heavy: sample less,<br/>cache stable prefix tokens]:::fix
-    Q1 -- "planner.refine" --> F2[Move refine off event loop<br/>or set refine_on_events=False]:::fix
-    Q1 -- "logging / format" --> F3[LOG_LEVEL=DEBUG in prod;<br/>switch to INFO]:::fix
-    Q1 -- "hashlib / sha256" --> F4[Big payload hashing —<br/>stop capturing full bodies]:::fix
-    Q1 -- "before_tool_callback" --> F5[Sync IO in handler;<br/>make async / queue]:::fix
-    Q1 -- "detect_drift" --> F6[O(events) scan: add cursor<br/>events_since_last_scan]:::fix
-    Q1 -- "check_plan_state /<br/>_check_*" --> F7[Invariant checker hot —<br/>only run in dev/CI]:::fix
-    Q1 -- "looks normal but slow" --> F8[Network slow: see<br/>agent-disconnects-repeatedly]:::fix
-
-    classDef sym fill:#fde2e4,stroke:#c0392b,color:#000
-    classDef fix fill:#d4edda,stroke:#27ae60,color:#000
-```
+Post-goldfive-migration this is almost always about the LLM itself,
+not harmonograf's callback machinery. The harmonograf side is span
+marshal + ring-buffer push, which is microseconds per envelope.
 
 ## Symptoms
 
-- **Client heartbeat**: `buffered_events` climbs, `cpu_self_pct` high,
-  `current_activity` stays on one step for long periods.
-- **Client log** (with DEBUG): callback entry / exit times far apart.
-  Possibly `harmonograf_client.adk: planner.refine blocked the event
-  loop for <x>s — consider disabling refine_on_events` (`adk.py:2063`).
-- **UI**: spans appear in chunks instead of smoothly; transport bar
-  shows transient back-pressure.
-- **py-spy** top: time spent in
-  `harmonograf_client.adk._AdkState.*`, `detect_drift`, `record_span`,
-  or the tokenizer used for context-window accounting.
+- **Client heartbeat**: `buffered_events` climbs, `cpu_self_pct`
+  high, `current_activity` stays on one step for long periods.
+- **UI**: spans appear in chunks instead of smoothly; the Gantt
+  shows multi-second gaps between span closes on the live edge.
+- **Intervention strip**: STEER cards stay at `pending` outcome
+  for many seconds.
+- **Goldfive log**: `goldfive.llm.duration_ms` values in the
+  tens of thousands.
 
 ## Immediate checks
 
 ```bash
-# py-spy top the running agent:
+# py-spy the running agent to find the dominant frame
 py-spy top --pid $(pgrep -f my_agent)
 
-# Dump a sample:
-py-spy dump --pid $(pgrep -f my_agent)
+# Recent LLM call durations
+grep -E 'goldfive.llm.duration_ms' /path/to/agent.log | tail -20
 
-# Heartbeat trend — buffered_events over time:
-grep buffered_events /path/to/agent.log | tail -40
+# Per-agent context-window usage
+grep -E 'goldfive.llm.request.chars|context_window_tokens' /path/to/agent.log | tail -20
 
-# Slow refines explicitly logged:
-grep 'planner.refine blocked the event loop' /path/to/agent.log
+# Heartbeat trend
+grep -E 'buffered_events|progress_counter' /path/to/agent.log | tail -30
 ```
 
-## Root cause candidates (ranked)
+## Root-cause candidates (ranked)
 
-1. **Tokenizer-heavy context-window accounting** — counting tokens
-   on every LLM call, especially with a pure-python tokenizer, is
-   expensive. If `context_window_tokens` updates every turn, this
-   adds up.
-2. **Blocking planner refine on the event loop** — `planner.refine`
-   is called synchronously on some drift paths and blocks the
-   asyncio loop until it returns. The adapter emits a warning:
-   `planner.refine blocked the event loop for %.1fs — consider
-   disabling refine_on_events` (`adk.py:2063`).
-3. **Excessive DEBUG logging** — running with `LOG_LEVEL=DEBUG` in
-   production will turn the `harmonograf_client.adk` logger into a
-   bottleneck. Every callback emits multiple lines.
-4. **Big payloads on every span** — attaching prompt + response bytes
-   to every LLM_CALL turns the buffer into a blob store. Hashing the
-   blob also costs CPU.
-5. **Synchronous reporting-tool handlers** — each reporting-tool
-   invocation hops through `before_tool_callback`; if the handler
-   does IO (writes to a file, hits a DB), the whole flow blocks.
-6. **Drift detector scanning full event history on every call** —
-   `detect_drift` in `_AdkState` may be O(events); if the session has
-   thousands of events, every scan gets slower. Rare but worth
+1. **Slow LLM provider** — a local Qwen3.5-35B routinely takes
+   20-60 s per call; a planner refine with a long task list can hit
+   90 s on a laptop. This is 99% of "high latency callback"
+   complaints. The fix is upstream, not in harmonograf.
+2. **Runaway context growth post-STEER** — every STEER adds the
+   drift body + task state into the planner's prompt. Over several
+   STEERs the prompt grows linearly. Check
+   `goldfive.llm.request.chars` on consecutive calls; linear growth
+   is the signature.
+3. **Tool loop not yet detected** — an agent calling the same tool
+   N times in a row. Each call takes its normal duration, but the
+   overall wall-clock balloons. Look for repeating TOOL_CALL names
+   in the Gantt; goldfive#181/#186's `ToolLoopTracker` will
+   eventually fire `LOOPING_REASONING` but may take several
+   repetitions.
+4. **Large payload hashing** — spans with multi-MB tool outputs /
+   LLM responses. Harmonograf hashes and chunks them; >50 MB
+   outputs are slow. Check `has_payload` on hot spans.
+5. **Logging pressure** — `LOG_LEVEL=DEBUG` in production with a
+   chatty logger format doing field-formatting on every span.
+6. **Duplicate plugin** (#68) — two `HarmonografTelemetryPlugin`
+   instances on the same PluginManager. One stays silent, but the
+   active one does the work twice on some paths if the user also
+   calls it directly. Not a common cause of latency but worth
    checking.
-7. **Invariant checker in the hot path** — running `check_plan_state`
-   after every transition in a large plan is O(plan size).
 
 ## Diagnostic steps
 
-### 1. Tokenizer
-
-py-spy top → frames containing `tiktoken`, `transformers`,
-`tokenizer`, or `encode`. If they dominate, the tokenizer is the
-cost.
-
-### 2. Blocking refine
+### 1. Confirm it's the LLM
 
 ```bash
-grep 'planner.refine blocked the event loop' /path/to/agent.log
+grep -E 'goldfive.llm.duration_ms' /path/to/agent.log | awk '{print $NF}' | sort -n | tail -20
 ```
 
-If present, the count and the duration tell you how often and how
-bad. The advice in the log line — disable `refine_on_events` — is
-the fix.
+If the tail is dominated by multi-thousand-ms values, the LLM is
+the bottleneck. If values are all < 500, look elsewhere.
 
-### 3. Debug logging
-
-Check `LOG_LEVEL` in the agent env:
+### 2. Check context growth
 
 ```bash
-env | grep -i log
+grep -E 'goldfive.llm.request.chars' /path/to/agent.log | tail -40
 ```
 
-If it's `DEBUG`, switch to `INFO` for production.
+If the numbers climb strictly monotonically across STEERs, you've
+got context accumulation. Possible remedies:
 
-### 4. Big payloads
+- Truncate the STEER body before forwarding.
+- Have goldfive prune completed tasks from the planner prompt
+  (off by default; an opt-in).
+- Move to a larger-context model and accept the growth.
+
+### 3. Loop detection
 
 ```bash
 sqlite3 data/harmonograf.db \
-  "SELECT digest, size FROM payloads ORDER BY size DESC LIMIT 20;"
+  "SELECT name, COUNT(*) FROM spans
+   WHERE agent_id='<AID>' AND kind='TOOL_CALL'
+     AND start_time > (strftime('%s','now')-300)
+   GROUP BY name HAVING COUNT(*) > 3 ORDER BY 2 DESC;"
 ```
 
-If the top sizes are > 1MB, you're storing blobs. Cut capture.
+More than 3 identical tool names in 5 minutes = loop candidate.
+Goldfive's tracker covers exact, name-only, and alternating
+patterns; thresholds are configurable.
 
-### 5. Synchronous tool handlers
+### 4. Payload pressure
 
-Search for `time.sleep`, blocking IO, or long CPU work inside
-reporting-tool bodies or `before_tool_callback` hooks.
+```bash
+sqlite3 data/harmonograf.db \
+  "SELECT digest, size, mime FROM payloads ORDER BY size DESC LIMIT 10;"
+```
 
-### 6. detect_drift hot
-
-py-spy top → `detect_drift` frames dominating. Profile the scan.
-
-### 7. Invariant hot
-
-py-spy top → `check_plan_state` / `_check_*` frames dominating.
-The checker is designed for debugging, not hot-path use.
+If the top entries are 50 MB+, the tool or LLM is producing
+unreasonable outputs.
 
 ## Fixes
 
-1. **Tokenizer**: sample less often (only N turns), or switch to a C
-   tokenizer (`tiktoken`), or cache the token count across turns for
-   stable prompt prefixes.
-2. **Blocking refine**: move `refine` to a background task via
-   `asyncio.create_task`, OR set `refine_on_events=False` and rely
-   only on reporting-tool-driven refines. The adapter's warning
-   documents this choice.
-3. **DEBUG logging**: set `LOG_LEVEL=INFO` in production; keep DEBUG
-   for investigation only.
-4. **Payloads**: stop capturing full payloads by default; capture
-   only the ones a user explicitly requests or that the drawer will
-   need.
-5. **Sync handlers**: make them `async` and `await` IO. Don't do
-   work in `before_tool_callback`; queue to a background task.
-6. **detect_drift**: add an `events_since_last_scan` cursor so each
-   scan is bounded.
-7. **Invariant checker**: don't run it on every transition in
-   production; run it on demand or in tests.
-
-## Prevention
-
-- Keep a latency SLO for `after_model_callback` round-trip (say,
-  100ms) and alert if exceeded.
-- Benchmark the callbacks in CI against a canned event log, assert
-  they finish within the SLO.
-- Treat `buffered_events` growth > 0 in steady state as a red flag
-  — either the transport is slow or the hot path is slow.
+1. **Slow LLM**: use a faster provider or a smaller model for the
+   planner. The planner refine is disproportionately slow because
+   of prompt size; smaller faster models run refine better.
+2. **Context growth**: truncate STEER bodies to ~1 KB at the UI
+   edge; prune completed tasks from the planner prompt in goldfive.
+3. **Tool loop**: tighten `ToolLoopTracker` thresholds; improve the
+   agent's instructions so it doesn't retry the same tool call.
+4. **Large payloads**: stop capturing full bodies on cumulative
+   LLM outputs; use `payload_ref` summaries.
+5. **Log noise**: set `LOG_LEVEL=INFO` in production.
+6. **Duplicate plugin**: deinstall the duplicate. Only the earliest
+   instance on the `PluginManager` is active; subsequent ones log
+   `duplicate HarmonografTelemetryPlugin instance detected` once
+   at INFO.
 
 ## Cross-links
 
-- [`runbooks/agent-disconnects-repeatedly.md`](agent-disconnects-repeatedly.md)
-  — slow hot path → heartbeat miss → disconnect.
-- [`dev-guide/debugging.md`](../dev-guide/debugging.md) §"Turning on
-  debug logging" — log levels per logger.
-- `client/harmonograf_client/adk.py:2062-2063` — the "blocked the
-  event loop" warning.
+- [dev-guide/performance-tuning.md](../dev-guide/performance-tuning.md)
+  — the full map of hot paths and their costs.
+- [runbooks/context-window-exceeded.md](context-window-exceeded.md)
+  — when the LLM is truncating inputs.
+- [runbooks/task-stuck-in-running.md](task-stuck-in-running.md) —
+  when a slow LLM call wedges a task outright.

--- a/docs/runbooks/span-tree-looks-wrong.md
+++ b/docs/runbooks/span-tree-looks-wrong.md
@@ -4,6 +4,26 @@ Spans display in the UI with nonsense parenting: orphans, spans with
 parents that don't exist, cross-agent links that look random, or a
 tree whose shape doesn't match what the agent actually did.
 
+## Expected with per-agent rows (#80)
+
+A single `goldfive.wrap` run now registers one harmonograf agent row
+per ADK agent — a coordinator plus its specialists plus AgentTool
+wrappers — with ids shaped like
+`<client.agent_id>:<adk_agent_name>`. This is **expected**, not a bug.
+If you upgraded harmonograf recently and see "too many" agent rows,
+that's the per-agent fix landing.
+
+The auto-registration path is in
+`server/harmonograf_server/ingest.py`'s `_handle_span_start`: the
+first span it sees with an unknown `agent_id` is treated as a
+sub-agent of the root, harvesting `hgraf.agent.*` metadata hints
+from the span's attributes.
+
+If an agent row appears with no spans, that's the auto-register
+happening but subsequent spans never arriving. Look for a duplicate
+`HarmonografTelemetryPlugin` (#68) or a plugin install that happened
+after the first callback.
+
 **Triage decision tree** — the orphan/cross-agent SQL queries below split
 the cases. Buffer drops account for most "vanished parent" symptoms.
 

--- a/docs/runbooks/task-stuck-in-pending.md
+++ b/docs/runbooks/task-stuck-in-pending.md
@@ -1,230 +1,152 @@
 # Runbook: Task stuck in PENDING
 
-> **Post-goldfive note.** Reporting-tool interception, the plan walker,
-> and the task state machine live in
-> [goldfive](https://github.com/pedapudi/goldfive) now. Line numbers
-> below reference the pre-migration `adk.py` and will not resolve.
-> Treat the conceptual triage as still accurate, but look in goldfive's
-> `DefaultSteerer` / `ADKAdapter` / executor code for the actual logic.
+A task is rendered in the plan (Gantt, Graph, task panel, drawer) but
+never transitions to `RUNNING`. This runbook covers the post-overlay
+world (goldfive#141-144).
 
-The plan is rendered, tasks are visible in the Gantt and drawer, but
-they never transition to RUNNING. The current-task strip stays empty
-or keeps displaying "no current task".
+## Expected vs pathological
 
-**Triage decision tree** — plan exists, tasks frozen at PENDING. The dominant
-cause is the LLM never calling `report_task_started`; check that first.
+Goldfive's overlay model drives tasks observation-first: a task moves
+to RUNNING only when an agent is observed working on it. Two states
+are **expected** at invocation end:
 
-```mermaid
-flowchart TD
-    Start([Tasks visible but never<br/>enter RUNNING]):::sym --> Q1{Client log mentions<br/>report_task_started /<br/>on_reporting_tool?}
-    Q1 -- "no" --> Q1a{Reporting tool<br/>registration skipped?}
-    Q1a -- "yes" --> F1a[Fix exception in adk.py:189;<br/>usually ADK version mismatch]:::fix
-    Q1a -- "no" --> F1b[Augmented instruction missing<br/>or model ignoring tool —<br/>verify tools.augment_instruction]:::fix
-    Q1 -- "yes, but no movement" --> Q2{parallel_mode=True?}
-    Q2 -- "yes" --> Q2a{Walker activity<br/>in log?}
-    Q2a -- "no" --> F2[Restart agent; walker<br/>crashed mid-plan]:::fix
-    Q2a -- "yes" --> Q3
-    Q2 -- "no" --> Q3{Server log: 'has no matching<br/>plan in session'?}
-    Q3 -- "yes" --> F3[Plan ID mismatch /<br/>stale task_index:<br/>restart agent to resubmit]:::fix
-    Q3 -- "no" --> Q4{assignee_agent_id ⊆<br/>agents in session?}
-    Q4 -- "no" --> F4[Start missing agent<br/>or fix assignee in plan]:::fix
-    Q4 -- "yes" --> F5[Set orchestrator_mode=True<br/>or check observer fallback<br/>parses model output]:::fix
+- `COMPLETED` — the task ran and finished.
+- `NOT_NEEDED` — no agent needed to do this task for the goal to be
+  satisfied. Goldfive flips unassigned `PENDING` tasks to `NOT_NEEDED`
+  when the outer invocation ends.
 
-    classDef sym fill:#fde2e4,stroke:#c0392b,color:#000
-    classDef fix fill:#d4edda,stroke:#27ae60,color:#000
-```
+So a task that sits at `PENDING` throughout a finished run and then
+flips to `NOT_NEEDED` at the end is **working as intended**. That is
+not a bug.
+
+The pathological case is:
+
+- The agent is still actively running.
+- A task sits at `PENDING` indefinitely.
+- No drift fires, no refine lands.
+
+That's what this runbook is about.
 
 ## Symptoms
 
-- **UI**: task rows are greyed out in the Gantt; drawer says
-  `0/N tasks running`.
-- **Client log** (nothing helpful by default, but with `LOG_LEVEL=DEBUG`):
-  - `DEBUG harmonograf_client.adk: ...` callback traces showing no
-    `state.on_task_start` lines
-  - Possibly `WARN goldfive.*` InvariantViolation lines on attempted
-    transitions — check goldfive's steerer log
-- **Server log**:
-  - `DEBUG harmonograf_server.ingest: hgraf.task_id=... on span=... has no matching plan in session=...`
-    (`ingest.py:714`)
-  - `WARN harmonograf_server.ingest: task_status_update for unknown task plan_id=... task_id=...`
-    (`ingest.py:680`)
+- **UI**: a task's row in the Gantt gutter is greyed out for many
+  minutes while other tasks have long since completed.
+- **Current task strip**: shows a different running task or falls
+  back to a completed one.
+- **Server log**: no movement — `UpdatedTaskStatus` deltas for this
+  task id never land.
+- **Goldfive log**: no `TaskStarted` / `TaskProgress` for this task.
 
 ## Immediate checks
 
 ```bash
-# Is the plan actually in sqlite?
+# What's the current plan's task roster + statuses?
 sqlite3 data/harmonograf.db \
-  "SELECT id, revision_index, revision_kind, summary FROM task_plans
-   WHERE session_id='SESSION_ID' ORDER BY revision_index DESC LIMIT 5;"
+  "SELECT id, title, status, assignee_agent_id, bound_span_id
+     FROM tasks
+     WHERE plan_id=(SELECT id FROM task_plans WHERE session_id='<SID>'
+                    ORDER BY revision_index DESC LIMIT 1);"
 
-# What statuses do the tasks have?
+# Has the plan been revised recently?
 sqlite3 data/harmonograf.db \
-  "SELECT id, status, bound_span_id, assignee_agent_id FROM task_plan_tasks
-   WHERE plan_id='PLAN_ID';"
+  "SELECT id, revision_index, revision_kind, revision_reason
+     FROM task_plans
+     WHERE session_id='<SID>'
+     ORDER BY revision_index DESC LIMIT 5;"
 
-# Did any span ever bind to a task?
+# Per-agent rows in this session — is the assignee even there?
 sqlite3 data/harmonograf.db \
-  "SELECT id, kind, name FROM spans
-   WHERE session_id='SESSION_ID'
-     AND json_extract(attributes, '$.\"hgraf.task_id\"') IS NOT NULL
-   LIMIT 10;"
-
-# Was a reporting tool ever intercepted?
-grep 'report_task_started\|reporting_tools_invoked\|_AdkState' /path/to/agent.log | tail -20
+  "SELECT id, name FROM agents WHERE session_id='<SID>';"
 ```
 
-## Root cause candidates (ranked)
+## Root-cause candidates (ranked)
 
-1. **Agent never called `report_task_started`** — the most common.
-   Reporting-tool calls are what drive transitions in sequential /
-   delegated modes. If the LLM didn't call the tool (or the tool wasn't
-   injected into the sub-agent because the instruction augmentation was
-   skipped), nothing moves. See `tools.augment_instruction` and
-   `_AdkState.on_reporting_tool` in `client/harmonograf_client/adk.py`.
-2. **Parallel walker not advancing** — in parallel mode
-   (`parallel_mode=True`), the rigid DAG walker sets
-   `_forced_task_id_var` before dispatching each task. If the walker
-   crashed or was never started, no ContextVar is set and spans arrive
-   without `hgraf.task_id`. The server will log
-   `hgraf.task_id=... on span=... has no matching plan in session=...`
-   — except actually it won't, because the attribute is absent
-   altogether; look for empty `attributes` on spans that should have
-   been bound.
-3. **Plan never registered in the session's task index** — the server's
-   `_task_index[session_id]` is populated from `_handle_task_plan`
-   (`ingest.py:654`). If the task plan was ingested before the server
-   restarted and wasn't rebuilt on boot, `_bind_task_to_span` hits the
-   storage scan fallback (`ingest.py:704`) and may still miss if the
-   plan_id stamped on the span doesn't match the stored plan.
-4. **Plan ID mismatch between agent and server** — the agent thinks the
-   current plan is `plan_123` but the server stored it as `plan_456`
-   because the agent re-submitted and the server deduped. Task updates
-   land under a plan nobody is listening for.
-5. **Assignee agent never connected** — tasks can't report progress
-   because the assignee doesn't exist. The task row will be annotated
-   with an agent that isn't in the session's agent list.
-6. **`HarmonografAgent` running in mode that bypasses reporting
-   tools** — `orchestrator_mode=False` with an inner agent that doesn't
-   use reporting tools. Observer fallback should catch this, but if
-   `after_model_callback` can't parse the responses, nothing happens.
-7. **Reporting-tool registration skipped** — look for:
-   `DEBUG harmonograf_client.adk: reporting tool registration skipped: <exc>`
-   (`adk.py:189`). If registration raised, the tools exist as names
-   only and are never intercepted.
+1. **Assignee agent isn't in the session** — the task is assigned to
+   a sub-agent that the ADK tree never instantiated. Goldfive can't
+   drive a task on an agent that doesn't exist. The `agents` query
+   above should include the assignee id (or its derived per-agent id
+   shape `<client>:<name>`). If it doesn't, that's your cause.
+2. **Reconciler hasn't observed the task yet** — goldfive's
+   observation-driven overlay binds tasks to spans when an agent's
+   activity matches the task's description. If no agent has done
+   anything recognisable, the overlay leaves the task at PENDING.
+   Common when the initial plan over-decomposed and the agent does
+   one compound step that the overlay doesn't attribute to any
+   specific task.
+3. **Plan ID mismatch** — after a refine the task appears under a
+   different plan_id, and the UI is reading a stale one. Check that
+   the highest `revision_index` plan is the one rendered. The
+   intervention aggregator expects monotone `revision_index`.
+4. **Agent wedged** — the assignee exists but isn't making progress.
+   Open
+   [runbooks/task-stuck-in-running.md](task-stuck-in-running.md) for
+   the other direction — a task *was* claimed, and now the agent
+   that claimed it is hung.
+5. **Goldfive steerer unreachable** — the agent's control subscription
+   for this session never came up, so goldfive can't dispatch a
+   STATUS_QUERY to see what's happening. Look for
+   `subscribe control: connection closed` in the agent log. See
+   [agent-disconnects-repeatedly.md](agent-disconnects-repeatedly.md).
 
 ## Diagnostic steps
 
-### 1. Did the LLM call the tool?
+### 1. Check the `agents` row shape
 
-With `LOG_LEVEL=DEBUG` on the client:
+With per-agent Gantt rows (#80), agent ids look like
+`<client.agent_id>:<adk_agent_name>`. If the task's `assignee_agent_id`
+is the bare `client.agent_id` but the actual agent is registered
+under a per-ADK-agent sub-id, the task won't bind.
 
-```bash
-grep -E 'report_task_|on_reporting_tool|_AdkState' /path/to/agent.log | head -40
-```
+Typical fix: refine the plan so `assignee_agent_id` matches one of the
+per-agent rows the server has registered. If you author plans
+programmatically, include the per-ADK-agent shape.
 
-If you see zero `report_task_*` lines, the LLM never called the tool.
-Either the instruction augmentation was skipped (grep for
-`reporting tool registration skipped`) or the model isn't following
-the instruction.
+### 2. Wait for the invocation end
 
-### 2. Parallel walker
+If the run is still active, goldfive will not flip the task to
+`NOT_NEEDED` until the invocation ends. Give it a few minutes; if the
+task flips to `NOT_NEEDED` when the agent finishes, it was never
+needed and there's no bug.
 
-```bash
-grep -E 'walker|_forced_task_id|parallel' /path/to/agent.log | tail -30
-```
+### 3. Send a STATUS_QUERY to the assignee
 
-If `parallel_mode=True` and there's no walker activity, check whether
-`HarmonografAgent.run_parallel` was actually called.
+From the Graph view, click `↻ Status` on the assignee's header. A
+`STATUS_QUERY` control goes to the agent; its self-report lands in
+`TaskReport`. A silent response (no reply) confirms the agent is
+wedged and you're in task-stuck-in-running territory.
 
-### 3. Task index
-
-```bash
-# After a server restart, the index is empty until a plan is
-# re-ingested; force it by listing plans:
-sqlite3 data/harmonograf.db \
-  "SELECT id, session_id, created_at FROM task_plans
-   ORDER BY created_at DESC LIMIT 10;"
-```
-
-If the plan exists in sqlite but the server hasn't seen a
-`_handle_task_plan` for it since startup, restart the agent (which will
-re-submit the plan).
-
-### 4. Plan ID mismatch
-
-Compare what the agent thinks the plan ID is vs what the server stored:
-
-```bash
-grep 'plan_id=\|submit_plan\|plan refined' /path/to/agent.log | tail -20
-sqlite3 data/harmonograf.db \
-  "SELECT id, revision_index FROM task_plans WHERE session_id='SESSION_ID'
-   ORDER BY revision_index DESC LIMIT 5;"
-```
-
-### 5. Assignee
+### 4. Inspect the latest plan
 
 ```bash
 sqlite3 data/harmonograf.db \
-  "SELECT DISTINCT assignee_agent_id FROM task_plan_tasks WHERE plan_id='PLAN_ID';"
-sqlite3 data/harmonograf.db \
-  "SELECT id FROM agents WHERE session_id='SESSION_ID';"
+  "SELECT revision_index, revision_kind, revision_reason, summary
+     FROM task_plans
+     WHERE session_id='<SID>'
+     ORDER BY revision_index DESC LIMIT 3;"
 ```
 
-The first list should be a subset of the second.
-
-### 6. Mode bypass
-
-Check the `HarmonografAgent` construction:
-
-```bash
-grep -E 'HarmonografAgent\(|orchestrator_mode|parallel_mode' /path/to/agent_source.py
-```
-
-### 7. Tool registration failure
-
-```bash
-grep 'reporting tool registration skipped\|reporting-tool registration raised' /path/to/agent.log
-```
-
-If present, the tools weren't injected into any sub-agent. The traceback
-in the message will name the culprit.
+If the latest plan's `revision_kind` is `REFINE_VALIDATION_FAILED`
+the planner couldn't write a coherent plan — the task stays where
+the last valid plan left it.
 
 ## Fixes
 
-1. **LLM not calling tool**: verify the instruction was augmented
-   (`tools.augment_instruction`), and that the model can see the tool
-   names. Turn on verbose logging and confirm the tool appears in the
-   request.
-2. **Parallel walker stopped**: re-run the agent; if a crash took the
-   walker out mid-plan, the plan is in an unrecoverable state in memory.
-3. **Task index stale**: restart the agent so it resubmits the plan,
-   OR clear `_task_index` by restarting the server.
-4. **Plan ID mismatch**: stop and restart the agent to force a clean
-   submit.
-5. **Missing assignee**: start the missing agent process; reconfigure
-   the plan's `assignee_agent_id` to a name that matches a real agent.
-6. **Mode bypass**: explicitly set `orchestrator_mode=True` unless you
-   know the inner agent fully controls its own reporting.
-7. **Tool registration crash**: fix the cause of the exception in
-   `reporting tool registration skipped: <exc>`; common culprit is an
-   ADK version mismatch in `agent.py:123`.
-
-## Prevention
-
-- Add a health check that asserts every session has at least one task
-  in RUNNING or COMPLETED within N seconds of the plan being submitted.
-- In CI, assert that every plan submission results in at least one
-  `report_task_started` within the first invocation.
-- Pin the ADK version so `reporting tool registration skipped` doesn't
-  re-appear after an upgrade.
+1. Make sure the task's `assignee_agent_id` matches an actual
+   per-agent row the server registered.
+2. If the assignee agent is present but the overlay doesn't bind the
+   task, a STEER annotation with a clarification like "work on
+   task X now" usually gets the reconciler's attention.
+3. If the planner produced an invalid revision, check the goldfive
+   log for the validation error and re-post a corrective STEER.
+4. If `NOT_NEEDED` at invocation end: nothing to fix. That's the
+   overlay working as intended.
 
 ## Cross-links
 
-- [`reporting-tools.md`](../reporting-tools.md) — reporting tool
-  reference.
-- [`dev-guide/debugging.md`](../dev-guide/debugging.md) §"A task won't
-  advance".
-- [`runbooks/task-stuck-in-running.md`](task-stuck-in-running.md) — the
-  symmetric case.
-- goldfive docs for choosing the right executor
-  (`SequentialExecutor` vs `ParallelDAGExecutor` vs delegated).
+- [runbooks/task-stuck-in-running.md](task-stuck-in-running.md) — the
+  symmetric case (task claimed but wedged).
+- [user-guide/tasks-and-plans.md](../user-guide/tasks-and-plans.md) —
+  the overlay-era task state machine.
+- [user-guide/gantt-view.md](../user-guide/gantt-view.md) — per-agent
+  Gantt rows and why assignee ids may look different from what you
+  wrote in the plan.

--- a/docs/runbooks/task-stuck-in-running.md
+++ b/docs/runbooks/task-stuck-in-running.md
@@ -1,220 +1,159 @@
 # Runbook: Task stuck in RUNNING
 
-> **Post-goldfive note.** Task state transitions and drift throttling
-> live in [goldfive](https://github.com/pedapudi/goldfive). `adk.py`
-> line-number references below are historical; check goldfive's
-> `DefaultSteerer` for current implementation.
-
-A task entered RUNNING and never completes. The agent row has an amber
-"stuck" marker; heartbeats still arrive; spans still end, but the task
-itself never progresses.
-
-**Triage decision tree** — distinguish "actually slow" from "actually wedged".
-Heartbeats arriving + `progress_counter` frozen is the canonical wedge signal.
-
-```mermaid
-flowchart TD
-    Start([Task RUNNING with<br/>amber 'stuck' marker]):::sym --> Q1{Heartbeats still<br/>arriving?}
-    Q1 -- "no" --> R1[See agent-disconnects-repeatedly]:::fix
-    Q1 -- "yes" --> Q2{Open TOOL_CALL span<br/>older than minutes?}
-    Q2 -- "yes" --> F2[Tool hung: py-spy dump,<br/>kill subprocess, add timeout]:::fix
-    Q2 -- "no" --> Q3{current_activity says<br/>'thinking' / large tokens?}
-    Q3 -- "yes" --> F3[False positive — long model<br/>think; raise sweep interval]:::fix
-    Q3 -- "no" --> Q4{progress_counter bumped<br/>only on reporting tools?}
-    Q4 -- "yes" --> F4[Counter frozen: bump inside<br/>tool body / long loops]:::fix
-    Q4 -- "no" --> Q5{py-spy top: hot frame<br/>outside ADK?}
-    Q5 -- "yes" --> F5[Infinite loop in agent code:<br/>send CANCEL, fix bug]:::fix
-    Q5 -- "no" --> Q6{Two parallel sub-agents<br/>fighting on session.state?}
-    Q6 -- "yes" --> F6[Deadlock: STEER cancel,<br/>fix state-flag contract]:::fix
-    Q6 -- "no" --> F7[LLM emitted prose 'Task<br/>complete' instead of tool —<br/>tighten instruction]:::fix
-
-    classDef sym fill:#fde2e4,stroke:#c0392b,color:#000
-    classDef fix fill:#d4edda,stroke:#27ae60,color:#000
-```
+A task entered `RUNNING` and never transitions out. The agent row
+has an amber "stuck" marker on the Graph view; heartbeats still
+arrive; the Gantt shows an open span that doesn't close.
 
 ## Symptoms
 
-- **UI**: agent header shows `⚠ stuck` (liveness tracker flagged it);
-  current-task strip shows a RUNNING task with a steadily increasing
-  age and no progress bar movement.
-- **Server log / heartbeat bus**:
-  - `STUCK_THRESHOLD_BEATS = 3` consecutive unchanged heartbeats
-    (`server/harmonograf_server/ingest.py:64`) published via
-    `publish_agent_status(..., stuck=True)`.
-  - Not a distinct log line by default — look at heartbeat deltas on
-    the bus or the agent header.
-- **Client log**:
-  - Heartbeats still arriving (`harmonograf_client.heartbeat`), but
-    `progress_counter` is unchanged across consecutive heartbeats.
+- **Graph view**: agent header shows `⚠ stuck` (the liveness tracker
+  flagged it after `STUCK_THRESHOLD_BEATS=3` consecutive unchanged
+  heartbeats).
+- **Gantt**: an open RUNNING span that steadily grows but never ends.
+- **Intervention strip**: `LOOPING_REASONING` drift has NOT (yet)
+  fired — the tool-loop detector only trips after several repetitions.
+- **Heartbeats**: still arriving; `progress_counter` unchanged.
 
 ## Immediate checks
 
 ```bash
-# Are heartbeats arriving at all?
+# Agent last heartbeat — still connected?
 sqlite3 data/harmonograf.db \
-  "SELECT id, last_heartbeat, status FROM agents WHERE id='AGENT_ID';"
+  "SELECT id, last_heartbeat, status, metadata FROM agents WHERE id='AGENT_ID';"
 date +%s
 
-# What is the agent currently doing, per its own accounting?
-grep -E 'current_activity|progress_counter' /path/to/agent.log | tail -20
-
-# What's the most recent span from this agent?
-sqlite3 data/harmonograf.db \
-  "SELECT id, kind, name, status, start_time, end_time FROM spans
-   WHERE agent_id='AGENT_ID' ORDER BY start_time DESC LIMIT 5;"
-
-# Is there an open span that never ended?
-sqlite3 data/harmonograf.db \
-  "SELECT id, kind, name, start_time FROM spans
-   WHERE agent_id='AGENT_ID' AND end_time IS NULL ORDER BY start_time DESC LIMIT 10;"
-
-# Did a drift ever fire?
-grep -E 'drift observed|plan refined|refine:' /path/to/agent.log | tail -20
-```
-
-## Root cause candidates (ranked)
-
-1. **Model is genuinely thinking for a long time** — long prompts,
-   tool-calling chains, or a model that's stalling on retry. Heartbeats
-   still arrive, `current_activity` reflects the thinking step, no spans
-   end. This is a false positive on "stuck".
-2. **Tool call hung** — an external tool (DB, HTTP, subprocess) is
-   blocking. The TOOL_CALL span is open; the callback for
-   `after_tool_callback` has not fired.
-3. **`progress_counter` not being incremented** — the agent is making
-   progress but isn't incrementing the counter, so the server's stuck
-   detector fires even though everything is fine. See
-   `server/harmonograf_server/ingest.py:565`.
-4. **Infinite loop in the agent code** — not the model; the wrapper
-   around it. Typical culprit: a while-loop polling some state that
-   never changes.
-5. **Deadlock on `session.state`** — two parallel sub-agents fighting
-   over the shared dict, one spinning waiting for a state flag the
-   other never sets.
-6. **Reporting-tool side effect never fired** — the LLM emitted
-   `report_task_completed` text instead of calling the tool. Goldfive's
-   steerer never gets the signal. See goldfive's steerer logs.
-7. **Drift throttled** — a detected drift that would have refined the
-   plan was suppressed by `_DRIFT_REFINE_THROTTLE_SECONDS = 2.0`
-   (`client/harmonograf_client/adk.py:378`). Usually not the root
-   cause, but it can mask repeated tool failures as a single stuck
-   task.
-
-## Diagnostic steps
-
-### 1. Long thinking
-
-Check `context_window_tokens` on the heartbeat. Large prompts → long
-thinks. Correlate with `harmonograf_client.adk` DEBUG logs showing
-`before_model_callback` but no `after_model_callback`.
-
-### 2. Tool hang
-
-```bash
-# Which span is open?
+# Still-open spans for this agent
 sqlite3 data/harmonograf.db \
   "SELECT id, kind, name, start_time FROM spans
    WHERE agent_id='AGENT_ID' AND end_time IS NULL
-     AND kind='TOOL_CALL' ORDER BY start_time DESC LIMIT 5;"
+   ORDER BY start_time DESC LIMIT 10;"
+
+# Are we in a tool loop? Check the tool-call span history.
+sqlite3 data/harmonograf.db \
+  "SELECT name, COUNT(*) FROM spans
+   WHERE agent_id='AGENT_ID' AND kind='TOOL_CALL'
+     AND start_time > (strftime('%s','now')-600)
+   GROUP BY name ORDER BY 2 DESC LIMIT 10;"
 ```
 
-If a TOOL_CALL has been open for minutes, the tool is blocked. Take
-a py-spy on the process:
+## Root-cause candidates (ranked)
+
+1. **LLM call hung** — a still-open `LLM_CALL` span older than a
+   minute or two on a local model. Check `goldfive.llm.duration_ms`
+   on the most recent LLM_CALL span. Values > 60 s flag a wedged
+   provider.
+2. **Tool hung** — an open `TOOL_CALL` span that never ends. The
+   tool's implementation is blocked (HTTP, DB, subprocess).
+3. **Tool loop detected but drift threshold not yet reached** —
+   goldfive's `ToolLoopTracker` (goldfive#181/#186) fires
+   `LOOPING_REASONING` only after N repetitions in exact / name /
+   alternating modes. If the agent is in a loop but hasn't hit the
+   threshold, the overlay hasn't refined yet.
+4. **Infinite loop in agent code (not ADK / model)** — the wrapper
+   around the model is spinning. `py-spy top` on the process will
+   show a hot frame outside ADK and the model client.
+5. **`session.state` deadlock** — two parallel sub-agents waiting
+   for a flag the other never sets.
+6. **Cancellation never delivered** — you sent CANCEL but it didn't
+   land. Check the Goldfive `ADKAdapter.invoke` side: on a cancel,
+   it calls `plugin.on_cancellation(invocation_id)` which flushes
+   open spans with `status=CANCELLED` (goldfive#167). If spans
+   stayed RUNNING after a cancel, the plugin's cancellation hook
+   didn't run — usually because the plugin was installed twice and
+   one instance stayed silent (#68).
+
+## Diagnostic steps
+
+### 1. Identify the open span
+
+```bash
+sqlite3 data/harmonograf.db \
+  "SELECT id, kind, name, start_time, attributes
+   FROM spans
+   WHERE agent_id='AGENT_ID' AND end_time IS NULL
+   ORDER BY start_time DESC LIMIT 5;"
+```
+
+If the newest is an `LLM_CALL`, skip to step 2. If `TOOL_CALL`,
+skip to step 3. If `INVOCATION` with no in-flight child, you likely
+have an agent-code loop; skip to step 4.
+
+### 2. LLM call hang
+
+```bash
+grep -E 'goldfive.llm.duration_ms' /path/to/agent.log | tail -10
+```
+
+Large durations (> 60 s) point at the provider. On `kikuchi` /
+local vLLM / Ollama, check that the upstream server is responsive:
+
+```bash
+curl -sS "$KIKUCHI_LLM_URL/v1/models" | head
+```
+
+If the provider is unresponsive, the hung span is a symptom, not a
+cause. Restart the provider.
+
+### 3. Tool hang
 
 ```bash
 py-spy dump --pid $(pgrep -f 'my_agent') | head -80
 ```
 
-Look for `_run_tool` or the tool's own frames.
+Look for your tool's frames. If a subprocess is the culprit, kill
+it and wrap the tool implementation in `asyncio.wait_for` or an
+ADK tool `time_limit`.
 
-### 3. Progress counter frozen
-
-Search for how the agent increments the counter:
-
-```bash
-grep -n 'progress_counter\|bump_progress\|record_progress' /path/to/agent_code
-```
-
-If the counter is only bumped on reporting-tool calls and the agent
-is doing work that doesn't call them, the server's "stuck" signal is
-spurious.
-
-### 4. Infinite loop
+### 4. Agent-code loop
 
 ```bash
 py-spy top --pid $(pgrep -f 'my_agent')
 ```
 
-A hot frame that is clearly not in the ADK / model path is your
-culprit.
+A hot frame outside ADK / the model client is the culprit. Send
+`CANCEL` via the control router to end the run, fix the loop, and
+restart.
 
-### 5. session.state deadlock
+### 5. Loop detector threshold
 
-`harmonograf.current_task_id`, `harmonograf.task_progress`, etc., are
-the shared keys. If two agents are both waiting for one of them, dump
-the state:
-
-```python
-# In a REPL attached to the agent process:
-from google.adk.sessions import InMemorySessionService  # or whatever
-print(session.state)
-```
-
-### 6. Reporting tool not invoked
+If you suspect a tool loop but `LOOPING_REASONING` hasn't fired yet:
 
 ```bash
-grep -E 'reporting_tools_invoked|before_tool_callback.*report_task' /path/to/agent.log | tail -20
+grep -E 'ToolLoopTracker|tool_loop' /path/to/agent.log | tail -30
 ```
 
-Zero hits → the LLM is describing completion in prose, not invoking
-the tool. `after_model_callback` has a text-marker fallback for
-"Task complete:" but it is best-effort.
+You can lower the threshold in goldfive's config, but usually it's
+better to let the detector fire at its natural point and refine.
 
-### 7. Drift throttle
+### 6. Duplicate plugin (for post-cancel cleanup)
 
 ```bash
-grep 'refine: throttled' /path/to/agent.log | tail -10
+grep 'duplicate HarmonografTelemetryPlugin' /path/to/agent.log
 ```
 
-If you see repeated throttle messages, the drift *is* firing but the
-refine is being suppressed. That is by design for 2 second windows,
-but if you see many throttles over minutes, the underlying detector
-is in a tight loop.
+If present, ensure only one `HarmonografTelemetryPlugin(client)` is
+installed. The duplicate stays silent on every callback — including
+`on_cancellation` — so a CANCEL won't flush its spans.
 
 ## Fixes
 
-1. **Long thinking**: raise the stuck threshold via the sweep interval
-   in `heartbeat_sweeper(..., interval_s=...)` or accept the false
-   positive.
-2. **Tool hang**: kill the tool subprocess; fix the timeout on the tool
-   implementation.
-3. **Progress counter frozen**: call `state.on_progress()` or whichever
-   helper your agent exposes inside long-running tool loops.
-4. **Infinite loop**: fix the bug, restart the agent. For an
-   emergency, send `CANCEL` via the control router to force-terminate
-   the run.
-5. **session.state deadlock**: send `STEER(cancel)` to free the run,
-   then fix the state-flag contract.
-6. **Reporting tool not invoked**: tighten the instruction template so
-   the model always calls `report_task_completed`. Or rely on the
-   observer fallback in `after_model_callback`.
-7. **Drift throttle**: look at the *underlying* drift kind and fix the
-   detector — it shouldn't fire more than once per real event.
-
-## Prevention
-
-- For long-running tools, always increment `progress_counter` inside
-  the tool body, not only at completion.
-- Add a fail-fast timeout to every tool implementation (ADK `time_limit`
-  on tools, or explicit `asyncio.wait_for` in the tool body).
-- Alert when a task has been RUNNING longer than 3× the expected
-  duration for its kind.
+1. **LLM hang**: restart the upstream provider; add a client-side
+   timeout on the adapter level.
+2. **Tool hang**: add `asyncio.wait_for` / ADK `time_limit` to the
+   tool body; kill the blocked subprocess.
+3. **Agent-code loop**: send CANCEL, fix the loop, restart.
+4. **Loop detector missed**: tune `ToolLoopTracker` thresholds in
+   goldfive, or refine instructions so the agent breaks out earlier.
+5. **Duplicate plugin**: remove the extra installation point
+   (usually `observe()` or `add_plugin` that runs after
+   `App(plugins=[...])`).
 
 ## Cross-links
 
-- [`dev-guide/debugging.md`](../dev-guide/debugging.md) §"An agent is
-  stuck" and §"Reading a heartbeat".
-- [`runbooks/drift-not-firing.md`](drift-not-firing.md) — when you
-  *want* a drift but nothing happens.
-- [`user-guide/troubleshooting.md`](../user-guide/troubleshooting.md)
-  §"Plan stuck / not progressing" — UI-side counterpart.
+- [runbooks/task-stuck-in-pending.md](task-stuck-in-pending.md) —
+  the symmetric case (task never claimed).
+- [runbooks/high-latency-callbacks.md](high-latency-callbacks.md) —
+  diagnose slow LLM / tool calls with `goldfive.llm.duration_ms`.
+- [dev-guide/client-library.md](../dev-guide/client-library.md) —
+  the cancellation sweep (`on_cancellation` hook) and why duplicate
+  plugins break it.

--- a/docs/runbooks/thinking-not-visible.md
+++ b/docs/runbooks/thinking-not-visible.md
@@ -37,14 +37,15 @@ flowchart TD
 - **UI**: Gantt shows LLM_CALL spans but no accompanying thinking
   stripes; drawer Thinking tab is empty or shows "no thought
   captured".
-- **Client log**:
-  - `INFO harmonograf_client.adk: emit_thinking_as_task_report inv=<id> report=<repr>`
-    (`adk.py:4923`) — this is the canonical emit path.
-  - Absence of the above means the emit path never ran.
-  - `DEBUG harmonograf_client.agent: HarmonografAgent: record_llm_thought failed: <exc>`
-    (`agent.py:1829`).
-  - `DEBUG harmonograf_client.agent: HarmonografAgent: emit_span_update(llm.thought) failed: <exc>`
-    (`agent.py:1838`).
+- **Client log** (`harmonograf_client.telemetry_plugin` at DEBUG):
+  - Successful reasoning capture shows up as `has_reasoning=true` on
+    an `LLM_CALL` span and (for large bodies) a payload upload with
+    `payload_role="reasoning"`, `mime="text/plain"`.
+  - Absence means no `llm_response.content.parts[*].thought` /
+    `choices[0].message.reasoning_content` / `content[*].type=="thinking"`
+    was extracted — check the provider and the
+    `_extract_reasoning` function in
+    `client/harmonograf_client/telemetry_plugin.py`.
 - **sqlite**: no rows in `spans` with a `llm.thought` attribute or
   similar.
 

--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -111,13 +111,40 @@ Once posted, annotations are visible in these places:
   of every annotation, sorted by time. Useful for a post-hoc walk-through
   of what was said where.
 
-## Who wrote what
+## Body constraints (#72)
+
+STEERING and HUMAN_RESPONSE annotations have a few practical limits
+enforced by the client-side bridge between harmonograf control
+delivery and goldfive:
+
+- **Empty bodies are rejected.** Whitespace-only bodies don't count.
+- **Bodies larger than 8 KiB are rejected.** The limit
+  (`STEER_BODY_MAX_BYTES = 8192`) protects the LLM context and the
+  wire from pathological payloads. If you need to pass more context,
+  attach a tool call or use a link inside the body.
+- **ASCII control characters are stripped** before the body reaches
+  the LLM, so attempts to smuggle escape sequences into a prompt via
+  the steer body are neutralised. Tabs and newlines are kept.
+
+Invalid bodies surface a rejection in the frontend and never reach the
+agent.
+
+## Who wrote what (#72)
 
 Each annotation stores an `author` field. The default author is `user`,
-set client-side when you post from the frontend. A deployment that
-authenticates multiple operators can override the author string
-server-side; the current release has no user-identity system in the
-frontend itself.
+set client-side when you post from the frontend. The author is
+propagated end-to-end:
+
+1. The UI posts the annotation via `PostAnnotation` with `author` set.
+2. The server synthesises a STEER `ControlEvent` and copies
+   `author` onto `event.steer.author` (goldfive#171), along with the
+   stored annotation's id on `event.steer.annotation_id`.
+3. Goldfive's steerer attributes the resulting drift back to that
+   author so the intervention history shows "who asked for this".
+
+A deployment that authenticates multiple operators can override the
+author string at the UI edge; the current release has no user-identity
+system in the frontend itself.
 
 ## Deleting / editing
 

--- a/docs/user-guide/control-actions.md
+++ b/docs/user-guide/control-actions.md
@@ -201,6 +201,54 @@ into the agent's task report line on the header box. See
   in `shortcuts.ts` but their handlers are still stubs. Use the popover
   or drawer until they get wired.
 
+#### Idempotency by `annotation_id` (goldfive#171, harmonograf#72)
+
+Every STEER control event carries the `annotation_id` of the stored
+annotation that authored it. Goldfive's steerer uses this id to
+**dedupe retries**: if the same annotation lands on the control path
+twice (network retry, operator-double-click, a stale `SubscribeControl`
+re-subscribing), it will not be applied twice. The first arrival wins
+and subsequent identical events ack `SUCCESS` without side effects.
+
+The `author` field propagates alongside so the drift surfaced in the
+intervention history carries the operator identity.
+
+#### Validation
+
+STEER bodies are rejected or sanitised before they reach the LLM:
+
+- Empty or whitespace-only bodies → rejected.
+- Bodies larger than 8 KiB → rejected (`STEER_BODY_MAX_BYTES`).
+- ASCII control characters → stripped (tabs and newlines preserved).
+
+See [annotations.md](annotations.md#body-constraints-72) for the
+details.
+
+#### Why STEER sometimes takes 30-70 seconds to apply
+
+The intervention ladder that follows a STEER runs through
+goldfive's planner LLM (typically Qwen3.5-35B via kikuchi for local
+demos). The planner has to:
+
+1. Observe the STEER drift on its next turn (couple of seconds).
+2. Call the refine LLM with the full task state + the STEER body.
+   On a local 35B model this is the slow path — 20-60 seconds per
+   refine call is normal; long contexts push that to 70+ seconds
+   (issue #86 caught one).
+3. Emit the refined plan via `PlanRevised`.
+
+Only *then* does the intervention card's outcome chip flip from
+`pending` to `→ rev N`. The intervention history aggregator uses a
+5-minute attribution window for user-control drifts so the STEER
+card and the resulting plan revision always merge cleanly, even on
+slow models.
+
+If the chip stays `pending` for more than a few minutes, the planner
+likely wedged; inspect the Gantt for a still-running LLM_CALL span on
+the planner row. The runbook at
+[runbooks/high-latency-callbacks.md](../../runbooks/high-latency-callbacks.md)
+walks through diagnosis.
+
 ### Approve / Reject
 
 - Scope: per-span. Only meaningful when the span status is

--- a/docs/user-guide/cookbook.md
+++ b/docs/user-guide/cookbook.md
@@ -359,7 +359,8 @@ posted while watching. Not a tarball.
 ## 7. Filter and triage by drift kind
 
 **Goal.** You know something broke, and you want to see only the
-`tool_error` revisions (or the `llm_refused`, or the `context_pressure`…).
+`TOOL_ERROR` revisions (or the `AGENT_REFUSAL`, or the
+`LOOPING_REASONING`…).
 
 **Prerequisites.** The session has had at least one drift-tagged
 revision. See [tasks-and-plans.md → drift kinds](tasks-and-plans.md#drift-kinds)

--- a/docs/user-guide/examples/cascading-refines.md
+++ b/docs/user-guide/examples/cascading-refines.md
@@ -1,23 +1,21 @@
 # Scenario: long-running plan with multiple refines and drift cascades
 
-A large plan (twelve tasks) running over ~30 minutes. Four drift events
-fire, each producing a plan revision. The second drift discovers new
-work, the third hits a context pressure wall, the fourth is an operator
-steer. This scenario is about **reading the cascade** without losing the
-thread of what happened.
+A plan (twelve tasks) running over ~35 minutes on a local Qwen3.5-35B.
+Four drift events fire, each producing a plan revision after the
+planner's refine LLM returns. This scenario is about **reading the
+cascade** without losing the thread of what happened.
 
 Four drifts hit one long session, each producing a plan revision. Use this as a map for the timeline below.
 
 ```mermaid
 timeline
-    title Cascading refines over ~35 minutes
+    title Cascading refines over ~35 minutes (Qwen3.5-35B)
     t=0 : session picked : 12 tasks pending
-    t=4m : llm_refused (red) : +1 ~1 reframe
-    t=8m : new_work_discovered (green) : +2
-    t=16m : context_pressure (grey-blue) : split draft
-    t=27m : user_steer (blue) : operator redirect
+    t=4m : AGENT_REFUSAL (red) : +1 ~1 reframe
+    t=8m : TOOL_ERROR (red) : +2 retry tasks
+    t=16m : PLAN_DIVERGENCE (amber) : cross-layer tool call
+    t=22m-32m : USER_STEER (purple) : operator redirect · planner refine takes 9-10 min
     t=35m : COMPLETED
-```
 
 ## Set-up
 
@@ -35,50 +33,46 @@ Normal `SEQ` start. Current task strip reads
 `Currently: Outline · RUNNING · SEQ · writer-coordinator`. Task panel
 shows twelve rows, one RUNNING.
 
-### t=4 min — first drift: `llm_refused`
+### t=4 min — first drift: `AGENT_REFUSAL`
 
-The drafter calls an LLM that flat-out refuses the request (safety
-filter). The client catches this in `after_model_callback` and stamps
-`drift_kind = "llm_refused"` on the active INVOCATION. The planner
+The drafter's LLM refuses the request outright (safety filter). The
+goldfive drift detector catches the refusal, emits a
+`DriftDetected(kind=AGENT_REFUSAL, severity=critical)` event, and the
+planner refines.
+
+Intervention timeline strip marker: red critical ring around a chevron
+glyph. Popover:
+
+- Source: `drift`, kind `AGENT_REFUSAL`.
+- Body: `drafter refused: safety filter`.
+- Outcome: `→ rev 1` once the planner returns (typically 30-60 s on
+  Qwen3.5-35B).
+- Plan diff: `+1 ~1`. New `Reframe section 3` task plus a modified
+  `Draft section 3` description.
+
+### t=8 min — second drift: `TOOL_ERROR`
+
+The fact-checker calls a lookup tool that times out. Goldfive sees the
+tool-error span on its `after_tool_callback` and emits
+`DriftDetected(kind=TOOL_ERROR, severity=warning)`.
+
+Strip marker: amber dashed-ring circle.
+
+- Body: `lookup(dates) failed: timeout`.
+- Outcome: `→ rev 2`. The planner adds two retry tasks with different
+  tool arguments.
+
+### t=16 min — third drift: `PLAN_DIVERGENCE`
+
+The drafter tries to call the fact-checker's tool directly (wrong
+layer of the plan — the three-stage gate from goldfive#178). Goldfive
+fires `DriftDetected(kind=PLAN_DIVERGENCE, severity=warning)` and
 refines.
 
-UI:
+Strip marker: amber chevron.
 
-- Pill: red `🚫 Refused` with detail `LLM refused to draft section 3:
-  safety filter`. Diff counts `+1 ~1`.
-- Revision adds a `Reframe section 3` task, modifies the original
-  `Draft section 3` description to carry the refusal note.
-- Task panel grows by one row.
-
-### t=8 min — second drift: `new_work_discovered`
-
-The fact-checker finds two dates that need additional primary sources
-and calls `report_new_work_discovered` (see
-[`docs/reporting-tools.md`](../../reporting-tools.md)). The planner accepts and splits the
-check-sources work into two new tasks.
-
-UI:
-
-- Pill: green `✨ New work` with detail `discovered: 2 dates need
-  primary sources`. Diff counts `+2 ~0`.
-- Drawer → Task → Plan revisions now shows two entries. The banner
-  pill stack may have already popped the first off.
-
-### t=16 min — third drift: `context_pressure`
-
-The drafter's LLM context is filling up as the draft grows. The model
-returns with `finish_reason = "MAX_TOKENS"`. The harmonograf client
-stamps `drift_kind = "context_pressure"` on the INVOCATION and fires a
-refine that splits the long draft task into two shorter drafts.
-
-UI:
-
-- Pill: grey-blue `⚡ Context limit`.
-- Plan diff: `+1 ~1`. The splitter inserts a new task, shrinks the
-  original. Modified chip shows `Draft part 2 of 2`.
-- This is the in-this-release path for noticing context pressure until
-  the context window overlay task lands. See
-  [gantt-view.md → context window overlay](../gantt-view.md#context-window-overlay-in-this-release).
+- Body: `drafter called cross-layer tool check_source`.
+- Outcome: `→ rev 3`.
 
 ### t=20 min — drafter goes quiet
 
@@ -96,23 +90,30 @@ You might annotate the drafter span with a `COMMENT`:
 `"waiting on cross-agent, not hung"` (drawer → Annotations tab,
 [annotations.md → drawer annotations tab](../annotations.md#drawer--annotations-tab)).
 
-### t=22 min — fourth drift: `user_steer`
+### t=22 min — fourth drift: `USER_STEER` (the slow one)
 
 You decide the draft is going too long and push a steer. Hover the
 drafter's active INVOCATION on the Gantt, click **Steer** in the
-popover, pick **+ Add to queue** (you don't want to interrupt the
-current turn), type `"Cut section 4 to two paragraphs."`, `⌘↵`.
+popover, type `"Cut section 4 to two paragraphs."`, `⌘↵`.
 
-UI:
+The UI acks in ~1 second:
 
-- The popover closes.
-- Within a few seconds, the drafter's next LLM_CALL bar opens and
-  carries your steer text in its prompt payload (verify with the
-  [Payload tab](../drawer.md#payload-tab) → Load full payload).
-- Pill: blue `👆 User steered` with detail `Cut section 4 to two
-  paragraphs`. Diff counts `+0 ~1`.
+- The annotation lands on the strip as a purple diamond marker.
+- The agent's next LLM_CALL picks up the STEER body on its next turn.
 
-![TODO: screenshot of the PlanRevisionBanner with a User steered pill](_screenshots/example-cascade-steer.png)
+Then the slow path:
+
+- The planner observes the drift and calls its refine LLM with the
+  full task state + steer body.
+- On Qwen3.5-35B this refine routinely takes **9-10 minutes** on a
+  long-context task list. The intervention card's outcome chip stays
+  at `pending` the entire time.
+- Finally the planner returns a revised plan. The strip marker's
+  outcome chip flips to `→ rev 4`, and the drift + plan_revised
+  events fold into the annotation card via the 5-minute attribution
+  window (harmonograf#86 / the extended `_USER_OUTCOME_WINDOW_S`).
+
+Plan diff: `+0 ~1`. Section 4 task gets its description trimmed.
 
 ### t=34 min — plan completes
 
@@ -149,29 +150,19 @@ Reading order:
 
 ## Log lines / attributes
 
-Four `drift_kind` values appear on their respective INVOCATIONs:
-`llm_refused`, `new_work_discovered`, `context_pressure`, `user_steer`.
-Each `TaskPlan` revision carries matching `revision_kind` and
-`revision_severity`.
+Four `DriftDetected` events land in goldfive's event stream:
+`AGENT_REFUSAL`, `TOOL_ERROR`, `PLAN_DIVERGENCE`, `USER_STEER`. Each
+`TaskPlan` revision carries the matching `revision_kind` and
+`revision_severity`, and the intervention aggregator surfaces them as
+four cards on the strip.
 
-On the drafter's pre-split INVOCATION (just before `context_pressure`):
+The slow STEER can be spotted by reading `goldfive.llm.duration_ms`
+off the planner's LLM_CALL span that followed the STEER — expect
+300000+ (5+ minutes) on Qwen3.5-35B for a heavy plan refine.
 
-```
-finish_reason = "MAX_TOKENS"
-drift_kind    = "context_pressure"
-drift_detail  = "MAX_TOKENS at section 5"
-```
-
-On any LLM_CALL following the `user_steer`:
-
-```
-hgraf.task_id = "draft-4"
-steer.merged  = "Cut section 4 to two paragraphs."
-```
-
-Server-side logs show a `refine` call for each drift; the frontend
-does not drive refines — see
-[tasks-and-plans.md → plan revisions](../tasks-and-plans.md#plan-revisions--live-replans).
+If the STEER card's outcome chip is stuck at `pending` for more than
+a few minutes, the planner may be wedged — see
+[runbooks/high-latency-callbacks.md](../../../runbooks/high-latency-callbacks.md).
 
 ## Patterns to notice
 

--- a/docs/user-guide/examples/delegated-handoff.md
+++ b/docs/user-guide/examples/delegated-handoff.md
@@ -1,10 +1,14 @@
 # Scenario: delegated handoff between specialist agents with drift detection
 
-A coordinator agent running in **delegated** mode (`OBS`) hands off to
-a chain of specialist agents using ADK's `AgentTool`. One specialist
-unexpectedly transfers to a fourth agent that is not in the plan, which
-fires a `transfer_to_unplanned_agent` drift. Harmonograf only observes
-— it does not drive the handoff.
+A coordinator agent running in delegated mode hands off to a chain of
+specialist agents using ADK's `AgentTool`. One specialist unexpectedly
+invokes a fourth agent that is not in the plan, which fires a
+`PLAN_DIVERGENCE` drift (the three-stage gate from goldfive#178 —
+cross-layer tool calls). Harmonograf only observes — it does not
+drive the handoff.
+
+With per-agent Gantt rows (#80), each specialist renders on its own row
+instead of collapsing onto the coordinator.
 
 This is the canonical example of how harmonograf acts as a monitor
 rather than an orchestrator.
@@ -22,7 +26,7 @@ sequenceDiagram
     Res-->>Coord: result
     Coord->>Web: AgentTool (planned)
     Web->>Dbg: AgentTool (UNPLANNED)
-    Note over Dbg: drift:<br/>transfer_to_unplanned_agent
+    Note over Dbg: drift:<br/>PLAN_DIVERGENCE
     Dbg-->>Web: result
     Web-->>Coord: result
     Coord->>Rev: AgentTool (planned)
@@ -90,7 +94,7 @@ plan — the plan expected `develop` → `review`, not `develop` →
 `debug` → `review`.
 
 The harmonograf client's drift detection catches this via the
-`unexpected_transfer` / `transfer_to_unplanned_agent` drift kinds (see
+`unexpected_transfer` / `PLAN_DIVERGENCE` drift kinds (see
 [tasks-and-plans.md → drift kinds](../tasks-and-plans.md#drift-kinds)).
 The client fires a deferential `refine` back to the planner with the
 current plan + drift context.
@@ -100,7 +104,7 @@ What you see in the UI:
 - A new orange solid TRANSFER arrow on the Graph view, from the
   web_developer column to the debugger column. Amber category on the
   PlanRevisionBanner pill: `↪ Unplanned transfer`.
-- The pill fires with detail text like `transfer_to_unplanned_agent:
+- The pill fires with detail text like `PLAN_DIVERGENCE:
   web_developer → debugger`.
 - The Plan revisions section in the drawer gains a new row. Expanded,
   it shows: added task `debug` (assignee `debugger`), modified `review`
@@ -154,7 +158,7 @@ On the web_developer's TRANSFER span:
 
 ```
 hgraf.task_id         = "develop"
-drift_kind            = "transfer_to_unplanned_agent"
+drift_kind            = "PLAN_DIVERGENCE"
 drift_severity        = "warning"
 drift_detail          = "web_developer -> debugger (not in plan)"
 ```
@@ -166,9 +170,9 @@ when the TRANSFER span has already closed.
 The subsequent plan revision carries:
 
 ```
-revision_kind     = "transfer_to_unplanned_agent"
+revision_kind     = "PLAN_DIVERGENCE"
 revision_severity = "warning"
-revision_reason   = "transfer_to_unplanned_agent: web_developer -> debugger"
+revision_reason   = "PLAN_DIVERGENCE: web_developer -> debugger"
 revision_index    = 1
 ```
 
@@ -184,8 +188,9 @@ revision_index    = 1
    span to match on. The Graph renders the forward arrow without a
    return. See [graph-view.md → following message flow](../graph-view.md#following-message-flow).
 4. **Drift detection still works without a walker.** Callback
-   inspection is the belt-and-suspenders path; you get `tool_error`,
-   `unexpected_transfer`, `context_pressure`, etc. even in `OBS` mode.
+   inspection is the belt-and-suspenders path; you get `TOOL_ERROR`,
+   `PLAN_DIVERGENCE`, `CONFABULATION_RISK`, `LOOPING_REASONING`, etc.
+   from goldfive's detectors regardless of orchestration mode.
 5. **The drawer's Links tab is the best way to walk a chain** in this
    scenario. `INVOKED` on the coordinator's TOOL_CALL points at the
    specialist's INVOCATION; `TRIGGERED_BY` points back. See

--- a/docs/user-guide/examples/index.md
+++ b/docs/user-guide/examples/index.md
@@ -13,20 +13,22 @@ If you want runnable code examples, see the test suites under
 ## Scenarios
 
 1. [Single-agent research assistant with a tool error](research-tool-error.md) —
-   one agent, a search tool that fails, a `tool_error` drift kind firing a
+   one agent, a search tool that fails, a `TOOL_ERROR` drift firing a
    refine, and the replanned run.
 2. [Multi-agent team with escalation to human review](escalation.md) —
    coordinator plus two specialists; a specialist escalates to a human
    decision via `WAIT_FOR_HUMAN`; operator approves from the drawer.
 3. [Parallel map-reduce over a task plan](parallel-map-reduce.md) —
    parallel orchestration walking a DAG of independent tasks; how the
-   walker forces `task_id` and how the Gantt visualizes fan-out.
+   Gantt visualizes fan-out with one row per ADK agent (#80).
 4. [Delegated handoff with drift detection](delegated-handoff.md) —
    specialist agents hand off via AgentTool; drift detection fires on an
-   unexpected transfer.
+   unexpected transfer (now surfaces as `PLAN_DIVERGENCE` or
+   `CONFABULATION_RISK` from the three-stage gate in goldfive#178).
 5. [Long-running plan with cascading refines](cascading-refines.md) — a
-   plan that replans several times over tens of minutes; how to read the
-   cascade without getting lost in the revision history.
+   plan that replans several times over ~35 minutes on Qwen3.5-35B;
+   how to read the cascade (including a 9-10 min STEER refine) without
+   losing thread.
 
 ## How to read these
 

--- a/docs/user-guide/examples/parallel-map-reduce.md
+++ b/docs/user-guide/examples/parallel-map-reduce.md
@@ -1,9 +1,13 @@
 # Scenario: parallel map-reduce over a task plan
 
-An orchestrator agent in **parallel** mode drives eight map tasks across
-two worker sub-agents, then a single reduce task. The walker pins each
-map task to a specific sub-agent via `forced_task_id` and fans them out
-respecting the DAG edges.
+An orchestrator agent drives eight map tasks across two worker
+sub-agents, then a single reduce task. The run uses goldfive's
+parallel executor on a fan-out DAG.
+
+With per-agent Gantt rows (#80), the orchestrator, `worker-a`, and
+`worker-b` each render on their own row — even though all three are
+instantiated inside one `goldfive.wrap` run from one harmonograf
+client.
 
 The DAG is the classic fan-out / fan-in: eight map tasks pinned to two workers, then one reduce on the orchestrator.
 

--- a/docs/user-guide/examples/research-tool-error.md
+++ b/docs/user-guide/examples/research-tool-error.md
@@ -92,19 +92,19 @@ attributes table):
 tool.name        = "web_search"
 tool.args        = "{\"query\":\"2026 arm m-series benchmarks\"}"
 error            = "HTTPError: 503 Service Unavailable"
-drift_kind       = "tool_error"
-drift_severity   = "warning"
 ```
 
-The `drift_kind` is also stamped on the **active INVOCATION** span, not
-just the failed tool — this is how the planner knows to fire a refine.
-See [`docs/protocol/data-model.md`](../../protocol/data-model.md) :: Span.attributes.
+Goldfive's `after_tool_callback` observes the failed tool and emits a
+`DriftDetected(kind=TOOL_ERROR, severity=warning)` event — this is the
+signal the planner uses to fire a refine. Harmonograf renders the
+drift as an amber circle marker on the InterventionsTimeline strip.
 
 ### t=5.2s — PlanRevisionBanner fires
 
 A red pill slides in at the top of the shell: **⚠ Tool error** with
 detail `HTTPError 503 from web_search` and diff counts `+1 ~1`. The pill
-auto-dismisses in ~4 seconds.
+auto-dismisses in ~4 seconds. The corresponding intervention marker
+stays on the strip with its outcome chip set to `→ rev 1`.
 
 ![TODO: screenshot of the banner pill "Tool error +1 ~1"](_screenshots/example-research-pill.png)
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -35,6 +35,27 @@ own `stream_id` from `Welcome`. This is the normal path when an agent
 forks worker processes that all share one identity. See
 [`docs/protocol/data-model.md`](../protocol/data-model.md) :: Agent.id.
 
+### Why does one `goldfive.wrap` run show N agent rows now?
+
+As of harmonograf#80, a single run drives a tree of ADK agents (a
+coordinator, its specialist sub-agents, AgentTool wrappers, workflow
+containers) and each renders on its own Gantt row with a derived id
+of the form `<client.agent_id>:<adk_agent_name>`. Old sessions
+recorded pre-#80 still collapse onto the client root — that's
+expected, they predate the fix. See
+[gantt-view.md → per-agent rows](gantt-view.md#per-agent-rows-80).
+
+### Why is there only one session per run now? (No more ghost sessions?)
+
+Lazy Hello (#84 / #85) deferred the `Hello` RPC until the client's
+first emitted envelope. Importing `harmonograf_client` in a launcher
+or interactive notebook no longer mints an empty session; the picker
+only shows sessions that actually had activity.
+
+One session per end-to-end `goldfive.wrap` call is now the contract —
+AgentTool sub-Runners inside the run land on the same session id as
+the root via the plugin's root-session rollup. Expected; not a bug.
+
 ### Why does my session say `0 agents`?
 
 The session was created (typically via a stale `ListSessions` row) but no
@@ -90,8 +111,9 @@ revision shows its drift kind, category, and a detailed diff. The
 [PlanRevisionBanner](tasks-and-plans.md#planrevisionbanner) you just
 saw is the transient version of the same data.
 
-Common drift kinds: `tool_error`, `new_work_discovered`,
-`context_pressure`, `user_steer`, `llm_refused`. See
+Common drift kinds: `TOOL_ERROR`, `USER_STEER`, `PLAN_DIVERGENCE`,
+`CONFABULATION_RISK`, `LOOPING_REASONING`, `AGENT_REFUSAL`,
+`HUMAN_INTERVENTION_REQUIRED`, `GOAL_DRIFT`. See
 [tasks-and-plans.md → drift kinds](tasks-and-plans.md#drift-kinds) for the
 complete table.
 
@@ -159,33 +181,60 @@ off for LLM_CALL spans.
 The Gantt renders a per-agent context-window overlay at the bottom of
 each agent row — see
 [gantt-view.md → context window overlay](gantt-view.md#context-window-overlay).
-The ratio also lands on the per-agent header chip for an at-a-glance read.
-For programmatic detection, the `context_pressure` drift kind fires when
-the planner sees the LLM hit `MAX_TOKENS` or `LENGTH` as its `finish_reason`
-and stamps the active
-INVOCATION and fires a `context_pressure` revision. Look for the `⚡
-Context limit` pill and revision row.
+The ratio also lands on the per-agent header chip for an at-a-glance
+read. For programmatic detection, goldfive's per-LLM-call metrics
+(goldfive#172) expose `goldfive.llm.request.chars` and
+`goldfive.llm.usage.*_tokens` — watch those approach `limit_tokens`.
 
-See [`docs/protocol/data-model.md`](../protocol/data-model.md) :: Span.attributes for the
-`finish_reason` key.
+See [runbooks/context-window-exceeded.md](../../runbooks/context-window-exceeded.md)
+for the full diagnosis flow.
 
-## Orchestration modes
+## Interventions
 
-### What are `SEQ`, `PAR`, and `OBS`?
+### Why does a single STEER show up as one card, not three?
 
-The three executor modes exposed by
-[goldfive](https://github.com/pedapudi/goldfive), rendered as chips on
-the current task strip and described in
-[tasks-and-plans.md → orchestration modes](tasks-and-plans.md#orchestration-modes):
+The intervention aggregator (server `interventions.py` + frontend
+`lib/interventions.ts`) deduplicates by `annotation_id`. A user STEER
+emits three wire events — the annotation itself, a `USER_STEER` drift
+goldfive mints from it, and a `PlanRevised` that follows once the
+planner refines — and the aggregator collapses all three onto the
+annotation row. See
+[trajectory-view.md → intervention cards dedup by annotation_id](trajectory-view.md#intervention-cards-dedup-by-annotation_id).
 
-- **`SEQ`** — `goldfive.SequentialExecutor`. Single-pass coordinator LLM
-  runs the whole plan; per-task lifecycle reported via reporting tools.
-- **`PAR`** — `goldfive.ParallelDAGExecutor`. A DAG batch walker drives
-  sub-agents directly, respecting plan edges as dependencies.
-- **`OBS`** — Delegated / observer mode. Inner agent owns its own task
-  sequencing; goldfive and harmonograf watch for drift.
+### Why does my STEER take 30-70 seconds to "apply"?
 
-Which mode a session is in is fixed at `Runner` construction time, not
+The steer is acknowledged by the agent within milliseconds; what
+takes 30-70 s is the *planner's refine call*. Goldfive's steerer
+observes the USER_STEER drift, calls its planner LLM with the full
+task state + the steer body, and emits `PlanRevised` only when the
+LLM returns. A local Qwen3.5-35B routinely takes 20-60 s for this.
+
+The intervention card's outcome chip flips from `pending` to
+`→ rev N` as soon as the revision lands, which can be a minute or two
+later. See
+[control-actions.md → why STEER sometimes takes 30-70 seconds to apply](control-actions.md#why-steer-sometimes-takes-30-70-seconds-to-apply).
+
+### Why does a completed session's Gantt open past the last span?
+
+Known UX rough edge tracked as harmonograf#89: the viewport opens to
+a window past the final span on completed sessions, and the LIVE
+badge may briefly show. Press **F** to fit the whole session, or drag
+the minimap to the spans region. A real fix is in flight.
+
+## Orchestration
+
+### What are the orchestration modes under the hood?
+
+Goldfive exposes three executor modes (`SequentialExecutor`,
+`ParallelDAGExecutor`, delegated/observer). Harmonograf renders them
+as chips on the current task strip. With the overlay refactor
+(goldfive#141-144) the per-task driving was replaced with an
+observation-driven overlay: tasks are driven by agent activity rather
+than pulled off a queue, and unassigned tasks transition from
+`PENDING → NOT_NEEDED` when the invocation ends. See
+[tasks-and-plans.md](tasks-and-plans.md).
+
+Which mode a session is in is fixed at `goldfive.wrap` call time, not
 toggleable from the UI.
 
 ### How do sub-agents know which task they are on in parallel mode?

--- a/docs/user-guide/gantt-view.md
+++ b/docs/user-guide/gantt-view.md
@@ -50,7 +50,28 @@ flowchart TB
 
 ## Reading the axes
 
-Time runs horizontally; agents are stacked vertically, one row each. A bar represents a span on its agent's row, positioned by its start and end time. Cross-agent edges (the bezier curves) connect a TRANSFER on one row to the invocation it kicked off on another row.
+Time runs horizontally; agents are stacked vertically, **one row per ADK
+agent**, positioned by start and end time. Cross-agent edges (the bezier
+curves) connect a TRANSFER on one row to the invocation it kicked off on
+another row.
+
+### Per-agent rows (#80)
+
+A single `goldfive.wrap` run drives a tree of ADK agents —
+typically a coordinator, a handful of specialists, AgentTool wrappers,
+and occasionally a `SequentialAgent` / `ParallelAgent` container. The
+Gantt puts each one on its own row.
+
+The row label comes from the ADK agent's `name` (e.g. `coordinator`,
+`research_agent`, `writer_agent`); the row id is
+`<client.agent_id>:<adk_agent_name>` under the hood, stamped by the
+client's `HarmonografTelemetryPlugin` via `before_agent_callback` /
+`after_agent_callback`.
+
+If you're looking at an older session recorded before harmonograf#80
+landed, every agent collapses onto the client-root row. Fresh sessions
+on a current client render one row per sub-agent; no migration is
+required.
 
 ```mermaid
 flowchart LR
@@ -185,6 +206,14 @@ the **↩ Follow live** button on the transport bar to re-attach.
 
 Pausing agents also unfollows live (since "now" isn't moving any more).
 Resuming agents re-attaches.
+
+**Caveat on completed sessions (#89 in flight).** When you open a
+completed session the viewport currently opens to a window past the
+last span, and the LIVE badge may briefly show in the header even
+though the run is long finished. Pan left to reach the session's
+actual time range. A UX fix is tracked as harmonograf#89; until it
+lands, either press **F** to fit the whole session or drag the minimap
+to the spans region.
 
 ## Actor rows — `user` and `goldfive`
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -164,10 +164,13 @@ revise the plan. Each drift has a **kind** and a **severity** (`info`,
 
 ### Drift kind
 Structured tag for the reason a plan revision fired. Examples:
-`tool_error`, `context_pressure`, `user_steer`, `new_work_discovered`,
-`llm_refused`, `agent_escalated`. Full table in
-[tasks-and-plans.md → drift kinds](tasks-and-plans.md#drift-kinds) and
-the source of truth is `frontend/src/gantt/driftKinds.ts`.
+`USER_STEER`, `PLAN_DIVERGENCE`, `CONFABULATION_RISK`, `TOOL_ERROR`,
+`LOOPING_REASONING`, `AGENT_REFUSAL`, `HUMAN_INTERVENTION_REQUIRED`,
+`GOAL_DRIFT`. Full table in
+[tasks-and-plans.md → drift kinds](tasks-and-plans.md#drift-kinds).
+Authoritative source is goldfive's `DriftKind` enum; the frontend
+deriver (`frontend/src/lib/interventions.ts`) renders whatever
+goldfive emits.
 
 ### Drift severity
 One of `info`, `warning`, `critical`. Populated on `TaskPlan.revision_severity`.
@@ -189,7 +192,10 @@ not-found. See [drawer.md → payload tab](drawer.md#payload-tab) and
 
 ### `finish_reason`
 LLM finish reason attribute (`MAX_TOKENS`, `LENGTH`, etc.) stamped on
-the relevant span. Used to fire `context_pressure` drift. See
+the relevant span. Used to surface context-pressure conditions —
+goldfive now exposes this via `goldfive.llm.usage.*_tokens` on
+per-LLM-call metrics (goldfive#172) and the frontend's per-agent
+context-window overlay. See
 [data-model → Span.attributes](../protocol/data-model.md#span).
 
 ### Focused agent
@@ -270,6 +276,20 @@ spans by id, fans out to watchers via the bus. Code lives in
 Control kind. Injects a user-turn message into the agent's conversation.
 Protocol-defined but not wired to a frontend control today — see
 [control-actions.md → inject message](control-actions.md#inject-message--intercept-transfer).
+
+### Intervention
+Any point in a run where the plan changed direction: a user STEER /
+CANCEL, a drift the detectors fired, or an autonomous goldfive revision
+(cascade cancel, refine retry, human-intervention-required). Harmonograf
+surfaces these as a merged chronological list via `ListInterventions`
+plus the `InterventionsTimeline` strip above the Gantt. See
+[trajectory-view.md](trajectory-view.md).
+
+### Intervention history
+The chronologically-ordered list of interventions for one session.
+Fetched once on session open via `ListInterventions` and kept live
+from `WatchSession` deltas by the frontend deriver in
+`lib/interventions.ts`.
 
 ### INVOCATION
 Span kind representing one complete agent turn — the outer wrapper

--- a/docs/user-guide/sessions.md
+++ b/docs/user-guide/sessions.md
@@ -9,6 +9,23 @@ Everything else in the UI is scoped to the currently-selected session.
 Selecting a different session reloads the Gantt, Graph, drawer, transport
 bar, and task panel.
 
+## One session per run (post lazy Hello, #84 / #85)
+
+Each end-to-end `goldfive.wrap` invocation corresponds to exactly one
+harmonograf session — the outer adk-web session id. A single run may
+drive a tree of ADK agents through AgentTool sub-Runners, each of
+which mints its own ADK session id, but the client's telemetry
+plugin caches the ROOT adk-web session id on first `before_run_callback`
+and stamps every subsequent span with it. The plan view, Gantt, and
+intervention history all land on the same session row.
+
+As of lazy Hello (harmonograf#85), constructing the client no longer
+opens a `StreamTelemetry` — the `Hello` frame is deferred until the
+first envelope arrives on the ring buffer. Importing
+`harmonograf_client` in a launcher or notebook no longer mints a ghost
+session that clutters the picker. If you expected a session to appear
+and don't see one, the agent likely hasn't emitted anything yet.
+
 ![Session picker showing multiple sessions with agent counts and status](../images/11-session-picker.png)
 
 ## Opening the picker

--- a/docs/user-guide/tasks-and-plans.md
+++ b/docs/user-guide/tasks-and-plans.md
@@ -12,23 +12,39 @@ If you want the protocol-level view of how plan execution is tracked, read
 
 A **task** is a single unit of planned work: title, description, assignee,
 status, optional `predictedStartMs` / `predictedDurationMs`, optional
-`boundSpanId`. Tasks have `PENDING` / `RUNNING` / `COMPLETED` / `FAILED` /
-`CANCELLED` status.
+`boundSpanId`. Tasks have six legal statuses:
+
+| Status | Meaning |
+|---|---|
+| `PENDING` | In the plan, not yet picked up by an agent. |
+| `RUNNING` | An agent has claimed the task and is working on it. |
+| `COMPLETED` | Finished successfully. |
+| `FAILED` | Finished with an error. |
+| `CANCELLED` | Explicitly cancelled by the user (`CANCEL` control) or by goldfive (`cascade_cancel`). |
+| `NOT_NEEDED` | Overlay-era terminal state (goldfive#141-144). The invocation ended without this task being needed — it was part of the original plan but the agent's work didn't require it. |
 
 Task state is monotonic — it only moves forward. The diagram below shows the legal transitions; you'll never see a task move backwards on the task panel.
 
 ```mermaid
 stateDiagram-v2
     [*] --> PENDING
-    PENDING --> RUNNING : report_task_started
-    RUNNING --> RUNNING : report_task_progress
-    RUNNING --> COMPLETED : report_task_completed
-    RUNNING --> FAILED : report_task_failed
+    PENDING --> RUNNING : agent picks up the task
+    PENDING --> NOT_NEEDED : invocation ends, task unassigned
+    PENDING --> CANCELLED : user CANCEL / cascade_cancel
+    RUNNING --> RUNNING : task progress events
+    RUNNING --> COMPLETED : finished successfully
+    RUNNING --> FAILED : error
     RUNNING --> CANCELLED : user CANCEL control
     COMPLETED --> [*]
     FAILED --> [*]
     CANCELLED --> [*]
+    NOT_NEEDED --> [*]
 ```
+
+`PENDING → NOT_NEEDED` at invocation end is expected under the overlay
+model. If a task stays PENDING indefinitely while agents are still
+actively running, that's a bug; see
+[runbooks/task-stuck-in-pending.md](../../runbooks/task-stuck-in-pending.md).
 
 
 A **plan** is an ordered (and possibly DAG-shaped) collection of tasks
@@ -124,56 +140,73 @@ The banner is transient. To see the full revision history, open the
 
 ## Drift kinds
 
-Every revision reason is tagged with a **drift kind** — the reason the
-planner decided to revise. The full table (`frontend/src/gantt/driftKinds.ts`):
+Every revision reason is tagged with a **drift kind** — the reason
+goldfive decided to revise, or the signal a detector fired. The
+canonical taxonomy lives in
+[`goldfive/v1/types.proto` `DriftKind`](https://github.com/pedapudi/goldfive/blob/main/proto/goldfive/v1/types.proto)
+— harmonograf reflects whatever goldfive emits. The current kinds:
 
-| Kind | Icon | Label | Category |
-|---|---|---|---|
-| `tool_error` | ⚠ | Tool error | error |
-| `tool_returned_error` | 🔻 | Bad result | error |
-| `tool_unexpected_result` | ❓ | Odd result | error |
-| `task_failed` | ✗ | Task failed | error |
-| `task_blocked` | ⛔ | Blocked | error |
-| `task_empty_result` | ○ | Empty result | error |
-| `new_work_discovered` / `task_result_new_work` | ✨ | New work | discovery |
-| `task_result_contradicts_plan` | ⟷ | Contradicts plan | divergence |
-| `plan_divergence` | ⟷ | Divergence | divergence |
-| `agent_reported_divergence` | ⟷ | Agent flagged divergence | divergence |
-| `llm_refused` | 🚫 | Refused | error |
-| `llm_merged_tasks` | ⊕ | Merged tasks | structural |
-| `llm_split_task` | ⊗ | Split task | structural |
-| `llm_reordered_work` | ⇄ | Reordered | structural |
-| `context_pressure` | ⚡ | Context limit | structural |
-| `user_steer` | 👆 | User steered | user |
-| `user_cancel` | ⏹ | User cancelled | user |
-| `unexpected_transfer` | ↪ | Unexpected transfer | divergence |
-| `agent_escalated` | ⚠ | Escalated | divergence |
-| `multiple_stamp_mismatches` | ≠ | Plan drift | divergence |
-| `tool_call_wrong_agent` | ↪ | Wrong agent | structural |
-| `transfer_to_unplanned_agent` | ↪ | Unplanned transfer | divergence |
-| `failed_span` | ✗ | Failed span | error |
-| `task_completion_out_of_order` | ≠ | Out of order | structural |
-| `external_signal` | ⟶ | External | user |
-| `coordinator_early_stop` | ⏸ | Early stop | divergence |
+| Kind | Category | When it fires |
+|---|---|---|
+| `USER_STEER` | user | Operator sent a STEER control / posted a STEERING annotation. |
+| `PLAN_DIVERGENCE` | divergence | Three-stage function_call gate (goldfive#178): an agent called a tool that belongs to another layer of the plan. |
+| `CONFABULATION_RISK` | divergence | Three-stage gate: an agent called a tool that doesn't exist in the registry — model hallucinated the name. |
+| `CONFUSION` | divergence | Planner couldn't reconcile the agent's output with the plan. |
+| `INTENT_DIVERGENCE` | divergence | Agent's output drifted from the original user intent. |
+| `AGENT_REFUSAL` | error | Agent refused a request (safety / policy). |
+| `TOOL_ERROR` | error | A tool call failed. |
+| `LOOPING_REASONING` | error | Tool-loop detector (goldfive#181/#186) fired — same tool+args, same tool-name pattern, or alternating pair repeating beyond threshold. |
+| `RUNAWAY_DELEGATION` | structural | One agent is delegating to sub-agents at a pathological rate. |
+| `REFINE_VALIDATION_FAILED` | structural | Goldfive's planner refine emitted an invalid plan. |
+| `HUMAN_INTERVENTION_REQUIRED` | error | Goldfive's intervention ladder reached the rung where only a human can resolve the situation. |
+| `GOAL_DRIFT` | divergence | Goal-aware refiner noticed the run moved away from the goal. |
+| `OFF_TOPIC` | divergence | Model started discussing something unrelated to the goal. |
 
-The drift taxonomy clusters into five categories, each with its own color in the UI. Use this map when you're triaging a noisy session — start by deciding which category bucket the most-recent pill belongs to, then drill into the specific kind.
+### Severity
+
+Each drift carries a severity (`info` / `warning` / `critical`) that
+drives the timeline ring color and the PlanRevisionBanner pill
+coloring. `CRITICAL` severity includes `CONFABULATION_RISK` (34) —
+hallucinated tool names — and `RUNAWAY_DELEGATION` (35);
+`HUMAN_INTERVENTION_REQUIRED` (37) and `GOAL_DRIFT` (38) ride at
+warning. Refer to goldfive's drift enum for the authoritative severity
+mapping.
+
+### User-control drifts
+
+`USER_STEER` and (where goldfive emits it) a `user_cancel` equivalent
+are special in the aggregator: they fold into the authoring
+annotation's intervention card via `annotation_id` propagation
+(goldfive#176 / harmonograf#75). One card per operator intervention,
+even though the wire emits three events (annotation + drift + plan
+revision).
+
+### Frontend rendering is tree-agnostic
+
+`frontend/src/lib/interventions.ts` and the InterventionsTimeline
+component render whatever kind string the server emits. New kinds
+added to goldfive tomorrow work without a harmonograf change — the
+source trichotomy (`user` / `drift` / `goldfive`) is the only
+taxonomy knowledge baked into the view.
+
+The drift taxonomy clusters by source on the InterventionsTimeline
+(user / drift / goldfive) and by severity for colour. Use this map
+when triaging a noisy session — start by deciding which source
+bucket the marker belongs to, then drill in on the specific kind.
 
 ```mermaid
 flowchart TD
     Drift([drift kind])
-    Drift --> Error[error · red<br/>tool_error · task_failed<br/>llm_refused · failed_span]
-    Drift --> Diverge[divergence · amber<br/>plan_divergence · unexpected_transfer<br/>agent_escalated]
-    Drift --> Discover[discovery · green<br/>new_work_discovered]
-    Drift --> User[user · blue<br/>user_steer · user_cancel<br/>external_signal]
-    Drift --> Struct[structural · grey-blue<br/>llm_merged_tasks · llm_split_task<br/>llm_reordered_work · context_pressure]
+    Drift --> UserSrc[user · purple<br/>USER_STEER · USER_CANCEL]
+    Drift --> DriftSrc[drift · amber<br/>TOOL_ERROR · AGENT_REFUSAL<br/>PLAN_DIVERGENCE · CONFABULATION_RISK<br/>LOOPING_REASONING · INTENT_DIVERGENCE<br/>GOAL_DRIFT · OFF_TOPIC · CONFUSION]
+    Drift --> Gf[goldfive · grey<br/>HUMAN_INTERVENTION_REQUIRED<br/>REFINE_VALIDATION_FAILED<br/>RUNAWAY_DELEGATION<br/>cascade_cancel · refine_retry]
 ```
 
-**Category** groups the kinds by color:
+**Source** groups the kinds for rendering:
 
-- `error` (red) — something went wrong mechanically.
-- `divergence` (amber) — the plan and reality don't agree.
-- `discovery` (green) — the agent found work it didn't expect.
-- `user` (blue/grey) — you (or something external) steered the run.
+- `user` (purple) — operator-initiated (STEER / CANCEL).
+- `drift` (amber) — detectors fired on agent behaviour.
+- `goldfive` (grey) — autonomous orchestrator action (escalation ladder).
 - `structural` (blue / grey) — the plan shape changed for reasons unrelated
   to correctness.
 

--- a/docs/user-guide/trajectory-view.md
+++ b/docs/user-guide/trajectory-view.md
@@ -1,215 +1,193 @@
 # Trajectory view
 
 The Trajectory view (`Trajectory` in the nav rail) is harmonograf's dedicated
-surface for **plan review, steering, and drift analysis**. Where the Gantt
-answers "what happened, when?", the Trajectory answers "how did this plan get
-from rev 0 to where it is now, and why did it change?".
+surface for **plan review, steering, and intervention history**. Where the
+Gantt answers "what happened, when?", the Trajectory answers "how did this
+plan get from rev 0 to where it is now, and what nudges (human, drift,
+goldfive) pushed it along the way?".
 
-![Trajectory view with three plan revisions and a DAG](../images/28-trajectory-overview.png)
+It unifies three things into one pane:
 
-It unifies two things that used to live in separate places — the plan DAG and
-the plan-diff history — into one pane, anchored on a horizontal ribbon of
-revisions. The DAG shows the current plan; the ribbon shows the plan over
-time; the detail pane on the right shows whatever you last clicked.
+- The **plan DAG** — the current revision rendered as a layered
+  left-to-right topological layout.
+- The **intervention timeline** — every user STEER, every drift, every
+  autonomous goldfive revision, as markers on a horizontal strip above
+  the DAG.
+- A **detail pane** on the right that shows whatever you last clicked.
 
 ## When to use it
 
 The Gantt shows a ticker-tape of spans. That works well when you're chasing a
 specific invocation or looking at overall pacing, but it hides two things
-that plan-driven runs really care about:
+plan-driven runs really care about:
 
 - **Plan structure.** Which tasks depend on which? Where is the DAG branchy
   vs. linear? A flat task panel can't show dependencies at a glance.
-- **How the plan evolved.** Between the initial plan and "now" there may be
-  several refines, each triggered by a different drift. The Gantt shows the
-  *effect* of each refine (a new bar starts, an old bar fails) but not the
-  *replan* — which tasks were added, removed, reworded, or reassigned.
+- **How the plan evolved under outside pressure.** Between the initial plan
+  and "now" there may be several refines, each triggered by a human STEER,
+  a drift detector fire, or goldfive's own intervention ladder (cascade
+  cancels, refine retries, human-intervention-required escalations). The
+  Gantt shows the *effect* of each refine but not the *decision*.
 
-The Trajectory is the pane you open when you want to answer "why is the plan
-shaped like this?" or "what did rev 2 change about rev 1?".
+The Trajectory is the pane you open to answer "why is the plan shaped like
+this?" or "what did rev 2 change about rev 1?" or "what was the human
+steering here?".
 
-## Region map
+## The intervention timeline strip
 
-```mermaid
-flowchart TB
-    Header[Header · rev counter · clear-diff button]
-    Ribbon[Ribbon · one segment per rev · pivots · drift markers]
-    subgraph Split
-      DAG[DAG pane · current-rev plan as layered DAG]
-      Detail[Detail pane · task or drift · metadata + drifts]
-    end
-    Header --> Ribbon --> Split
-    DAG --- Detail
-```
+The spine of the view is the **InterventionsTimeline** (`#71`, redesigned
+in `#76`) — a horizontal strip of markers showing every intervention in
+chronological order. It also sits above the Gantt in the main view, so
+the same vocabulary applies everywhere.
 
-| Region | What it is |
-|---|---|
-| **Header** | Title, rev counter (`rev N of M`), hint about shift-click-to-diff, and a `clear diff` button when a compare rev is pinned. |
-| **Rev chips** | One clickable chip per rev on the far right of the header. Click = pin a rev; shift-click = diff against it. |
-| **Ribbon** | One horizontal segment per rev. Between segments, a pivot glyph (↻) colored by severity. Each segment carries a row of drift markers for drifts observed during that rev. |
-| **DAG pane** | The current rev rendered as a layered DAG (left-to-right Kahn topological layout). One card per task; arrows for edges; drift-count badges on tasks that accumulated drifts. |
-| **Detail pane** | On the right. Shows whatever you last selected — a task card (assignee, bound span, drifts on this task) or a drift marker (kind, severity, detail, observed time, task id, agent id). |
+### Three channels: glyph · color · ring
 
-## Reading the ribbon
+Every marker uses three orthogonal visual channels:
 
-The ribbon is the spine of the view. It reads like a timeline of the planner's
-decisions: one segment per rev, pivot glyphs at the boundaries where a refine
-fired, drift markers on each segment marking the drifts that happened while
-that rev was live.
-
-```mermaid
-flowchart LR
-    R0[REV 0<br/>initial plan]
-    P1(↻ pivot<br/>severity-colored)
-    R1[REV 1<br/>refined]
-    P2(↻ pivot)
-    R2[REV 2<br/>refined]
-    R0 --> P1 --> R1 --> P2 --> R2
-```
-
-Each segment shows:
-
-- **Rev number and summary.** `REV 1 — Refined: primary API failed, routed via backup.` The summary text comes from the planner's `summary` field on the revised plan.
-- **A row of drift markers** beneath the label. One marker per drift observed during that rev. Circles (●) are model/runner-authored drifts; stars (★) are user-authored pivots (`user_steer`, `user_cancel`, `user_pause`). Both are colored by severity — blue (info) · amber (warning) · red (critical).
-- **A pivot glyph (↻)** at the *start* of the segment (except rev 0). The pivot is colored by the revision's severity, so the eye can trace catastrophic replans from info-level tweaks by color alone.
-
-### Drift severity, not drift count
-
-Harmonograf leans on severity rather than drift count because *some drift is
-expected*. A reasoning model that re-routes around a failed API, or that
-notices a missed citation and adds a task, is doing its job. Those events
-should render but not scream. A plan divergence or a tool refusal is what you
-want to jump to.
-
-The severity palette is consistent across the ribbon, the pivot glyphs, the
-task cards, and the detail pane:
-
-| Severity | Color | What it usually means |
+| Channel | Drives | Values |
 |---|---|---|
-| `info` | blue | Model-initiated refinement, discovery, reordering |
-| `warning` | amber | Recoverable failure, divergence, unexpected transfer |
-| `critical` | red | Unrecoverable failure, plan contradiction, refusal |
+| **Color (fill)** | *source* — who initiated | `user` (purple), `drift` (amber), `goldfive` (grey) |
+| **Glyph** | *kind* — what was done | diamond = user STEER, diamond-x = user CANCEL, chevron = drift that caused a plan revise, circle = drift that did not cause a revise, square = autonomous goldfive action |
+| **Ring** | *severity* — how loud | no ring = info, dashed = warning, solid red = critical |
 
-(Drift *kinds* are documented on [tasks-and-plans.md](tasks-and-plans.md#drift-kinds);
-the trajectory view groups by severity because that's the axis that matters
-for prioritization.)
+New drift kinds emitted by goldfive tomorrow render correctly without any
+frontend change: the strip never inspects kind taxonomies. It only knows
+the source trichotomy, which is assigned once by the deriver.
+
+### Stable X anchor
+
+The marker X positions are computed once per session-relative time window
+and held steady. Hovering a marker will *not* shift its neighbors even
+when the session is live and the parent's end-of-window is advancing
+every frame. The strip advances on a coarse 1-second tick only.
+
+### Density clustering
+
+Markers whose centers fall within ~2 % of the strip width of each other
+collapse into a single cluster badge. Hover the badge to see the group;
+click to pin its popover. Typical sighting: a cascade-cancel that
+triggers five CANCELLED tasks at once.
+
+### Deterministic popover
+
+The popover is anchored to the marker's x position, not the cursor — so
+moving the mouse inside the popover doesn't drag it around, and clicking
+a marker pins the popover (click again to unpin, or click outside the
+strip).
+
+### Axis ticks
+
+4-8 session-relative time labels (`10s`, `30s`, `1m`, `5m`, …) render
+along the bottom of the strip so you can orient the markers in time at a
+glance.
+
+## Card anatomy (single-row popover)
+
+Clicking or hovering a marker opens a popover with these fields:
+
+| Field | Source | What it tells you |
+|---|---|---|
+| **Source glyph + label** | `source` | "User", "Drift", or "Goldfive" with the matching color. |
+| **Kind** | `kind` | `STEER` / `CANCEL` / `LOOPING_REASONING` / `TOOL_ERROR` / `CASCADE_CANCEL` / `REFINE_RETRY` / … |
+| **Timestamp** | `at` | Session-relative `m:ss` (e.g. `2:34`). |
+| **Body preview** | `body_or_reason` | For user STEER: the operator's note. For drift: the detector's detail. First ~200 chars; click **Show full** for the rest. |
+| **Author** | `author` | For user-sourced: the poster (default `user`). Empty for drift / goldfive. |
+| **Severity ring** | `severity` | Echoes the marker ring — `info` / `warning` / `critical`. |
+| **Outcome chip** | `outcome` | `→ rev 3` when a plan revision was attributed, `→ cancel 2 tasks` when a cascade cancel fired, `pending` while goldfive is still refining, `recorded` when no follow-up was correlated. |
+| **Jump to rev** | — | If the outcome is `plan_revised:rN`, a button jumps the DAG pane to that revision. |
+
+### Intervention cards dedup by annotation_id
+
+A single user STEER used to surface as three cards: the annotation
+itself, the USER_STEER drift goldfive emitted, and the `plan_revised:rN`
+that followed. As of `#81` / `#87`, the aggregator collapses all three
+onto one card — the annotation row — whose outcome carries the revision
+attribution. This works even when the planner's refine LLM takes 30-70
+seconds (Qwen3.5-35B often does), thanks to an extended 5-minute
+attribution window scoped to user-control drifts (`#86`).
+
+## Filtering
+
+The drawer's **Interventions** tab lists the same rows vertically with
+filter chips:
+
+- **Source:** user · drift · goldfive
+- **Severity:** info · warning · critical
+- **Outcome:** plan revised · cascade cancel · pending · recorded
+
+Filters compose. Picking `user + critical` shows only operator
+intervention cards that escalated a severity-critical outcome.
 
 ## The DAG pane
 
-The DAG is a left-to-right Kahn topological layout: every task's horizontal
-position is its longest-path distance from a root, so edges always go right.
-Within a layer, tasks are stacked vertically.
-
-![DAG with a failed task on layer 1 and a recovered backup on layer 2](../images/29-trajectory-drift-detail.png)
+The DAG below the strip is a left-to-right Kahn topological layout:
+every task's horizontal position is its longest-path distance from a
+root, so edges always go right. Within a layer, tasks stack vertically.
 
 Each card shows:
 
 - **Title** on the first line.
 - **Status and assignee** on the second line (e.g. `completed · worker`).
-- **A 6px color bar** on the left edge encoding task status:
+- **A 6 px color bar** on the left edge encoding task status:
 
   | Status | Color |
   |---|---|
-  | `PENDING` / `UNSPECIFIED` / `CANCELLED` | grey |
+  | `PENDING` / `UNSPECIFIED` / `NOT_NEEDED` / `CANCELLED` | grey |
   | `RUNNING` | blue |
   | `COMPLETED` | green |
   | `FAILED` | red |
   | `BLOCKED` | amber |
 
-- **A severity-colored drift badge** in the top-right corner of the card when
-  one or more drifts point at that task. The badge number is the drift count;
-  the color is the worst severity observed.
+- **A severity-colored drift badge** in the top-right corner when one or
+  more drifts point at that task.
 
-Click a card to select the task. The detail pane on the right loads with the
-task's description, assignee, and the list of drifts that pointed at it. If
-the task has a `boundSpanId`, the inspector drawer also opens on that span so
-you can drill into the actual execution without leaving the view.
-
-### Drift detail
-
-Click a drift marker on the ribbon — the detail pane shows the drift's kind,
-severity, detail string, observed time, the task id it targeted, and the
-agent id that reported it.
-
-This is the fastest way to answer "why did this rev happen?". Start on the
-pivot glyph that separates rev N-1 from rev N, hit the drift marker that
-sits on rev N-1's segment, and you'll see the planner-facing reason.
+Click a card to select the task. The detail pane shows its description,
+assignee, bound span, and drifts-on-this-task. If `bound_span_id` is
+set, the inspector drawer also opens on that span.
 
 ## Diffing two revs
 
-The trajectory view is also a plan-diff view. Shift-click any rev chip to pin
-it as a **compare rev**. The current rev renders with diff marks overlaid:
-
-![Rev 2 diffed against rev 0 — `clear diff` button visible](../images/31-trajectory-diff-mode.png)
-
-- **Added** tasks (present in current, absent from compare) get a green dashed
-  outline.
-- **Modified** tasks (same id, different title/description/assignee) get a
-  blue dashed outline.
-- **Removed** tasks (present in compare, absent from current) render as a
-  stripped-down list in a "Removed in rev" aside on the right of the DAG so
-  they don't corrupt the current-rev layout.
-
-The rev counter in the header updates to read
-`rev 2 of 2 · comparing to rev 0`. Click `clear diff` to go back to straight
-current-rev view.
-
-You can shift-click any rev against any other rev — `rev 0` against `rev 2`,
-`rev 1` against `rev 0`, etc. The diff is computed live from the stored
-revisions; nothing is pre-baked.
-
-## Task detail
-
-Clicking a task card pins it in the detail pane:
-
-![Task detail showing drifts that targeted the selected task](../images/30-trajectory-task-detail.png)
-
-You get the task's title, status, assignee, bound span id, and a **Drifts on
-this task** section listing every drift whose `task_id` pointed at this task
-across all revs. Each row is colored by severity and shows `kind · severity
-— detail`.
-
-If the task is bound to a real span (`boundSpanId`), clicking it also opens
-the inspector drawer on that span — so you can read the trajectory narrative
-here and drop into the execution detail without navigating away.
+Shift-click any rev chip to pin it as a **compare rev**. The current rev
+renders with diff marks overlaid: added tasks get a green dashed outline,
+modified tasks get a blue dashed outline, removed tasks appear in a
+"Removed in rev" aside on the right so they don't corrupt the current-rev
+layout. Click `clear diff` to exit.
 
 ## Live updates
 
 The Trajectory view live-subscribes to the same registries the Gantt does
-(`store.tasks`, `store.drifts`, `store.spans`). As the agent runs:
+(`store.spans`, `store.drifts`, `store.tasks`, `annotationStore`) and
+re-derives the intervention list via `lib/interventions.ts` on every
+WatchSession delta. As the agent runs:
 
-- New plans push new segments onto the ribbon, with the latest rev auto-
-  selected.
-- New drifts materialize as markers on whichever segment was live when they
-  were observed.
+- New annotations and drifts materialize as markers on the strip
+  (fade-in once; subsequent renders don't replay the entrance).
+- Plan revisions push new chips into the rev counter.
 - Status changes repaint the corresponding card on the DAG.
 
-If you've pinned a specific rev (clicked a chip), the live pin *sticks* — the
-ribbon will keep growing, but the DAG and detail pane stay on the rev you
-chose. Click the latest chip (or any chip) again to un-pin.
+If you've pinned a specific rev (clicked a chip), the live pin *sticks* —
+the ribbon grows, but the DAG and detail pane stay on the pinned rev.
 
 ## Interaction summary
 
 | Input | Result |
 |---|---|
+| Hover a marker | Preview popover at the marker's anchor position. |
+| Click a marker | Pin the popover. Click again (or outside) to unpin. |
+| Hover/click a cluster badge | Show the group. |
 | Click a rev chip | Pin that rev as the current rev. |
-| Shift-click a rev chip | Pin that rev as the compare rev (enables diff mode). |
+| Shift-click a rev chip | Pin as compare rev (diff mode). |
 | Click `clear diff` | Exit diff mode. |
-| Click a task card | Pin the task in the detail pane. Open the inspector drawer on the bound span if one exists. |
-| Click a drift marker on the ribbon | Pin the drift in the detail pane. |
-
-Nav: the Trajectory view lives at `navSection === 'trajectory'` in the UI
-store; it's reachable from the nav rail (`↪ Trajectory`) alongside Sessions,
-Activity, Graph, Notes, and Settings.
+| Click a task card | Pin it in the detail pane; open the drawer on the bound span if one exists. |
+| Click the `→ rev N` chip on a popover | Jump the DAG pane to that revision. |
 
 ## Related pages
 
-- [Tasks and plans](tasks-and-plans.md) — the task state machine, drift kind
-  taxonomy, and the PlanRevisionBanner that announces new revs as they land.
-- [Actors and attribution](actors.md) — how the synthetic `__user__` and
-  `__goldfive__` actor rows get populated from the same drifts the Trajectory
-  ribbon shows.
-- [Gantt view](gantt-view.md) — the other half of the picture (spans, agent
-  rows, cross-agent edges).
-- [Control actions](control-actions.md) — how to steer a run (the steerings
-  you send show up as `user_steer` markers on the ribbon).
+- [Tasks and plans](tasks-and-plans.md) — the task state machine and
+  the drift kind taxonomy harmonograf reflects from goldfive.
+- [Control actions](control-actions.md) — how to STEER / CANCEL a run;
+  the cards you see here are the receipts for those actions.
+- [Annotations](annotations.md) — how STEER / HUMAN_RESPONSE / COMMENT
+  are authored and stored.
+- [Gantt view](gantt-view.md) — the other half of the picture (spans,
+  per-agent rows, cross-agent edges).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,104 +1,122 @@
 # Harmonograf frontend
 
-React + TypeScript + Vite dev server for the Harmonograf console.
+React 19 + TypeScript + Vite dev server for the Harmonograf console.
+
+## Layout
+
+```
+frontend/src/
+├── main.tsx / App.tsx           Vite entry; mounts <Shell />
+├── index.css                    Material Design 3 tokens + global styles
+├── theme/                       Color, typography tokens
+├── gantt/                       Canvas Gantt renderer (SessionStore, AgentRegistry, TaskRegistry, layout, viewport, spatial index)
+├── rpc/                         Connect-RPC transport, hooks, proto converters
+├── state/                       Zustand stores: ui, sessions, annotations, approvals, popover
+├── lib/                         shortcuts, interventions deriver (mirrors server aggregator)
+├── components/
+│   ├── shell/                   Shell, AppBar, NavRail, Drawer
+│   ├── Gantt/                   Minimap, context-window badges
+│   ├── Interventions/           InterventionsTimeline (the #71/#76 strip)
+│   ├── Interaction/             SpanPopover, steering controls
+│   ├── DelegationTooltip/       Delegation edge hover cards
+│   ├── TransportBar/            Live/paused indicator + controls
+│   ├── LiveActivity/            Current-activity panel
+│   ├── OrchestrationTimeline/   Task-stage timeline (secondary)
+│   ├── SessionPicker/
+│   └── TaskStages/
+├── pb/                          Generated protobuf-es stubs (checked in; never edit)
+└── __tests__/                   Vitest
+```
 
 ## Running against a server
 
-`pnpm dev` starts Vite on `http://127.0.0.1:5173`. The app talks gRPC-Web to
-`harmonograf_server` at the URL in `VITE_HARMONOGRAF_API`; if that env var is
-unset, it falls back to `http://127.0.0.1:7532`, which matches the server's
-default `--web-port`. So:
+`pnpm dev` starts Vite on `http://127.0.0.1:5173`. The app talks
+gRPC-Web to the harmonograf server's gRPC-Web listener on
+`http://127.0.0.1:5174` by default (overridable via the
+`VITE_HARMONOGRAF_API` env var).
 
 ```bash
-# Terminal 1
-python -m harmonograf_server           # binds 127.0.0.1:7532 (gRPC-Web)
-# Terminal 2
-pnpm dev                               # Vite on :5173, talks to :7532
+# Terminal 1 — server on :7531 (native gRPC) + :5174 (gRPC-Web)
+python -m harmonograf_server --store sqlite --data-dir data
+
+# Terminal 2 — Vite dev server on :5173, talks to :5174
+pnpm dev
 ```
 
-To point the frontend at a non-default server (different port or host), set
-`VITE_HARMONOGRAF_API` before launching Vite:
+Do not confuse the ports:
+
+- `7531` — native gRPC, for agent clients only.
+- `5174` — gRPC-Web, for the browser (this is what the frontend
+  talks to).
+- `5173` — Vite dev server (the HTML/JS/CSS the browser loads).
 
 ```bash
-VITE_HARMONOGRAF_API=http://127.0.0.1:17532 pnpm dev
+# Point at a non-default backend:
+VITE_HARMONOGRAF_API=http://127.0.0.1:15174 pnpm dev
 ```
 
-The env var name is `VITE_HARMONOGRAF_API` (the `VITE_` prefix is required so
-Vite exposes it to the browser bundle). If the URL is unreachable the session
-picker falls back to a "Server unreachable — showing demo sessions" view.
+If the URL is unreachable, the session picker falls back to a
+"Server unreachable — showing demo sessions" view backed by
+`SessionPicker/mockSessions.ts`.
 
----
+## Running the full demo
 
-## Vite template notes
+From the repo root, `make demo` boots the server, the Vite dev
+server, and `adk web` with the presentation agent all at once.
+That's the fastest path to a running demo. See
+[`docs/dev-guide/setup.md`](../docs/dev-guide/setup.md) for
+environment variables (`KIKUCHI_LLM_URL`, `USER_MODEL_NAME`,
+`GOLDFIVE_EXAMPLE_PLANNER_MODEL`).
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+## Development
 
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+pnpm install --frozen-lockfile    # install deps
+pnpm dev                          # HMR dev server
+pnpm test                         # vitest one-shot
+pnpm test:watch                   # vitest watch
+pnpm build                        # production build into dist/
+pnpm lint                         # ESLint
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+`pnpm build` runs `tsc -b` (type check) then `vite build`. The
+build artifacts land in `dist/` and are not committed.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Proto codegen
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+Generated stubs under `src/pb/` come from `make proto-ts` at the
+repo root (uses `buf generate` against `proto/harmonograf/v1/`).
+They are checked into git. Do not hand-edit.
+
+## Architecture notes
+
+- **Two data planes.** The canvas Gantt reads mutable stores
+  (`SessionStore`, `AgentRegistry`, `TaskRegistry`) that the
+  renderer reads on every animation frame. Zustand holds only
+  UI-level state (selection, viewport, drawer visibility). See
+  [`docs/dev-guide/frontend.md`](../docs/dev-guide/frontend.md).
+
+- **InterventionsTimeline (#71 / #76).** The strip above the Gantt
+  renders a unified intervention history derived client-side from
+  annotations + drifts + plan revisions via `lib/interventions.ts`.
+  Marker positioning uses a stable X anchor so hover-driven
+  re-renders don't shift markers; density clustering collapses
+  nearby markers into a single badge.
+
+- **Per-agent Gantt rows (#80).** The client's
+  `HarmonografTelemetryPlugin` stamps a per-ADK-agent id on every
+  span. The server auto-registers a harmonograf `Agent` row for
+  each distinct id on first sight. The frontend renders one row
+  per agent; no special code path needed.
+
+- **Lazy Hello (#84 / #85).** The session picker does not show a
+  session until the agent actually emits its first span; importing
+  the client library no longer mints ghost sessions.
+
+## Related docs
+
+- [`docs/user-guide/`](../docs/user-guide/) — the user-facing
+  reference for every UI surface.
+- [`docs/dev-guide/frontend.md`](../docs/dev-guide/frontend.md) —
+  the canonical engineering guide for this package.
+- [`docs/design/`](../docs/design/) — architectural notes and ADRs.


### PR DESCRIPTION
## Summary

Comprehensive refresh of the dev-guide, user-guide, runbooks, and `.agents/skills/` to reflect the current state of the codebase after:

- The goldfive migration (orchestration moved out of harmonograf).
- Lazy Hello (#84 / #85) — no more ghost sessions.
- Per-agent Gantt rows (#80) — one row per ADK agent.
- Plugin dedup (#68) — duplicate `HarmonografTelemetryPlugin` self-silences.
- Unified intervention history (#71, #76) — redesigned timeline strip.
- Intervention card dedup by annotation_id (#81, #87).
- STEER body validation + author propagation (#72).
- Related goldfive changes (#170-172, #177, #178, #181, #186) surfaced through the docs.

## Scope

| Group | Files |
|---|---|
| `docs/dev-guide/` | 15 files — index, setup, architecture, client-library, frontend, server, storage-backends, working-with-protos, migration, testing, debugging, deployment, security-model, performance-tuning, contributing |
| `docs/user-guide/` | 11 files + 5 examples — trajectory-view (major rewrite), gantt-view, sessions, annotations, control-actions, tasks-and-plans, faq, glossary, cookbook, index; examples/{cascading-refines, delegated-handoff, escalation, parallel-map-reduce, research-tool-error} |
| `docs/runbooks/` | 14 files — major refresh on drift-not-firing, task-stuck-in-pending, task-stuck-in-running, high-latency-callbacks; smaller updates elsewhere |
| `.agents/skills/` | 31 skills — major rewrites on obsolete orchestration-era skills, smaller updates on proto/control/annotation skills |
| `frontend/README.md` | Current layout, port conventions, InterventionsTimeline and per-agent row notes |

Other agents own README/top-level/tour and design/protocol/adr/internals — this PR does not touch those.

## Test plan

- [ ] CI green on all four jobs (Python lint/tests, frontend lint/build, proto drift).
- [ ] Spot-check one runbook end-to-end against a live demo (pick `drift-not-firing.md`).
- [ ] Spot-check one skill against a real task (pick `hgraf-add-proto-field`).
- [ ] Verify `docs/dev-guide/index.md` TOC references exist.
- [ ] Verify `docs/user-guide/index.md` TOC references exist.