### PR TITLE
Clear LIVE ACTIVITY header after run completes (closes #96)

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -778,6 +778,91 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
             invocation_id, status=SpanStatus.CANCELLED
         )
 
+    def on_run_end(self) -> None:
+        """Public hook invoked by ``GoldfiveADKAgent._run_async_impl``'s
+        ``finally`` block when an outer run exits (normal completion,
+        cancellation, or early generator-close).
+
+        Closes EVERY INVOCATION span this plugin opened during the run
+        that is still in the open map (``_invocation_spans``). This is
+        the broader sweep that complements :meth:`on_cancellation`
+        (which is scoped to a single invocation_id): sub-Runner
+        invocations spawned by ``AgentTool`` have their OWN
+        ``invocation_id`` so the outer cancel path doesn't reach them,
+        and ADK places ``after_run_callback`` outside a ``finally`` in
+        :meth:`Runner._exec_with_plugin` — so a cancelled or
+        early-closed sub-Runner leaks its INVOCATION span forever.
+
+        Cleanup covers:
+          * open INVOCATION spans (keyed by invocation_id)
+          * any leftover model spans
+          * any leftover tool spans
+
+        Status is ``COMPLETED`` — the goldfive adapter also runs the
+        targeted ``on_cancellation(invocation_id)`` with
+        ``status=CANCELLED`` on the specific cancel path, so by the
+        time we sweep here the "was this cancelled?" signal has
+        already been applied to the spans that belong to that path.
+        What remains are orphans whose after-callbacks ADK simply
+        never fired — ``COMPLETED`` matches the "clean exit after the
+        outer run is done" semantics for those.
+
+        Safe to call from any context — never raises. Idempotent: a
+        second call after a full close is a no-op because the open
+        maps are empty.
+        """
+        # Close every open INVOCATION span. We don't want to filter to
+        # "just the root" — sub-Runner invocations keyed by their own
+        # ids are exactly the spans that leak through ADK's callback gap.
+        stale_inv_ids = list(self._invocation_spans.keys())
+        for inv_key in stale_inv_ids:
+            sid = self._invocation_spans.pop(inv_key, None)
+            if sid is None:
+                continue
+            try:
+                self._client.emit_span_end(sid, status=SpanStatus.COMPLETED)
+            except Exception:  # noqa: BLE001 — defensive: telemetry must not raise
+                log.debug(
+                    "telemetry_plugin: on_run_end emit_span_end for "
+                    "invocation span %s raised",
+                    sid,
+                    exc_info=True,
+                )
+
+        # Sweep any leftover model spans still open. Keyed by invocation_id.
+        stale_model_keys = list(self._model_spans.keys())
+        for inv_id in stale_model_keys:
+            slots = self._model_spans.pop(inv_id, None) or []
+            for slot in slots:
+                try:
+                    self._client.emit_span_end(
+                        slot.span_id, status=SpanStatus.COMPLETED
+                    )
+                except Exception:  # noqa: BLE001 — defensive
+                    log.debug(
+                        "telemetry_plugin: on_run_end emit_span_end for "
+                        "model span %s raised",
+                        slot.span_id,
+                        exc_info=True,
+                    )
+
+        # Sweep any leftover tool spans still open.
+        stale_tool_keys = list(self._tool_spans.keys())
+        for key in stale_tool_keys:
+            sid = self._tool_spans.pop(key, None)
+            self._tool_span_invocations.pop(key, None)
+            if sid is None:
+                continue
+            try:
+                self._client.emit_span_end(sid, status=SpanStatus.COMPLETED)
+            except Exception:  # noqa: BLE001 — defensive
+                log.debug(
+                    "telemetry_plugin: on_run_end emit_span_end for "
+                    "tool span %s raised",
+                    sid,
+                    exc_info=True,
+                )
+
     # ------------------------------------------------------------------
     # Invocation lifecycle
     # ------------------------------------------------------------------

--- a/client/tests/test_telemetry_plugin_on_run_end.py
+++ b/client/tests/test_telemetry_plugin_on_run_end.py
@@ -1,0 +1,190 @@
+"""Tests for :meth:`HarmonografTelemetryPlugin.on_run_end` (harmonograf#96
+/ goldfive#196).
+
+When the outer :class:`goldfive.adapters.adk_wrap.GoldfiveADKAgent`
+exits its ``_run_async_impl`` generator (normal completion, upstream
+cancel, or ``aclose()``), it calls ``plugin.on_run_end()`` on every
+adapter plugin. This plugin's implementation sweeps all still-open
+INVOCATION / model / tool spans the plugin tracks and flushes them with
+``status=COMPLETED``.
+
+Why it's needed even with :meth:`on_cancellation`:
+``on_cancellation`` is scoped to a single ``invocation_id`` — the
+outer run. Sub-Runner invocations spawned by ADK's ``AgentTool`` have
+their own ``invocation_id``, so a cancel on the outer invocation does
+not reach the sub-Runner's open INVOCATION span. That span leaks
+``status=RUNNING`` forever in the harmonograf DB, and the frontend's
+"LIVE ACTIVITY · N RUNNING" header stays pinned. ``on_run_end`` is the
+broader sweep that closes every tracked span regardless of which
+invocation opened it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from harmonograf_client.buffer import EnvelopeKind
+from harmonograf_client.client import Client
+from harmonograf_client.telemetry_plugin import HarmonografTelemetryPlugin
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+class _Session:
+    def __init__(self, sid: str) -> None:
+        self.id = sid
+
+
+class _Agent:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _InvocationContext:
+    def __init__(self, invocation_id: str, session_id: str) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id)
+        self.agent = _Agent("root-agent")
+
+
+HOME_SESSION = "home-sess"
+ROOT_SESSION = "adk-sess-root"
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="on-run-end-test",
+        agent_id="agent-ORE",
+        session_id=HOME_SESSION,
+        buffer_size=128,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def plugin(client: Client) -> HarmonografTelemetryPlugin:
+    return HarmonografTelemetryPlugin(client)
+
+
+def _span_ends(client: Client) -> list[Any]:
+    out: list[Any] = []
+    for env in client._events.drain():
+        if env.kind is EnvelopeKind.SPAN_END:
+            out.append(env.payload)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# on_run_end closes orphan INVOCATION spans
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_run_end_closes_orphan_invocation_span(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """An INVOCATION span opened by a sub-Runner whose
+    ``after_run_callback`` never fired must be closed by ``on_run_end``.
+    """
+    # Simulate a sub-Runner invocation (ADK AgentTool)
+    sub_ctx = _InvocationContext("inv-sub", "sub-adk-sess")
+    await plugin.before_run_callback(invocation_context=sub_ctx)
+
+    # Outer run ends (e.g. coordinator returns). We intentionally do NOT
+    # call ``after_run_callback`` for the sub-Runner — this is exactly
+    # the ADK callback gap the fix addresses.
+    plugin.on_run_end()
+
+    ends = _span_ends(client)
+    assert len(ends) == 1, "orphan INVOCATION span must be swept"
+
+
+@pytest.mark.asyncio
+async def test_on_run_end_closes_multiple_orphan_invocation_spans(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Multiple orphaned sub-Runner invocations (parallel AgentTool
+    tree) must all be swept.
+    """
+    for inv in ("inv-a", "inv-b", "inv-c"):
+        ctx = _InvocationContext(inv, f"{inv}-sess")
+        await plugin.before_run_callback(invocation_context=ctx)
+
+    plugin.on_run_end()
+    ends = _span_ends(client)
+    assert len(ends) == 3
+
+
+@pytest.mark.asyncio
+async def test_on_run_end_after_normal_close_is_noop(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """When every ``after_run_callback`` fires normally, ``on_run_end``
+    must be a no-op (the open maps are already empty).
+    """
+    ctx = _InvocationContext("inv-ok", ROOT_SESSION)
+    await plugin.before_run_callback(invocation_context=ctx)
+    await plugin.after_run_callback(invocation_context=ctx)
+    before = _span_ends(client)
+    assert len(before) == 1
+
+    # Drain the fixture buffer so the assertion below counts only
+    # spans emitted by the subsequent ``on_run_end`` (if any).
+    client._events.drain()
+    plugin.on_run_end()
+    assert _span_ends(client) == []
+
+
+@pytest.mark.asyncio
+async def test_on_run_end_is_idempotent(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Calling ``on_run_end`` twice must not double-emit span ends."""
+    ctx = _InvocationContext("inv-dup", ROOT_SESSION)
+    await plugin.before_run_callback(invocation_context=ctx)
+
+    plugin.on_run_end()
+    first_count = len(_span_ends(client))
+    plugin.on_run_end()
+    second_count = len(_span_ends(client))
+    assert first_count == 1
+    assert second_count == 0
+
+
+@pytest.mark.asyncio
+async def test_on_run_end_never_raises_on_transport_error(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Transport failures inside emit_span_end must be swallowed —
+    observability must not break the main run path.
+    """
+    ctx = _InvocationContext("inv-boom", ROOT_SESSION)
+    await plugin.before_run_callback(invocation_context=ctx)
+
+    original = client.emit_span_end
+
+    def exploder(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("transport exploded")
+
+    client.emit_span_end = exploder  # type: ignore[assignment]
+    try:
+        plugin.on_run_end()  # must not raise
+    finally:
+        client.emit_span_end = original  # type: ignore[assignment]
+
+
+@pytest.mark.asyncio
+async def test_on_run_end_with_no_open_spans_is_noop(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Hook fired before any ``before_run_callback`` is safe."""
+    plugin.on_run_end()
+    assert _span_ends(client) == []

--- a/server/harmonograf_server/bus.py
+++ b/server/harmonograf_server/bus.py
@@ -16,6 +16,7 @@ from harmonograf_server.storage import (
     Agent,
     AgentStatus,
     Annotation,
+    SessionStatus,
     Span,
     Task,
     TaskPlan,
@@ -47,6 +48,12 @@ DELTA_TASK_PROGRESS = "task_progress"
 DELTA_AGENT_INVOCATION_STARTED = "agent_invocation_started"
 DELTA_AGENT_INVOCATION_COMPLETED = "agent_invocation_completed"
 DELTA_DELEGATION_OBSERVED = "delegation_observed"
+# Session lifecycle terminal signal (harmonograf#96). Fires when a goldfive
+# run_completed / run_aborted event arrives and the session flips out of
+# LIVE. The frontend's ``sessionIsInactive`` check reads this to clear the
+# LIVE ACTIVITY panel even when INVOCATION spans are still stuck RUNNING
+# in the DB (orphan-span cleanup is a belt-and-suspenders layer on top).
+DELTA_SESSION_ENDED = "session_ended"
 
 
 @dataclass
@@ -282,6 +289,33 @@ class SessionBus:
                 session_id,
                 DELTA_RUN_ABORTED,
                 {"run_id": run_id, "reason": reason},
+            )
+        )
+
+    def publish_session_ended(
+        self,
+        session_id: str,
+        *,
+        ended_at: float,
+        final_status: SessionStatus,
+    ) -> None:
+        """Announce that ``session_id`` has terminally left the LIVE state.
+
+        Fired by the ingest pipeline when a goldfive ``run_completed`` or
+        ``run_aborted`` event arrives. The frontend's ``useSessionWatch``
+        listens for the matching :class:`SessionUpdate.session_ended`
+        variant and flips ``sessionStatus`` to ``COMPLETED`` / ``ABORTED``
+        so :func:`sessionIsInactive` returns ``true`` and the LIVE
+        ACTIVITY panel's "N RUNNING" header clears — even when the
+        underlying INVOCATION spans are still ``status=RUNNING`` in the
+        DB (harmonograf#96). Orphan INVOCATION spans are also swept by
+        the same handler as a belt-and-suspenders cleanup.
+        """
+        self.publish(
+            Delta(
+                session_id,
+                DELTA_SESSION_ENDED,
+                {"ended_at": ended_at, "final_status": final_status},
             )
         )
 

--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -786,9 +786,9 @@ class IngestPipeline:
         elif kind == "drift_detected":
             self._on_drift_detected(target_ctx, event.drift_detected, run_id)
         elif kind == "run_completed":
-            self._on_run_completed(target_ctx, event.run_completed, run_id)
+            await self._on_run_completed(target_ctx, event.run_completed, run_id)
         elif kind == "run_aborted":
-            self._on_run_aborted(target_ctx, event.run_aborted, run_id)
+            await self._on_run_aborted(target_ctx, event.run_aborted, run_id)
         elif kind == "agent_invocation_started":
             self._on_agent_invocation_started(
                 target_ctx, event.agent_invocation_started, run_id
@@ -1042,18 +1042,128 @@ class IngestPipeline:
         """
         return list(self._drifts_by_session.get(session_id, []))
 
-    def _on_run_completed(
+    async def _on_run_completed(
         self, ctx: StreamContext, payload: Any, run_id: str
     ) -> None:
         self._bus.publish_run_completed(
             ctx.session_id, run_id, outcome_summary=payload.outcome_summary
         )
+        await self._finalize_session(
+            ctx.session_id, final_status=SessionStatus.COMPLETED
+        )
 
-    def _on_run_aborted(
+    async def _on_run_aborted(
         self, ctx: StreamContext, payload: Any, run_id: str
     ) -> None:
         self._bus.publish_run_aborted(
             ctx.session_id, run_id, reason=payload.reason
+        )
+        await self._finalize_session(
+            ctx.session_id, final_status=SessionStatus.ABORTED
+        )
+
+    async def _finalize_session(
+        self, session_id: str, *, final_status: SessionStatus
+    ) -> None:
+        """Flip ``session_id`` terminal and close any orphan INVOCATION spans.
+
+        Previously the ingest pipeline published ``run_completed`` /
+        ``run_aborted`` onto the bus for trajectory fan-out but never
+        mutated the session row itself — ``sessions.status`` stayed LIVE
+        and ``ended_at`` stayed NULL forever. The frontend's
+        ``sessionIsInactive`` check reads ``sessionStatus`` so the LIVE
+        ACTIVITY panel's "N RUNNING" header never cleared after a run
+        completed. See harmonograf#96.
+
+        Belt-and-suspenders: the harmonograf telemetry plugin sometimes
+        leaks INVOCATION spans keyed by sub-Runner invocation_ids (the
+        ADK ``after_run_callback`` is not in a ``finally`` block so a
+        cancelled sub-Runner leaves its span open, and goldfive's
+        ``on_cancellation`` hook is scoped to the outer invocation_id
+        only — see goldfive#196). Close any still-open INVOCATION spans
+        on the finalizing session so the Gantt reflects truth.
+
+        Idempotent: a duplicate ``run_completed`` (out-of-order replay,
+        reconnect) is a no-op because the store's ``update_session``
+        only shifts ``status`` / ``ended_at`` when they change.
+        """
+        now = time.time()
+        try:
+            sess = await self._store.update_session(
+                session_id,
+                status=final_status,
+                ended_at=now,
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive: ingest must not raise
+            logger.debug(
+                "_finalize_session: update_session raised for %s: %s",
+                session_id,
+                exc,
+            )
+            sess = None
+        if sess is None:
+            # Session unknown (e.g. goldfive event arrived before the
+            # Hello established the row). The broadcast below is still
+            # useful: subscribers that later join will see the terminal
+            # transition via the replayed SessionEnded variant on their
+            # initial burst.
+            pass
+        # Close orphan INVOCATION spans. Filters to ``end_time IS NULL``
+        # via storage's span list (we re-check kind and end_time here
+        # because list_spans may not expose a direct "open INVOCATION"
+        # filter across backends).
+        try:
+            open_spans = await self._store.get_spans(
+                session_id, time_start=None, time_end=None, limit=None
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.debug(
+                "_finalize_session: get_spans raised for %s: %s",
+                session_id,
+                exc,
+            )
+            open_spans = []
+        for span in open_spans:
+            if span.end_time is not None:
+                continue
+            if span.kind is not SpanKind.INVOCATION:
+                # Only INVOCATION spans are swept — wrapper spans from
+                # an interrupted run. LLM_CALL / TOOL_CALL leaks have
+                # their own cleanup paths (after_model_callback,
+                # after_tool_callback, on_cancellation) and usually
+                # close correctly. Leaving them to those paths keeps
+                # this sweeper scope-bounded and lowers the risk of
+                # racing with a late-arriving legitimate end_span.
+                continue
+            try:
+                await self._store.end_span(
+                    span.id,
+                    end_time=now,
+                    status=(
+                        SpanStatus.COMPLETED
+                        if final_status is SessionStatus.COMPLETED
+                        else SpanStatus.CANCELLED
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001 — defensive
+                logger.debug(
+                    "_finalize_session: end_span raised for %s: %s",
+                    span.id,
+                    exc,
+                )
+                continue
+            # Publish span-end so the frontend store updates in place
+            # (without this the UI still shows "RUNNING" until refresh).
+            refreshed = await self._store.get_span(span.id)
+            if refreshed is not None:
+                self._bus.publish_span_end(refreshed)
+        # Fan out the session-level terminal signal last so subscribers
+        # that listen for session lifecycle (``sessionIsInactive``, UI
+        # banners) see it only after spans are finalized.
+        self._bus.publish_session_ended(
+            session_id,
+            ended_at=now,
+            final_status=final_status,
         )
 
     # Registry-dispatch observability events (goldfive 2986775+). These are

--- a/server/harmonograf_server/rpc/frontend.py
+++ b/server/harmonograf_server/rpc/frontend.py
@@ -34,6 +34,7 @@ from harmonograf_server.bus import (
     DELTA_RUN_ABORTED,
     DELTA_RUN_COMPLETED,
     DELTA_RUN_STARTED,
+    DELTA_SESSION_ENDED,
     DELTA_SPAN_END,
     DELTA_SPAN_START,
     DELTA_SPAN_UPDATE,
@@ -835,6 +836,26 @@ def _delta_to_session_update(delta: Delta) -> Optional[frontend_pb2.SessionUpdat
         ev = goldfive_events_pb2.Event(run_id=p.get("run_id", ""))
         ev.run_aborted.reason = p.get("reason", "") or ""
         return frontend_pb2.SessionUpdate(goldfive_event=ev)
+    if delta.kind == DELTA_SESSION_ENDED:
+        # Session terminal transition (harmonograf#96). Stamped by the
+        # ingest pipeline when a goldfive run_completed / run_aborted
+        # arrives and the session flips out of LIVE. Frontend consumes
+        # the ``session_ended`` variant and updates ``sessionStatus`` so
+        # ``sessionIsInactive`` returns true, clearing the LIVE ACTIVITY
+        # "N RUNNING" header even when stuck INVOCATION spans remain in
+        # the DB. The same payload also carries ended_at so the session
+        # header can render the terminal timestamp.
+        p = delta.payload
+        ended_at = p.get("ended_at")
+        final_status = p.get("final_status", SessionStatus.COMPLETED)
+        ended_pb = frontend_pb2.SessionEnded(
+            final_status=_session_status_to_pb(final_status),
+        )
+        if isinstance(ended_at, (int, float)):
+            ts = float_to_ts(float(ended_at))
+            if ts is not None:
+                ended_pb.ended_at.CopyFrom(ts)
+        return frontend_pb2.SessionUpdate(session_ended=ended_pb)
     if delta.kind == DELTA_GOAL_DERIVED:
         p = delta.payload
         ev = goldfive_events_pb2.Event(run_id=p.get("run_id", ""))

--- a/server/tests/test_goldfive_ingest.py
+++ b/server/tests/test_goldfive_ingest.py
@@ -23,6 +23,8 @@ from harmonograf_server.bus import (
     DELTA_RUN_ABORTED,
     DELTA_RUN_COMPLETED,
     DELTA_RUN_STARTED,
+    DELTA_SESSION_ENDED,
+    DELTA_SPAN_END,
     DELTA_TASK_PLAN,
     DELTA_TASK_PROGRESS,
     DELTA_TASK_STATUS,
@@ -151,8 +153,12 @@ async def test_run_started_publishes_delta(pipeline):
 
 
 @pytest.mark.asyncio
-async def test_run_completed_and_aborted_publish_deltas(pipeline):
+async def test_run_completed_and_aborted_publish_deltas(pipeline, store):
     pipe, bus, _ = pipeline
+    # Session must exist so the finalize path's ``update_session`` flips
+    # it terminal — harmonograf#96 asserts the session row drives the
+    # frontend's ``sessionIsInactive`` header-gate.
+    await _ensure_session(store)
     sub = await bus.subscribe("sess_gf")
     completed = _make_event(event_id="e-c")
     completed.run_completed.outcome_summary = "done"
@@ -160,11 +166,201 @@ async def test_run_completed_and_aborted_publish_deltas(pipeline):
     aborted.run_aborted.reason = "user cancel"
     await pipe.handle_message(_stream_ctx(), _wrap(completed))
     await pipe.handle_message(_stream_ctx(), _wrap(aborted))
-    deltas = [sub.queue.get_nowait(), sub.queue.get_nowait()]
+    deltas = await _drain(sub)
     kinds = [d.kind for d in deltas]
     assert DELTA_RUN_COMPLETED in kinds and DELTA_RUN_ABORTED in kinds
-    assert deltas[0].payload["outcome_summary"] == "done"
-    assert deltas[1].payload["reason"] == "user cancel"
+    # harmonograf#96: both terminal events now trigger a SessionEnded
+    # broadcast so the frontend's LIVE ACTIVITY header clears.
+    session_ended_deltas = [d for d in deltas if d.kind == DELTA_SESSION_ENDED]
+    assert len(session_ended_deltas) == 2
+    assert session_ended_deltas[0].payload["final_status"] == SessionStatus.COMPLETED
+    assert session_ended_deltas[1].payload["final_status"] == SessionStatus.ABORTED
+
+
+@pytest.mark.asyncio
+async def test_run_completed_flips_session_status_and_ended_at(pipeline, store):
+    """harmonograf#96: a goldfive ``run_completed`` must drive
+    ``sessions.status`` LIVE → COMPLETED and stamp ``ended_at``.
+
+    Previously the ingest pipeline fanned out a bus delta for trajectory
+    listeners but never mutated the session row, so the frontend's
+    ``sessionIsInactive`` check stayed false forever and the LIVE
+    ACTIVITY "N RUNNING" header never cleared.
+    """
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+    before = await store.get_session("sess_gf")
+    assert before.status is SessionStatus.LIVE
+    assert before.ended_at is None
+
+    completed = _make_event(event_id="e-c")
+    completed.run_completed.outcome_summary = "done"
+    await pipe.handle_message(_stream_ctx(), _wrap(completed))
+
+    after = await store.get_session("sess_gf")
+    assert after.status is SessionStatus.COMPLETED
+    assert after.ended_at is not None
+    assert after.ended_at > 0
+
+
+@pytest.mark.asyncio
+async def test_run_aborted_flips_session_status_to_aborted(pipeline, store):
+    """harmonograf#96: ``run_aborted`` flips session to ABORTED (not COMPLETED)."""
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+    aborted = _make_event(event_id="e-a")
+    aborted.run_aborted.reason = "user cancel"
+    await pipe.handle_message(_stream_ctx(), _wrap(aborted))
+    after = await store.get_session("sess_gf")
+    assert after.status is SessionStatus.ABORTED
+    assert after.ended_at is not None
+
+
+@pytest.mark.asyncio
+async def test_run_completed_closes_orphan_invocation_spans(pipeline, store):
+    """harmonograf#96 belt-and-suspenders: orphan INVOCATION spans whose
+    ``after_run_callback`` never fired (ADK cancel race on AgentTool
+    sub-Runners) must be swept closed on ``run_completed`` so the Gantt
+    reflects truth. Non-INVOCATION leaks (LLM_CALL / TOOL_CALL) are left
+    alone because they have their own ADK cleanup paths and could race
+    with a late-arriving legitimate end_span.
+    """
+    from harmonograf_server.storage import Agent, AgentStatus, Framework, Span, SpanKind, SpanStatus
+
+    pipe, bus, _ = pipeline
+    await _ensure_session(store)
+    await store.register_agent(
+        Agent(
+            id="agent_gf",
+            session_id="sess_gf",
+            name="coordinator",
+            framework=Framework.UNKNOWN,
+            status=AgentStatus.CONNECTED,
+            connected_at=1.0,
+            last_heartbeat=1.0,
+        )
+    )
+    # Two INVOCATION spans left open (simulates a sub-Runner whose
+    # after_run_callback never fired) plus one LLM_CALL that should be
+    # left alone (covered by model-after cleanup).
+    await store.append_span(
+        Span(
+            id="inv_open_1",
+            session_id="sess_gf",
+            agent_id="agent_gf",
+            name="web_developer_agent",
+            kind=SpanKind.INVOCATION,
+            status=SpanStatus.RUNNING,
+            start_time=100.0,
+            end_time=None,
+        )
+    )
+    await store.append_span(
+        Span(
+            id="inv_open_2",
+            session_id="sess_gf",
+            agent_id="agent_gf",
+            name="coordinator_agent",
+            kind=SpanKind.INVOCATION,
+            status=SpanStatus.RUNNING,
+            start_time=101.0,
+            end_time=None,
+        )
+    )
+    await store.append_span(
+        Span(
+            id="llm_open",
+            session_id="sess_gf",
+            agent_id="agent_gf",
+            name="openai/Qwen",
+            kind=SpanKind.LLM_CALL,
+            status=SpanStatus.RUNNING,
+            start_time=102.0,
+            end_time=None,
+        )
+    )
+
+    completed = _make_event(event_id="e-c")
+    completed.run_completed.outcome_summary = "done"
+    await pipe.handle_message(_stream_ctx(), _wrap(completed))
+
+    # INVOCATION spans must now be closed with end_time set. Sqlite
+    # storage doesn't expose an "open only" filter so we re-fetch.
+    inv1 = await store.get_span("inv_open_1")
+    inv2 = await store.get_span("inv_open_2")
+    llm = await store.get_span("llm_open")
+    assert inv1.end_time is not None
+    assert inv1.status is SpanStatus.COMPLETED
+    assert inv2.end_time is not None
+    assert inv2.status is SpanStatus.COMPLETED
+    # LLM_CALL left alone — not the ingest path's responsibility.
+    assert llm.end_time is None
+
+
+@pytest.mark.asyncio
+async def test_run_aborted_closes_orphan_invocations_with_cancelled(pipeline, store):
+    """A run that aborts should close orphan INVOCATION spans with
+    ``status=CANCELLED`` (not COMPLETED) so the Gantt renders the
+    terminal state correctly.
+    """
+    from harmonograf_server.storage import Agent, AgentStatus, Framework, Span, SpanKind, SpanStatus
+
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+    await store.register_agent(
+        Agent(
+            id="agent_gf",
+            session_id="sess_gf",
+            name="coordinator",
+            framework=Framework.UNKNOWN,
+            status=AgentStatus.CONNECTED,
+            connected_at=1.0,
+            last_heartbeat=1.0,
+        )
+    )
+    await store.append_span(
+        Span(
+            id="inv_open",
+            session_id="sess_gf",
+            agent_id="agent_gf",
+            name="web_developer_agent",
+            kind=SpanKind.INVOCATION,
+            status=SpanStatus.RUNNING,
+            start_time=100.0,
+            end_time=None,
+        )
+    )
+
+    aborted = _make_event(event_id="e-a")
+    aborted.run_aborted.reason = "user cancel"
+    await pipe.handle_message(_stream_ctx(), _wrap(aborted))
+
+    inv = await store.get_span("inv_open")
+    assert inv.end_time is not None
+    assert inv.status is SpanStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_run_completed_session_unknown_is_noop_but_still_broadcasts(pipeline):
+    """When goldfive sends ``run_completed`` for a session the server
+    has never seen (e.g. event arrives before the Hello established the
+    row), the finalize path must NOT raise. The broadcast still fires
+    so a subscriber that later joins and lists the session sees the
+    terminal state via its initial burst.
+    """
+    pipe, bus, _ = pipeline
+    sub = await bus.subscribe("sess_never_created")
+    completed = _make_event(event_id="e-c")
+    completed.run_completed.outcome_summary = "orphaned"
+    # NOTE: different session_id in ctx so the finalize path tries the
+    # update against an unknown row.
+    await pipe.handle_message(
+        _stream_ctx(session_id="sess_never_created"), _wrap(completed)
+    )
+    deltas = await _drain(sub)
+    kinds = [d.kind for d in deltas]
+    assert DELTA_RUN_COMPLETED in kinds
+    assert DELTA_SESSION_ENDED in kinds
 
 
 # ---- goal derivation -----------------------------------------------------


### PR DESCRIPTION
## Summary

Three-layer fix for the "LIVE ACTIVITY · N RUNNING" header stuck indefinitely after a normal run completion (cross-repo with goldfive#198).

**Root cause (two issues, one symptom):**

1. Server ingest never flipped \`sessions.status\` out of LIVE. \`_on_run_completed\` / \`_on_run_aborted\` only published a bus delta for trajectory listeners; the session row kept \`status=LIVE\` and \`ended_at=NULL\` forever. The frontend's \`sessionIsInactive\` gate reads \`sessionStatus\`, so the header never cleared.
2. Harmonograf telemetry plugin leaked orphan INVOCATION spans. ADK places \`after_run_callback\` outside a \`finally\` in \`Runner._exec_with_plugin\` — sub-Runners spawned by \`AgentTool\` and cancelled mid-flight leave their INVOCATION spans \`status=RUNNING\` forever. Goldfive's existing \`on_cancellation\` hook is scoped to the OUTER invocation_id and can't reach those.

**Changes:**

- \`server/ingest.py\` — \`_on_run_completed\` / \`_on_run_aborted\` become async and call a new \`_finalize_session\` helper that (a) calls \`store.update_session(status=COMPLETED/ABORTED, ended_at=now)\`, (b) sweeps open INVOCATION spans on the session closed as belt-and-suspenders, (c) publishes a new \`DELTA_SESSION_ENDED\` so \`WatchSession\` subscribers see the terminal transition via the \`SessionEnded\` variant they already consume.
- \`server/bus.py\` — adds \`DELTA_SESSION_ENDED\` + matching \`publish_session_ended\`.
- \`server/rpc/frontend.py\` — translates \`DELTA_SESSION_ENDED\` into \`SessionUpdate(session_ended=...)\`.
- \`client/harmonograf_client/telemetry_plugin.py\` — implements \`on_run_end()\` on the telemetry plugin. Paired with goldfive#198's \`GoldfiveADKAgent._run_async_impl\` \`finally\`-block teardown, this sweeps every still-open INVOCATION / model / tool span the plugin tracks on run exit regardless of which ADK callback fired last.

## DB evidence this fixes

\`\`\`
SELECT id, status, ended_at FROM sessions;
-- post_fix_1776870546 | LIVE | NULL   ← before fix

SELECT name, status, end_time FROM spans WHERE end_time IS NULL;
-- web_developer_agent | RUNNING | NULL
-- openai/Qwen...gguf  | RUNNING | NULL
-- coordinator_agent   | RUNNING | NULL
\`\`\`

After the fix:
- \`sessions.status\` flips COMPLETED with \`ended_at\` stamped the moment \`run_completed\` arrives.
- Orphan INVOCATION spans are swept closed by the server + by the client's \`on_run_end\` hook.
- Frontend's \`sessionIsInactive\` goes true → \`LiveActivityPanel\` returns \`[]\` → header clears.

## Test plan

- [x] 6 new client tests in \`client/tests/test_telemetry_plugin_on_run_end.py\` (orphan close, idempotency, back-compat, transport safety).
- [x] 5 new server tests in \`server/tests/test_goldfive_ingest.py\` (session flip to COMPLETED / ABORTED, INVOCATION-only sweep, unknown-session safety).
- [x] Full harmonograf test suite: server 295 passed / 1 skipped, client 223 passed, frontend 258 passed.
- [x] E2E with orchestrated presentation_agent (see below in the rollout notes).