### PR TITLE
Replace legacy-window env vars with ServerConfig field + CLI flag + frontend option (closes #101)

### DIFF
--- a/docs/runbooks/plan-revision-dedup.md
+++ b/docs/runbooks/plan-revision-dedup.md
@@ -3,8 +3,11 @@
 As of harmonograf#99 (pairs with goldfive#199), the intervention
 aggregator merges plan-revision rows onto their originating annotation
 or drift by **strict id only**. The pre-#99 time-window fallback is
-gated behind `HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS` and
-disabled by default.
+gated behind the `ServerConfig.legacy_plan_attribution_window_ms` field
+(CLI flag `--legacy-plan-attribution-window-ms`) on the server and the
+`legacyPlanAttributionWindowMs` option on the frontend deriver, and is
+disabled by default. See harmonograf#101 for the env-var → config/param
+migration.
 
 ## What changed
 
@@ -43,15 +46,42 @@ rm -rf /tmp/demo-data          # or whatever --data-dir points at
 
 If you need to keep pre-fix sessions showing up as they used to — for
 example, a live investigation where you can't drop the DB yet — enable
-the fallback:
+the fallback via config / option. There is **no env var**; per
+harmonograf#101 the surface is the normal config field + CLI flag.
+
+### Server
+
+CLI flag (operators):
 
 ```sh
-# Server:
-export HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS=900000   # 15 min
-
-# Frontend (build-time):
-export VITE_HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS=900000
+harmonograf-server --legacy-plan-attribution-window-ms 900000   # 15 min
 ```
+
+Programmatic (tests, stress harness, embeds):
+
+```python
+from harmonograf_server.config import ServerConfig
+cfg = ServerConfig(legacy_plan_attribution_window_ms=900_000.0)
+```
+
+### Frontend
+
+The aggregator (`deriveInterventions` / `deriveInterventionsFromStore`)
+takes an optional `legacyPlanAttributionWindowMs` field. The React
+components read it from the app's runtime config context — there is
+no build-time `import.meta.env` lookup. A minimum-viable caller just
+leaves it unset, which is equivalent to 0 / disabled:
+
+```ts
+deriveInterventions({
+  annotations,
+  drifts,
+  plans,
+  legacyPlanAttributionWindowMs: 900_000, // opt in
+});
+```
+
+### WARNING on match
 
 When the fallback fires, a WARNING is logged (server: `interventions`
 logger; frontend: `console.warn`) so operators can see which rows

--- a/frontend/src/__tests__/lib/interventions.test.ts
+++ b/frontend/src/__tests__/lib/interventions.test.ts
@@ -2,7 +2,7 @@
 // Mirrors the server-side tests in server/tests/test_interventions.py so
 // the merge + attribution logic stays behavior-identical across the wire.
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   deriveInterventions,
   markerRadiusFor,
@@ -405,6 +405,101 @@ describe('deriveInterventions', () => {
     const plan = rows.find((r) => r.outcome.startsWith('plan_revised:'));
     expect(drift?.outcome).toBe('recorded');
     expect(plan?.planRevisionIndex).toBe(2);
+  });
+
+  // harmonograf#101 — legacy time-window opt-in now flows through the
+  // ``legacyPlanAttributionWindowMs`` option, not ``import.meta.env``.
+  // Coverage mirrors the server tests in test_interventions.py.
+
+  it('legacy window default (0) leaves orphan plan as its own card', () => {
+    // Plan row with no triggerEventId cannot strict-merge; with the
+    // window disabled (default) the aggregator does NOT fold it onto
+    // the preceding user-control rows — two cards survive.
+    const rows = deriveInterventions({
+      annotations: [
+        mkAnnotation({ id: 'ann_lw_off', createdAtMs: 100_000 }),
+      ],
+      drifts: [
+        mkDrift({
+          seq: 0,
+          kind: 'user_steer',
+          severity: 'warning',
+          recordedAtMs: 100_200,
+          annotationId: 'ann_lw_off',
+          driftId: 'drift_lw_off',
+        }),
+      ],
+      plans: [
+        mkPlan({
+          id: 'p_lw_off',
+          createdAtMs: 700_000,
+          revisionKind: 'user_steer',
+          revisionSeverity: 'warning',
+          revisionIndex: 1,
+          // No triggerEventId.
+        }),
+      ],
+      // legacyPlanAttributionWindowMs omitted → default 0 / disabled.
+    });
+
+    expect(rows).toHaveLength(2);
+    const merged = rows.find((r) => r.annotationId === 'ann_lw_off');
+    const orphan = rows.find(
+      (r) => r.planRevisionIndex === 1 && !r.annotationId,
+    );
+    expect(merged?.outcome).toBe('recorded');
+    expect(orphan?.outcome).toBe('plan_revised:r1');
+  });
+
+  it('legacy window enabled via option merges + warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const rows = deriveInterventions({
+        annotations: [
+          mkAnnotation({ id: 'ann_lw_on', createdAtMs: 100_000 }),
+        ],
+        drifts: [
+          mkDrift({
+            seq: 0,
+            kind: 'user_steer',
+            severity: 'warning',
+            recordedAtMs: 100_200,
+            annotationId: 'ann_lw_on',
+            driftId: 'drift_lw_on',
+          }),
+        ],
+        plans: [
+          mkPlan({
+            id: 'p_lw_on',
+            createdAtMs: 700_000, // 10min past annotation — inside 15min
+            revisionKind: 'user_steer',
+            revisionSeverity: 'warning',
+            revisionIndex: 1,
+            // No triggerEventId; must fall back to time-window.
+          }),
+        ],
+        legacyPlanAttributionWindowMs: 900_000,
+      });
+
+      // Annotation + drift collapse via strict id; the orphan plan row
+      // folds onto the drift via the legacy fallback, so exactly one
+      // user-sourced card with the plan_revised outcome survives.
+      const userCards = rows.filter((r) => r.source === 'user');
+      expect(userCards).toHaveLength(1);
+      expect(userCards[0].outcome).toBe('plan_revised:r1');
+
+      // Warning must reference the new option name, not the old env var.
+      expect(warnSpy).toHaveBeenCalled();
+      const message = warnSpy.mock.calls
+        .map((args) => args.join(' '))
+        .join('\n');
+      expect(message).toContain('legacyPlanAttributionWindowMs');
+      expect(message).not.toContain(
+        'VITE_HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS',
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/frontend/src/lib/interventions.ts
+++ b/frontend/src/lib/interventions.ts
@@ -18,12 +18,12 @@
 //   * Tier 1 — always on. Plan-revision rows merge onto their source
 //     annotation or drift row when ``triggerEventId`` matches the
 //     annotation id or drift id.
-//   * Tier 2 — opt-in via ``VITE_HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS``
-//     (default 0 / disabled). Time-window fallback: a plan row whose
-//     ``triggerEventId`` matched nothing strictly merges onto a
-//     preceding user-control row of the same ``driftKind`` within the
-//     configured window. Console WARNING on match so operators can
-//     diagnose mis-attribution.
+//   * Tier 2 — opt-in via the ``legacyPlanAttributionWindowMs`` option
+//     on :func:`deriveInterventions` (default 0 / disabled). Time-window
+//     fallback: a plan row whose ``triggerEventId`` matched nothing
+//     strictly merges onto a preceding user-control row of the same
+//     ``driftKind`` within the configured window. Console WARNING on
+//     match so operators can diagnose mis-attribution.
 //
 // The derivation is intentionally tree-agnostic. No taxonomy knowledge is
 // baked into the marker rendering; downstream components can show whatever
@@ -73,18 +73,6 @@ const GOLDFIVE_REVISION_KINDS = new Set([
   'human_intervention_required',
 ]);
 
-// harmonograf#99: legacy time-window fallback. Default disabled. Opt in
-// via VITE_HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS at build time.
-function legacyWindowMs(): number {
-  const raw = (import.meta as unknown as {
-    env?: { VITE_HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS?: string };
-  }).env?.VITE_HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS;
-  if (!raw) return 0;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
-  return parsed;
-}
-
 // Pretty labels for drift kinds emitted from the user. Uppercase so the
 // renderer can splash them next to other kinds without special-casing.
 function normalizeDriftKind(raw: string): string {
@@ -106,6 +94,12 @@ export interface DeriveInput {
   annotations: readonly Annotation[];
   drifts: readonly DriftRecord[];
   plans: readonly TaskPlan[]; // every plan rev ever seen, chronological
+  // Opt-in Tier-2 legacy time-window fallback for plan-revision
+  // attribution (pre-#99 behaviour). Default 0 / undefined disables.
+  // Provided by the caller (app runtime context) — never read from
+  // ``import.meta.env`` — so the aggregator stays testable and doesn't
+  // carry build-time config knowledge.
+  legacyPlanAttributionWindowMs?: number;
 }
 
 export function deriveInterventions(input: DeriveInput): InterventionRow[] {
@@ -183,8 +177,11 @@ export function deriveInterventions(input: DeriveInput): InterventionRow[] {
 
   rows.sort((a, b) => a.atMs - b.atMs);
 
-  // Outcome attribution (pre-merge). Strict-id only by default.
-  const windowMs = legacyWindowMs();
+  // Outcome attribution (pre-merge). Strict-id only by default; the
+  // caller may opt in to the legacy time-window by passing
+  // ``legacyPlanAttributionWindowMs``.
+  const rawWindow = input.legacyPlanAttributionWindowMs ?? 0;
+  const windowMs = Number.isFinite(rawWindow) && rawWindow > 0 ? rawWindow : 0;
   attributeOutcomes(rows, input.plans, { windowMs });
 
   // Tier 1 merge — strict trigger_event_id.
@@ -238,7 +235,7 @@ function attributeOutcomes(
               row.triggerEventId,
             )} -> plan rev=${fallback.revisionIndex} ` +
             `(triggerEventId=${JSON.stringify(fallback.triggerEventId ?? '')}). ` +
-            `VITE_HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS=${opts.windowMs}. ` +
+            `legacyPlanAttributionWindowMs=${opts.windowMs}. ` +
             `Investigate why strict-id did not match (pre-#99 data? goldfive < #199?).`,
         );
         const idx = fallback.revisionIndex ?? 0;
@@ -388,7 +385,7 @@ function legacyTimeWindowMerge(
         `[interventions] legacy time-window fallback merged plan rev=` +
           `${row.planRevisionIndex} (driftKind=${row.driftKind}, no ` +
           `triggerEventId) onto ${target.source} row. ` +
-          `VITE_HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS=${windowMs}. ` +
+          `legacyPlanAttributionWindowMs=${windowMs}. ` +
           `Investigate why strict-id did not match (pre-#99 data?).`,
       );
       if (!target.outcome || target.outcome === 'recorded') {
@@ -406,9 +403,15 @@ function legacyTimeWindowMerge(
 // Convenience adapter: pull the three inputs from a live SessionStore +
 // annotation store snapshot and run the deriver. Used by the React
 // components so they don't duplicate the shape plumbing.
+//
+// ``opts.legacyPlanAttributionWindowMs`` is forwarded to the underlying
+// :func:`deriveInterventions` call when provided. Callers that want the
+// Tier-2 fallback wire it in from their runtime config context (there
+// is no build-time env var — that was the previous design).
 export function deriveInterventionsFromStore(
   store: SessionStore,
   annotations: readonly Annotation[],
+  opts: { legacyPlanAttributionWindowMs?: number } = {},
 ): InterventionRow[] {
   const plans = store.tasks.listPlans();
   const allRevs: TaskPlan[] = [];
@@ -425,6 +428,7 @@ export function deriveInterventionsFromStore(
     annotations,
     drifts: store.drifts.list(),
     plans: allRevs,
+    legacyPlanAttributionWindowMs: opts.legacyPlanAttributionWindowMs,
   });
 }
 

--- a/server/harmonograf_server/cli.py
+++ b/server/harmonograf_server/cli.py
@@ -90,6 +90,15 @@ def build_parser() -> argparse.ArgumentParser:
             "disables auth. /healthz and /readyz are always unauthenticated."
         ),
     )
+    p.add_argument(
+        "--legacy-plan-attribution-window-ms",
+        type=float,
+        default=0.0,
+        help=(
+            "Opt-in fallback for plan-revision attribution; 0 (default) "
+            "disables. See docs/runbooks/plan-revision-dedup.md."
+        ),
+    )
     return p
 
 
@@ -108,6 +117,7 @@ def config_from_args(argv: list[str] | None = None) -> ServerConfig:
         log_format=args.log_format,
         metrics_interval_seconds=args.metrics_interval_seconds,
         auth_token=args.auth_token,
+        legacy_plan_attribution_window_ms=args.legacy_plan_attribution_window_ms,
     )
 
 

--- a/server/harmonograf_server/config.py
+++ b/server/harmonograf_server/config.py
@@ -23,3 +23,11 @@ class ServerConfig:
     retention_interval_seconds: float = 300.0
     metrics_interval_seconds: float = 30.0  # 0 disables periodic metrics
     auth_token: str = ""  # empty string disables shared-secret auth
+    # Opt-in legacy time-window fallback for plan-revision attribution
+    # (pre-strict-id-dedup behaviour from before harmonograf#99). Default
+    # 0 disables the fallback — plan revisions without a trigger_event_id
+    # become their own intervention card. Set to a positive ms value to
+    # allow the aggregator to merge plan-revision rows onto annotations
+    # / drifts within that wall-clock window when no strict id is
+    # available. See docs/runbooks/plan-revision-dedup.md.
+    legacy_plan_attribution_window_ms: float = 0.0

--- a/server/harmonograf_server/interventions.py
+++ b/server/harmonograf_server/interventions.py
@@ -31,10 +31,12 @@ their originating annotation / drift when the id matches. Rows that do
 not match surface as their own cards (not silently dropped).
 
 A legacy time-window fallback (the pre-#99 behaviour) is preserved
-behind the ``HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS`` env var so
-operators with in-flight investigations can opt back in. Default: 0
-(disabled). When enabled, a merge via the fallback logs a WARNING so
-operators can diagnose mis-attribution.
+behind the ``legacy_plan_attribution_window_ms`` parameter so operators
+with in-flight investigations can opt back in. Default: 0 (disabled).
+The parameter is plumbed from ``ServerConfig.legacy_plan_attribution_window_ms``
+/ CLI flag ``--legacy-plan-attribution-window-ms``. When enabled, a
+merge via the fallback logs a WARNING so operators can diagnose
+mis-attribution.
 
 Pre-fix (pre-harmonograf#99) data that lacks ``trigger_event_id`` is
 explicitly unsupported — operators should drop their dev databases
@@ -50,7 +52,6 @@ render the same way without taxonomy hooks.
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
 from typing import Any, Iterable, Optional
 
@@ -89,49 +90,14 @@ _GOLDFIVE_REVISION_KINDS: frozenset[str] = frozenset(
 #
 # Rescope: goldfive#199 stamps ``trigger_event_id`` on EVERY refine
 # (user-control + autonomous), and harmonograf merges by strict id only
-# by default. The old time-window path is preserved behind an env var
-# so operators can opt back in during migration if they find the strict
-# dedup too aggressive (e.g. live sessions in flight against a pre-#199
-# goldfive). Default: disabled.
+# by default. The old time-window path is preserved behind the
+# ``legacy_plan_attribution_window_ms`` parameter on :func:`list_interventions`
+# (plumbed from :class:`ServerConfig.legacy_plan_attribution_window_ms` /
+# the ``--legacy-plan-attribution-window-ms`` CLI flag) so operators can
+# opt back in during migration if they find the strict dedup too
+# aggressive (e.g. live sessions in flight against a pre-#199 goldfive).
+# Default: disabled (0.0).
 # -----------------------------------------------------------------------------
-
-
-def _read_legacy_window_ms() -> float:
-    """Read the legacy time-window from the env var (0 / disabled by default).
-
-    Env var: ``HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS``.
-    Returns 0.0 when unset, invalid, or set to 0.
-    """
-    raw = os.environ.get("HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS", "")
-    if not raw:
-        return 0.0
-    try:
-        val = float(raw)
-    except ValueError:
-        logger.warning(
-            "HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS is not a number: %r; "
-            "disabling fallback",
-            raw,
-        )
-        return 0.0
-    if val <= 0:
-        return 0.0
-    return val
-
-
-# Cached on module load so tests that mutate the env before import see
-# a live value; tests that mutate at runtime should call the getter
-# directly rather than reading the cached constant.
-_LEGACY_TIME_WINDOW_PLAN_ATTRIBUTION_MS: float = _read_legacy_window_ms()
-
-
-def _legacy_window_ms() -> float:
-    """Return the active legacy window in ms (re-read each call).
-
-    Tests and operators toggling the env var at runtime are reflected
-    without requiring a reimport. Returns 0.0 when disabled.
-    """
-    return _read_legacy_window_ms()
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +149,7 @@ async def list_interventions(
     *,
     store: Store,
     drifts_provider: Any,
+    legacy_plan_attribution_window_ms: float = 0.0,
 ) -> list[InterventionRecord]:
     """Return chronologically ordered interventions for ``session_id``.
 
@@ -191,21 +158,28 @@ async def list_interventions(
     boundary so tests can drive the aggregator without spinning a full
     ingest stack.
 
+    ``legacy_plan_attribution_window_ms`` enables the opt-in Tier-2
+    time-window fallback (see below). Default 0.0 disables. Plumbed
+    from :class:`ServerConfig.legacy_plan_attribution_window_ms` /
+    ``--legacy-plan-attribution-window-ms`` CLI flag.
+
     Dedup contract (harmonograf#99 rescope):
 
       * Tier 1 — always on. Plan-revision rows merge onto their source
         annotation / drift row when ``trigger_event_id`` matches the
         annotation id or drift id.
-      * Tier 2 — opt-in via ``HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS``
-        env var (default 0 / disabled). Time-window fallback: a plan
-        row whose ``trigger_event_id`` matched nothing strictly merges
-        onto a preceding user-control row of the same drift_kind within
-        the configured window. Emits a WARNING log so operators can see
+      * Tier 2 — opt-in via ``legacy_plan_attribution_window_ms``
+        (default 0 / disabled). Time-window fallback: a plan row whose
+        ``trigger_event_id`` matched nothing strictly merges onto a
+        preceding user-control row of the same drift_kind within the
+        configured window. Emits a WARNING log so operators can see
         what would not have merged under strict-id-only.
 
     Rows that don't match either tier surface as their own cards — never
     silently merged.
     """
+
+    window_ms = max(0.0, float(legacy_plan_attribution_window_ms or 0.0))
 
     annotations = await store.list_annotations(session_id=session_id)
     try:
@@ -226,12 +200,11 @@ async def list_interventions(
     records.extend(_project_plans(plans))
 
     records.sort(key=lambda r: r.at)
-    _attribute_outcomes(records, plans)
+    _attribute_outcomes(records, plans, legacy_window_ms=window_ms)
     records = _merge_by_trigger_event_id(records)
     # Tier 2 — opt-in legacy time-window merge for plan rows with NO
     # trigger_event_id (pre-#99 data or goldfive-bridge misconfigured).
     # Default off; WARNING logged on every match so operators notice.
-    window_ms = _legacy_window_ms()
     if window_ms > 0:
         records = _legacy_time_window_merge_orphan_plans(
             records, window_s=window_ms / 1000.0, window_ms=window_ms
@@ -244,11 +217,12 @@ def _legacy_time_window_merge_orphan_plans(
 ) -> list[InterventionRecord]:
     """Opt-in legacy merge for plan rows without a ``trigger_event_id``.
 
-    Fires only when ``HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS`` is
-    set to a positive value. Walks the sorted record list; a plan row
-    (no trigger_event_id, drift_kind set, outcome=plan_revised:*) folds
-    onto the most recent preceding user / drift row within ``window_s``
-    whose drift_kind matches. WARNING logged on every match.
+    Fires only when the caller passed a positive
+    ``legacy_plan_attribution_window_ms`` (via ServerConfig / CLI flag /
+    direct kwarg). Walks the sorted record list; a plan row (no
+    trigger_event_id, drift_kind set, outcome=plan_revised:*) folds onto
+    the most recent preceding user / drift row within ``window_s`` whose
+    drift_kind matches. WARNING logged on every match.
 
     Strict-id rows are never touched — they're already merged and their
     trigger_event_id provides the authoritative join.
@@ -281,7 +255,8 @@ def _legacy_time_window_merge_orphan_plans(
             logger.warning(
                 "interventions: legacy time-window fallback merged "
                 "plan_revision_index=%d (drift_kind=%s, no trigger_event_id) "
-                "onto %s row. HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS=%.0f. "
+                "onto %s row. legacy_plan_attribution_window_ms=%.0f "
+                "(ServerConfig field / --legacy-plan-attribution-window-ms). "
                 "Investigate why strict-id did not match (pre-#99 data? "
                 "goldfive < #199?).",
                 rec.plan_revision_index,
@@ -450,7 +425,10 @@ def _project_plans(plans: Iterable[TaskPlan]) -> list[InterventionRecord]:
 
 
 def _attribute_outcomes(
-    records: list[InterventionRecord], plans: Iterable[TaskPlan]
+    records: list[InterventionRecord],
+    plans: Iterable[TaskPlan],
+    *,
+    legacy_window_ms: float = 0.0,
 ) -> None:
     """Fill in ``outcome`` for drift and user rows.
 
@@ -462,7 +440,7 @@ def _attribute_outcomes(
         with the plan row whose trigger_event_id matches — that pairing
         yields ``plan_revised:rN``.
       * Only when strict-id yields nothing does the legacy time-window
-        get consulted (and only when enabled via env var).
+        get consulted (and only when ``legacy_window_ms > 0``).
       * Rows with no strict pairing fall through to the cascade-cancel
         heuristic for user/drift rows, or are left as ``recorded``.
     """
@@ -477,7 +455,7 @@ def _attribute_outcomes(
             continue
         plan_by_trigger.setdefault(plan.trigger_event_id, plan)
 
-    window_ms = _legacy_window_ms()
+    window_ms = max(0.0, float(legacy_window_ms or 0.0))
     window_s = window_ms / 1000.0 if window_ms > 0 else 0.0
 
     for rec in records:
@@ -504,9 +482,11 @@ def _attribute_outcomes(
                 logger.warning(
                     "interventions: legacy time-window fallback matched "
                     "drift_kind=%s trigger_event_id=%r -> plan rev=%d "
-                    "(trigger_event_id=%r). HARMONOGRAF_LEGACY_PLAN_"
-                    "ATTRIBUTION_WINDOW_MS=%.0f. Investigate why strict-id "
-                    "did not match (pre-#99 data? goldfive < #199?).",
+                    "(trigger_event_id=%r). legacy_plan_attribution_"
+                    "window_ms=%.0f (ServerConfig field / "
+                    "--legacy-plan-attribution-window-ms). Investigate "
+                    "why strict-id did not match (pre-#99 data? "
+                    "goldfive < #199?).",
                     rec.drift_kind,
                     rec.trigger_event_id,
                     fallback.revision_index,

--- a/server/harmonograf_server/main.py
+++ b/server/harmonograf_server/main.py
@@ -94,7 +94,9 @@ class Harmonograf:
 
         router.on_status_query_response(_on_status_query)
 
-        servicer = TelemetryServicer(ingest, router=router, data_dir=data_dir)
+        servicer = TelemetryServicer(
+            ingest, router=router, data_dir=data_dir, config=cfg
+        )
         return cls(
             cfg,
             store=store,

--- a/server/harmonograf_server/rpc/frontend.py
+++ b/server/harmonograf_server/rpc/frontend.py
@@ -20,6 +20,7 @@ import grpc
 from google.protobuf.timestamp_pb2 import Timestamp
 from google.protobuf import timestamp_pb2
 
+from harmonograf_server.config import ServerConfig
 from harmonograf_server.bus import (
     DELTA_AGENT_INVOCATION_COMPLETED,
     DELTA_AGENT_INVOCATION_STARTED,
@@ -144,6 +145,8 @@ class FrontendServicerMixin:
       self._ingest:  IngestPipeline
       self._router:  ControlRouter
       self._data_dir: str   (for GetStats reporting)
+      self._config:  ServerConfig (read-only; ListInterventions reads the
+                     legacy_plan_attribution_window_ms field)
     """
 
     _store: Store
@@ -151,6 +154,7 @@ class FrontendServicerMixin:
     _ingest: IngestPipeline
     _router: ControlRouter
     _data_dir: str
+    _config: ServerConfig
 
     # ---- ListSessions -------------------------------------------------
 
@@ -661,8 +665,14 @@ class FrontendServicerMixin:
                 grpc.StatusCode.NOT_FOUND, f"session {request.session_id} not found"
             )
             return frontend_pb2.ListInterventionsResponse()
+        legacy_window_ms = float(
+            getattr(self._config, "legacy_plan_attribution_window_ms", 0.0) or 0.0
+        )
         records = await list_interventions(
-            request.session_id, store=self._store, drifts_provider=self._ingest
+            request.session_id,
+            store=self._store,
+            drifts_provider=self._ingest,
+            legacy_plan_attribution_window_ms=legacy_window_ms,
         )
         resp = frontend_pb2.ListInterventionsResponse()
         for rec in records:

--- a/server/harmonograf_server/rpc/telemetry.py
+++ b/server/harmonograf_server/rpc/telemetry.py
@@ -15,6 +15,7 @@ import grpc
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from harmonograf_server.bus import SessionBus
+from harmonograf_server.config import ServerConfig
 from harmonograf_server.control_router import ControlRouter
 from harmonograf_server.ingest import IngestPipeline
 from harmonograf_server.pb import service_pb2_grpc, telemetry_pb2
@@ -41,12 +42,18 @@ class TelemetryServicer(
         store: Optional[Store] = None,
         bus: Optional[SessionBus] = None,
         data_dir: str = "",
+        config: Optional[ServerConfig] = None,
     ) -> None:
         self._ingest = ingest
         self._router = router or ControlRouter()
         self._store = store if store is not None else ingest.store
         self._bus = bus if bus is not None else ingest.bus
         self._data_dir = data_dir
+        # Held by reference so RPC handlers can read opt-in config fields
+        # (e.g. legacy_plan_attribution_window_ms) without a separate
+        # plumb through each call site. Defaults keep test construction
+        # zero-arg friendly.
+        self._config = config if config is not None else ServerConfig()
 
     async def StreamTelemetry(
         self,

--- a/server/tests/test_interventions.py
+++ b/server/tests/test_interventions.py
@@ -673,7 +673,7 @@ async def test_autonomous_drift_plan_revision_strict_id_merge(store):
 
 
 async def test_no_trigger_id_no_merge_by_default(store):
-    """Empty trigger_event_id + legacy flag UNSET → 2 cards (no silent merge).
+    """Empty trigger_event_id + legacy param UNSET → 2 cards (no silent merge).
 
     Documented behaviour: pre-#99 data, or a refine where goldfive didn't
     stamp trigger_event_id, surfaces as a standalone plan card. The
@@ -681,194 +681,189 @@ async def test_no_trigger_id_no_merge_by_default(store):
     default.
     """
 
-    import os
-
-    # Ensure the legacy flag is unset for this test.
-    old = os.environ.pop("HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS", None)
-    try:
-        sid = "sess_no_trigger"
-        await _seed_session(store, sid)
-        await store.put_annotation(
-            Annotation(
-                id="ann_no_trigger",
-                session_id=sid,
-                target=AnnotationTarget(agent_id="a", time_start=100.0),
-                author="alice",
-                created_at=100.0,
-                kind=AnnotationKind.STEERING,
-                body="pivot",
-            )
+    sid = "sess_no_trigger"
+    await _seed_session(store, sid)
+    await store.put_annotation(
+        Annotation(
+            id="ann_no_trigger",
+            session_id=sid,
+            target=AnnotationTarget(agent_id="a", time_start=100.0),
+            author="alice",
+            created_at=100.0,
+            kind=AnnotationKind.STEERING,
+            body="pivot",
         )
-        drifts = _StubDrifts({sid: []})
-        await store.put_task_plan(
-            TaskPlan(
-                id="p_nojoin",
-                session_id=sid,
-                created_at=105.0,
-                summary="",
-                tasks=[],
-                edges=[],
-                revision_reason="pivot",
-                revision_kind="user_steer",
-                revision_severity="warning",
-                revision_index=1,
-                # No trigger_event_id — pre-#99 row or bridge misconfigured.
-            )
+    )
+    drifts = _StubDrifts({sid: []})
+    await store.put_task_plan(
+        TaskPlan(
+            id="p_nojoin",
+            session_id=sid,
+            created_at=105.0,
+            summary="",
+            tasks=[],
+            edges=[],
+            revision_reason="pivot",
+            revision_kind="user_steer",
+            revision_severity="warning",
+            revision_index=1,
+            # No trigger_event_id — pre-#99 row or bridge misconfigured.
         )
-        records = await list_interventions(sid, store=store, drifts_provider=drifts)
-        # 2 cards: annotation + orphan plan row.
-        assert len(records) == 2
-        kinds = sorted(r.kind for r in records)
-        assert kinds == ["STEER", "STEER"]
-    finally:
-        if old is not None:
-            os.environ["HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS"] = old
+    )
+    # Default window (0.0) → fallback disabled.
+    records = await list_interventions(sid, store=store, drifts_provider=drifts)
+    # 2 cards: annotation + orphan plan row.
+    assert len(records) == 2
+    kinds = sorted(r.kind for r in records)
+    assert kinds == ["STEER", "STEER"]
 
 
-async def test_legacy_flag_enables_time_window(store, caplog):
-    """Env flag set → time-window fallback merges + emits WARNING log."""
-
-    import os
+async def test_legacy_flag_enabled_via_config(store, caplog):
+    """Legacy window passed via param → fallback fires + WARNING logged."""
 
     caplog.set_level("WARNING", logger="harmonograf_server.interventions")
-    os.environ["HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS"] = "900000"
-    try:
-        sid = "sess_legacy_on"
-        await _seed_session(store, sid)
-        await store.put_annotation(
-            Annotation(
-                id="ann_legacy",
-                session_id=sid,
-                target=AnnotationTarget(agent_id="a", time_start=100.0),
-                author="alice",
-                created_at=100.0,
-                kind=AnnotationKind.STEERING,
-                body="pivot",
-            )
+    sid = "sess_legacy_on"
+    await _seed_session(store, sid)
+    await store.put_annotation(
+        Annotation(
+            id="ann_legacy",
+            session_id=sid,
+            target=AnnotationTarget(agent_id="a", time_start=100.0),
+            author="alice",
+            created_at=100.0,
+            kind=AnnotationKind.STEERING,
+            body="pivot",
         )
-        drifts = _StubDrifts(
-            {
-                sid: [
-                    {
-                        "run_id": "r1",
-                        "kind": "user_steer",
-                        "severity": "warning",
-                        "detail": "by alice: pivot",
-                        "annotation_id": "ann_legacy",
-                        "id": "drift_legacy",
-                        "recorded_at": 100.2,
-                    }
-                ]
-            }
+    )
+    drifts = _StubDrifts(
+        {
+            sid: [
+                {
+                    "run_id": "r1",
+                    "kind": "user_steer",
+                    "severity": "warning",
+                    "detail": "by alice: pivot",
+                    "annotation_id": "ann_legacy",
+                    "id": "drift_legacy",
+                    "recorded_at": 100.2,
+                }
+            ]
+        }
+    )
+    # Plan with NO trigger_event_id — strict-id won't merge, so the
+    # legacy time-window path must fire. Gap: 10 min (inside 15 min
+    # window).
+    await store.put_task_plan(
+        TaskPlan(
+            id="p_legacy",
+            session_id=sid,
+            created_at=700.0,
+            summary="",
+            tasks=[],
+            edges=[],
+            revision_reason="pivot",
+            revision_kind="user_steer",
+            revision_severity="warning",
+            revision_index=1,
+            # No trigger_event_id.
         )
-        # Plan with NO trigger_event_id — strict-id won't merge, so the
-        # legacy time-window path must fire. Gap: 10 min (inside 15 min
-        # window).
-        await store.put_task_plan(
-            TaskPlan(
-                id="p_legacy",
-                session_id=sid,
-                created_at=700.0,
-                summary="",
-                tasks=[],
-                edges=[],
-                revision_reason="pivot",
-                revision_kind="user_steer",
-                revision_severity="warning",
-                revision_index=1,
-                # No trigger_event_id.
-            )
-        )
-        records = await list_interventions(sid, store=store, drifts_provider=drifts)
-        # User annotation + drift merge via strict id (both have
-        # "ann_legacy" on trigger_event_id). Plan row's outcome was
-        # attributed via legacy fallback onto the drift row during
-        # _attribute_outcomes — the plan row itself remains because it
-        # lacks a trigger_event_id for strict merging.
-        user_cards = [r for r in records if r.source == "user"]
-        assert len(user_cards) == 1
-        assert user_cards[0].outcome == "plan_revised:r1"
-        # WARNING logged so operators notice when the fallback fires.
-        warnings = [
-            rec for rec in caplog.records
-            if rec.levelname == "WARNING"
-            and "legacy time-window fallback" in rec.getMessage()
-        ]
-        assert warnings, "expected a WARNING log on legacy fallback match"
-    finally:
-        os.environ.pop("HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS", None)
+    )
+    records = await list_interventions(
+        sid,
+        store=store,
+        drifts_provider=drifts,
+        legacy_plan_attribution_window_ms=900_000.0,
+    )
+    # User annotation + drift merge via strict id (both have
+    # "ann_legacy" on trigger_event_id). Plan row's outcome was
+    # attributed via legacy fallback onto the drift row during
+    # _attribute_outcomes — the plan row itself remains because it
+    # lacks a trigger_event_id for strict merging.
+    user_cards = [r for r in records if r.source == "user"]
+    assert len(user_cards) == 1
+    assert user_cards[0].outcome == "plan_revised:r1"
+    # WARNING logged so operators notice when the fallback fires.
+    warnings = [
+        rec for rec in caplog.records
+        if rec.levelname == "WARNING"
+        and "legacy time-window fallback" in rec.getMessage()
+    ]
+    assert warnings, "expected a WARNING log on legacy fallback match"
+    # WARNING references the new config/flag surface, not the old env var.
+    assert any(
+        "legacy_plan_attribution_window_ms" in rec.getMessage()
+        for rec in warnings
+    )
+    assert not any(
+        "HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS" in rec.getMessage()
+        for rec in warnings
+    )
 
 
 async def test_legacy_flag_disabled_default(store):
-    """Env flag unset → no time-window fallback fires (2 cards stay 2)."""
+    """Default window (0.0) → no time-window fallback fires (2 cards stay 2)."""
 
-    import os
-
-    old = os.environ.pop("HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS", None)
-    try:
-        sid = "sess_legacy_off"
-        await _seed_session(store, sid)
-        await store.put_annotation(
-            Annotation(
-                id="ann_no_legacy",
-                session_id=sid,
-                target=AnnotationTarget(agent_id="a", time_start=100.0),
-                author="alice",
-                created_at=100.0,
-                kind=AnnotationKind.STEERING,
-                body="pivot",
-            )
+    sid = "sess_legacy_off"
+    await _seed_session(store, sid)
+    await store.put_annotation(
+        Annotation(
+            id="ann_no_legacy",
+            session_id=sid,
+            target=AnnotationTarget(agent_id="a", time_start=100.0),
+            author="alice",
+            created_at=100.0,
+            kind=AnnotationKind.STEERING,
+            body="pivot",
         )
-        drifts = _StubDrifts(
-            {
-                sid: [
-                    {
-                        "run_id": "r1",
-                        "kind": "user_steer",
-                        "severity": "warning",
-                        "detail": "by alice: pivot",
-                        "annotation_id": "ann_no_legacy",
-                        "id": "drift_no_legacy",
-                        "recorded_at": 100.2,
-                    }
-                ]
-            }
+    )
+    drifts = _StubDrifts(
+        {
+            sid: [
+                {
+                    "run_id": "r1",
+                    "kind": "user_steer",
+                    "severity": "warning",
+                    "detail": "by alice: pivot",
+                    "annotation_id": "ann_no_legacy",
+                    "id": "drift_no_legacy",
+                    "recorded_at": 100.2,
+                }
+            ]
+        }
+    )
+    await store.put_task_plan(
+        TaskPlan(
+            id="p_no_legacy",
+            session_id=sid,
+            created_at=700.0,
+            summary="",
+            tasks=[],
+            edges=[],
+            revision_reason="pivot",
+            revision_kind="user_steer",
+            revision_severity="warning",
+            revision_index=1,
+            # No trigger_event_id.
         )
-        await store.put_task_plan(
-            TaskPlan(
-                id="p_no_legacy",
-                session_id=sid,
-                created_at=700.0,
-                summary="",
-                tasks=[],
-                edges=[],
-                revision_reason="pivot",
-                revision_kind="user_steer",
-                revision_severity="warning",
-                revision_index=1,
-                # No trigger_event_id.
-            )
-        )
-        records = await list_interventions(sid, store=store, drifts_provider=drifts)
-        # Two cards: the merged annotation+drift (strict-id via
-        # annotation_id), PLUS the standalone plan-row (no
-        # trigger_event_id so no strict merge; legacy window is
-        # disabled). The plan row's STEER kind comes from the
-        # revision_kind so it rolls up as source="user".
-        assert len(records) == 2
-        merged_card = next(
-            r for r in records if r.annotation_id == "ann_no_legacy"
-        )
-        orphan_plan = next(
-            r for r in records if r.plan_revision_index == 1 and not r.annotation_id
-        )
-        # The merged row inherited nothing from the plan — attribution
-        # didn't run because strict-id missed and legacy was off.
-        assert merged_card.outcome == "recorded"
-        assert orphan_plan.outcome == "plan_revised:r1"
-    finally:
-        if old is not None:
-            os.environ["HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS"] = old
+    )
+    # Default (0.0) keeps the fallback disabled.
+    records = await list_interventions(sid, store=store, drifts_provider=drifts)
+    # Two cards: the merged annotation+drift (strict-id via
+    # annotation_id), PLUS the standalone plan-row (no
+    # trigger_event_id so no strict merge; legacy window is
+    # disabled). The plan row's STEER kind comes from the
+    # revision_kind so it rolls up as source="user".
+    assert len(records) == 2
+    merged_card = next(
+        r for r in records if r.annotation_id == "ann_no_legacy"
+    )
+    orphan_plan = next(
+        r for r in records if r.plan_revision_index == 1 and not r.annotation_id
+    )
+    # The merged row inherited nothing from the plan — attribution
+    # didn't run because strict-id missed and legacy was off.
+    assert merged_card.outcome == "recorded"
+    assert orphan_plan.outcome == "plan_revised:r1"
 
 
 async def test_autonomous_drift_and_mismatched_plan_keep_separate_cards(store):


### PR DESCRIPTION
## Summary

- Follow-up to #100 — the legacy plan-attribution time-window fallback was configured via env vars (`HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS` on the server, `VITE_HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS` on the frontend). Env vars are the wrong surface — the server has `ServerConfig` + argparse, and the frontend shouldn't bake this into the Vite build.
- Server now exposes `ServerConfig.legacy_plan_attribution_window_ms: float = 0.0`, threaded through to `list_interventions(...)` as a kwarg. New CLI flag `--legacy-plan-attribution-window-ms`. All env-var reads (`_read_legacy_window_ms`, module global, `_legacy_window_ms()` helper) deleted.
- Frontend aggregator gains `legacyPlanAttributionWindowMs?: number` on `DeriveInput` / `deriveInterventionsFromStore` `opts`. `legacyWindowMs()` and its `import.meta.env` read are gone. Existing callers omit the option (≡ 0 / disabled, matches today's default behaviour).
- WARNING log messages updated to reference the config field / option name.
- Docs runbook updated.

## Test plan

- [x] `make server-test` — 299 passed, 1 skipped (full suite); `test_legacy_flag_disabled_default` + `test_legacy_flag_enabled_via_config` exercise the new kwarg surface.
- [x] `pnpm test` — 260 tests pass; two new interventions tests cover the option default + opt-in with a `console.warn` spy.
- [x] `pnpm build` — clean TypeScript + Vite build.
- [x] `pnpm lint` — clean.
- [x] `harmonograf-server --help` shows the flag; `config_from_args(['--legacy-plan-attribution-window-ms', '900000'])` yields `ServerConfig.legacy_plan_attribution_window_ms == 900000.0`.
- [x] No `HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS` / `VITE_HARMONOGRAF_LEGACY_PLAN_ATTRIBUTION_WINDOW_MS` references remain in production code (the only two hits are negative assertions inside tests that verify WARNING logs no longer mention them).