### PR TITLE
Consolidate 8 server-side tunables into ServerConfig + 4 CLI flags (closes #103)

### DIFF
--- a/.agents/skills/hgraf-tune-heartbeat/SKILL.md
+++ b/.agents/skills/hgraf-tune-heartbeat/SKILL.md
@@ -13,18 +13,18 @@ You need to change how often agents emit heartbeats, how long before an agent is
 
 1. Read the Heartbeat proto message: `proto/harmonograf/v1/telemetry.proto:94-124`. Key fields: `buffered_events`, `dropped_events`, `dropped_spans_critical`, `progress_counter`, `current_activity`, `context_window_tokens/limit_tokens`.
 2. Read the client heartbeat builder: `client/harmonograf_client/heartbeat.py:21 DEFAULT_INTERVAL_SECONDS = 5.0` and `build_heartbeat()`.
-3. Read the server stuck detector: `server/harmonograf_server/ingest.py:62-64`:
-   - `HEARTBEAT_TIMEOUT_S = 15.0`
-   - `HEARTBEAT_CHECK_INTERVAL_S = 5.0`
-   - `STUCK_THRESHOLD_BEATS = 3` (3 consecutive unchanged heartbeats ≈ 15s)
-4. Read the stuck update logic around `ingest.py:566` where `stuck_heartbeat_count` is incremented or cleared.
+3. Read the server tunables on `ServerConfig` (`server/harmonograf_server/config.py`, harmonograf#102):
+   - `heartbeat_timeout_seconds: float = 15.0` (CLI: `--heartbeat-timeout-seconds`)
+   - `heartbeat_check_interval_seconds: float = 5.0` (constructor-only)
+   - `stuck_threshold_beats: int = 3` (constructor-only; 3 consecutive unchanged heartbeats ≈ 15s)
+4. Read the stuck update logic in `ingest.py` where `stuck_heartbeat_count` is incremented or cleared (search for `_stuck_threshold_beats`).
 
 ## The math
 
 The **detection window** for "agent is stuck" is:
 
 ```
-stuck_window_s ≈ HEARTBEAT_INTERVAL_CLIENT × STUCK_THRESHOLD_BEATS
+stuck_window_s ≈ HEARTBEAT_INTERVAL_CLIENT × stuck_threshold_beats
 ```
 
 With defaults: `5s × 3 = 15s`. That's the interval where an agent whose `progress_counter` has not changed is declared stuck.
@@ -32,14 +32,14 @@ With defaults: `5s × 3 = 15s`. That's the interval where an agent whose `progre
 The **disconnect window** ("agent is gone") is:
 
 ```
-disconnect_window_s = HEARTBEAT_TIMEOUT_S
+disconnect_window_s = heartbeat_timeout_seconds
 ```
 
-Default 15s. The server sweeper (see `HEARTBEAT_CHECK_INTERVAL_S = 5.0`) runs every 5s and marks any stream whose `last_heartbeat` is older than the timeout as `CRASHED`.
+Default 15s. The server sweeper (see `heartbeat_check_interval_seconds = 5.0`) runs every 5s and marks any stream whose `last_heartbeat` is older than the timeout as `CRASHED`.
 
-**Invariant**: `HEARTBEAT_TIMEOUT_S > HEARTBEAT_INTERVAL_CLIENT + 1 jitter slot`. With 5s interval, 15s timeout leaves room for two full missed beats + processing delay. If you halve the interval, you can halve the timeout — not before.
+**Invariant**: `heartbeat_timeout_seconds > HEARTBEAT_INTERVAL_CLIENT + 1 jitter slot`. With 5s interval, 15s timeout leaves room for two full missed beats + processing delay. If you halve the interval, you can halve the timeout — not before.
 
-**Second invariant**: `HEARTBEAT_CHECK_INTERVAL_S ≤ HEARTBEAT_TIMEOUT_S`. The sweeper must run more often than the timeout to catch every stuck client within one window.
+**Second invariant**: `heartbeat_check_interval_seconds ≤ heartbeat_timeout_seconds`. The sweeper must run more often than the timeout to catch every stuck client within one window.
 
 ## Step-by-step to shorten the detection window (e.g. 5s stuck detection)
 
@@ -48,9 +48,9 @@ Default 15s. The server sweeper (see `HEARTBEAT_CHECK_INTERVAL_S = 5.0`) runs ev
 Target: detect stuck in 5s. That means:
 
 - Client interval: 1s
-- `STUCK_THRESHOLD_BEATS`: 5 (1s × 5 = 5s)
-- `HEARTBEAT_TIMEOUT_S`: 4s — safe as 1s × 4, but 5s is safer for jitter.
-- `HEARTBEAT_CHECK_INTERVAL_S`: 1s
+- `stuck_threshold_beats`: 5 (1s × 5 = 5s)
+- `heartbeat_timeout_seconds`: 4s — safe as 1s × 4, but 5s is safer for jitter.
+- `heartbeat_check_interval_seconds`: 1s
 
 ### 2. Change the client interval
 
@@ -58,17 +58,28 @@ The transport's `heartbeat_interval_s` is configurable on `TransportConfig` (`cl
 
 Verify with `grep -n heartbeat_interval client/harmonograf_client/transport.py` — the relevant lines are around 484 (wait with timeout) and 514 (deadline check).
 
-### 3. Change the server constants
+### 3. Change the server tunables
 
-Edit `server/harmonograf_server/ingest.py:62`:
+As of harmonograf#102, the three server knobs live on `ServerConfig`, not as module-level constants. Pick the surface that fits:
 
-```python
-HEARTBEAT_TIMEOUT_S = 5.0
-HEARTBEAT_CHECK_INTERVAL_S = 1.0
-STUCK_THRESHOLD_BEATS = 5
+**CLI (for the heartbeat timeout only)**:
+
+```bash
+harmonograf-server --heartbeat-timeout-seconds 5.0 ...
 ```
 
-Both `HEARTBEAT_TIMEOUT_S` and the `IngestPipeline.__init__(heartbeat_timeout_s=...)` argument get read, so the constant is the default and callers can still override.
+**Programmatic / tests (all three)**:
+
+```python
+from harmonograf_server.config import ServerConfig
+cfg = ServerConfig(
+    heartbeat_timeout_seconds=5.0,
+    heartbeat_check_interval_seconds=1.0,
+    stuck_threshold_beats=5,
+)
+```
+
+The fields are read by `IngestPipeline.__init__` (heartbeat-timeout + stuck-threshold) and by `Harmonograf.start()` when it spawns `heartbeat_sweeper(interval_s=...)` (the check interval). Tests that construct an `IngestPipeline` directly can still pass the kwargs — `heartbeat_timeout_s`, `stuck_threshold_beats` — instead of building a full `ServerConfig`.
 
 ### 4. Review tests
 
@@ -94,7 +105,7 @@ The transport test at `client/tests/test_transport_mock.py:303` uses `heartbeat_
 
 - **Shorter interval → more wire traffic**: each heartbeat is ~100 bytes. 1s cadence × N agents = N × 100 bytes/s upstream per agent. At 100 agents that's still only 10 KB/s — cheap.
 - **Shorter interval → busier transport loop**: the transport wakes every interval anyway to check its batching queue. Dropping from 5s to 1s adds 4 wakes/s per agent process. Measurable, not meaningful.
-- **Shorter stuck window → more false positives**: an LLM call that takes 20s with `STUCK_THRESHOLD_BEATS=3 interval=5s` is currently NOT flagged as stuck because `progress_counter` only changes at callback boundaries — and the middle of an LLM call has no boundaries. **If you tighten the window below typical LLM latency, you'll get amber "stuck" borders on every slow model call.** Benchmark your slowest model call before tightening.
+- **Shorter stuck window → more false positives**: an LLM call that takes 20s with `stuck_threshold_beats=3 interval=5s` is currently NOT flagged as stuck because `progress_counter` only changes at callback boundaries — and the middle of an LLM call has no boundaries. **If you tighten the window below typical LLM latency, you'll get amber "stuck" borders on every slow model call.** Benchmark your slowest model call before tightening.
 - **Longer timeout → slower disconnect detection**: users see "connected" for longer after the agent process is actually dead. 15s is the default for a reason — it's short enough to matter, long enough to ride out GC pauses.
 
 ## Frontend impact
@@ -107,4 +118,4 @@ The transport test at `client/tests/test_transport_mock.py:303` uses `heartbeat_
 - **Halving the interval without halving the timeout**: disconnect detection gets slower relative to heartbeat cadence, and stuck windows shrink below LLM call latency. Keep them proportional.
 - **Tuning only the server**: the client runs on its own schedule. If the server expects 1s beats and the client still sends at 5s, every legitimate agent looks stuck.
 - **Assuming `progress_counter` ticks every 5s**: it ticks on *activity*, not on wall time. A long, silent LLM call will not bump it. This is intentional — stuck-ness is about forward progress, not uptime.
-- **Skipping the test updates**: `test_ingest_extensive.py` encodes the count "3 consecutive heartbeats". Changing `STUCK_THRESHOLD_BEATS` without updating the test leaves you with a false-green that checks the old value.
+- **Skipping the test updates**: `test_ingest_extensive.py` encodes the count "3 consecutive heartbeats". Changing `stuck_threshold_beats` without updating the test leaves you with a false-green that checks the old value.

--- a/docs/dev-guide/deployment.md
+++ b/docs/dev-guide/deployment.md
@@ -209,6 +209,82 @@ uv run python -m harmonograf_server \
 The Makefile `server-run` target uses the defaults
 (`Makefile:87-88`).
 
+## Operational tunables
+
+Everything the server can be tuned with lives on
+`ServerConfig` (`server/harmonograf_server/config.py`). As of
+harmonograf#102 there are **no module-level constants** — every knob
+is either a `ServerConfig` field or a CLI flag (which in turn sets a
+field). This means you can configure the server from three places
+that all resolve to the same object:
+
+1. `harmonograf-server --flag value ...` on the command line.
+2. `ServerConfig(field=value, ...)` programmatically from a test or
+   embedder.
+3. A thin wrapper that parses your own config format and constructs a
+   `ServerConfig` before calling `Harmonograf.from_config(cfg)`.
+
+### CLI flags → ServerConfig map
+
+| CLI flag | ServerConfig field | Default | Purpose |
+|---|---|---|---|
+| `--host` | `host` | `127.0.0.1` | Bind address for both listeners |
+| `--port` | `grpc_port` | `7531` | Native gRPC port |
+| `--web-port` | `web_port` | `7532` | gRPC-Web + health port |
+| `--store` | `store_backend` | `sqlite` | `sqlite` or `memory` |
+| `--data-dir` | `data_dir` | `~/.harmonograf/data` | sqlite file + payload tree |
+| `--log-level` | `log_level` | `INFO` | `DEBUG`/`INFO`/`WARNING`/`ERROR` |
+| `--log-format` | `log_format` | `text` | `text` or `json` |
+| `--grace` | `grace_seconds` | `5.0` | Shutdown grace period |
+| `--retention-hours` | `retention_hours` | `0.0` | Purge terminal sessions older than N hours (0 = disabled) |
+| `--retention-interval-seconds` | `retention_interval_seconds` | `300.0` | Retention sweep cadence |
+| `--metrics-interval-seconds` | `metrics_interval_seconds` | `30.0` | Periodic metrics snapshot (0 = disabled) |
+| `--auth-token` | `auth_token` | `""` | Shared bearer-token secret (empty = disabled) |
+| `--heartbeat-timeout-seconds` | `heartbeat_timeout_seconds` | `15.0` | Declare a stream `DISCONNECTED` after this many seconds of silence (harmonograf#102) |
+| `--payload-max-bytes` | `payload_max_bytes` | `67108864` (64 MiB) | DoS guard — per-digest payload ceiling (harmonograf#102) |
+| `--rpc-watch-window-seconds` | `rpc_watch_window_seconds` | `3600.0` | Default `WatchSession` replay window when the client does not supply one (harmonograf#102) |
+| `--rpc-span-tree-limit` | `rpc_span_tree_limit` | `10000` | Cap on `GetSpanTree` responses when the client does not supply a limit (harmonograf#102) |
+
+### Constructor-only fields (no CLI surface)
+
+Four tunables are programmatic-only because operators essentially
+never change them — they are stable defaults that tests and embedders
+can still override via `ServerConfig(...)`:
+
+| ServerConfig field | Default | Purpose |
+|---|---|---|
+| `heartbeat_check_interval_seconds` | `5.0` | How often the heartbeat sweeper runs. Lower is more responsive but burns more CPU; must stay `<= heartbeat_timeout_seconds` |
+| `stuck_threshold_beats` | `3` | Consecutive identical `progress_counter` heartbeats before the `is_stuck` flag flips on an agent |
+| `rpc_payload_chunk_bytes` | `262144` (256 KiB) | Chunk size on `GetPayload` stream replies |
+| `rpc_send_control_timeout_seconds` | `5.0` | Fallback timeout on `SendControl` / `PostAnnotation` delivery when the request does not supply `ack_timeout_ms` |
+
+### Programmatic usage
+
+For tests or embedders that bypass the CLI:
+
+```python
+from harmonograf_server.config import ServerConfig
+from harmonograf_server.main import Harmonograf
+
+cfg = ServerConfig(
+    host="127.0.0.1",
+    grpc_port=7531,
+    web_port=7532,
+    # Long-running ETL deployment — raise the watch window + tighten
+    # the heartbeat timeout for a flakier upstream network.
+    heartbeat_timeout_seconds=30.0,
+    rpc_watch_window_seconds=86400.0,  # 24h
+    rpc_span_tree_limit=50_000,
+    payload_max_bytes=256 * 1024 * 1024,  # 256 MiB
+)
+app = await Harmonograf.from_config(cfg)
+await app.run()
+```
+
+See the operational-tuning guidance in
+[`performance-tuning.md`](performance-tuning.md) for when and why
+to move each knob.
+
 ## TLS and auth — what's built in
 
 **Nothing built in for TLS.** The native gRPC listener is opened

--- a/docs/dev-guide/performance-tuning.md
+++ b/docs/dev-guide/performance-tuning.md
@@ -57,31 +57,30 @@ the callback hot path" and "Frontend frame budget" below for how.
 
 The client ships a `Heartbeat` message every `HEARTBEAT_INTERVAL_S`
 seconds (default `5.0`, `client/harmonograf_client/transport.py:50`).
-The server's stuckness detector compares three consecutive heartbeats
-with the same `progress_counter` and, if they match, flips the agent
-to `stuck` — see `STUCK_THRESHOLD_BEATS = 3` at
-`server/harmonograf_server/ingest.py:64` and the timeout window
-`HEARTBEAT_TIMEOUT_S = 15.0` at `ingest.py:62`.
+The server's stuckness detector compares consecutive heartbeats
+with the same `progress_counter` and, once enough match, flips the
+agent to `stuck`. As of harmonograf#102 these knobs live on
+`ServerConfig` (`server/harmonograf_server/config.py`), not as
+module-level constants:
 
-These knobs are coupled and both live in code, not config, for v0:
-
-| Knob | Default | Effect |
-|---|---|---|
-| `HEARTBEAT_INTERVAL_S` (client) | `5.0` s | How often the send loop builds a `Heartbeat` |
-| `HEARTBEAT_TIMEOUT_S` (server) | `15.0` s | How long before the ingest pipeline declares a stream `DISCONNECTED` |
-| `STUCK_THRESHOLD_BEATS` (server) | `3` | Consecutive unchanged `progress_counter` heartbeats before `is_stuck` flips |
-| `HEARTBEAT_CHECK_INTERVAL_S` (server) | `5.0` s | How often the `heartbeat_sweeper` scans for expired streams (`ingest.py:63`) |
+| Knob | Default | Surface | Effect |
+|---|---|---|---|
+| `HEARTBEAT_INTERVAL_S` (client) | `5.0` s | `client/harmonograf_client/transport.py` | How often the send loop builds a `Heartbeat` |
+| `heartbeat_timeout_seconds` (server) | `15.0` s | `ServerConfig` + `--heartbeat-timeout-seconds` | How long before the ingest pipeline declares a stream `DISCONNECTED` |
+| `stuck_threshold_beats` (server) | `3` | `ServerConfig` (constructor-only) | Consecutive unchanged `progress_counter` heartbeats before `is_stuck` flips |
+| `heartbeat_check_interval_seconds` (server) | `5.0` s | `ServerConfig` (constructor-only) | How often the `heartbeat_sweeper` scans for expired streams |
 
 The invariants are:
 
-- `HEARTBEAT_TIMEOUT_S >= 3 × HEARTBEAT_INTERVAL_S`. A single lost
-  heartbeat due to GC pause or a brief TCP stall must not disconnect
-  the agent. The 3× factor is what lets you lose two consecutive
-  heartbeats and still survive.
-- `STUCK_THRESHOLD_BEATS × HEARTBEAT_INTERVAL_S ≈ HEARTBEAT_TIMEOUT_S`.
-  The stuck-detector watches for three unchanged heartbeats; that is
-  ~15 s at the default cadence. If you halve the cadence, also halve
-  the threshold or the UI will lag the real stuck signal by 30 s.
+- `heartbeat_timeout_seconds >= 3 × HEARTBEAT_INTERVAL_S`. A single
+  lost heartbeat due to GC pause or a brief TCP stall must not
+  disconnect the agent. The 3× factor is what lets you lose two
+  consecutive heartbeats and still survive.
+- `stuck_threshold_beats × HEARTBEAT_INTERVAL_S ≈ heartbeat_timeout_seconds`.
+  The stuck-detector watches for N unchanged heartbeats; that is
+  ~15 s at the default cadence (3 repeats × 5 s). If you halve the
+  cadence, also halve the threshold or the UI will lag the real stuck
+  signal by 30 s.
 
 **When to retune.** Lower the interval (to, say, 2 s) if you are
 debugging liveness bugs and want faster feedback in the UI. Raise it
@@ -148,10 +147,12 @@ per ten spans at 256 KiB means a 2.5 MiB burst of payload bytes per
 300 spans. At 1 MiB, the same ratio would mean a 10 MiB burst — enough
 to stall the gRPC send queue for seconds.
 
-The server enforces a hard ceiling of `PAYLOAD_MAX_BYTES = 64 * 1024 * 1024`
-per digest (`ingest.py:65`). That is the cliff; do not touch it without
-also auditing `_PayloadAssembler.add()` (`ingest.py:99`) for memory
-safety.
+The server enforces a per-digest hard ceiling of 64 MiB by default,
+configurable via `ServerConfig.payload_max_bytes` or
+`--payload-max-bytes` (harmonograf#102). That is the cliff; do not
+raise it without also auditing `_PayloadAssembler.add()` in
+`ingest.py` for memory safety — each active upload holds its
+partial chunks in RAM until the final `last=true` frame arrives.
 
 ### Orchestration performance: tune it in goldfive
 

--- a/docs/dev-guide/security-model.md
+++ b/docs/dev-guide/security-model.md
@@ -110,9 +110,9 @@ The only thing the server actively validates beyond syntax:
   transport corruption, not against a malicious client. A client
   that *wanted* to inject bad bytes would just supply the digest of
   the bad bytes.
-- **Payload size ceiling** (`ingest.py:65, 99-102`) —
-  `PAYLOAD_MAX_BYTES = 64 * 1024 * 1024` per digest. This is a DoS
-  bound, not authentication.
+- **Payload size ceiling** — `ServerConfig.payload_max_bytes`
+  (default 64 MiB, tunable via `--payload-max-bytes` since
+  harmonograf#102). This is a DoS bound, not authentication.
 - **STEER body validation** (`client/harmonograf_client/_control_bridge.py`) —
   the client-side bridge between harmonograf control delivery and
   goldfive rejects empty bodies and bodies larger than
@@ -333,12 +333,12 @@ flowchart TD
 - **Tampering with stored data at rest.** Anyone with write access
   to the data directory can rewrite sessions. Mitigation:
   filesystem permissions.
-- **DoS from a misbehaving client.** The payload size ceiling at
-  `ingest.py:65` is a bound, not a defense. A client that opens
-  thousands of sessions or emits at 100× the expected rate can
-  still exhaust the server. `HEARTBEAT_TIMEOUT_S` at `ingest.py:62`
-  reaps dead streams but does nothing about live-and-spamming
-  ones.
+- **DoS from a misbehaving client.** The payload size ceiling
+  (`ServerConfig.payload_max_bytes`) is a bound, not a defense. A
+  client that opens thousands of sessions or emits at 100× the
+  expected rate can still exhaust the server.
+  `ServerConfig.heartbeat_timeout_seconds` reaps dead streams but
+  does nothing about live-and-spamming ones.
 
 ### In scope (the things v0 actually defends against)
 

--- a/docs/protocol/payload-flow.md
+++ b/docs/protocol/payload-flow.md
@@ -94,10 +94,11 @@ Client protocol:
 Chunk sizing:
 
 - **Recommended**: up to 256 KiB per chunk.
-- **Hard ceiling**: `PAYLOAD_MAX_BYTES = 64 MiB` total per digest in
-  `server/harmonograf_server/ingest.py`. Exceeding it aborts the
-  assembler and raises a `ValueError` on the stream. The stream does
-  **not** close — subsequent chunks for other digests still land.
+- **Hard ceiling**: 64 MiB per digest by default, configurable via
+  `ServerConfig.payload_max_bytes` / `--payload-max-bytes`
+  (harmonograf#102). Exceeding it aborts the assembler and raises a
+  `ValueError` on the stream. The stream does **not** close —
+  subsequent chunks for other digests still land.
 - Very small payloads may arrive in a single chunk with `last=true`.
 
 Server-side assembly lives in `_PayloadAssembler` in `ingest.py`:

--- a/docs/protocol/telemetry-stream.md
+++ b/docs/protocol/telemetry-stream.md
@@ -203,7 +203,8 @@ message PayloadUpload {
 
 - Chunks for distinct digests may interleave freely.
 - Chunk size ≤ 256 KiB (recommended; server accepts larger).
-- Hard ceiling: **64 MiB per digest** (`ingest.PAYLOAD_MAX_BYTES`).
+- Hard ceiling: **64 MiB per digest** by default
+  (`ServerConfig.payload_max_bytes`, CLI `--payload-max-bytes`).
   Exceeding it aborts the assembler with `ValueError`.
 - On `last=true`, server recomputes sha256 over the reassembled bytes
   and **rejects the whole payload on mismatch** (`_handle_payload`
@@ -214,8 +215,9 @@ message PayloadUpload {
 ### `Heartbeat` (oneof tag 6)
 
 Periodic liveness + health report. Default cadence is 5s; the server
-declares the stream dead after `HEARTBEAT_TIMEOUT_S = 15s` of silence
-and closes it.
+declares the stream dead after `ServerConfig.heartbeat_timeout_seconds`
+(default 15s, CLI `--heartbeat-timeout-seconds`) of silence and closes
+it.
 
 ```proto
 message Heartbeat {
@@ -237,10 +239,10 @@ Server behaviour:
 
 - `last_heartbeat` updated on the agent row.
 - **Stuckness detection:** `progress_counter` must advance across
-  heartbeats. If the same counter is seen for `STUCK_THRESHOLD_BEATS = 3`
-  consecutive heartbeats (≈15 s) **while an INVOCATION span is
-  RUNNING**, the server flips `is_stuck` true and publishes an
-  `AgentStatusChanged` delta.
+  heartbeats. If the same counter is seen for
+  `ServerConfig.stuck_threshold_beats` (default 3, ≈15 s) consecutive
+  heartbeats **while an INVOCATION span is RUNNING**, the server
+  flips `is_stuck` true and publishes an `AgentStatusChanged` delta.
 - `current_activity` is echoed into `AgentStatusChanged.current_activity`
   so the UI updates without waiting for a span update.
 - `context_window_tokens` / `context_window_limit_tokens = 0` is treated
@@ -248,7 +250,9 @@ Server behaviour:
   writing them. Non-zero samples are persisted and fan out as
   `ContextWindowSample` deltas on `WatchSession`.
 
-Heartbeat handling and the stuck-detection state machine — `progress_counter` must change between beats or the server escalates after `STUCK_THRESHOLD_BEATS` consecutive identical values:
+Heartbeat handling and the stuck-detection state machine —
+`progress_counter` must change between beats or the server escalates
+after `stuck_threshold_beats` consecutive identical values:
 
 ```mermaid
 stateDiagram-v2
@@ -257,11 +261,11 @@ stateDiagram-v2
     Healthy --> Watching: heartbeat<br/>counter unchanged<br/>(count = 1)
     Watching --> Watching: heartbeat<br/>counter unchanged<br/>(count++)
     Watching --> Healthy: heartbeat<br/>counter advanced
-    Watching --> Stuck: count >= STUCK_THRESHOLD_BEATS (3)
+    Watching --> Stuck: count >= stuck_threshold_beats (3)
     Stuck --> Healthy: heartbeat<br/>counter advanced
-    Healthy --> Disconnected: no heartbeat for<br/>HEARTBEAT_TIMEOUT_S (15s)
-    Watching --> Disconnected: no heartbeat for<br/>HEARTBEAT_TIMEOUT_S
-    Stuck --> Disconnected: no heartbeat for<br/>HEARTBEAT_TIMEOUT_S
+    Healthy --> Disconnected: no heartbeat for<br/>heartbeat_timeout_seconds (15s)
+    Watching --> Disconnected: no heartbeat for<br/>heartbeat_timeout_seconds
+    Stuck --> Disconnected: no heartbeat for<br/>heartbeat_timeout_seconds
 ```
 
 ### `ControlAck` (oneof tag 7)

--- a/docs/protocol/wire-ordering.md
+++ b/docs/protocol/wire-ordering.md
@@ -246,11 +246,12 @@ way — they're just periodic pings. But the server does use them for:
 - **Stuckness detection** — see
   [`telemetry-stream.md#heartbeat`](telemetry-stream.md#heartbeat).
   `progress_counter` must advance across heartbeats or the agent is
-  declared stuck after `STUCK_THRESHOLD_BEATS = 3` (≈15 s) while an
-  INVOCATION is RUNNING.
+  declared stuck after `stuck_threshold_beats` (default 3, ≈15 s)
+  while an INVOCATION is RUNNING.
 - **Last-seen wall-clock** — the `last_heartbeat` field on `Agent`.
-  If no heartbeat arrives for `HEARTBEAT_TIMEOUT_S = 15 s`, the
-  server flips the agent to `DISCONNECTED` and closes its streams.
+  If no heartbeat arrives for `heartbeat_timeout_seconds` (default
+  15 s, CLI `--heartbeat-timeout-seconds`), the server flips the
+  agent to `DISCONNECTED` and closes its streams.
 
 Clients that fall silent on telemetry but keep a heartbeat thread
 alive are treated as connected; clients that emit spans without

--- a/docs/runbooks/task-stuck-in-running.md
+++ b/docs/runbooks/task-stuck-in-running.md
@@ -7,8 +7,8 @@ arrive; the Gantt shows an open span that doesn't close.
 ## Symptoms
 
 - **Graph view**: agent header shows `⚠ stuck` (the liveness tracker
-  flagged it after `STUCK_THRESHOLD_BEATS=3` consecutive unchanged
-  heartbeats).
+  flagged it after `ServerConfig.stuck_threshold_beats` (default 3)
+  consecutive unchanged heartbeats).
 - **Gantt**: an open RUNNING span that steadily grows but never ends.
 - **Intervention strip**: `LOOPING_REASONING` drift has NOT (yet)
   fired — the tool-loop detector only trips after several repetitions.

--- a/server/harmonograf_server/cli.py
+++ b/server/harmonograf_server/cli.py
@@ -99,6 +99,48 @@ def build_parser() -> argparse.ArgumentParser:
             "disables. See docs/runbooks/plan-revision-dedup.md."
         ),
     )
+    # ---- heartbeat + payload (harmonograf#102) ----------------------
+    p.add_argument(
+        "--heartbeat-timeout-seconds",
+        type=float,
+        default=15.0,
+        help=(
+            "declare a telemetry stream DISCONNECTED if no heartbeat has "
+            "arrived within this many seconds; raise on flaky networks "
+            "(default: 15.0)"
+        ),
+    )
+    p.add_argument(
+        "--payload-max-bytes",
+        type=int,
+        default=64 * 1024 * 1024,
+        help=(
+            "reject any single payload whose assembled chunks exceed this "
+            "many bytes; DoS guard + ops knob for large-artifact "
+            "deployments (default: 67108864 = 64 MiB)"
+        ),
+    )
+    # ---- RPC behavior (harmonograf#102) -----------------------------
+    p.add_argument(
+        "--rpc-watch-window-seconds",
+        type=float,
+        default=3600.0,
+        help=(
+            "default WatchSession replay window in seconds when the "
+            "client does not supply window_start/window_end; raise for "
+            "long-running sessions (default: 3600)"
+        ),
+    )
+    p.add_argument(
+        "--rpc-span-tree-limit",
+        type=int,
+        default=10_000,
+        help=(
+            "cap the number of spans returned per GetSpanTree request "
+            "when the client does not supply an explicit limit; lower "
+            "for security-minded deployments (default: 10000)"
+        ),
+    )
     return p
 
 
@@ -118,6 +160,10 @@ def config_from_args(argv: list[str] | None = None) -> ServerConfig:
         metrics_interval_seconds=args.metrics_interval_seconds,
         auth_token=args.auth_token,
         legacy_plan_attribution_window_ms=args.legacy_plan_attribution_window_ms,
+        heartbeat_timeout_seconds=args.heartbeat_timeout_seconds,
+        payload_max_bytes=args.payload_max_bytes,
+        rpc_watch_window_seconds=args.rpc_watch_window_seconds,
+        rpc_span_tree_limit=args.rpc_span_tree_limit,
     )
 
 

--- a/server/harmonograf_server/config.py
+++ b/server/harmonograf_server/config.py
@@ -23,6 +23,7 @@ class ServerConfig:
     retention_interval_seconds: float = 300.0
     metrics_interval_seconds: float = 30.0  # 0 disables periodic metrics
     auth_token: str = ""  # empty string disables shared-secret auth
+
     # Opt-in legacy time-window fallback for plan-revision attribution
     # (pre-strict-id-dedup behaviour from before harmonograf#99). Default
     # 0 disables the fallback — plan revisions without a trigger_event_id
@@ -31,3 +32,26 @@ class ServerConfig:
     # / drifts within that wall-clock window when no strict id is
     # available. See docs/runbooks/plan-revision-dedup.md.
     legacy_plan_attribution_window_ms: float = 0.0
+
+    # ---- heartbeat + payload (ingest.py) -----------------------------
+    # Moved from module-level constants in harmonograf_server.ingest
+    # (harmonograf#102). Operators tune ``heartbeat_timeout_seconds`` on
+    # flaky networks and ``payload_max_bytes`` as a DoS guard / ops knob
+    # for large-artifact deployments; the other two are rarely-touched
+    # internal defaults and stay constructor-only.
+    heartbeat_timeout_seconds: float = 15.0
+    heartbeat_check_interval_seconds: float = 5.0
+    stuck_threshold_beats: int = 3
+    payload_max_bytes: int = 64 * 1024 * 1024
+
+    # ---- RPC behavior (rpc/frontend.py) ------------------------------
+    # Moved from module-level constants in harmonograf_server.rpc.frontend
+    # (harmonograf#102). ``rpc_watch_window_seconds`` + ``rpc_span_tree_limit``
+    # are exposed as CLI flags (operators with long-running sessions or
+    # security-sensitive deployments may want to adjust); the chunk size
+    # and per-control ack timeout are sensible defaults that stay
+    # constructor-only.
+    rpc_payload_chunk_bytes: int = 256 * 1024
+    rpc_watch_window_seconds: float = 3600.0
+    rpc_span_tree_limit: int = 10_000
+    rpc_send_control_timeout_seconds: float = 5.0

--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -64,10 +64,14 @@ _TASK_BINDING_SPAN_KINDS = frozenset({SpanKind.LLM_CALL, SpanKind.TOOL_CALL})
 logger = logging.getLogger(__name__)
 
 
-HEARTBEAT_TIMEOUT_S = 15.0
-HEARTBEAT_CHECK_INTERVAL_S = 5.0
-STUCK_THRESHOLD_BEATS = 3  # 3 consecutive unchanged heartbeats ≈ 15s
-PAYLOAD_MAX_BYTES = 64 * 1024 * 1024  # hard ceiling per digest — guards against runaway uploads
+# Default tunables for constructor kwargs. Production callers pass
+# values from ``ServerConfig`` (harmonograf#102 moved these off
+# module-level state); these literals are only the fallback used by
+# tests and ad-hoc consumers that construct an ``IngestPipeline``
+# without a config object.
+_DEFAULT_HEARTBEAT_TIMEOUT_S = 15.0
+_DEFAULT_STUCK_THRESHOLD_BEATS = 3
+_DEFAULT_PAYLOAD_MAX_BYTES = 64 * 1024 * 1024
 
 _SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
 
@@ -97,14 +101,17 @@ class _PayloadAssembler:
     digest: str
     mime: str
     total_size: int
+    max_bytes: int = _DEFAULT_PAYLOAD_MAX_BYTES
     chunks: list[bytes] = field(default_factory=list)
     received_bytes: int = 0
     evicted: bool = False
 
     def add(self, chunk: bytes) -> None:
         self.received_bytes += len(chunk)
-        if self.received_bytes > PAYLOAD_MAX_BYTES:
-            raise ValueError(f"payload {self.digest} exceeds {PAYLOAD_MAX_BYTES} bytes")
+        if self.received_bytes > self.max_bytes:
+            raise ValueError(
+                f"payload {self.digest} exceeds {self.max_bytes} bytes"
+            )
         self.chunks.append(chunk)
 
     def finalize(self) -> bytes:
@@ -184,13 +191,17 @@ class IngestPipeline:
         *,
         control_sink: Optional[ControlAckSink] = None,
         now_fn: Callable[[], float] = time.time,
-        heartbeat_timeout_s: float = HEARTBEAT_TIMEOUT_S,
+        heartbeat_timeout_s: float = _DEFAULT_HEARTBEAT_TIMEOUT_S,
+        stuck_threshold_beats: int = _DEFAULT_STUCK_THRESHOLD_BEATS,
+        payload_max_bytes: int = _DEFAULT_PAYLOAD_MAX_BYTES,
     ) -> None:
         self._store = store
         self._bus = bus
         self._control_sink = control_sink or _NullControlAckSink()
         self._now = now_fn
         self._heartbeat_timeout_s = heartbeat_timeout_s
+        self._stuck_threshold_beats = stuck_threshold_beats
+        self._payload_max_bytes = payload_max_bytes
 
         # per-agent connection registry: agent_id -> {stream_id: StreamContext}
         self._streams_by_agent: dict[str, dict[str, StreamContext]] = {}
@@ -617,7 +628,10 @@ class IngestPipeline:
         assembler = ctx.payloads.get(msg.digest)
         if assembler is None:
             assembler = _PayloadAssembler(
-                digest=msg.digest, mime=msg.mime, total_size=msg.total_size
+                digest=msg.digest,
+                mime=msg.mime,
+                total_size=msg.total_size,
+                max_bytes=self._payload_max_bytes,
             )
             ctx.payloads[msg.digest] = assembler
         if msg.chunk:
@@ -657,7 +671,7 @@ class IngestPipeline:
             ctx.stuck_heartbeat_count = 0
             ctx.last_progress_counter = msg.progress_counter
         ctx.current_activity = msg.current_activity
-        now_stuck = ctx.stuck_heartbeat_count >= STUCK_THRESHOLD_BEATS
+        now_stuck = ctx.stuck_heartbeat_count >= self._stuck_threshold_beats
         if now_stuck != ctx.is_stuck:
             ctx.is_stuck = now_stuck
             self._bus.publish_agent_status(

--- a/server/harmonograf_server/main.py
+++ b/server/harmonograf_server/main.py
@@ -87,7 +87,14 @@ class Harmonograf:
 
         bus = SessionBus()
         router = ControlRouter()
-        ingest = IngestPipeline(store, bus, control_sink=router)
+        ingest = IngestPipeline(
+            store,
+            bus,
+            control_sink=router,
+            heartbeat_timeout_s=cfg.heartbeat_timeout_seconds,
+            stuck_threshold_beats=cfg.stuck_threshold_beats,
+            payload_max_bytes=cfg.payload_max_bytes,
+        )
 
         async def _on_status_query(session_id: str, agent_id: str, span_id: str, report: str) -> None:
             bus.publish_task_report(session_id, agent_id, report, invocation_span_id=span_id)
@@ -123,7 +130,11 @@ class Harmonograf:
 
         # Background sweep for heartbeat timeouts.
         self._sweeper_task = asyncio.create_task(
-            heartbeat_sweeper(self.ingest), name="heartbeat_sweeper"
+            heartbeat_sweeper(
+                self.ingest,
+                interval_s=self.cfg.heartbeat_check_interval_seconds,
+            ),
+            name="heartbeat_sweeper",
         )
 
         # Retention sweeper (no-op when retention_hours == 0).

--- a/server/harmonograf_server/rpc/frontend.py
+++ b/server/harmonograf_server/rpc/frontend.py
@@ -20,7 +20,6 @@ import grpc
 from google.protobuf.timestamp_pb2 import Timestamp
 from google.protobuf import timestamp_pb2
 
-from harmonograf_server.config import ServerConfig
 from harmonograf_server.bus import (
     DELTA_AGENT_INVOCATION_COMPLETED,
     DELTA_AGENT_INVOCATION_STARTED,
@@ -47,6 +46,7 @@ from harmonograf_server.bus import (
     Delta,
     SessionBus,
 )
+from harmonograf_server.config import ServerConfig
 from harmonograf_server.control_router import ControlRouter, DeliveryResult
 from harmonograf_server.convert import (
     _AGENT_STATUS_TO_PB,
@@ -83,10 +83,8 @@ from harmonograf_server.storage import (
 logger = logging.getLogger(__name__)
 
 
-PAYLOAD_CHUNK_BYTES = 256 * 1024
-DEFAULT_WATCH_WINDOW_S = 3600.0
-DEFAULT_SPAN_TREE_LIMIT = 10_000
-DEFAULT_SEND_CONTROL_TIMEOUT_S = 5.0
+# Module-level tunables were moved to ``ServerConfig`` in
+# harmonograf#102; the mixin reads ``self._config.rpc_*`` below.
 
 
 def _now_ts() -> Timestamp:
@@ -145,8 +143,10 @@ class FrontendServicerMixin:
       self._ingest:  IngestPipeline
       self._router:  ControlRouter
       self._data_dir: str   (for GetStats reporting)
-      self._config:  ServerConfig (read-only; ListInterventions reads the
-                     legacy_plan_attribution_window_ms field)
+      self._config:  ServerConfig — RPC tunables (watch window,
+                     span-tree limit, payload chunk size, ack timeout)
+                     plus ``legacy_plan_attribution_window_ms`` read by
+                     ListInterventions.
     """
 
     _store: Store
@@ -257,8 +257,11 @@ class FrontendServicerMixin:
             if request.HasField("window_end"):
                 window_end = ts_to_float(request.window_end)
             if window_start is None and window_end is None:
-                # default: last hour (or all, whichever smaller)
-                window_start = max(0.0, time.time() - DEFAULT_WATCH_WINDOW_S)
+                # default: last ``rpc_watch_window_seconds`` (or all,
+                # whichever smaller)
+                window_start = max(
+                    0.0, time.time() - self._config.rpc_watch_window_seconds
+                )
 
             spans = await self._store.get_spans(
                 session_id, time_start=window_start, time_end=window_end
@@ -390,6 +393,7 @@ class FrontendServicerMixin:
             return
 
         meta = record.meta
+        chunk_bytes_limit = self._config.rpc_payload_chunk_bytes
         # First chunk carries the summary metadata. If summary_only, that is
         # also the last chunk.
         first = frontend_pb2.PayloadChunk(
@@ -399,7 +403,7 @@ class FrontendServicerMixin:
             summary=meta.summary,
             last=request.summary_only or len(record.bytes_) == 0,
         )
-        if not request.summary_only and len(record.bytes_) <= PAYLOAD_CHUNK_BYTES:
+        if not request.summary_only and len(record.bytes_) <= chunk_bytes_limit:
             first.chunk = record.bytes_
             first.last = True
         yield first
@@ -407,9 +411,9 @@ class FrontendServicerMixin:
             return
 
         data = record.bytes_
-        for offset in range(0, len(data), PAYLOAD_CHUNK_BYTES):
-            chunk_bytes = data[offset : offset + PAYLOAD_CHUNK_BYTES]
-            is_last = offset + PAYLOAD_CHUNK_BYTES >= len(data)
+        for offset in range(0, len(data), chunk_bytes_limit):
+            chunk_bytes = data[offset : offset + chunk_bytes_limit]
+            is_last = offset + chunk_bytes_limit >= len(data)
             yield frontend_pb2.PayloadChunk(
                 digest=meta.digest, chunk=chunk_bytes, last=is_last
             )
@@ -431,7 +435,7 @@ class FrontendServicerMixin:
         window_end = (
             ts_to_float(request.window_end) if request.HasField("window_end") else None
         )
-        limit = request.limit or DEFAULT_SPAN_TREE_LIMIT
+        limit = request.limit or self._config.rpc_span_tree_limit
 
         agent_ids = list(request.agent_ids) or [None]
         collected: list[Span] = []
@@ -525,7 +529,11 @@ class FrontendServicerMixin:
         else:
             event.kind = gf_control_pb2.CONTROL_KIND_INJECT_MESSAGE
             event.inject_message.text = request.body
-        timeout = (request.ack_timeout_ms / 1000.0) if request.ack_timeout_ms else DEFAULT_SEND_CONTROL_TIMEOUT_S
+        timeout = (
+            (request.ack_timeout_ms / 1000.0)
+            if request.ack_timeout_ms
+            else self._config.rpc_send_control_timeout_seconds
+        )
         outcome = await self._router.deliver(
             session_id=request.session_id,
             agent_id=target_agent,
@@ -572,7 +580,11 @@ class FrontendServicerMixin:
             )
             return frontend_pb2.SendControlResponse()
 
-        timeout = (request.ack_timeout_ms / 1000.0) if request.ack_timeout_ms else DEFAULT_SEND_CONTROL_TIMEOUT_S
+        timeout = (
+            (request.ack_timeout_ms / 1000.0)
+            if request.ack_timeout_ms
+            else self._config.rpc_send_control_timeout_seconds
+        )
         # Copy so the router can stamp ``id``/``issued_at`` without mutating
         # the caller's request message.
         event = gf_control_pb2.ControlEvent()

--- a/server/harmonograf_server/rpc/telemetry.py
+++ b/server/harmonograf_server/rpc/telemetry.py
@@ -49,10 +49,13 @@ class TelemetryServicer(
         self._store = store if store is not None else ingest.store
         self._bus = bus if bus is not None else ingest.bus
         self._data_dir = data_dir
-        # Held by reference so RPC handlers can read opt-in config fields
-        # (e.g. legacy_plan_attribution_window_ms) without a separate
-        # plumb through each call site. Defaults keep test construction
-        # zero-arg friendly.
+        # ``_config`` is held by reference so RPC handlers and the
+        # FrontendServicerMixin can read both opt-in fields (e.g.
+        # ``legacy_plan_attribution_window_ms``) and the harmonograf#102
+        # RPC tunables (watch window, span-tree limit, payload chunk
+        # size, control-ack timeout) without threading each knob through
+        # every call site. Tests and ad-hoc callers that omit ``config``
+        # get ``ServerConfig()`` defaults.
         self._config = config if config is not None else ServerConfig()
 
     async def StreamTelemetry(

--- a/server/tests/test_bootstrap.py
+++ b/server/tests/test_bootstrap.py
@@ -133,3 +133,189 @@ def test_cli_parser_defaults():
     assert cfg2.grpc_port == 9000
     assert cfg2.web_port == 9001
     assert cfg2.host == "0.0.0.0"
+
+
+# ---- harmonograf#102: server tunables on ServerConfig + CLI ----------
+
+def test_server_config_tunable_defaults_match_pre_refactor_module_constants():
+    """Ship the same defaults the module-level constants had before the
+    refactor — ingest/RPC behaviour must not change when nothing is
+    overridden. Guards against silent regressions in default tuning.
+    """
+    cfg = ServerConfig()
+    # ingest.py
+    assert cfg.heartbeat_timeout_seconds == 15.0
+    assert cfg.heartbeat_check_interval_seconds == 5.0
+    assert cfg.stuck_threshold_beats == 3
+    assert cfg.payload_max_bytes == 64 * 1024 * 1024
+    # rpc/frontend.py
+    assert cfg.rpc_payload_chunk_bytes == 256 * 1024
+    assert cfg.rpc_watch_window_seconds == 3600.0
+    assert cfg.rpc_span_tree_limit == 10_000
+    assert cfg.rpc_send_control_timeout_seconds == 5.0
+
+
+def test_cli_heartbeat_timeout_flag():
+    from harmonograf_server.cli import config_from_args
+
+    # Default is surfaced.
+    assert config_from_args([]).heartbeat_timeout_seconds == 15.0
+    # Override flows through to ServerConfig.
+    cfg = config_from_args(["--heartbeat-timeout-seconds", "45"])
+    assert cfg.heartbeat_timeout_seconds == 45.0
+
+
+def test_cli_payload_max_bytes_flag():
+    from harmonograf_server.cli import config_from_args
+
+    assert config_from_args([]).payload_max_bytes == 64 * 1024 * 1024
+    cfg = config_from_args(["--payload-max-bytes", "131072"])
+    assert cfg.payload_max_bytes == 131072
+
+
+def test_cli_rpc_watch_window_flag():
+    from harmonograf_server.cli import config_from_args
+
+    assert config_from_args([]).rpc_watch_window_seconds == 3600.0
+    cfg = config_from_args(["--rpc-watch-window-seconds", "7200"])
+    assert cfg.rpc_watch_window_seconds == 7200.0
+
+
+def test_cli_rpc_span_tree_limit_flag():
+    from harmonograf_server.cli import config_from_args
+
+    assert config_from_args([]).rpc_span_tree_limit == 10_000
+    cfg = config_from_args(["--rpc-span-tree-limit", "500"])
+    assert cfg.rpc_span_tree_limit == 500
+
+
+def test_server_config_heartbeat_check_interval_default_and_override():
+    # Default matches the pre-refactor module constant.
+    assert ServerConfig().heartbeat_check_interval_seconds == 5.0
+    # No CLI flag for this one — constructor-only.
+    cfg = ServerConfig(heartbeat_check_interval_seconds=1.0)
+    assert cfg.heartbeat_check_interval_seconds == 1.0
+
+
+def test_server_config_stuck_threshold_beats_default_and_override():
+    assert ServerConfig().stuck_threshold_beats == 3
+    cfg = ServerConfig(stuck_threshold_beats=5)
+    assert cfg.stuck_threshold_beats == 5
+
+
+def test_server_config_rpc_payload_chunk_bytes_default_and_override():
+    assert ServerConfig().rpc_payload_chunk_bytes == 256 * 1024
+    cfg = ServerConfig(rpc_payload_chunk_bytes=65536)
+    assert cfg.rpc_payload_chunk_bytes == 65536
+
+
+def test_server_config_rpc_send_control_timeout_default_and_override():
+    assert ServerConfig().rpc_send_control_timeout_seconds == 5.0
+    cfg = ServerConfig(rpc_send_control_timeout_seconds=10.0)
+    assert cfg.rpc_send_control_timeout_seconds == 10.0
+
+
+def test_ingest_pipeline_honors_payload_max_bytes_override():
+    """Constructor kwarg threads through to the payload assembler so
+    operators tuning ``--payload-max-bytes`` get the DoS guard they
+    asked for.
+    """
+    import asyncio
+
+    from harmonograf_server.bus import SessionBus
+    from harmonograf_server.ingest import IngestPipeline
+    from harmonograf_server.pb import telemetry_pb2
+    from harmonograf_server.storage import make_store
+
+    async def _run():
+        store = make_store("memory")
+        await store.start()
+        bus = SessionBus()
+        pipe = IngestPipeline(store, bus, payload_max_bytes=16)
+        hello = telemetry_pb2.Hello(agent_id="a1", session_id="sess_cap")
+        ctx, _ = await pipe.handle_hello(hello)
+        # First chunk fits; the second pushes us over the 16-byte cap.
+        up1 = telemetry_pb2.PayloadUpload(
+            digest="deadbeef", mime="text/plain", total_size=32, chunk=b"x" * 12
+        )
+        await pipe._handle_payload(ctx, up1)
+        up2 = telemetry_pb2.PayloadUpload(
+            digest="deadbeef", mime="text/plain", total_size=32, chunk=b"x" * 8
+        )
+        try:
+            await pipe._handle_payload(ctx, up2)
+        except ValueError as e:
+            assert "16 bytes" in str(e)
+        else:
+            raise AssertionError("expected ValueError for exceeded payload cap")
+
+    asyncio.run(_run())
+
+
+def test_ingest_pipeline_honors_stuck_threshold_override():
+    """A looser ``stuck_threshold_beats`` means the stuck flag flips
+    only after the configured number of repeats.
+    """
+    import asyncio
+
+    from harmonograf_server.bus import SessionBus
+    from harmonograf_server.ingest import IngestPipeline
+    from harmonograf_server.pb import telemetry_pb2
+    from harmonograf_server.storage import make_store
+
+    async def _run():
+        store = make_store("memory")
+        await store.start()
+        bus = SessionBus()
+        # Five identical beats required before ``is_stuck`` flips.
+        pipe = IngestPipeline(store, bus, stuck_threshold_beats=5)
+        hello = telemetry_pb2.Hello(agent_id="a1", session_id="sess_stuck")
+        ctx, _ = await pipe.handle_hello(hello)
+        # First beat seeds the baseline; ``stuck_heartbeat_count`` only
+        # increments on the SECOND identical beat. With threshold=5 we
+        # therefore need 5 identical repeats after the baseline to trip,
+        # i.e. 5 identical beats in total (baseline + 4 repeats keeps
+        # the count at 4, below 5).
+        for _ in range(5):
+            hb = telemetry_pb2.Heartbeat(progress_counter=7, current_activity="loop")
+            await pipe._handle_heartbeat(ctx, hb)
+        assert ctx.is_stuck is False  # count == 4, still < 5
+        # Sixth identical beat hits the override threshold.
+        await pipe._handle_heartbeat(
+            ctx, telemetry_pb2.Heartbeat(progress_counter=7, current_activity="loop")
+        )
+        assert ctx.is_stuck is True
+
+    asyncio.run(_run())
+
+
+def test_telemetry_servicer_uses_configured_rpc_tunables():
+    """The frontend mixin reads ``self._config.rpc_*`` — verify that
+    a ``TelemetryServicer`` constructed with a ``ServerConfig`` exposes
+    the config instance so the RPC tunables take effect.
+    """
+    from harmonograf_server.bus import SessionBus
+    from harmonograf_server.ingest import IngestPipeline
+    from harmonograf_server.rpc.telemetry import TelemetryServicer
+    from harmonograf_server.storage import make_store
+
+    store = make_store("memory")
+    bus = SessionBus()
+    ingest = IngestPipeline(store, bus)
+    cfg = ServerConfig(
+        rpc_watch_window_seconds=120.0,
+        rpc_span_tree_limit=42,
+        rpc_payload_chunk_bytes=1024,
+        rpc_send_control_timeout_seconds=9.0,
+    )
+    servicer = TelemetryServicer(ingest, data_dir="", config=cfg)
+    assert servicer._config.rpc_watch_window_seconds == 120.0
+    assert servicer._config.rpc_span_tree_limit == 42
+    assert servicer._config.rpc_payload_chunk_bytes == 1024
+    assert servicer._config.rpc_send_control_timeout_seconds == 9.0
+
+    # Back-compat: omitting ``config`` falls back to ServerConfig defaults
+    # (preserves behaviour for tests and ad-hoc callers).
+    default_servicer = TelemetryServicer(ingest, data_dir="")
+    assert default_servicer._config.rpc_watch_window_seconds == 3600.0
+    assert default_servicer._config.rpc_span_tree_limit == 10_000


### PR DESCRIPTION
## Summary

- Moves the 8 module-level tunables scattered across `server/harmonograf_server/ingest.py` (heartbeat timeout/check-interval, stuck threshold, payload cap) and `server/harmonograf_server/rpc/frontend.py` (payload chunk size, default watch window, span-tree limit, send-control timeout) into `ServerConfig` fields, following the same pattern #101 used for `legacy_plan_attribution_window_ms`.
- Exposes the 4 operationally-significant ones as CLI flags: `--heartbeat-timeout-seconds`, `--payload-max-bytes`, `--rpc-watch-window-seconds`, `--rpc-span-tree-limit`. The other 4 remain constructor-only — tests and embedders can still override them via `ServerConfig(...)`, but operators rarely touch them.
- No behaviour changes. Defaults are identical to the pre-refactor module constants; a dedicated test (`test_server_config_tunable_defaults_match_pre_refactor_module_constants`) guards against silent regressions.

## Wiring

- `IngestPipeline.__init__` gains `stuck_threshold_beats` and `payload_max_bytes` kwargs alongside the existing `heartbeat_timeout_s`. Private `_DEFAULT_*` sentinels preserve the same literal defaults for ad-hoc construction (tests that build an `IngestPipeline` without a full `ServerConfig`).
- `_PayloadAssembler` takes `max_bytes` on construction, so the DoS ceiling is per-pipeline rather than a module global.
- `TelemetryServicer` takes `config: Optional[ServerConfig] = None`; `FrontendServicerMixin` reads `self._config.rpc_*` instead of four module-level `DEFAULT_*` constants. Omitting `config` falls back to `ServerConfig()` defaults — preserves behaviour for tests.
- `Harmonograf.from_config` threads the fields into `IngestPipeline` + `TelemetryServicer`; `heartbeat_sweeper` gets `interval_s` from `cfg.heartbeat_check_interval_seconds`.

## Verification

```
$ grep -nE '^(HEARTBEAT_|PAYLOAD_MAX_BYTES|STUCK_THRESHOLD_BEATS|PAYLOAD_CHUNK_BYTES|DEFAULT_WATCH_WINDOW_S|DEFAULT_SPAN_TREE_LIMIT|DEFAULT_SEND_CONTROL_TIMEOUT_S)' \
    server/harmonograf_server/ingest.py server/harmonograf_server/rpc/frontend.py
(no output)
```

`harmonograf-server --help` shows the 4 new flags with their defaults + rationale in the help text.

## Test plan

- [x] `server/tests/test_bootstrap.py` — 12 new tests:
  - One per CLI flag (default + override): `test_cli_heartbeat_timeout_flag`, `test_cli_payload_max_bytes_flag`, `test_cli_rpc_watch_window_flag`, `test_cli_rpc_span_tree_limit_flag`.
  - One per constructor-only field: `test_server_config_heartbeat_check_interval_default_and_override`, `test_server_config_stuck_threshold_beats_default_and_override`, `test_server_config_rpc_payload_chunk_bytes_default_and_override`, `test_server_config_rpc_send_control_timeout_default_and_override`.
  - Three end-to-end behaviour checks: `test_ingest_pipeline_honors_payload_max_bytes_override` (upload a 20-byte payload against a 16-byte cap), `test_ingest_pipeline_honors_stuck_threshold_override` (threshold=5 does not flip at default=3), `test_telemetry_servicer_uses_configured_rpc_tunables`.
  - One defaults-match regression guard: `test_server_config_tunable_defaults_match_pre_refactor_module_constants`.
- [x] Full server test suite: 311 passed, 1 skipped (was 299 + 12 new).

## Docs

- [x] `docs/dev-guide/deployment.md` — new "Operational tunables" section with the full CLI->ServerConfig map and a programmatic-usage example.
- [x] `docs/dev-guide/performance-tuning.md`, `docs/dev-guide/security-model.md`, `docs/protocol/telemetry-stream.md`, `docs/protocol/payload-flow.md`, `docs/protocol/wire-ordering.md`, `docs/runbooks/task-stuck-in-running.md`, and the `.agents/skills/hgraf-tune-heartbeat/SKILL.md` skill — all references to the deleted module constants rewritten to `ServerConfig.*` names.

## Coordination

- #101 (`ServerConfig.legacy_plan_attribution_window_ms` + `--legacy-plan-attribution-window-ms`) was open-but-unmerged when this branch forked off `main`; I added my fields in distinct `ServerConfig` regions ("heartbeat + payload" and "RPC behaviour" themed blocks) to minimise text conflicts when one of the two PRs lands first. No overlap in the `cli.py` or `config_from_args` changes.