### PR TITLE
Add explicit ClientConfig; drop env-var reads from core (#105)

### DIFF
--- a/client/harmonograf_client/__init__.py
+++ b/client/harmonograf_client/__init__.py
@@ -36,6 +36,7 @@ Public surface (stable):
 from __future__ import annotations
 
 from .client import Client
+from .config import ClientConfig
 from .enums import Capability, SpanKind, SpanStatus
 from .observe import observe
 from .sink import HarmonografSink
@@ -45,6 +46,7 @@ from .transport import ControlAckSpec
 __all__ = [
     "Capability",
     "Client",
+    "ClientConfig",
     "ControlAckSpec",
     "HarmonografSink",
     "HarmonografTelemetryPlugin",

--- a/client/harmonograf_client/config.py
+++ b/client/harmonograf_client/config.py
@@ -1,0 +1,109 @@
+"""Client-side configuration.
+
+Mirrors the shape of server :class:`ServerConfig`: a plain dataclass
+constructed explicitly by callers (or via helpers that map from
+argparse / environment variables). Keeps identity and connection
+parameters off the ambient process environment so tests and embedded
+usages don't need to monkeypatch ``os.environ``.
+
+Historically two env vars sneaked into the client:
+
+- ``HARMONOGRAF_SERVER`` — transport server address, read by
+  :func:`harmonograf_client.observe`.
+- ``HARMONOGRAF_HOME`` — identity root directory, read by
+  :func:`harmonograf_client.identity._default_root`.
+
+Both are now surfaced as explicit :class:`ClientConfig` fields.
+Callers that still want the legacy env-driven behaviour can opt in via
+:meth:`ClientConfig.from_environ`; everything else should pass the
+config explicitly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional
+
+
+# The client's default transport target. Matches the server's default
+# gRPC listener (:class:`ServerConfig.grpc_port`). Exposed as a module
+# constant so tests and callers can reference it instead of hard-coding
+# the string.
+DEFAULT_SERVER_ADDR: str = "127.0.0.1:7531"
+
+
+@dataclass
+class ClientConfig:
+    """Explicit client configuration.
+
+    Attributes
+    ----------
+    server_addr:
+        Address of the harmonograf server the client connects to, in
+        ``host:port`` form (no scheme). Defaults to
+        :data:`DEFAULT_SERVER_ADDR` (``"127.0.0.1:7531"``) which matches
+        the local-dev server.
+    home_dir:
+        Local identity root — parent of the ``agents/`` directory that
+        stores persisted :class:`AgentIdentity` records. ``None`` means
+        use the platform default (``~/.harmonograf``); callers with
+        test isolation or multi-tenant needs pass an explicit
+        :class:`Path`.
+
+    Notes
+    -----
+    There's room to grow this dataclass (TLS options, bearer-token
+    mirror of :class:`ServerConfig.auth_token`, default heartbeat
+    interval, etc.). Keep the surface lean for now — adding a field
+    later is a non-breaking change, renaming one isn't.
+    """
+
+    server_addr: str = DEFAULT_SERVER_ADDR
+    home_dir: Optional[Path] = None
+
+    @classmethod
+    def from_environ(
+        cls, env: Optional[Mapping[str, str]] = None
+    ) -> "ClientConfig":
+        """Factory that reads the legacy ``HARMONOGRAF_*`` env vars.
+
+        Intended for backwards compatibility only: callers that have
+        been setting ``HARMONOGRAF_SERVER`` / ``HARMONOGRAF_HOME`` in
+        their shell / systemd unit / CI workflow can migrate by
+        replacing::
+
+            # old — implicit env read inside observe() / identity
+            observe(runner, name="agent")
+
+        with::
+
+            # new — explicit, zero ambient-env magic
+            from harmonograf_client import ClientConfig, observe
+            observe(runner, name="agent", config=ClientConfig.from_environ())
+
+        New code should construct :class:`ClientConfig` directly with
+        the values it has — ``ClientConfig(server_addr="...", ...)``.
+
+        Parameters
+        ----------
+        env:
+            Mapping to read variables from. Defaults to ``os.environ``
+            (read lazily here, not at import time, so the helper sees
+            runtime env updates). Pass an explicit dict in tests.
+
+        Returns
+        -------
+        A :class:`ClientConfig` with fields populated from the provided
+        environment, falling back to the dataclass defaults for any
+        var that's unset or empty.
+        """
+        import os
+
+        e: Mapping[str, str] = env if env is not None else os.environ
+        raw_addr = e.get("HARMONOGRAF_SERVER") or ""
+        raw_home = e.get("HARMONOGRAF_HOME") or ""
+        return cls(
+            server_addr=raw_addr or cls.server_addr,
+            home_dir=Path(raw_home).expanduser() if raw_home else None,
+        )

--- a/client/harmonograf_client/identity.py
+++ b/client/harmonograf_client/identity.py
@@ -30,9 +30,15 @@ _NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
 
 
 def _default_root() -> Path:
-    override = os.environ.get("HARMONOGRAF_HOME")
-    if override:
-        return Path(override).expanduser()
+    """Return the platform default identity root (``~/.harmonograf``).
+
+    The legacy ``HARMONOGRAF_HOME`` env var used to be consulted here
+    implicitly; as of harmonograf#105 it is read only on explicit
+    opt-in via :meth:`ClientConfig.from_environ`. Callers that want a
+    non-default root must pass it through
+    :class:`ClientConfig.home_dir` (or the legacy ``root=`` kwarg on
+    :func:`load_or_create` / :func:`identity_path`).
+    """
     return Path.home() / ".harmonograf"
 
 

--- a/client/harmonograf_client/observe.py
+++ b/client/harmonograf_client/observe.py
@@ -18,10 +18,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from typing import TYPE_CHECKING, Any
 
 from .client import Client
+from .config import ClientConfig
 from .sink import HarmonografSink
 
 if TYPE_CHECKING:
@@ -37,6 +37,7 @@ def observe(
     name: str | None = None,
     framework: str = "CUSTOM",
     server_addr: str | None = None,
+    config: ClientConfig | None = None,
     install_adk_telemetry: bool = True,
 ) -> "goldfive.Runner":
     """Attach a :class:`HarmonografSink` to ``runner`` and return it.
@@ -61,7 +62,7 @@ def observe(
     client:
         Optional pre-built :class:`Client` to reuse (e.g. shared across
         multiple runners). When omitted, a new ``Client`` is constructed
-        from ``name`` / ``framework`` / ``server_addr``.
+        from ``name`` / ``framework`` / ``config`` (or ``server_addr``).
     name:
         Client display name. Defaults to ``"agent"``. Ignored when
         ``client`` is provided.
@@ -69,10 +70,17 @@ def observe(
         Client framework tag (shown in the UI). Defaults to
         ``"CUSTOM"``. Ignored when ``client`` is provided.
     server_addr:
-        Harmonograf server address. When omitted, reads the
-        ``HARMONOGRAF_SERVER`` environment variable; falls back to
-        ``Client``'s own default (``127.0.0.1:7531``). Ignored when
-        ``client`` is provided.
+        Harmonograf server address. Takes precedence over
+        ``config.server_addr`` when both are provided. When neither is
+        given, falls back to :data:`ClientConfig.server_addr`'s default
+        (``127.0.0.1:7531``). Ignored when ``client`` is provided.
+    config:
+        Optional :class:`ClientConfig` carrying explicit server address
+        and identity root. When omitted, a default
+        :class:`ClientConfig` is used (no env reads). Pass
+        :meth:`ClientConfig.from_environ` to preserve the legacy
+        ``HARMONOGRAF_SERVER`` / ``HARMONOGRAF_HOME`` behaviour. Ignored
+        when ``client`` is provided.
     install_adk_telemetry:
         When ``True`` (default), best-effort install
         :class:`HarmonografTelemetryPlugin` on the runner so ADK
@@ -99,7 +107,6 @@ def observe(
     should share a single ``Client``+bridge pair instead.
     """
     if client is None:
-        resolved_addr = server_addr or os.environ.get("HARMONOGRAF_SERVER")
         client_kwargs: dict[str, Any] = {
             "name": name or "agent",
             "framework": framework,
@@ -113,8 +120,18 @@ def observe(
             # built ``client=`` with custom capabilities.
             "capabilities": ["STEERING", "HUMAN_IN_LOOP"],
         }
-        if resolved_addr:
-            client_kwargs["server_addr"] = resolved_addr
+        # Explicit ``server_addr`` kwarg wins over ``config.server_addr``
+        # so the pre-#105 keyword-arg ergonomics are preserved. Only
+        # forward to Client when the caller actually supplied an address
+        # somewhere — leaving the kwarg out lets :class:`Client`'s
+        # dataclass default apply, matching the legacy no-arg behaviour
+        # and keeping the test-spy surface unchanged for that path.
+        if server_addr is not None:
+            client_kwargs["server_addr"] = server_addr
+        elif config is not None:
+            client_kwargs["server_addr"] = config.server_addr
+        if config is not None and config.home_dir is not None:
+            client_kwargs["identity_root"] = str(config.home_dir)
         client = Client(**client_kwargs)
 
     sink = HarmonografSink(client)

--- a/client/tests/test_client_config.py
+++ b/client/tests/test_client_config.py
@@ -1,0 +1,252 @@
+"""Unit tests for :class:`harmonograf_client.ClientConfig`.
+
+harmonograf#105 replaced the two implicit env-var reads inside the
+client (``HARMONOGRAF_SERVER`` / ``HARMONOGRAF_HOME``) with an
+explicit :class:`ClientConfig` dataclass. These tests pin down:
+
+- Default field values.
+- The :meth:`ClientConfig.from_environ` factory: populates, falls
+  through, ignores empty strings, expands ``~``.
+- Integration with :func:`observe` — passing an explicit config routes
+  the address through to :class:`Client`.
+- Integration with identity — ``home_dir`` feeds the identity
+  persistence path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from harmonograf_client import ClientConfig, identity, observe
+from harmonograf_client.client import Client
+from harmonograf_client.config import DEFAULT_SERVER_ADDR
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+class _FakeRunner:
+    """Minimal stand-in for ``goldfive.Runner`` — same shape as
+    ``tests/test_observe.py::_FakeRunner``, duplicated here to keep the
+    config tests self-contained.
+    """
+
+    def __init__(self) -> None:
+        self.sinks: list[Any] = []
+        self._control: Any = None
+        self._close_hooks: list[Any] = []
+
+    def add_sink(self, sink: Any) -> None:
+        self.sinks.append(sink)
+
+    def add_close_hook(self, hook: Any) -> None:
+        self._close_hooks.append(hook)
+
+    @property
+    def control(self) -> Any:
+        return self._control
+
+    @control.setter
+    def control(self, value: Any) -> None:
+        self._control = value
+
+    async def close(self) -> None:
+        for hook in self._close_hooks:
+            await hook()
+
+
+# ---------------------------------------------------------------------
+# Dataclass defaults + from_environ factory
+# ---------------------------------------------------------------------
+
+
+def test_default_config_values() -> None:
+    cfg = ClientConfig()
+    assert cfg.server_addr == "127.0.0.1:7531"
+    assert cfg.server_addr == DEFAULT_SERVER_ADDR
+    assert cfg.home_dir is None
+
+
+def test_from_environ_reads_both_vars() -> None:
+    cfg = ClientConfig.from_environ(
+        {"HARMONOGRAF_SERVER": "other:9000", "HARMONOGRAF_HOME": "/tmp/x"}
+    )
+    assert cfg.server_addr == "other:9000"
+    assert cfg.home_dir == Path("/tmp/x")
+
+
+def test_from_environ_falls_through_when_vars_unset() -> None:
+    cfg = ClientConfig.from_environ({})
+    assert cfg.server_addr == DEFAULT_SERVER_ADDR
+    assert cfg.home_dir is None
+
+
+def test_from_environ_ignores_empty_strings() -> None:
+    cfg = ClientConfig.from_environ(
+        {"HARMONOGRAF_SERVER": "", "HARMONOGRAF_HOME": ""}
+    )
+    assert cfg.server_addr == DEFAULT_SERVER_ADDR
+    assert cfg.home_dir is None
+
+
+def test_from_environ_partial_population() -> None:
+    cfg = ClientConfig.from_environ({"HARMONOGRAF_SERVER": "only-addr:1"})
+    assert cfg.server_addr == "only-addr:1"
+    assert cfg.home_dir is None
+
+    cfg2 = ClientConfig.from_environ({"HARMONOGRAF_HOME": "/tmp/only-home"})
+    assert cfg2.server_addr == DEFAULT_SERVER_ADDR
+    assert cfg2.home_dir == Path("/tmp/only-home")
+
+
+def test_from_environ_expands_tilde_in_home_dir(monkeypatch) -> None:
+    # Route HOME so ``expanduser`` is deterministic under test.
+    monkeypatch.setenv("HOME", "/tmp/fake-home")
+    cfg = ClientConfig.from_environ({"HARMONOGRAF_HOME": "~/.harmonograf"})
+    assert cfg.home_dir == Path("/tmp/fake-home/.harmonograf")
+
+
+def test_from_environ_defaults_to_os_environ(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without an explicit mapping, ``from_environ`` reads ``os.environ``."""
+    monkeypatch.setenv("HARMONOGRAF_SERVER", "live.env:4242")
+    monkeypatch.delenv("HARMONOGRAF_HOME", raising=False)
+    cfg = ClientConfig.from_environ()
+    assert cfg.server_addr == "live.env:4242"
+    assert cfg.home_dir is None
+
+
+# ---------------------------------------------------------------------
+# observe() integration
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_observe_accepts_explicit_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passing a :class:`ClientConfig` with a custom ``server_addr``
+    must route that address through to the constructed :class:`Client`.
+    """
+    captured: dict[str, Any] = {}
+    original_init = Client.__init__
+
+    def spy_init(self: Client, **kwargs: Any) -> None:
+        captured.update(kwargs)
+        kwargs["_transport_factory"] = make_factory([])
+        original_init(self, **kwargs)
+
+    monkeypatch.setattr(Client, "__init__", spy_init)
+    monkeypatch.delenv("HARMONOGRAF_SERVER", raising=False)
+
+    runner = _FakeRunner()
+    observe(runner, name="cfg", config=ClientConfig(server_addr="explicit:1111"))
+
+    assert captured["server_addr"] == "explicit:1111"
+    await runner.close()
+    runner.sinks[0]._client.shutdown(flush_timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_observe_no_config_and_no_env_uses_client_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No config, no env, no server_addr => Client's own default applies
+    (server_addr kwarg omitted from Client.__init__).
+    """
+    captured: dict[str, Any] = {}
+    original_init = Client.__init__
+
+    def spy_init(self: Client, **kwargs: Any) -> None:
+        captured.update(kwargs)
+        kwargs["_transport_factory"] = make_factory([])
+        original_init(self, **kwargs)
+
+    monkeypatch.setattr(Client, "__init__", spy_init)
+    # Explicitly set the env to prove observe() does not read it.
+    monkeypatch.setenv("HARMONOGRAF_SERVER", "should.be.ignored:0")
+
+    runner = _FakeRunner()
+    observe(runner, name="default-cfg")
+
+    assert "server_addr" not in captured
+    await runner.close()
+    runner.sinks[0]._client.shutdown(flush_timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_observe_config_home_dir_feeds_identity_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``config.home_dir`` must become the Client's identity root.
+
+    Verified end-to-end: after ``observe`` returns, the on-disk identity
+    record lives under ``config.home_dir/agents/<name>.json`` and
+    nowhere else.
+    """
+    captured: dict[str, Any] = {}
+    original_init = Client.__init__
+
+    def spy_init(self: Client, **kwargs: Any) -> None:
+        captured.update(kwargs)
+        kwargs["_transport_factory"] = make_factory([])
+        original_init(self, **kwargs)
+
+    monkeypatch.setattr(Client, "__init__", spy_init)
+
+    runner = _FakeRunner()
+    cfg = ClientConfig(server_addr="x:1", home_dir=tmp_path)
+    observe(runner, name="home-agent", config=cfg)
+
+    assert captured["identity_root"] == str(tmp_path)
+    assert (tmp_path / "agents" / "home-agent.json").exists()
+
+    await runner.close()
+    runner.sinks[0]._client.shutdown(flush_timeout=0.1)
+
+
+# ---------------------------------------------------------------------
+# identity integration
+# ---------------------------------------------------------------------
+
+
+def test_identity_respects_config_home_dir(tmp_path: Path) -> None:
+    """:func:`identity.load_or_create` accepts an explicit ``root``;
+    ``ClientConfig.home_dir`` is the canonical source for that path.
+    """
+    cfg = ClientConfig(home_dir=tmp_path)
+    ident = identity.load_or_create(
+        "cfg-identity", framework="ADK", root=cfg.home_dir
+    )
+    assert ident.name == "cfg-identity"
+    assert (tmp_path / "agents" / "cfg-identity.json").exists()
+
+
+def test_identity_default_root_ignores_harmonograf_home_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: ``identity._default_root`` no longer consults
+    ``HARMONOGRAF_HOME`` — the env read moved onto
+    :meth:`ClientConfig.from_environ`.
+    """
+    monkeypatch.setenv("HARMONOGRAF_HOME", str(tmp_path))
+    assert identity._default_root() == Path.home() / ".harmonograf"
+
+
+def test_from_environ_round_trips_through_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Legacy env-driven callers can migrate by piping
+    ``ClientConfig.from_environ().home_dir`` into ``load_or_create``.
+    """
+    monkeypatch.setenv("HARMONOGRAF_HOME", str(tmp_path))
+    cfg = ClientConfig.from_environ()
+    assert cfg.home_dir == tmp_path
+    ident = identity.load_or_create(
+        "roundtrip", framework="ADK", root=cfg.home_dir
+    )
+    assert (tmp_path / "agents" / "roundtrip.json").exists()
+    assert ident.name == "roundtrip"

--- a/client/tests/test_identity.py
+++ b/client/tests/test_identity.py
@@ -65,8 +65,36 @@ def test_distinct_names_get_distinct_ids(tmp_path):
     assert a.agent_id != b.agent_id
 
 
-def test_honors_harmonograf_home_env(tmp_path, monkeypatch):
+def test_ignores_harmonograf_home_env_by_default(tmp_path, monkeypatch):
+    """Regression guard for harmonograf#105.
+
+    The implicit ``HARMONOGRAF_HOME`` read inside ``_default_root`` is
+    gone — callers that want the legacy env-driven behaviour opt in via
+    :meth:`ClientConfig.from_environ` and pass the resulting ``home_dir``
+    through as the ``root`` kwarg.
+    """
     monkeypatch.setenv("HARMONOGRAF_HOME", str(tmp_path))
-    ident = identity.load_or_create("envtest", framework="ADK")
+    # Without an explicit root, _default_root() resolves to
+    # ~/.harmonograf — NOT the env var.
+    assert identity._default_root() == (tmp_path.home() / ".harmonograf")
+
+
+def test_honors_explicit_root(tmp_path):
+    """Passing ``root=`` explicitly routes identity to that directory."""
+    ident = identity.load_or_create("roottest", framework="ADK", root=tmp_path)
+    assert (tmp_path / "agents" / "roottest.json").exists()
+    assert ident.name == "roottest"
+
+
+def test_client_config_from_environ_feeds_root(tmp_path, monkeypatch):
+    """Legacy env-driven behaviour via :meth:`ClientConfig.from_environ`."""
+    from harmonograf_client import ClientConfig
+
+    monkeypatch.setenv("HARMONOGRAF_HOME", str(tmp_path))
+    cfg = ClientConfig.from_environ()
+    assert cfg.home_dir == tmp_path
+    ident = identity.load_or_create(
+        "envtest", framework="ADK", root=cfg.home_dir
+    )
     assert (tmp_path / "agents" / "envtest.json").exists()
     assert ident.name == "envtest"

--- a/client/tests/test_observe.py
+++ b/client/tests/test_observe.py
@@ -22,7 +22,7 @@ from typing import Any
 
 import pytest
 
-from harmonograf_client import observe
+from harmonograf_client import ClientConfig, observe
 from harmonograf_client.client import Client
 from harmonograf_client.sink import HarmonografSink
 
@@ -128,6 +128,13 @@ async def test_observe_reuses_provided_client(client: Client) -> None:
 async def test_observe_respects_harmonograf_server_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Legacy env-var behaviour via explicit ``ClientConfig.from_environ``.
+
+    As of harmonograf#105 ``observe`` no longer reads
+    ``HARMONOGRAF_SERVER`` implicitly. Callers that want the legacy
+    env-driven behaviour opt in via
+    :meth:`ClientConfig.from_environ`; this test documents that path.
+    """
     captured: dict[str, Any] = {}
     original_init = Client.__init__
 
@@ -141,9 +148,97 @@ async def test_observe_respects_harmonograf_server_env(
     monkeypatch.setenv("HARMONOGRAF_SERVER", "remote.example:9999")
 
     runner = _FakeRunner()
-    observe(runner, name="env-client")
+    observe(runner, name="env-client", config=ClientConfig.from_environ())
 
     assert captured["server_addr"] == "remote.example:9999"
+    await runner.close()
+    runner.sinks[0]._client.shutdown(flush_timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_observe_ignores_harmonograf_server_env_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without an explicit config, ``HARMONOGRAF_SERVER`` is not read.
+
+    Regression guard for harmonograf#105: the implicit env read inside
+    ``observe`` is gone. The env var still exists for legacy callers
+    but they must opt in via :meth:`ClientConfig.from_environ`.
+    """
+    captured: dict[str, Any] = {}
+    original_init = Client.__init__
+
+    def spy_init(self: Client, **kwargs: Any) -> None:
+        captured.update(kwargs)
+        kwargs["_transport_factory"] = make_factory([])
+        original_init(self, **kwargs)
+
+    monkeypatch.setattr(Client, "__init__", spy_init)
+    monkeypatch.setenv("HARMONOGRAF_SERVER", "remote.example:9999")
+
+    runner = _FakeRunner()
+    observe(runner, name="no-env-read")
+
+    # No config / server_addr passed => env is NOT consulted, and the
+    # server_addr kwarg is omitted so Client's own default applies.
+    assert "server_addr" not in captured
+    await runner.close()
+    runner.sinks[0]._client.shutdown(flush_timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_observe_accepts_explicit_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passing a :class:`ClientConfig` routes its ``server_addr`` through."""
+    captured: dict[str, Any] = {}
+    original_init = Client.__init__
+
+    def spy_init(self: Client, **kwargs: Any) -> None:
+        captured.update(kwargs)
+        kwargs["_transport_factory"] = make_factory([])
+        original_init(self, **kwargs)
+
+    monkeypatch.setattr(Client, "__init__", spy_init)
+    monkeypatch.delenv("HARMONOGRAF_SERVER", raising=False)
+
+    runner = _FakeRunner()
+    observe(
+        runner,
+        name="cfg-client",
+        config=ClientConfig(server_addr="cfg.example:9000"),
+    )
+
+    assert captured["server_addr"] == "cfg.example:9000"
+    await runner.close()
+    runner.sinks[0]._client.shutdown(flush_timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_observe_explicit_server_addr_overrides_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``server_addr=`` kwarg takes precedence over ``config.server_addr``."""
+    captured: dict[str, Any] = {}
+    original_init = Client.__init__
+
+    def spy_init(self: Client, **kwargs: Any) -> None:
+        captured.update(kwargs)
+        kwargs["_transport_factory"] = make_factory([])
+        original_init(self, **kwargs)
+
+    monkeypatch.setattr(Client, "__init__", spy_init)
+    monkeypatch.delenv("HARMONOGRAF_SERVER", raising=False)
+
+    runner = _FakeRunner()
+    observe(
+        runner,
+        name="override",
+        server_addr="kwarg.example:1234",
+        config=ClientConfig(server_addr="cfg.example:9000"),
+    )
+
+    assert captured["server_addr"] == "kwarg.example:1234"
     await runner.close()
     runner.sinks[0]._client.shutdown(flush_timeout=0.1)
 

--- a/client/tests/test_transport_mock.py
+++ b/client/tests/test_transport_mock.py
@@ -206,7 +206,17 @@ def server():
 
 @pytest.fixture()
 def isolated_identity(tmp_path, monkeypatch):
-    monkeypatch.setenv("HARMONOGRAF_HOME", str(tmp_path))
+    """Isolate :func:`identity.load_or_create` to ``tmp_path``.
+
+    Pre-#105 this fixture relied on setting ``HARMONOGRAF_HOME``; the
+    implicit env read is gone, so we now monkeypatch ``_default_root``
+    directly. Tests construct :class:`Client` without passing
+    ``identity_root=``; the patched default sends all identity I/O
+    into ``tmp_path`` regardless.
+    """
+    from harmonograf_client import identity as _identity
+
+    monkeypatch.setattr(_identity, "_default_root", lambda: tmp_path)
     yield tmp_path
 
 

--- a/docs/dev-guide/client-library.md
+++ b/docs/dev-guide/client-library.md
@@ -11,6 +11,12 @@ compose.
 
 ## Recent shape changes (what this doc assumes)
 
+- **Explicit `ClientConfig` (#105).** The two legacy env-var reads
+  inside the client (`HARMONOGRAF_SERVER` / `HARMONOGRAF_HOME`) are
+  gone. Callers construct a `ClientConfig` dataclass explicitly, or —
+  if they want the legacy env-driven behaviour — opt in via
+  `ClientConfig.from_environ()`. See [Explicit configuration](#explicit-configuration-103)
+  below.
 - **Lazy Hello (#85).** The transport defers the `Hello` RPC until the
   first envelope arrives on the ring buffer. Construction no longer
   opens a stream; ghost sessions from importing the library are gone.
@@ -51,12 +57,61 @@ The public surface is deliberately narrow (from
 `client/harmonograf_client/__init__.py`):
 
 - `Client`
+- `ClientConfig`
 - `HarmonografSink`
 - `HarmonografTelemetryPlugin`
 - `ControlAckSpec`
 - `Capability`, `SpanKind`, `SpanStatus`
 
 Anything not on that list is internal — feel free to rename it.
+
+## Explicit configuration (#105)
+
+`ClientConfig` is a plain dataclass that collects the two
+instance-level knobs the client used to read from the ambient
+environment:
+
+```python
+from harmonograf_client import ClientConfig
+
+cfg = ClientConfig(
+    server_addr="prod.harmonograf.internal:7531",
+    home_dir=Path("/var/lib/myagent"),
+)
+```
+
+Both fields are optional:
+
+- `server_addr` defaults to `"127.0.0.1:7531"` — the local-dev server.
+- `home_dir` defaults to `None`, which means identity files land under
+  `~/.harmonograf/` via `identity._default_root()`. Pass an explicit
+  `Path` for multi-tenant / test-isolation scenarios.
+
+### Legacy env-driven callers
+
+Pre-#105, two env vars were consulted implicitly:
+
+| Env var | Read by | Replacement |
+|---|---|---|
+| `HARMONOGRAF_SERVER` | `observe()` | `ClientConfig.server_addr` |
+| `HARMONOGRAF_HOME` | `identity._default_root()` | `ClientConfig.home_dir` |
+
+Neither is read by the core library anymore. Callers that still want
+the legacy behaviour opt in explicitly:
+
+```python
+from harmonograf_client import ClientConfig, observe
+
+# Pick up HARMONOGRAF_SERVER / HARMONOGRAF_HOME from the process env.
+cfg = ClientConfig.from_environ()
+observe(runner, name="my-agent", config=cfg)
+```
+
+`ClientConfig.from_environ()` accepts an optional `env=` mapping for
+deterministic testing; when omitted it reads `os.environ` lazily.
+
+New code should construct `ClientConfig` with explicit values — no
+env-var indirection, no monkey-patching in tests.
 
 ## Data flow
 
@@ -103,6 +158,11 @@ from harmonograf_client import Client
 client = Client(name="researcher")                               # 127.0.0.1:7531 default
 client = Client(name="researcher", server_addr="localhost:7531") # explicit
 ```
+
+For higher-level callers (the `observe()` helper) the two knobs are
+surfaced together as a [`ClientConfig`](#explicit-configuration-103)
+dataclass so scripts don't have to thread `server_addr` and
+`identity_root` separately.
 
 Shutdown is explicit: `client.shutdown(flush_timeout=5.0)` flushes pending
 envelopes and tears down the transport.

--- a/docs/goldfive-integration.md
+++ b/docs/goldfive-integration.md
@@ -137,8 +137,25 @@ runner = harmonograf_client.observe(
 )
 ```
 
-When `server_addr` is omitted, `observe` reads `$HARMONOGRAF_SERVER` and
-otherwise falls back to `Client`'s default (`127.0.0.1:7531`).
+When neither `server_addr` nor `config` is passed, `observe` falls
+back to `Client`'s default (`127.0.0.1:7531`). As of harmonograf#105
+`$HARMONOGRAF_SERVER` is no longer read implicitly — opt in via an
+explicit `ClientConfig`:
+
+```python
+from harmonograf_client import ClientConfig
+
+# Legacy env-driven behaviour, explicit
+runner = harmonograf_client.observe(
+    goldfive.wrap(root_agent), config=ClientConfig.from_environ()
+)
+
+# Or construct directly
+runner = harmonograf_client.observe(
+    goldfive.wrap(root_agent),
+    config=ClientConfig(server_addr="remote:7531"),
+)
+```
 
 ### Composing with other sinks
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -262,13 +262,35 @@ target defaults it to `dummy` when unset; if you are running the underlying
 commands by hand, set it yourself.
 
 **The agent calls reporting tools but nothing shows up in harmonograf.**
-Verify the `HARMONOGRAF_SERVER` env var matches the server's gRPC port (`7531`
-by default). `make demo` sets this for you; if you are running the agent
-outside the Makefile target, set it explicitly:
+Verify the agent is pointed at the server's gRPC port (`7531` by default).
+Two ways:
 
-```bash
-HARMONOGRAF_SERVER=127.0.0.1:7531 uv run --extra demo adk web .demo-agents
-```
+- Python, preferred — construct a `ClientConfig` explicitly:
+
+  ```python
+  from harmonograf_client import ClientConfig, observe
+  observe(runner, name="my-agent",
+          config=ClientConfig(server_addr="127.0.0.1:7531"))
+  ```
+
+- Legacy — via the `HARMONOGRAF_SERVER` env var, with `from_environ()`
+  to opt in (no longer read implicitly as of harmonograf#105):
+
+  ```bash
+  HARMONOGRAF_SERVER=127.0.0.1:7531 uv run --extra demo adk web .demo-agents
+  ```
+
+  Code that drives `observe()` from an env-based agent needs to surface
+  the env read:
+
+  ```python
+  observe(runner, config=ClientConfig.from_environ())
+  ```
+
+  `make demo` sets the env for you and the reference agents already
+  call `from_environ()`; if you are running the agent outside the
+  Makefile target, set it yourself or migrate to explicit
+  `ClientConfig`.
 
 **Tasks appear in harmonograf but never transition past `STARTED`.**
 The agent is emitting spans but not calling `report_task_completed`. This is


### PR DESCRIPTION
## Summary

- Introduces `ClientConfig` — a dataclass collecting `server_addr` and `home_dir` — to replace two implicit env-var reads in the client library (`HARMONOGRAF_SERVER` in `observe.py`, `HARMONOGRAF_HOME` in `identity.py`).
- `observe()` now takes an optional `config: ClientConfig`; core library code no longer reads `os.environ`.
- Legacy env-driven callers opt in explicitly via `ClientConfig.from_environ()`. All remaining `os.environ` reads in the library live inside that one classmethod.
- Mirrors the shape of server-side `ServerConfig` so config surfaces feel symmetric across the two halves of the codebase.

Closes #105.

## Test plan

- [x] `make client-test` — 241 passed, 1 warning
- [x] `make server-test` — 299 passed, 1 skipped (unrelated)
- [x] `grep -rn "os.environ" client/harmonograf_client/` shows only `config.py:from_environ` (no core-path env reads)
- [x] New `test_client_config.py` covers defaults, `from_environ` variants, precedence of kwarg over config, and the `config.home_dir → Client.identity_root` integration path
- [x] Existing tests that relied on env-var magic (`test_observe`, `test_identity`, `test_transport_mock`'s `isolated_identity` fixture) updated to use explicit config
- [ ] CI: 4 jobs (server-test / client-test / frontend-test / e2e) all green