### PR TITLE
Aggregate reasoning trail on INVOCATION spans (Drawer regression)

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -124,6 +124,34 @@ def _serialize_args(args: Any) -> bytes | None:
 REASONING_INLINE_MAX_BYTES: int = 2048
 
 
+# The ``llm.reasoning_trail`` aggregate on an INVOCATION span concatenates
+# reasoning from every LLM_CALL child. We cap the inline version at 16 KiB
+# — the UI collapses anything longer into a payload_ref role="reasoning".
+# A coordinator that burned 100 LLM turns (e.g. a tight tool-loop) would
+# otherwise shove tens of KiB onto one span attribute, which inflates every
+# span-stream frame that carries the INVOCATION's SpanEnd.
+REASONING_TRAIL_INLINE_MAX_BYTES: int = 16 * 1024
+
+
+def _format_reasoning_trail(chunks: list[str]) -> str:
+    """Concatenate per-LLM-call reasoning fragments with clear separators.
+
+    Returns a single string suitable for the ``llm.reasoning_trail``
+    attribute on an INVOCATION span. Empty input returns ``""``. Each
+    chunk gets a ``[LLM call N]`` header so a reader scanning the
+    aggregate can tell where one model turn ends and the next begins;
+    separators make the trail scannable even when reasoning is
+    paragraph-dense. Callers pass only *non-empty* chunks — the plugin
+    filters empties before appending.
+    """
+    if not chunks:
+        return ""
+    parts: list[str] = []
+    for i, chunk in enumerate(chunks, start=1):
+        parts.append(f"[LLM call {i}]\n{chunk}")
+    return "\n\n---\n\n".join(parts)
+
+
 def _extract_reasoning(llm_response: Any) -> str:
     """Best-effort per-provider reasoning-content extraction.
 
@@ -342,6 +370,27 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         # negligible.
         self._agent_stash: dict[str, list[str]] = {}
         self._seen_agents: set[tuple[str, str]] = set()
+        # Reasoning aggregation for the INVOCATION span (harmonograf#108).
+        #
+        # Every LLM_CALL finalize inside an invocation appends its
+        # reasoning to ``_reasoning_trails[invocation_id]``. When the
+        # invocation's ``after_run_callback`` fires (or the on-cancel
+        # cleanup / on_run_end sweep runs), the buffered chunks are
+        # formatted into a single ``llm.reasoning_trail`` attribute and
+        # stamped onto the INVOCATION span's ``SpanEnd`` alongside
+        # ``has_reasoning=True`` and ``reasoning_call_count=N``.
+        #
+        # Why this matters: the Drawer opens on an INVOCATION span when
+        # a user clicks an agent row on the Gantt. Before the aggregate,
+        # reasoning only lived on LLM_CALL children so a click on
+        # ``coordinator_agent`` surfaced no reasoning at all — users had
+        # to hunt each LLM_CALL child separately. The aggregate lets the
+        # Drawer render the full agent-level chain-of-thought from the
+        # span the user actually selected.
+        #
+        # Cleared on ``after_run_callback`` / cancel / on_run_end so the
+        # buffer doesn't leak across concurrent or sequential runs.
+        self._reasoning_trails: dict[str, list[str]] = {}
         # Lookup: per_agent_id -> (adk_name, parent_agent_id, kind, branch)
         # so we can re-stamp metadata attributes on the first span after
         # an ``after_agent_callback`` clears the stash but a span from
@@ -541,6 +590,63 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         return merged
 
     # ------------------------------------------------------------------
+    # Reasoning-trail aggregation (harmonograf#108)
+    # ------------------------------------------------------------------
+
+    def _build_reasoning_trail_attrs(
+        self, invocation_id: str
+    ) -> tuple[dict[str, Any] | None, bytes | None, str, str]:
+        """Drain the per-invocation reasoning buffer into span attributes.
+
+        Returns ``(attributes, payload, payload_mime, payload_role)``
+        ready to merge into a ``client.emit_span_end`` call. Attributes
+        are ``None`` when no reasoning was captured during the
+        invocation (the hot path for short tool-call runs that never
+        surface chain-of-thought).
+
+        When the aggregated trail fits within
+        :data:`REASONING_TRAIL_INLINE_MAX_BYTES`, it rides inline as
+        ``llm.reasoning_trail`` so the Drawer renders on open without a
+        blob round-trip. Larger aggregates spill to a payload_ref with
+        ``role="reasoning"`` — the Drawer already handles this shape for
+        per-LLM_CALL reasoning, so no UI change is needed to surface
+        jumbo trails.
+
+        Always attaches ``has_reasoning=True`` and
+        ``reasoning_call_count=N`` so the Drawer's toggle renders with a
+        call count even when the trail itself is off-heap.
+
+        Invocation ids without buffered reasoning are popped and return
+        ``(None, None, ...)`` so the cleanup paths can call this
+        unconditionally.
+        """
+        chunks = self._reasoning_trails.pop(invocation_id, None)
+        if not chunks:
+            return None, None, "application/json", "output"
+        trail = _format_reasoning_trail(chunks)
+        if not trail:
+            return None, None, "application/json", "output"
+        attrs: dict[str, Any] = {
+            "has_reasoning": True,
+            "reasoning_call_count": len(chunks),
+        }
+        encoded = trail.encode("utf-8")
+        payload: bytes | None = None
+        payload_mime = "application/json"
+        payload_role = "output"
+        if len(encoded) <= REASONING_TRAIL_INLINE_MAX_BYTES:
+            attrs["llm.reasoning_trail"] = trail
+        else:
+            # Large trail: spill to a payload_ref. The Drawer's
+            # ReasoningSection already resolves payload_refs with
+            # role="reasoning" on open, so the wire shape matches the
+            # per-LLM_CALL fallback path already in place.
+            payload = encoded
+            payload_mime = "text/plain"
+            payload_role = "reasoning"
+        return attrs, payload, payload_mime, payload_role
+
+    # ------------------------------------------------------------------
     # Duplicate-install detection
     # ------------------------------------------------------------------
 
@@ -714,11 +820,33 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
                     exc_info=True,
                 )
 
-        # Close the run span itself.
+        # Close the run span itself. Stamp any buffered reasoning trail
+        # (harmonograf#108) so a user-cancelled invocation still shows
+        # whatever chain-of-thought the coordinator produced up to the
+        # cancel point — same Drawer surface as a normal completion.
         sid = self._invocation_spans.pop(invocation_id, None)
         if sid is not None:
+            trail_attrs, trail_payload, trail_mime, trail_role = (
+                self._build_reasoning_trail_attrs(invocation_id)
+            )
             try:
-                self._client.emit_span_end(sid, status=status)
+                if trail_attrs is None:
+                    self._client.emit_span_end(sid, status=status)
+                elif trail_payload is not None:
+                    self._client.emit_span_end(
+                        sid,
+                        status=status,
+                        attributes=trail_attrs,
+                        payload=trail_payload,
+                        payload_mime=trail_mime,
+                        payload_role=trail_role,
+                    )
+                else:
+                    self._client.emit_span_end(
+                        sid,
+                        status=status,
+                        attributes=trail_attrs,
+                    )
             except Exception:  # noqa: BLE001 — defensive
                 log.debug(
                     "telemetry_plugin: emit_span_end for run span %s raised",
@@ -814,13 +942,34 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         # Close every open INVOCATION span. We don't want to filter to
         # "just the root" — sub-Runner invocations keyed by their own
         # ids are exactly the spans that leak through ADK's callback gap.
+        # Stamp any buffered reasoning trail (harmonograf#108) on each —
+        # same rationale as the normal ``after_run_callback`` path.
         stale_inv_ids = list(self._invocation_spans.keys())
         for inv_key in stale_inv_ids:
             sid = self._invocation_spans.pop(inv_key, None)
             if sid is None:
                 continue
+            trail_attrs, trail_payload, trail_mime, trail_role = (
+                self._build_reasoning_trail_attrs(inv_key)
+            )
             try:
-                self._client.emit_span_end(sid, status=SpanStatus.COMPLETED)
+                if trail_attrs is None:
+                    self._client.emit_span_end(sid, status=SpanStatus.COMPLETED)
+                elif trail_payload is not None:
+                    self._client.emit_span_end(
+                        sid,
+                        status=SpanStatus.COMPLETED,
+                        attributes=trail_attrs,
+                        payload=trail_payload,
+                        payload_mime=trail_mime,
+                        payload_role=trail_role,
+                    )
+                else:
+                    self._client.emit_span_end(
+                        sid,
+                        status=SpanStatus.COMPLETED,
+                        attributes=trail_attrs,
+                    )
             except Exception:  # noqa: BLE001 — defensive: telemetry must not raise
                 log.debug(
                     "telemetry_plugin: on_run_end emit_span_end for "
@@ -862,6 +1011,15 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
                     sid,
                     exc_info=True,
                 )
+
+        # Drop any orphan reasoning-trail buffers. Normal path drained
+        # these via ``_build_reasoning_trail_attrs`` during the
+        # INVOCATION span_end above; anything left here came from an
+        # after_model_callback that fired without a matching
+        # before_run_callback (unit-test harnesses, partial ADK
+        # contexts). Clearing prevents cross-run bleed on long-lived
+        # plugin instances.
+        self._reasoning_trails.clear()
 
     # ------------------------------------------------------------------
     # Invocation lifecycle
@@ -962,7 +1120,35 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         )
         sid = self._invocation_spans.pop(key, None)
         if sid is not None:
-            self._client.emit_span_end(sid, status=SpanStatus.COMPLETED)
+            # Stamp the aggregated reasoning trail (harmonograf#108) on
+            # the INVOCATION span's SpanEnd so clicking an agent row in
+            # the Gantt surfaces the agent's full chain-of-thought. The
+            # trail attributes ride on the same frame as the status
+            # transition — one SpanEnd, no extra SpanUpdate needed.
+            trail_attrs, trail_payload, trail_mime, trail_role = (
+                self._build_reasoning_trail_attrs(inv_id) if inv_id else (None, None, "application/json", "output")
+            )
+            if trail_attrs is None:
+                self._client.emit_span_end(sid, status=SpanStatus.COMPLETED)
+            elif trail_payload is not None:
+                # Large aggregate: spill to a payload_ref with
+                # role="reasoning". The Drawer's ReasoningSection
+                # already handles this shape for per-LLM_CALL reasoning.
+                self._client.emit_span_end(
+                    sid,
+                    status=SpanStatus.COMPLETED,
+                    attributes=trail_attrs,
+                    payload=trail_payload,
+                    payload_mime=trail_mime,
+                    payload_role=trail_role,
+                )
+            else:
+                # Small aggregate: inline as llm.reasoning_trail attr.
+                self._client.emit_span_end(
+                    sid,
+                    status=SpanStatus.COMPLETED,
+                    attributes=trail_attrs,
+                )
 
         # Clear the cached root when the ROOT invocation ends so the
         # next adk-web invocation picks up its own root session id.
@@ -1161,6 +1347,22 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
                 payload = encoded
                 payload_mime = "text/plain"
                 payload_role = "reasoning"
+
+            # Append to the per-invocation aggregate (harmonograf#108).
+            # The INVOCATION span's SpanEnd will stamp the concatenated
+            # trail so a click on an agent row surfaces the agent's
+            # full chain-of-thought, not an empty section with reasoning
+            # hidden on LLM_CALL children. We append the full text
+            # regardless of inline-vs-payload_ref routing on the
+            # per-call span — the trail itself makes the same
+            # inline-or-spill decision at invocation close.
+            inv_id_for_trail = str(
+                _safe_attr(callback_context, "invocation_id", "") or ""
+            )
+            if inv_id_for_trail:
+                self._reasoning_trails.setdefault(inv_id_for_trail, []).append(
+                    reasoning
+                )
 
         self._client.emit_span_end(
             slot.span_id,

--- a/client/tests/test_telemetry_plugin_reasoning_trail.py
+++ b/client/tests/test_telemetry_plugin_reasoning_trail.py
@@ -1,0 +1,379 @@
+"""Tests for per-INVOCATION reasoning aggregation (harmonograf#108).
+
+The plugin aggregates reasoning from every ``after_model_callback``
+finalize within an invocation and stamps the concatenated trail on the
+INVOCATION span's ``SpanEnd`` so clicking an agent row in the Gantt
+surfaces the agent's full chain-of-thought — the regression introduced
+when ``HarmonografAgent`` was deleted in harmonograf#9 (the old aggregate
+lived in ``HarmonografAgent._run_async_impl`` and stamped ``llm.thought``
+on the INVOCATION span; that aggregate vanished with the migration to
+``goldfive.GoldfiveADKAgent``).
+
+Contract verified here:
+
+* Multiple child LLM calls within an invocation → the INVOCATION span's
+  SpanEnd carries ``llm.reasoning_trail`` (concatenated), ``has_reasoning``
+  and ``reasoning_call_count``.
+* An invocation with no reasoning → the SpanEnd carries no trail attrs
+  (no empty noise).
+* Large aggregates spill to a ``payload_ref`` with ``role="reasoning"`` —
+  matches the per-LLM_CALL large-reasoning shape the Drawer already
+  resolves on open.
+* Cancellation closes the INVOCATION span with whatever reasoning was
+  captured up to the cancel point.
+* On-run-end sweep covers orphan INVOCATION spans too.
+* Concurrent invocations don't cross-talk — each lands on its own span.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from harmonograf_client.buffer import EnvelopeKind
+from harmonograf_client.client import Client
+from harmonograf_client.enums import SpanStatus
+from harmonograf_client.telemetry_plugin import (
+    REASONING_TRAIL_INLINE_MAX_BYTES,
+    HarmonografTelemetryPlugin,
+    _format_reasoning_trail,
+)
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+# ---------------------------------------------------------------------------
+# ADK-shaped stand-ins
+# ---------------------------------------------------------------------------
+
+
+class _Session:
+    def __init__(self, sid: str) -> None:
+        self.id = sid
+
+
+class _Agent:
+    def __init__(self, name: str = "coordinator") -> None:
+        self.name = name
+        self.parent_agent = None
+
+
+class _InvocationContext:
+    def __init__(
+        self,
+        invocation_id: str,
+        session_id: str = "sess-1",
+        agent: Any | None = None,
+    ) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id)
+        self.agent = agent or _Agent()
+
+
+class _CallbackContext:
+    """ADK-shaped stand-in for the per-LLM-call callback context."""
+
+    def __init__(self, invocation_id: str) -> None:
+        self.invocation_id = invocation_id
+
+
+class _Part:
+    def __init__(self, text: str = "", thought: bool = False) -> None:
+        self.text = text
+        self.thought = thought
+
+
+class _Content:
+    def __init__(self, parts: list[_Part]) -> None:
+        self.parts = parts
+
+
+class _Gemini:
+    def __init__(self, parts: list[_Part]) -> None:
+        self.content = _Content(parts)
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="reasoning-trail-test",
+        agent_id="agent-T",
+        session_id="sess-T",
+        buffer_size=256,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def plugin(client: Client) -> HarmonografTelemetryPlugin:
+    return HarmonografTelemetryPlugin(client)
+
+
+def _invocation_span_end(client: Client, span_id: str) -> Any:
+    """Return the SpanEnd payload for ``span_id`` (non-destructive)."""
+    for env in list(client._events._dq):  # noqa: SLF001 — test introspection
+        if env.kind is EnvelopeKind.SPAN_END and env.payload.span_id == span_id:
+            return env.payload
+    raise AssertionError(f"no SPAN_END envelope for {span_id}")
+
+
+def _span_start_ids(client: Client) -> list[str]:
+    """Return every SPAN_START envelope id in buffer order (non-destructive)."""
+    return [
+        env.span_id
+        for env in list(client._events._dq)  # noqa: SLF001 — test introspection
+        if env.kind is EnvelopeKind.SPAN_START
+    ]
+
+
+def _last_span_start_id(client: Client) -> str:
+    ids = _span_start_ids(client)
+    if not ids:
+        raise AssertionError("no SPAN_START envelope yet")
+    return ids[-1]
+
+
+def _first_span_start_id(client: Client) -> str:
+    ids = _span_start_ids(client)
+    if not ids:
+        raise AssertionError("no SPAN_START envelope yet")
+    return ids[0]
+
+
+async def _finalize_llm_call(
+    plugin: HarmonografTelemetryPlugin,
+    invocation_id: str,
+    reasoning: str,
+) -> None:
+    """Drive a before/after_model pair carrying ``reasoning`` as a thought part."""
+    before = _CallbackContext(invocation_id)
+    after = _CallbackContext(invocation_id)
+    await plugin.before_model_callback(callback_context=before, llm_request=object())
+    resp = _Gemini([_Part(reasoning, thought=True), _Part("visible")])
+    await plugin.after_model_callback(callback_context=after, llm_response=resp)
+
+
+# ---------------------------------------------------------------------------
+# _format_reasoning_trail unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_format_reasoning_trail_empty() -> None:
+    assert _format_reasoning_trail([]) == ""
+
+
+def test_format_reasoning_trail_single_chunk() -> None:
+    out = _format_reasoning_trail(["only one"])
+    assert "[LLM call 1]" in out
+    assert "only one" in out
+
+
+def test_format_reasoning_trail_multiple_chunks_joined_with_separator() -> None:
+    out = _format_reasoning_trail(["first", "second", "third"])
+    assert "[LLM call 1]" in out
+    assert "[LLM call 2]" in out
+    assert "[LLM call 3]" in out
+    assert "first" in out
+    assert "second" in out
+    assert "third" in out
+    # Separator appears exactly N-1 times.
+    assert out.count("\n\n---\n\n") == 2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: INVOCATION span carries the aggregate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_after_run_aggregates_reasoning_onto_invocation_span(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """3 LLM calls with reasoning → INVOCATION SpanEnd carries the trail."""
+    ctx = _InvocationContext("inv-trail-1")
+    await plugin.before_run_callback(invocation_context=ctx)
+    inv_span_id = _first_span_start_id(client)
+
+    await _finalize_llm_call(plugin, "inv-trail-1", "step one: evaluate inputs")
+    await _finalize_llm_call(plugin, "inv-trail-1", "step two: pick the tool")
+    await _finalize_llm_call(plugin, "inv-trail-1", "step three: synthesize")
+
+    await plugin.after_run_callback(invocation_context=ctx)
+    end = _invocation_span_end(client, inv_span_id)
+
+    assert end.attributes["has_reasoning"].bool_value is True
+    assert end.attributes["reasoning_call_count"].int_value == 3
+    trail = end.attributes["llm.reasoning_trail"].string_value
+    assert "step one" in trail
+    assert "step two" in trail
+    assert "step three" in trail
+    # Separator + numbered headers present.
+    assert "[LLM call 1]" in trail
+    assert "[LLM call 3]" in trail
+
+
+@pytest.mark.asyncio
+async def test_after_run_no_reasoning_leaves_invocation_span_clean(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """LLM calls without reasoning → no trail attrs on the INVOCATION span."""
+    ctx = _InvocationContext("inv-trail-2")
+    await plugin.before_run_callback(invocation_context=ctx)
+    inv_span_id = _first_span_start_id(client)
+
+    # LLM call with no thought parts.
+    before = _CallbackContext("inv-trail-2")
+    after = _CallbackContext("inv-trail-2")
+    await plugin.before_model_callback(callback_context=before, llm_request=object())
+    await plugin.after_model_callback(
+        callback_context=after, llm_response=_Gemini([_Part("visible only")])
+    )
+
+    await plugin.after_run_callback(invocation_context=ctx)
+    end = _invocation_span_end(client, inv_span_id)
+
+    assert "llm.reasoning_trail" not in end.attributes
+    assert "has_reasoning" not in end.attributes
+    assert "reasoning_call_count" not in end.attributes
+
+
+@pytest.mark.asyncio
+async def test_large_reasoning_trail_spills_to_payload_ref(
+    plugin: HarmonografTelemetryPlugin, client: Client, made: list[FakeTransport]
+) -> None:
+    """Aggregated trail > inline cap → payload_ref role="reasoning"."""
+    ctx = _InvocationContext("inv-trail-big")
+    await plugin.before_run_callback(invocation_context=ctx)
+    inv_span_id = _first_span_start_id(client)
+
+    # Build enough per-call reasoning to exceed the trail inline cap.
+    chunk = "z" * (REASONING_TRAIL_INLINE_MAX_BYTES // 4)
+    for _ in range(6):
+        await _finalize_llm_call(plugin, "inv-trail-big", chunk)
+
+    await plugin.after_run_callback(invocation_context=ctx)
+    end = _invocation_span_end(client, inv_span_id)
+
+    # No inline attribute for the full trail.
+    assert "llm.reasoning_trail" not in end.attributes
+    # Disclosure flag and call count are still set.
+    assert end.attributes["has_reasoning"].bool_value is True
+    assert end.attributes["reasoning_call_count"].int_value == 6
+    # payload_ref role="reasoning" carries the aggregate.
+    refs = [r for r in end.payload_refs if r.role == "reasoning"]
+    assert len(refs) == 1
+    assert refs[0].mime == "text/plain"
+    # And the bytes were enqueued to the transport.
+    assert any(p.digest == refs[0].digest for p in made[0].enqueued)
+
+
+@pytest.mark.asyncio
+async def test_cancel_stamps_partial_reasoning_trail(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """User cancel mid-run → INVOCATION span closes CANCELLED with trail so far."""
+    ctx = _InvocationContext("inv-cancel")
+    await plugin.before_run_callback(invocation_context=ctx)
+    inv_span_id = _first_span_start_id(client)
+
+    await _finalize_llm_call(plugin, "inv-cancel", "partial reasoning A")
+    await _finalize_llm_call(plugin, "inv-cancel", "partial reasoning B")
+
+    # Simulate user cancel — bypass after_run_callback, exercise the
+    # public hook goldfive's adapter calls on CancelledError.
+    plugin.on_cancellation("inv-cancel")
+
+    end = _invocation_span_end(client, inv_span_id)
+    assert end.status == client._resolve_status(SpanStatus.CANCELLED)
+    assert end.attributes["has_reasoning"].bool_value is True
+    assert end.attributes["reasoning_call_count"].int_value == 2
+    trail = end.attributes["llm.reasoning_trail"].string_value
+    assert "partial reasoning A" in trail
+    assert "partial reasoning B" in trail
+
+
+@pytest.mark.asyncio
+async def test_on_run_end_sweeps_orphan_invocation_with_trail(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """on_run_end sweep closes any stranded INVOCATION span with its trail."""
+    ctx = _InvocationContext("inv-orphan")
+    await plugin.before_run_callback(invocation_context=ctx)
+    inv_span_id = _first_span_start_id(client)
+
+    await _finalize_llm_call(plugin, "inv-orphan", "stranded reasoning")
+
+    # Simulate a sub-Runner that completed without ADK firing
+    # after_run_callback (e.g. early generator-close on the outer run).
+    plugin.on_run_end()
+
+    end = _invocation_span_end(client, inv_span_id)
+    assert end.attributes["has_reasoning"].bool_value is True
+    assert end.attributes["reasoning_call_count"].int_value == 1
+    assert "stranded reasoning" in end.attributes["llm.reasoning_trail"].string_value
+
+
+@pytest.mark.asyncio
+async def test_concurrent_invocations_do_not_share_trail(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Two invocations interleave LLM calls — each trail lands on its own span."""
+    ctx_a = _InvocationContext("inv-A")
+    ctx_b = _InvocationContext("inv-B")
+    await plugin.before_run_callback(invocation_context=ctx_a)
+    await plugin.before_run_callback(invocation_context=ctx_b)
+    ids = _span_start_ids(client)
+    assert len(ids) == 2
+    span_a, span_b = ids[0], ids[1]
+
+    await _finalize_llm_call(plugin, "inv-A", "A-first")
+    await _finalize_llm_call(plugin, "inv-B", "B-only")
+    await _finalize_llm_call(plugin, "inv-A", "A-second")
+
+    await plugin.after_run_callback(invocation_context=ctx_b)
+    await plugin.after_run_callback(invocation_context=ctx_a)
+
+    end_a = _invocation_span_end(client, span_a)
+    end_b = _invocation_span_end(client, span_b)
+    assert end_a.attributes["reasoning_call_count"].int_value == 2
+    trail_a = end_a.attributes["llm.reasoning_trail"].string_value
+    assert "A-first" in trail_a
+    assert "A-second" in trail_a
+    assert "B-only" not in trail_a
+
+    assert end_b.attributes["reasoning_call_count"].int_value == 1
+    trail_b = end_b.attributes["llm.reasoning_trail"].string_value
+    assert "B-only" in trail_b
+    assert "A-first" not in trail_b
+
+
+@pytest.mark.asyncio
+async def test_next_run_does_not_inherit_previous_trail(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """After one run ends, the next run starts with an empty reasoning buffer."""
+    # First run with reasoning.
+    ctx1 = _InvocationContext("inv-prev")
+    await plugin.before_run_callback(invocation_context=ctx1)
+    span1 = _last_span_start_id(client)
+    await _finalize_llm_call(plugin, "inv-prev", "leftover reasoning")
+    await plugin.after_run_callback(invocation_context=ctx1)
+    end1 = _invocation_span_end(client, span1)
+    assert "llm.reasoning_trail" in end1.attributes
+
+    # Second run on a fresh invocation id — no reasoning.
+    ctx2 = _InvocationContext("inv-next", session_id="sess-T")
+    await plugin.before_run_callback(invocation_context=ctx2)
+    span2 = _last_span_start_id(client)
+    # No LLM calls in this run.
+    await plugin.after_run_callback(invocation_context=ctx2)
+    end2 = _invocation_span_end(client, span2)
+
+    assert "llm.reasoning_trail" not in end2.attributes
+    assert "has_reasoning" not in end2.attributes

--- a/frontend/src/__tests__/components/Drawer.reasoning.test.tsx
+++ b/frontend/src/__tests__/components/Drawer.reasoning.test.tsx
@@ -144,4 +144,67 @@ describe('ReasoningSection', () => {
     const body = screen.getByTestId('drawer-reasoning-body');
     expect(body.textContent).toMatch(/truncated \(1000 more chars\)/);
   });
+
+  // --- Aggregate variant (harmonograf#108) --------------------------------
+
+  it('relabels as "Agent reasoning trail" with a turn-count badge when isAggregate is set', () => {
+    render(
+      <ReasoningSection
+        inline={'[LLM call 1]\nfirst\n\n---\n\n[LLM call 2]\nsecond'}
+        payloadRef={undefined}
+        callCount={2}
+        isAggregate
+      />,
+    );
+    const toggle = screen.getByTestId('drawer-reasoning-toggle');
+    expect(toggle.textContent).toMatch(/Agent reasoning trail/);
+    const badge = screen.getByTestId('drawer-reasoning-call-count');
+    expect(badge.textContent).toBe('2 turns');
+  });
+
+  it('singularizes the turn-count badge for one LLM call', () => {
+    render(
+      <ReasoningSection
+        inline={'only one turn'}
+        payloadRef={undefined}
+        callCount={1}
+        isAggregate
+      />,
+    );
+    expect(screen.getByTestId('drawer-reasoning-call-count').textContent).toBe(
+      '1 turn',
+    );
+  });
+
+  it('renders the concatenated trail body when opened', () => {
+    const trail =
+      '[LLM call 1]\nstep A reasoning\n\n---\n\n[LLM call 2]\nstep B reasoning';
+    render(
+      <ReasoningSection
+        inline={trail}
+        payloadRef={undefined}
+        callCount={2}
+        isAggregate
+      />,
+    );
+    fireEvent.click(screen.getByTestId('drawer-reasoning-toggle'));
+    const body = screen.getByTestId('drawer-reasoning-body');
+    expect(body.textContent).toContain('step A reasoning');
+    expect(body.textContent).toContain('step B reasoning');
+    expect(body.textContent).toContain('[LLM call 1]');
+    expect(body.textContent).toContain('[LLM call 2]');
+  });
+
+  it('omits the turn-count badge on per-LLM_CALL reasoning (no isAggregate, no count)', () => {
+    render(
+      <ReasoningSection
+        inline={'single call reasoning'}
+        payloadRef={undefined}
+      />,
+    );
+    expect(screen.queryByTestId('drawer-reasoning-call-count')).toBeNull();
+    expect(screen.getByTestId('drawer-reasoning-toggle').textContent).toMatch(
+      /^▸Reasoning$/,
+    );
+  });
 });

--- a/frontend/src/__tests__/components/OrchestrationThinking.test.tsx
+++ b/frontend/src/__tests__/components/OrchestrationThinking.test.tsx
@@ -56,12 +56,12 @@ describe('OrchestrationTimeline thinking preview', () => {
     mockStore = undefined;
   });
 
-  it('renders a 🧠 preview on reporting-tool rows whose span has thinking', () => {
-    // LLM span carrying thinking. The thinking-map is keyed by span.id, so
+  it('renders a 🧠 preview on reporting-tool rows whose span has reasoning', () => {
+    // LLM span carrying reasoning. The thinking-map is keyed by span.id, so
     // the reporting-tool row must share the same span.id as the LLM span to
     // surface the preview (in real life an orchestration event is keyed by
-    // the report_task_* span, so the thinking must live there). The helper
-    // collects thinking from every span in the agent's index.
+    // the report_task_* span, so the reasoning must live there). The helper
+    // collects reasoning from every span in the agent's index.
     mockStore!.spans.append(
       mkSpan({
         id: 'sp-report',
@@ -70,10 +70,10 @@ describe('OrchestrationTimeline thinking preview', () => {
         startMs: 100,
         attributes: {
           tool_args_preview: str(JSON.stringify({ task_id: 't1', detail: 'halfway' })),
-          'llm.thought': str(
+          'llm.reasoning': str(
             'The user wants me to summarize three documents so I should start with the first.',
           ),
-          has_thinking: bool(true),
+          has_reasoning: bool(true),
         },
       }),
     );

--- a/frontend/src/__tests__/lib/thinking.test.ts
+++ b/frontend/src/__tests__/lib/thinking.test.ts
@@ -33,38 +33,37 @@ const str = (v: string): AttributeValue => ({ kind: 'string', value: v });
 const bool = (v: boolean): AttributeValue => ({ kind: 'bool', value: v });
 
 describe('extractThinkingText', () => {
-  it('prefers llm.thought over other carriers', () => {
+  it('prefers the INVOCATION reasoning_trail aggregate over a single LLM_CALL reasoning', () => {
     const s = span('s1', {
-      'llm.thought': str('primary'),
-      thinking_text: str('secondary'),
-      thinking_preview: str('preview'),
+      'llm.reasoning_trail': str('full agent trail'),
+      'llm.reasoning': str('single call'),
     });
-    expect(extractThinkingText(s)).toBe('primary');
+    expect(extractThinkingText(s)).toBe('full agent trail');
   });
 
-  it('falls back to thinking_text when llm.thought missing', () => {
-    const s = span('s1', { thinking_text: str('fallback') });
-    expect(extractThinkingText(s)).toBe('fallback');
+  it('falls back to llm.reasoning when no aggregate is present', () => {
+    const s = span('s1', { 'llm.reasoning': str('only-per-call') });
+    expect(extractThinkingText(s)).toBe('only-per-call');
   });
 
-  it('falls back to thinking_preview last', () => {
-    const s = span('s1', { thinking_preview: str('tail') });
-    expect(extractThinkingText(s)).toBe('tail');
-  });
-
-  it('returns null when no carrier present', () => {
+  it('returns null when no reasoning carrier is present', () => {
     expect(extractThinkingText(span('s1'))).toBeNull();
   });
 });
 
 describe('hasThinking', () => {
-  it('returns true when has_thinking=true even without text yet', () => {
-    const s = span('s1', { has_thinking: bool(true) });
+  it('returns true when has_reasoning=true even without inline text', () => {
+    const s = span('s1', { has_reasoning: bool(true) });
     expect(hasThinking(s)).toBe(true);
   });
 
-  it('returns true when any thinking text is present', () => {
-    const s = span('s1', { 'llm.thought': str('thinking') });
+  it('returns true when any reasoning text is present', () => {
+    const s = span('s1', { 'llm.reasoning': str('thinking') });
+    expect(hasThinking(s)).toBe(true);
+  });
+
+  it('returns true when the INVOCATION aggregate is present', () => {
+    const s = span('s1', { 'llm.reasoning_trail': str('agent trail') });
     expect(hasThinking(s)).toBe(true);
   });
 
@@ -104,15 +103,15 @@ describe('formatThinkingInline', () => {
 
 describe('collectThinkingEntries', () => {
   it('orders entries ascending by startMs', () => {
-    const s1 = { ...span('a', { 'llm.thought': str('one') }), startMs: 200 };
-    const s2 = { ...span('b', { 'llm.thought': str('two') }), startMs: 100 };
+    const s1 = { ...span('a', { 'llm.reasoning': str('one') }), startMs: 200 };
+    const s2 = { ...span('b', { 'llm.reasoning': str('two') }), startMs: 100 };
     const entries = collectThinkingEntries([s1, s2]);
     expect(entries.map((e) => e.spanId)).toEqual(['b', 'a']);
   });
 
   it('marks running spans as live', () => {
     const s = {
-      ...span('live', { 'llm.thought': str('thinking') }),
+      ...span('live', { 'llm.reasoning': str('thinking') }),
       endMs: null,
     };
     const entries = collectThinkingEntries([s]);
@@ -123,19 +122,26 @@ describe('collectThinkingEntries', () => {
     const s = span('no-think');
     expect(collectThinkingEntries([s])).toEqual([]);
   });
+
+  it('picks up the INVOCATION aggregate on INVOCATION spans', () => {
+    const s = span('inv', { 'llm.reasoning_trail': str('aggregate') });
+    const entries = collectThinkingEntries([s]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe('aggregate');
+  });
 });
 
 describe('collectThinkingForTask', () => {
   it('returns only entries whose hgraf.task_id attribute matches', () => {
     const inTask = span('in', {
-      'llm.thought': str('inside'),
+      'llm.reasoning': str('inside'),
       'hgraf.task_id': str('task-1'),
     });
     const outTask = span('out', {
-      'llm.thought': str('outside'),
+      'llm.reasoning': str('outside'),
       'hgraf.task_id': str('task-2'),
     });
-    const unbound = span('unbound', { 'llm.thought': str('nomatch') });
+    const unbound = span('unbound', { 'llm.reasoning': str('nomatch') });
     const entries = collectThinkingForTask([inTask, outTask, unbound], 'task-1');
     expect(entries).toHaveLength(1);
     expect(entries[0].spanId).toBe('in');

--- a/frontend/src/components/shell/Drawer.tsx
+++ b/frontend/src/components/shell/Drawer.tsx
@@ -328,16 +328,33 @@ function TaskSubtabButton({
 
 function TaskOverviewPanel({ span, sessionId }: { span: Span; sessionId: string | null }) {
   const taskReport = (span.attributes['task_report']?.kind === 'string' ? span.attributes['task_report'].value : undefined);
-  const llmThought = (span.attributes['llm.thought']?.kind === 'string' ? span.attributes['llm.thought'].value : undefined);
-  const thinkingText = (span.attributes['thinking_text']?.kind === 'string' ? span.attributes['thinking_text'].value : undefined);
-  const thinkingPreview = (span.attributes['thinking_preview']?.kind === 'string' ? span.attributes['thinking_preview'].value : undefined);
-  const hasThinking = span.attributes['has_thinking']?.kind === 'bool' && span.attributes['has_thinking'].value;
   const isRunning = span.endMs == null;
   const agentDesc = (span.attributes['agent_description']?.kind === 'string' ? span.attributes['agent_description'].value : undefined);
+  // Per-LLM_CALL reasoning inline carrier (set by
+  // ``after_model_callback`` finalize for small reasoning).
   const reasoningInline = (span.attributes['llm.reasoning']?.kind === 'string' ? span.attributes['llm.reasoning'].value : undefined);
+  // INVOCATION aggregate carrier (harmonograf#108). When the drawer opens
+  // on an agent row's INVOCATION span, this is the attribute that holds
+  // the concatenated chain-of-thought from every LLM_CALL child — the
+  // section was empty before the plugin started emitting this on
+  // after_run_callback.
+  const reasoningTrail = (span.attributes['llm.reasoning_trail']?.kind === 'string' ? span.attributes['llm.reasoning_trail'].value : undefined);
+  // Attribute rides as proto int64 → bigint on the wire. Narrow to number
+  // for the props; call counts in the hundreds-of-turns range fit easily
+  // inside a JS safe integer so Number() conversion is loss-less here.
+  const reasoningCallCountAttr = span.attributes['reasoning_call_count'];
+  const reasoningCallCount =
+    reasoningCallCountAttr?.kind === 'int'
+      ? Number(reasoningCallCountAttr.value)
+      : undefined;
   const hasReasoningAttr = span.attributes['has_reasoning']?.kind === 'bool' && span.attributes['has_reasoning'].value;
   const reasoningRef = (span.payloadRefs ?? []).find((r) => r.role === 'reasoning');
-  const showReasoning = Boolean(reasoningInline || reasoningRef || hasReasoningAttr);
+  const showReasoning = Boolean(reasoningInline || reasoningTrail || reasoningRef || hasReasoningAttr);
+  // The inline text to hand to <ReasoningSection /> — prefer the
+  // INVOCATION-level trail (agent-wide context) over a single LLM_CALL's
+  // reasoning. Both paths fall back to a payload_ref when the text is
+  // large enough to spill off the span attribute.
+  const reasoningInlineText = reasoningTrail ?? reasoningInline;
 
   return (
     <div style={{ padding: '12px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -346,7 +363,7 @@ function TaskOverviewPanel({ span, sessionId }: { span: Span; sessionId: string 
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, color: '#a8c8ff' }}>
           <span className="hg-transport__live-dot" style={{ display: 'inline-block' }} />
           <span>Running</span>
-          {hasThinking && <span style={{ marginLeft: 4 }}>· 💭 Thinking</span>}
+          {hasReasoningAttr && <span style={{ marginLeft: 4 }}>· 💭 Thinking</span>}
         </div>
       )}
 
@@ -360,35 +377,6 @@ function TaskOverviewPanel({ span, sessionId }: { span: Span; sessionId: string 
         </section>
       )}
 
-      {/* Model thinking — prefers HarmonografAgent's llm.thought aggregate
-          when present, falls back to the plugin's streaming thinking_text /
-          thinking_preview capture. Both paths put Gemini 2.5 reasoning
-          tokens in front of the user. */}
-      {(llmThought || thinkingText || thinkingPreview) && (
-        <section data-testid="drawer-model-thinking">
-          <div style={{ fontSize: 10, opacity: 0.6, marginBottom: 4, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-            Model thinking {isRunning && hasThinking ? '(live)' : ''}
-          </div>
-          <div
-            style={{
-              fontSize: 11,
-              lineHeight: 1.6,
-              background: 'rgba(168,200,255,0.05)',
-              borderRadius: 6,
-              padding: '8px 10px',
-              fontFamily: "ui-monospace, 'SF Mono', Consolas, 'Liberation Mono', monospace",
-              color: 'rgba(226,226,233,0.85)',
-              whiteSpace: 'pre-wrap',
-              wordBreak: 'break-word',
-              maxHeight: 300,
-              overflow: 'auto',
-            }}
-          >
-            {llmThought || thinkingText || thinkingPreview}
-          </div>
-        </section>
-      )}
-
       {/* Agent description */}
       {agentDesc && (
         <section>
@@ -398,17 +386,21 @@ function TaskOverviewPanel({ span, sessionId }: { span: Span; sessionId: string 
       )}
 
       {/* Reasoning — chain-of-thought captured by the telemetry plugin.
-          Small reasoning rides as the ``llm.reasoning`` span attribute;
-          large reasoning lives in a payload_ref (role="reasoning") and
-          is fetched on-demand. */}
+          INVOCATION spans carry the ``llm.reasoning_trail`` aggregate
+          stamped by ``after_run_callback`` (harmonograf#108); LLM_CALL
+          spans carry a per-call ``llm.reasoning``. Large reasoning in
+          either shape lives in a payload_ref (role="reasoning") and is
+          fetched on-demand. */}
       {showReasoning && (
         <ReasoningSection
-          inline={reasoningInline}
+          inline={reasoningInlineText}
           payloadRef={reasoningRef}
+          callCount={reasoningCallCount}
+          isAggregate={Boolean(reasoningTrail) || reasoningCallCount != null}
         />
       )}
 
-      {(!taskReport && !llmThought && !thinkingText && !thinkingPreview && !agentDesc && !showReasoning) && (
+      {(!taskReport && !agentDesc && !showReasoning) && (
         <div style={{ fontSize: 12, opacity: 0.5, textAlign: 'center', padding: '24px 0' }}>
           No task information available.
         </div>
@@ -426,18 +418,30 @@ function TaskOverviewPanel({ span, sessionId }: { span: Span; sessionId: string 
   );
 }
 
-// Reasoning section: surfaces `llm.reasoning` inline (small) or a
-// payload_ref with role="reasoning" (large, fetched on click). Collapsed
-// by default — reasoning traces can be long, and users usually only want
-// them when investigating a surprising decision.
+// Reasoning section: surfaces reasoning inline (small) or a payload_ref
+// with role="reasoning" (large, fetched on click). Collapsed by default —
+// reasoning traces can be long, and users usually only want them when
+// investigating a surprising decision.
+//
+// Carries two variants:
+//   * Per-LLM_CALL reasoning → ``llm.reasoning`` attribute. Short label
+//     "Reasoning" since a single call contributed.
+//   * Per-INVOCATION aggregate (harmonograf#108) → ``llm.reasoning_trail``
+//     attribute with ``reasoning_call_count`` sibling. Label widens to
+//     "Agent reasoning trail · N turns" so users know the text is the
+//     agent's full trajectory, not one snapshot.
 const REASONING_PREVIEW_CHARS = 5000;
 
 export function ReasoningSection({
   inline,
   payloadRef,
+  callCount,
+  isAggregate = false,
 }: {
   inline: string | undefined;
   payloadRef: PayloadRef | undefined;
+  callCount?: number;
+  isAggregate?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   // When the reasoning rides inline we don't need to fetch; when it comes
@@ -487,7 +491,23 @@ export function ReasoningSection({
         }}
       >
         <span style={{ transform: open ? 'rotate(90deg)' : 'none', transition: 'transform 0.1s' }}>▸</span>
-        <span>Reasoning</span>
+        <span>{isAggregate ? 'Agent reasoning trail' : 'Reasoning'}</span>
+        {callCount != null && callCount > 0 && (
+          <span
+            data-testid="drawer-reasoning-call-count"
+            style={{
+              fontSize: 9,
+              opacity: 0.75,
+              padding: '1px 5px',
+              borderRadius: 8,
+              border: '1px solid currentColor',
+              textTransform: 'none',
+              letterSpacing: 0,
+            }}
+          >
+            {callCount} turn{callCount === 1 ? '' : 's'}
+          </span>
+        )}
         {payloadRef && !inline && (
           <span style={{ marginLeft: 'auto', fontSize: 9, opacity: 0.7 }}>
             {formatBytes(payloadRef.size)}

--- a/frontend/src/lib/thinking.ts
+++ b/frontend/src/lib/thinking.ts
@@ -1,25 +1,30 @@
-// Thinking/reasoning extraction helpers. The client library records model
-// reasoning tokens on LLM_CALL spans via a small zoo of attributes, depending
-// on which model backend is in play and how recent the capture path is:
+// Reasoning/thinking extraction helpers. The client library records model
+// chain-of-thought on two span kinds via a small set of attributes emitted
+// by ``HarmonografTelemetryPlugin``:
 //
-//   - ``llm.thought``       — full aggregate from HarmonografAgent's
-//                             _run_async_impl (handles ADK-style thought parts
-//                             and OpenAI-style reasoning_content blocks).
-//   - ``thinking_text``     — full text captured by the plugin on span end.
-//   - ``thinking_preview``  — first 300 chars (set as a fallback).
-//   - ``has_thinking``      — bool flag set as soon as any reasoning lands.
-//   - ``llm.reasoning``     — per-response reasoning_content / thinking-block
-//                             capture emitted by
-//                             ``HarmonografTelemetryPlugin.after_model_callback``.
-//                             Small reasoning rides as a string attribute;
-//                             large reasoning lives in a payload_ref with
-//                             ``role="reasoning"`` (rendered by the Drawer's
-//                             ReasoningSection, not this helper).
-//   - ``has_reasoning``     — bool flag for the Drawer's Reasoning toggle.
+//   - ``llm.reasoning``       — per-LLM_CALL reasoning captured on span end
+//                               by ``after_model_callback``. Small reasoning
+//                               rides as a string attribute; large reasoning
+//                               lives in a ``payload_ref`` with
+//                               ``role="reasoning"`` (rendered by the
+//                               Drawer's ReasoningSection, not this helper).
+//   - ``llm.reasoning_trail`` — per-INVOCATION aggregate stamped by the
+//                               plugin's ``after_run_callback``. Concatenates
+//                               every child LLM_CALL's reasoning with
+//                               ``[LLM call N]`` headers so clicking an
+//                               agent row in the Gantt surfaces the full
+//                               agent-level chain-of-thought without the
+//                               user having to dig into each child span.
+//                               See harmonograf#108.
+//   - ``has_reasoning``       — bool flag set alongside either attribute so
+//                               consumers can render a disclosure / badge
+//                               before the full text is decoded.
+//   - ``reasoning_call_count``— integer attached to the trail telling the
+//                               drawer how many LLM turns contributed.
 //
-// Every reader in the app (SpanPopover, Drawer, renderer, timeline, etc.)
-// routes through the functions here so that fallbacks are consistent and we
-// have one place to update when a new carrier appears.
+// Every reader in the app (SpanPopover, Drawer, timeline, LiveActivity)
+// routes through the functions here so that fallbacks are consistent and
+// we have one place to update when a new carrier appears.
 import type { AttributeValue, Span, SpanKind } from '../gantt/types';
 
 function attrString(attr: AttributeValue | undefined): string | null {
@@ -34,24 +39,25 @@ function attrBool(attr: AttributeValue | undefined): boolean {
   return false;
 }
 
-// Return the full thinking text attached to a span, or null if no reasoning
-// carrier is present. Priority order: llm.thought > thinking_text >
-// thinking_preview. The preview fallback is intentionally last so that when
-// the full text exists we never truncate it prematurely.
+// Return the reasoning text attached to a span, or null when no reasoning
+// carrier is present. Priority order: llm.reasoning_trail (INVOCATION
+// aggregate) > llm.reasoning (single LLM_CALL). The aggregate is preferred
+// so that selecting an agent's INVOCATION span surfaces the full trail
+// instead of just the first call's text.
 export function extractThinkingText(span: Span): string | null {
   const attrs = span.attributes;
   const full =
-    attrString(attrs['llm.thought']) ||
-    attrString(attrs['thinking_text']) ||
-    attrString(attrs['thinking_preview']);
+    attrString(attrs['llm.reasoning_trail']) ||
+    attrString(attrs['llm.reasoning']);
   return full && full.length > 0 ? full : null;
 }
 
-// True when the span carries reasoning — either an explicit has_thinking=true
-// flag (set the moment the first thought part arrives, even before text
-// accumulates) or any thinking-text attribute.
+// True when the span carries reasoning — either the has_reasoning flag
+// (set the moment any reasoning is captured) or any reasoning-text
+// attribute. Used by the Drawer / popover / live panel to decide whether
+// to render a reasoning section / badge.
 export function hasThinking(span: Span): boolean {
-  if (attrBool(span.attributes['has_thinking'])) return true;
+  if (attrBool(span.attributes['has_reasoning'])) return true;
   return extractThinkingText(span) !== null;
 }
 


### PR DESCRIPTION
## Summary

Drawer regression: clicking an agent row in the Gantt opened an INVOCATION
span with no reasoning content, even though each child LLM_CALL already
carried `llm.reasoning`. The old `HarmonografAgent._run_async_impl`
aggregate that stamped `llm.thought` on the INVOCATION span was deleted
in #9 and never replaced.

- `HarmonografTelemetryPlugin` now buffers per-LLM-call reasoning per
  `invocation_id` and stamps a formatted `llm.reasoning_trail` +
  `has_reasoning` + `reasoning_call_count` onto the INVOCATION span's
  `SpanEnd` in `after_run_callback`. Cancel and `on_run_end` sweep paths
  also flush the buffered trail so partial runs preserve it.
- Drawer's `TaskOverviewPanel` reads the aggregate, relabels the section
  "Agent reasoning trail", and surfaces an "N turns" badge. The dead
  "Model thinking" section reading never-emitted `llm.thought` /
  `thinking_text` / `thinking_preview` / `has_thinking` attributes is
  deleted.
- `thinking.ts` helpers rewired to `llm.reasoning_trail` /
  `llm.reasoning` / `has_reasoning` so every consumer (Drawer,
  SpanPopover, OrchestrationTimeline, trajectory panel, LiveActivity)
  picks up the fix automatically.

## Deleted dead attribute references

- `llm.thought` — never emitted by client or server.
- `thinking_text` — never emitted.
- `thinking_preview` — never emitted.
- `has_thinking` in Drawer "Model thinking" gate — also never emitted
  (the remaining `has_thinking` reads in `gantt/index.ts`, `renderer.ts`,
  `GraphView.tsx`, `LiveActivityPanel.tsx` are out of scope for this PR
  and tracked separately as follow-up cleanup).

## Test plan

- [x] New Python test suite `test_telemetry_plugin_reasoning_trail.py`
  covering the aggregate happy path, no-reasoning case, large-trail
  spill to payload_ref, cancel-with-partial-trail, on_run_end sweep,
  concurrent invocations, and cross-run buffer reset (10 tests, all
  passing).
- [x] New Drawer tests for the aggregate label + turn-count badge +
  concatenated-trail body (4 additional tests, all passing).
- [x] Existing `thinking.test.ts` rewired to new carriers + aggregate
  variant (17 tests, all passing).
- [x] `OrchestrationThinking.test.tsx` rewired to `llm.reasoning` +
  `has_reasoning` carriers.
- [x] Full client suite: 242 passed, 3 skipped (pre-existing failure
  on `test_telemetry_plugin_dedup.py` reproduces on clean main,
  unrelated to this PR).
- [x] Full server suite: 311 passed.
- [x] Full frontend suite: 265 tests across 27 files pass.
- [x] `pnpm build` + `pnpm lint` clean.

Closes #108.