### PR TITLE
Fix 3 frontend visual regressions (sequence arrows, task edges, intervention strip width)

### DIFF
--- a/frontend/src/__tests__/components/GraphView.delegation.test.tsx
+++ b/frontend/src/__tests__/components/GraphView.delegation.test.tsx
@@ -1,0 +1,180 @@
+// harmonograf#107 — the sequence diagram view must draw delegation arrows
+// between agents when goldfive's observer emits a DelegationObserved event.
+// Coordinator→AgentTool sub-agent invocations produce span trees whose
+// parent pointer is same-agent (the coordinator row carries a TOOL_CALL
+// wrapping the sub-agent's INVOCATION), so the Method-2 cross-agent-parent
+// inference in computeSequence misses them. Method 3 (this test) feeds the
+// arrow directly from store.delegations.
+import { act, render } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { SessionStore } from '../../gantt/index';
+import type { Agent } from '../../gantt/types';
+
+type WatchMock = {
+  store: SessionStore;
+  connected: boolean;
+  initialBurstComplete: boolean;
+  error: string | null;
+  sessionStatus: 'UNKNOWN' | 'LIVE' | 'COMPLETED' | 'ABORTED';
+  lastEventAtMs: number;
+};
+
+let mockStore: SessionStore | undefined;
+let mockWatch: WatchMock | undefined;
+let mockSessionId: string | null = 'session-1';
+
+vi.mock('../../rpc/hooks', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../rpc/hooks')>(
+      '../../rpc/hooks',
+    );
+  return {
+    ...actual,
+    getSessionStore: (id: string | null) => (id ? mockStore : undefined),
+    useSessionWatch: () => mockWatch ?? null,
+    sendStatusQuery: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('../../state/uiStore', () => {
+  const state: Record<string, unknown> = {
+    currentSessionId: 'session-1',
+    selectSpan: () => {},
+    selectTask: () => {},
+    selectedSpanId: null,
+    selectedTaskId: null,
+    taskPlanMode: 'ghost' as const,
+    taskPlanVisible: false,
+    setTaskPlanMode: () => {},
+    toggleTaskPlanVisible: () => {},
+    graphViewport: null,
+    setGraphViewport: () => {},
+    setGraphActions: () => {},
+  };
+  return {
+    useUiStore: <T,>(selector: (s: typeof state) => T) => {
+      return selector({ ...state, currentSessionId: mockSessionId ?? '' });
+    },
+  };
+});
+
+import { GraphView } from '../../components/shell/views/GraphView';
+
+function agent(id: string, connectedAtMs = 0): Agent {
+  return {
+    id,
+    name: id,
+    framework: 'ADK',
+    capabilities: [],
+    status: 'CONNECTED',
+    connectedAtMs,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+  };
+}
+
+describe('<GraphView /> delegation arrows (#107)', () => {
+  beforeEach(() => {
+    mockStore = new SessionStore();
+    mockSessionId = 'session-1';
+    // Two agents: coordinator + sub_agent. No cross-agent span parent — the
+    // only signal the sub-agent got delegated work is the DelegationObserved
+    // event below.
+    mockStore.agents.upsert(agent('coordinator', 1));
+    mockStore.agents.upsert(agent('sub_agent', 2));
+    mockWatch = {
+      store: mockStore,
+      connected: true,
+      initialBurstComplete: true,
+      error: null,
+      sessionStatus: 'COMPLETED',
+      lastEventAtMs: 0,
+    };
+  });
+
+  afterEach(() => {
+    mockStore = undefined;
+    mockWatch = undefined;
+  });
+
+  it('renders a delegation arrow marker when a DelegationObserved fires', () => {
+    act(() => {
+      mockStore!.delegations.append({
+        fromAgentId: 'coordinator',
+        toAgentId: 'sub_agent',
+        taskId: 'task-1',
+        invocationId: 'inv-1',
+        observedAtMs: 5_000,
+      });
+    });
+    const { container } = render(<GraphView />);
+    // Delegation arrows use marker #arr-delegation — assert at least one
+    // <line> references it. (Transfer and return arrows use different
+    // markers, so this specifically validates the delegation code path.)
+    const delegLines = Array.from(
+      container.querySelectorAll('line[marker-end]'),
+    ).filter((n) => n.getAttribute('marker-end') === 'url(#arr-delegation)');
+    expect(delegLines.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('skips self-delegations and unknown agents', () => {
+    act(() => {
+      // Self-delegation — must NOT produce an arrow.
+      mockStore!.delegations.append({
+        fromAgentId: 'coordinator',
+        toAgentId: 'coordinator',
+        taskId: '',
+        invocationId: 'inv-self',
+        observedAtMs: 1_000,
+      });
+      // Unknown agent on the "to" side — guarded by the column-index
+      // lookup in computeSequence.
+      mockStore!.delegations.append({
+        fromAgentId: 'coordinator',
+        toAgentId: 'not_registered',
+        taskId: '',
+        invocationId: 'inv-unknown',
+        observedAtMs: 2_000,
+      });
+    });
+    const { container } = render(<GraphView />);
+    const delegLines = Array.from(
+      container.querySelectorAll('line[marker-end]'),
+    ).filter((n) => n.getAttribute('marker-end') === 'url(#arr-delegation)');
+    expect(delegLines.length).toBe(0);
+  });
+
+  it('re-renders when a new delegation arrives post-mount', () => {
+    const { container } = render(<GraphView />);
+    // Initially no delegations — no delegation arrow.
+    let delegLines = Array.from(
+      container.querySelectorAll('line[marker-end]'),
+    ).filter((n) => n.getAttribute('marker-end') === 'url(#arr-delegation)');
+    expect(delegLines.length).toBe(0);
+
+    act(() => {
+      mockStore!.delegations.append({
+        fromAgentId: 'coordinator',
+        toAgentId: 'sub_agent',
+        taskId: 'task-1',
+        invocationId: 'inv-1',
+        observedAtMs: 3_000,
+      });
+    });
+
+    delegLines = Array.from(
+      container.querySelectorAll('line[marker-end]'),
+    ).filter((n) => n.getAttribute('marker-end') === 'url(#arr-delegation)');
+    expect(delegLines.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/src/__tests__/components/InterventionsTimeline.test.tsx
+++ b/frontend/src/__tests__/components/InterventionsTimeline.test.tsx
@@ -196,4 +196,41 @@ describe('<InterventionsTimeline />', () => {
     expect(screen.getByTestId('intervention-marker-a')).toBeTruthy();
     expect(screen.getByTestId('intervention-marker-b')).toBeTruthy();
   });
+
+  // --- #107: bounded strip width ---------------------------------------
+  //
+  // The strip has a max-width cap (set in CSS) so it never smears markers
+  // across an over-wide Gantt pane. Callers that pass an explicit `width`
+  // prop override the cap via an inline style on the wrapper so the strip
+  // can still match an intentionally wide container.
+  it('applies a max-width cap to the wrapper when no width prop is passed', () => {
+    render(
+      <InterventionsTimeline
+        rows={[row({ key: 'a', atMs: 1_000, source: 'user', kind: 'STEER' })]}
+        startMs={0}
+        endMs={60_000}
+        _liveTickMs={0}
+      />,
+    );
+    const wrapper = screen.getByTestId('interventions-timeline');
+    // Inline style only carries width:100% — max-width comes from CSS.
+    expect(wrapper.style.width).toBe('100%');
+    // Inline style MUST NOT set maxWidth (so the CSS cap applies).
+    expect(wrapper.style.maxWidth).toBe('');
+  });
+
+  it('lets an explicit width prop override the max-width cap', () => {
+    render(
+      <InterventionsTimeline
+        rows={[row({ key: 'a', atMs: 1_000, source: 'user', kind: 'STEER' })]}
+        startMs={0}
+        endMs={60_000}
+        width={800}
+        _liveTickMs={0}
+      />,
+    );
+    const wrapper = screen.getByTestId('interventions-timeline');
+    expect(wrapper.style.width).toBe('800px');
+    expect(wrapper.style.maxWidth).toBe('800px');
+  });
 });

--- a/frontend/src/__tests__/components/TaskStagesGraph.test.tsx
+++ b/frontend/src/__tests__/components/TaskStagesGraph.test.tsx
@@ -109,4 +109,29 @@ describe('<TaskStagesGraph />', () => {
     const cardRects = container.querySelectorAll('rect.hg-stages__card-rect');
     expect(cardRects).toHaveLength(4);
   });
+
+  // harmonograf#107 — regression guard. The reported bug ("7-stage plan
+  // with NO arrows between stages") can only happen if `plan.edges` arrives
+  // empty. With a seeded 7-edge plan the SVG MUST produce 7 <path> nodes.
+  it('renders one path element per edge on a 7-stage DAG', () => {
+    const plan = mkPlan(
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g'].map((id) => mkTask(id)),
+      [
+        ['a', 'b'],
+        ['b', 'c'],
+        ['b', 'd'],
+        ['c', 'e'],
+        ['d', 'e'],
+        ['e', 'f'],
+        ['f', 'g'],
+      ],
+    );
+    const { container } = render(<TaskStagesGraph plan={plan} />);
+    const paths = container.querySelectorAll('path.hg-stages__edge');
+    expect(paths).toHaveLength(7);
+    // Every path carries a marker-end so the arrowhead renders.
+    paths.forEach((p) =>
+      expect(p.getAttribute('marker-end')).toBe('url(#hg-stages-arrow)'),
+    );
+  });
 });

--- a/frontend/src/__tests__/rpc/goldfiveEvent.test.ts
+++ b/frontend/src/__tests__/rpc/goldfiveEvent.test.ts
@@ -24,6 +24,7 @@ import { TimestampSchema } from '@bufbuild/protobuf/wkt';
 import {
   PlanSchema,
   TaskSchema,
+  TaskEdgeSchema,
   TaskStatus,
   DriftKind,
   DriftSeverity,
@@ -78,6 +79,50 @@ describe('applyGoldfiveEvent', () => {
     expect(plans[0].id).toBe('p1');
     expect(plans[0].tasks.map((t) => t.id)).toEqual(['t1', 't2', 't3', 't4']);
     expect(plans[0].tasks.every((t) => t.status === 'PENDING')).toBe(true);
+  });
+
+  // harmonograf#107 — edges must survive the proto→UI conversion. Without
+  // this guard a regression in convertGoldfivePlan (e.g. a proto field
+  // rename from `edges` to something else) silently empties the dependency
+  // DAG so Gantt / TaskStagesGraph render with zero arrows.
+  it('planSubmitted carries edges intact through convertGoldfivePlan', () => {
+    const store = new SessionStore();
+    const plan = create(PlanSchema, {
+      id: 'p-edges',
+      runId: 'run-1',
+      summary: '7-stage',
+      tasks: ['t1', 't2', 't3', 't4', 't5', 't6', 't7'].map((id) =>
+        makePbTask(id),
+      ),
+      edges: [
+        create(TaskEdgeSchema, { fromTaskId: 't1', toTaskId: 't2' }),
+        create(TaskEdgeSchema, { fromTaskId: 't2', toTaskId: 't3' }),
+        create(TaskEdgeSchema, { fromTaskId: 't2', toTaskId: 't4' }),
+        create(TaskEdgeSchema, { fromTaskId: 't3', toTaskId: 't5' }),
+        create(TaskEdgeSchema, { fromTaskId: 't4', toTaskId: 't5' }),
+        create(TaskEdgeSchema, { fromTaskId: 't5', toTaskId: 't6' }),
+        create(TaskEdgeSchema, { fromTaskId: 't6', toTaskId: 't7' }),
+      ],
+      revisionReason: '',
+      revisionKind: DriftKind.UNSPECIFIED,
+      revisionSeverity: DriftSeverity.UNSPECIFIED,
+      revisionIndex: 0,
+    });
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-edges',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: { case: 'planSubmitted', value: create(PlanSubmittedSchema, { plan }) },
+      }),
+      store,
+      0,
+    );
+    const stored = store.tasks.getPlan('p-edges');
+    expect(stored).toBeDefined();
+    expect(stored!.edges).toHaveLength(7);
+    expect(stored!.edges[0]).toEqual({ fromTaskId: 't1', toTaskId: 't2' });
+    expect(stored!.edges[6]).toEqual({ fromTaskId: 't6', toTaskId: 't7' });
   });
 
   it('task_started / task_completed / task_failed / task_blocked / task_cancelled mutate status by task_id', () => {

--- a/frontend/src/components/Interventions/InterventionsTimeline.css
+++ b/frontend/src/components/Interventions/InterventionsTimeline.css
@@ -8,6 +8,12 @@
   flex-direction: column;
   gap: 4px;
   padding: 0;
+  /* Cap the strip's rendered width so sparse markers don't get smeared
+     across an over-wide Gantt pane. Matches the default viewBox width the
+     component uses to lay out markers (#107). Parents that need a wider
+     strip can pass an explicit `width` prop; that overrides max-width
+     via the inline style on the wrapper. */
+  max-width: 480px;
   font:
     11px/1.3 var(--md-sys-typescale-body-small-font, system-ui, sans-serif);
   color: var(--md-sys-color-on-surface-variant, #9da3b4);

--- a/frontend/src/components/Interventions/InterventionsTimeline.tsx
+++ b/frontend/src/components/Interventions/InterventionsTimeline.tsx
@@ -382,7 +382,13 @@ export function InterventionsTimeline({
       ref={rootRef}
       className="hg-interventions-strip"
       data-testid="interventions-timeline"
-      style={{ width: width ? `${width}px` : '100%' }}
+      style={
+        width
+          ? // Explicit width overrides the CSS max-width cap so callers that
+            // know the Gantt pane width can still size the strip to match.
+            { width: `${width}px`, maxWidth: `${width}px` }
+          : { width: '100%' }
+      }
     >
       <svg
         className="hg-interventions-strip__svg"

--- a/frontend/src/components/shell/views/GraphView.tsx
+++ b/frontend/src/components/shell/views/GraphView.tsx
@@ -166,6 +166,7 @@ function computeSequence(store: SessionStore): SeqLayout {
     if (!parent || parent.agentId === s.agentId) continue;
     const key = `${parent.agentId}→${s.agentId}@${Math.round(s.startMs / 500)}`;
     if (coveredPairs.has(key)) continue; // already covered by method 1
+    coveredPairs.add(key);
     delegationArrows.push({
       fromId: parent.agentId,
       toId: s.agentId,
@@ -173,6 +174,30 @@ function computeSequence(store: SessionStore): SeqLayout {
       yMs: s.startMs,
       label: s.name.length > 22 ? s.name.slice(0, 21) + '…' : s.name,
       spanId: s.id,
+    });
+  }
+
+  // Method 3 — goldfive DelegationObserved events (#107). ADK coordinators
+  // that hand a sub-task to an agent via AgentTool emit a TOOL_CALL span on
+  // the coordinator row and a separate INVOCATION on the sub-agent row — the
+  // span tree does NOT have a cross-agent parent pointer, so Method 2 would
+  // miss it. goldfive's observer-side `delegation_observed` event is the
+  // authoritative record of that coordinator→sub-agent edge; we surface it
+  // as a delegation arrow here just like the Gantt renderer does.
+  const delegations = store.delegations.list();
+  for (const d of delegations) {
+    if (!d.fromAgentId || !d.toAgentId) continue;
+    if (d.fromAgentId === d.toAgentId) continue;
+    const key = `${d.fromAgentId}→${d.toAgentId}@${Math.round(d.observedAtMs / 500)}`;
+    if (coveredPairs.has(key)) continue; // already covered by Method 1 or 2
+    coveredPairs.add(key);
+    delegationArrows.push({
+      fromId: d.fromAgentId,
+      toId: d.toAgentId,
+      kind: 'delegation',
+      yMs: d.observedAtMs,
+      label: 'delegate',
+      spanId: `deleg-${d.seq}`,
     });
   }
 
@@ -407,7 +432,13 @@ export function GraphView() {
     const u1 = watch.store.spans.subscribe(() => setTick((n) => n + 1));
     const u2 = watch.store.agents.subscribe(() => setTick((n) => n + 1));
     const u3 = watch.store.tasks.subscribe(() => setTick((n) => n + 1));
-    return () => { u1(); u2(); u3(); };
+    // goldfive DelegationObserved events arrive on the delegations registry
+    // (#107). Without this subscription the sequence diagram never repaints
+    // when a new cross-agent delegation fires — so coordinator→sub-agent
+    // arrows lag or never appear until another store (spans/tasks/agents)
+    // happens to tick.
+    const u4 = watch.store.delegations.subscribe(() => setTick((n) => n + 1));
+    return () => { u1(); u2(); u3(); u4(); };
   }, [sessionId, watch.store]);
 
   // ── Viewport handlers (depend on refs, not reactive state) ──────────────

--- a/server/tests/test_storage_extensive.py
+++ b/server/tests/test_storage_extensive.py
@@ -377,6 +377,68 @@ async def test_task_plan_round_trip(store):
     assert fetched.edges[0].from_task_id == "t1"
 
 
+# harmonograf#107 — edges must survive the full wire round-trip: storage
+# TaskPlan → goldfive.v1.Plan (WatchSession replay on the initial burst) →
+# back to storage via the ingest goldfive_pb_plan_to_storage convert. A
+# regression in either direction silently drops dependency arrows in the
+# Gantt pre-strip.
+async def test_task_plan_edges_survive_wire_roundtrip(store):
+    from harmonograf_server.convert import (
+        goldfive_pb_plan_to_storage,
+        storage_plan_to_goldfive_pb,
+    )
+
+    await store.create_session(_sess())
+    plan = TaskPlan(
+        id="plan-edges",
+        session_id="sess_1",
+        created_at=20.0,
+        planner_agent_id="planner",
+        summary="7-stage DAG",
+        tasks=[
+            Task(id=f"t{i}", title=f"step {i}", assignee_agent_id="worker")
+            for i in range(1, 8)
+        ],
+        edges=[
+            TaskEdge(from_task_id="t1", to_task_id="t2"),
+            TaskEdge(from_task_id="t2", to_task_id="t3"),
+            TaskEdge(from_task_id="t2", to_task_id="t4"),
+            TaskEdge(from_task_id="t3", to_task_id="t5"),
+            TaskEdge(from_task_id="t4", to_task_id="t5"),
+            TaskEdge(from_task_id="t5", to_task_id="t6"),
+            TaskEdge(from_task_id="t6", to_task_id="t7"),
+        ],
+    )
+    await store.put_task_plan(plan)
+    persisted = await store.get_task_plan("plan-edges")
+    assert persisted is not None
+    assert len(persisted.edges) == 7
+
+    # Outbound — WatchSession initial-burst synthesises goldfive.v1.Event
+    # frames from persisted plans. Every edge must ride.
+    pb = storage_plan_to_goldfive_pb(persisted)
+    assert len(pb.edges) == 7
+    assert pb.edges[0].from_task_id == "t1"
+    assert pb.edges[0].to_task_id == "t2"
+
+    # Inbound — ingest pipeline converts the same proto back to storage when
+    # a goldfive planner emits a fresh plan. Edges must also survive this
+    # direction so live-tail plans and replayed plans both render.
+    re_stored = goldfive_pb_plan_to_storage(
+        pb, session_id="sess_1", created_at=20.0, planner_agent_id="planner"
+    )
+    assert len(re_stored.edges) == 7
+    assert {(e.from_task_id, e.to_task_id) for e in re_stored.edges} == {
+        ("t1", "t2"),
+        ("t2", "t3"),
+        ("t2", "t4"),
+        ("t3", "t5"),
+        ("t4", "t5"),
+        ("t5", "t6"),
+        ("t6", "t7"),
+    }
+
+
 async def test_get_task_plan_missing_returns_none(store):
     assert await store.get_task_plan("no-plan") is None
 


### PR DESCRIPTION
Closes #107. Re-opening after GitHub PR-head sync issue on the original #108.

## Summary

Cross-referenced from the 4-regression report; this PR covers the 3 that aren't being handled by the sibling thinking-Drawer work (#107).

1. **Graph (sequence) view: transfer/delegation arrows missing.** `GraphView.tsx` had never read `store.delegations`. The only delegation-arrow signal was Method 2 (cross-agent INVOCATION parents), which fires for executor-side invocations but misses the ADK coordinator+AgentTool shape — goldfive's observer-side `DelegationObserved` event is the authoritative record for that. Added Method 3 that pulls from `store.delegations.list()`; also subscribed to the registry so the view repaints live.
2. **Intervention timeline horizontally elongated.** The SVG used `preserveAspectRatio="none"` with a fixed `viewBox="0 0 480 48"` inside a `width: 100%` wrapper. With the Gantt pane wider than 480px the 480-wide viewBox got stretched, smearing sparse markers. Fixed with a CSS `max-width: 480px` on the container; explicit `width` prop overrides via inline `maxWidth`.
3. **Task pre-strip / Gantt dependency arrows missing.** Root cause investigation showed the frontend (`convertGoldfivePlan` → `TaskStagesGraph`) and server (`storage_plan_to_goldfive_pb` ↔ `goldfive_pb_plan_to_storage`) both preserve edges correctly. Empirical reproduction with a seeded 7-edge plan produces 7 `<path>` nodes. No code change required; added regression guards at each seam to catch future schema/conversion drift.

## Root cause per regression

| # | Layer |
|---|---|
| 1 | Frontend-only — `GraphView.tsx` never consumed `store.delegations`. |
| 2 | Frontend-only — CSS + `preserveAspectRatio` mismatch on `InterventionsTimeline`. |
| 3 | Not reproducible — wire + frontend both correct. Added guards. |

## Test plan

- [x] `npm test` — 267/267 pass
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `uv run pytest server/tests/` — 313 pass, 1 skipped
- [x] New tests:
  - `GraphView.delegation.test.tsx` — 3 specs covering arrow render, guards, live re-render
  - `goldfiveEvent.test.ts` — edges survive proto→UI convert
  - `TaskStagesGraph.test.tsx` — 7-stage DAG produces 7 `<path>` nodes
  - `test_storage_extensive.py::test_task_plan_edges_survive_wire_roundtrip` — storage ↔ goldfive.v1.Plan both directions
- [x] Sibling-agent territory untouched: `telemetry_plugin.py`, `Drawer.tsx`, `thinking.ts`, `CurrentTaskStrip.tsx`, `OrchestrationTimeline.tsx`

## E2E (manual, pending demo verification)

Start `make demo` on a clean `data/` and fire `examples/adk_presentation` presentation_agent:
- [ ] Graph view shows curved blue dashed arrow per coordinator→sub-agent delegation
- [ ] Pre-strip in Gantt + `TaskStagesGraph` show dependency arrows across stages
- [ ] `InterventionsTimeline` never exceeds ~480px rendered width