### PR TITLE
Fix 5-layer observability regression: kind_string, goldfive_events, span_links, duplicate INVOCATION, agent-id resolution (closes #113)

### DIFF
--- a/client/harmonograf_client/client.py
+++ b/client/harmonograf_client/client.py
@@ -418,7 +418,16 @@ class Client:
         enum_val = getattr(types_pb2, f"SPAN_KIND_{name}", None)
         if enum_val is None:
             return types_pb2.SPAN_KIND_CUSTOM, name
-        return enum_val, ""
+        # Stamp the string label on every span — both known enum values
+        # and CUSTOM kinds. The server stores ``kind_string`` on the
+        # ``spans`` row; historically only CUSTOM kinds set it (the
+        # enum-known branch returned ""), which left ``kind_string``
+        # NULL for every INVOCATION / LLM_CALL / TOOL_CALL span and
+        # broke SQL filters / exports keyed on that column. Populating
+        # it consistently makes the column a reliable denormalized
+        # mirror of the enum for DB consumers, without any change to
+        # the wire shape (kind_string was already a field on the proto).
+        return enum_val, name
 
     def _resolve_status(self, status: str | SpanStatus) -> int:
         types_pb2 = self._types_pb2

--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -370,6 +370,43 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         # negligible.
         self._agent_stash: dict[str, list[str]] = {}
         self._seen_agents: set[tuple[str, str]] = set()
+
+        # harmonograf#113: nested-Runner invocation aliasing.
+        #
+        # ``goldfive.wrap`` produces a :class:`GoldfiveADKAgent` whose
+        # ``_run_async_impl`` drives an internal :class:`InMemoryRunner`
+        # around the user's real root agent. Under adk-web, ADK fires
+        # ``before_run_callback`` TWICE for the SAME root agent — once
+        # for the outer adk-web Runner (over ``GoldfiveADKAgent``),
+        # once for goldfive's inner Runner (over the actual
+        # coordinator). ``GoldfiveADKAgent`` copies its inner's
+        # ``name`` through (so both invocations report the same
+        # per-agent id from the plugin's POV) but the OUTER
+        # invocation produces no LLM calls of its own — only the
+        # inner does — so the outer INVOCATION span is a pure duplicate
+        # wrapper that:
+        #   * fragments the Gantt coordinator row into two identical
+        #     bars,
+        #   * confuses Drawer span selection (outer has no reasoning
+        #     trail; inner carries the full chain-of-thought),
+        #   * and on user cancel mid-run leaks as ``status=RUNNING``
+        #     because ``on_cancellation`` closes only one of the two
+        #     invocation ids.
+        #
+        # We detect the wrapper agent by class name
+        # (``GoldfiveADKAgent`` or any subclass whose bases include
+        # it) and short-circuit: no span opens, ``_invocation_spans``
+        # skips the entry, and LLM calls — which all arrive from the
+        # inner invocation_id — route to the inner's span unchanged.
+        # Cancellation on the outer invocation_id becomes a harmless
+        # no-op (no span to close); cancellation on the inner closes
+        # the real span normally.
+        #
+        # Class-name detection instead of ``isinstance`` avoids a hard
+        # dependency on goldfive from the client — the plugin stays
+        # installable in an environment that doesn't ship goldfive at
+        # all.
+        self._goldfive_wrapper_invocations: set[str] = set()
         # Reasoning aggregation for the INVOCATION span (harmonograf#108).
         #
         # Every LLM_CALL finalize inside an invocation appends its
@@ -1025,6 +1062,27 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     # Invocation lifecycle
     # ------------------------------------------------------------------
 
+    def _is_goldfive_wrapper_agent(self, agent: Any) -> bool:
+        """Return True when ``agent`` is a goldfive.wrap wrapper agent.
+
+        Walks ``type(agent).__mro__`` and looks for a class named
+        ``GoldfiveADKAgent``. Matches the runtime class under
+        ``goldfive.adapters.adk_wrap`` without importing goldfive — the
+        client must stay installable in environments that ship only
+        ADK (no goldfive). Returns False on any lookup failure so
+        telemetry degrades to the pre-fix behaviour (duplicate
+        INVOCATION spans) rather than raising.
+        """
+        if agent is None:
+            return False
+        try:
+            for cls in type(agent).__mro__:
+                if cls.__name__ == "GoldfiveADKAgent":
+                    return True
+        except Exception:  # noqa: BLE001 — defensive
+            return False
+        return False
+
     async def before_run_callback(self, *, invocation_context: Any) -> None:
         if self._maybe_disable_as_duplicate(invocation_context):
             return
@@ -1068,6 +1126,14 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
                         exc_info=True,
                     )
 
+        # Goldfive.wrap nested-Runner detection (harmonograf#113).
+        # Skip the wrapper agent's INVOCATION entirely — see the
+        # docstring on ``_goldfive_wrapper_invocations`` for why.
+        if self._is_goldfive_wrapper_agent(agent):
+            if inv_id:
+                self._goldfive_wrapper_invocations.add(inv_id)
+            return
+
         attrs: dict[str, Any] = {}
         if inv_id:
             attrs["adk.invocation_id"] = inv_id
@@ -1096,6 +1162,14 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         if self._maybe_disable_as_duplicate(invocation_context):
             return
         inv_id = str(_safe_attr(invocation_context, "invocation_id", "") or "")
+        # Goldfive.wrap wrapper short-circuit (harmonograf#113). The
+        # matching ``before_run_callback`` opened no span for this
+        # invocation_id, so this after_run is a no-op. Dropping the
+        # tracking flag keeps the set from growing unbounded across
+        # many sequential runs.
+        if inv_id and inv_id in self._goldfive_wrapper_invocations:
+            self._goldfive_wrapper_invocations.discard(inv_id)
+            return
         # Close any model-call spans that never saw a non-partial
         # finalize (error paths, client disconnect mid-stream). Without
         # this sweep such spans would leak forever.

--- a/client/tests/test_client_api.py
+++ b/client/tests/test_client_api.py
@@ -102,6 +102,27 @@ class TestEmitSpanStart:
         env = _drain(client)[0]
         assert env.payload.span.kind_string == "WEIRD_KIND"
 
+    def test_known_enum_kind_also_stamps_kind_string(self, client):
+        """harmonograf#113: ``kind_string`` rides on every span.
+
+        Before the fix, ``_resolve_kind`` returned ``""`` whenever the
+        kind resolved to a known enum value, which left the storage
+        ``spans.kind_string`` column NULL for every INVOCATION /
+        LLM_CALL / TOOL_CALL span. That broke SQL filters / exports
+        keyed on the column. Populating it consistently for known
+        kinds matches the CUSTOM-kind shape and gives DB consumers a
+        reliable string label without needing to decode the enum.
+        """
+        client.emit_span_start(kind="LLM_CALL", name="m1")
+        client.emit_span_start(kind="TOOL_CALL", name="t1")
+        client.emit_span_start(kind="INVOCATION", name="i1")
+        envs = _drain(client)
+        assert [e.payload.span.kind_string for e in envs] == [
+            "LLM_CALL",
+            "TOOL_CALL",
+            "INVOCATION",
+        ]
+
     def test_attributes_are_typed(self, client):
         client.emit_span_start(
             kind="TOOL_CALL",

--- a/client/tests/test_telemetry_plugin_goldfive_wrap.py
+++ b/client/tests/test_telemetry_plugin_goldfive_wrap.py
@@ -1,0 +1,192 @@
+"""Regression tests for the goldfive.wrap wrapper-agent detection path.
+
+Under ``goldfive.wrap``, ADK fires ``before_run_callback`` TWICE for
+the same logical agent:
+
+1. The outer adk-web Runner fires it against ``GoldfiveADKAgent``,
+   whose ``_run_async_impl`` delegates to goldfive's internal
+   ``InMemoryRunner`` around the user's real root agent.
+2. goldfive's inner Runner then fires it against the real root agent.
+
+``GoldfiveADKAgent`` copies its inner's ``name`` through, so from the
+plugin's perspective both invocations look like the same agent. Before
+harmonograf#113, this produced two INVOCATION spans on the same
+coordinator row — the outer one leaked as RUNNING on user cancel
+(``on_cancellation`` only closes one of the two invocation_ids) and
+confused Drawer span selection because the OUTER span has no LLM
+children (all real work happens inside the inner).
+
+The fix detects ``GoldfiveADKAgent`` via class name
+(``type(agent).__mro__``) and skips the wrapper's INVOCATION entirely
+— no span opens, ``after_run`` is a no-op, and the inner Runner's
+spans carry the full chain-of-thought.
+
+Class-name detection (instead of ``isinstance``) keeps the client
+installable in environments that don't ship goldfive at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from harmonograf_client.buffer import EnvelopeKind
+from harmonograf_client.client import Client
+from harmonograf_client.telemetry_plugin import HarmonografTelemetryPlugin
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+class _Session:
+    def __init__(self, sid: str) -> None:
+        self.id = sid
+
+
+class _RealAgent:
+    """Stands in for the user's real root agent (coordinator_agent)."""
+
+    def __init__(self, name: str = "coordinator_agent") -> None:
+        self.name = name
+
+
+class GoldfiveADKAgent(_RealAgent):
+    """Class-name-matching stand-in for the real wrapper.
+
+    Only the class name matters for the detection path; the runtime
+    object's behaviour is irrelevant. We subclass ``_RealAgent`` so
+    the fake ``ctx.agent.name`` still resolves to the inner's name,
+    matching the production wrapper that propagates ``name`` through.
+    """
+
+    pass
+
+
+class _InvocationContext:
+    def __init__(self, invocation_id: str, agent: Any) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session("sess-wrap")
+        self.agent = agent
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="test",
+        session_id="home-sess",
+        buffer_size=64,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def plugin(client: Client) -> HarmonografTelemetryPlugin:
+    return HarmonografTelemetryPlugin(client)
+
+
+def _span_starts(client: Client) -> list[Any]:
+    return [
+        env.payload.span
+        for env in client._events.drain()
+        if env.kind is EnvelopeKind.SPAN_START
+    ]
+
+
+@pytest.mark.asyncio
+async def test_wrapper_before_run_opens_no_span(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    wrapper = GoldfiveADKAgent()
+    ctx = _InvocationContext("inv-outer", wrapper)
+    await plugin.before_run_callback(invocation_context=ctx)
+    # No INVOCATION span was emitted.
+    assert _span_starts(client) == []
+    # Wrapper invocation is tracked so after_run can short-circuit.
+    assert "inv-outer" in plugin._goldfive_wrapper_invocations
+
+
+@pytest.mark.asyncio
+async def test_wrapper_after_run_is_noop(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    wrapper = GoldfiveADKAgent()
+    ctx = _InvocationContext("inv-outer", wrapper)
+    await plugin.before_run_callback(invocation_context=ctx)
+    await plugin.after_run_callback(invocation_context=ctx)
+    # after_run drops the tracking flag cleanly.
+    assert "inv-outer" not in plugin._goldfive_wrapper_invocations
+    # No SpanEnd envelope — nothing to close.
+    ends = [
+        env
+        for env in client._events.drain()
+        if env.kind is EnvelopeKind.SPAN_END
+    ]
+    assert ends == []
+
+
+@pytest.mark.asyncio
+async def test_real_agent_before_run_still_opens_span(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Non-wrapper agent — the common case — still emits an INVOCATION."""
+    real = _RealAgent()
+    ctx = _InvocationContext("inv-inner", real)
+    await plugin.before_run_callback(invocation_context=ctx)
+    starts = _span_starts(client)
+    assert len(starts) == 1
+    assert starts[0].name == "coordinator_agent"
+
+
+@pytest.mark.asyncio
+async def test_wrap_then_inner_emits_exactly_one_span(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """End-to-end: outer wrapper fires, then inner real agent fires.
+
+    The outer should be skipped and the inner should produce the only
+    INVOCATION — matching the ``coordinator_agent`` row the Gantt
+    should show with a single bar.
+    """
+    wrapper = GoldfiveADKAgent()
+    real = _RealAgent()
+    outer_ctx = _InvocationContext("inv-outer", wrapper)
+    inner_ctx = _InvocationContext("inv-inner", real)
+
+    await plugin.before_run_callback(invocation_context=outer_ctx)
+    await plugin.before_run_callback(invocation_context=inner_ctx)
+
+    starts = _span_starts(client)
+    assert len(starts) == 1, (
+        f"expected one INVOCATION span, got {len(starts)} — wrapper was "
+        "not short-circuited"
+    )
+
+
+@pytest.mark.asyncio
+async def test_wrapper_cancel_is_noop(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """``on_cancellation`` on a wrapper invocation must not raise.
+
+    The inner real agent's cancellation path closes the only
+    INVOCATION span that actually exists; the wrapper's ``on_cancel``
+    is a harmless no-op.
+    """
+    wrapper = GoldfiveADKAgent()
+    ctx = _InvocationContext("inv-outer", wrapper)
+    await plugin.before_run_callback(invocation_context=ctx)
+    # Should not raise:
+    plugin.on_cancellation("inv-outer")
+    # Still tracked (cancel doesn't unregister the wrapper flag — that
+    # happens on after_run) but no span existed to be closed.
+    ends = [
+        env
+        for env in client._events.drain()
+        if env.kind is EnvelopeKind.SPAN_END
+    ]
+    assert ends == []

--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -44,6 +44,7 @@ from harmonograf_server.storage import (
     Agent,
     AgentStatus,
     Framework,
+    GoldfiveEventRecord,
     Session,
     SessionStatus,
     SpanKind,
@@ -777,6 +778,40 @@ class IngestPipeline:
             sequence,
             kind,
         )
+        # Persist the event envelope verbatim before dispatch. Writes
+        # are idempotent on (session_id, run_id, sequence); a reconnect
+        # replay or duplicate delivery is safe. The bus fan-out below
+        # still runs so live subscribers see the event immediately —
+        # persistence is additive. See harmonograf#113.
+        if kind is not None and run_id:
+            try:
+                raw_bytes = event.SerializeToString()
+            except Exception as exc:  # noqa: BLE001 — proto edge cases
+                logger.debug(
+                    "goldfive event serialize failed session_id=%s kind=%s: %s",
+                    target_ctx.session_id,
+                    kind,
+                    exc,
+                )
+                raw_bytes = b""
+            try:
+                await self._store.append_goldfive_event(
+                    GoldfiveEventRecord(
+                        session_id=target_ctx.session_id,
+                        run_id=run_id,
+                        sequence=int(sequence),
+                        kind=kind,
+                        recorded_at=self._now(),
+                        payload_bytes=raw_bytes,
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001 — defensive: ingest must not raise
+                logger.debug(
+                    "goldfive event persist failed session_id=%s kind=%s: %s",
+                    target_ctx.session_id,
+                    kind,
+                    exc,
+                )
         if kind == "run_started":
             await self._on_run_started(target_ctx, event.run_started, run_id)
         elif kind == "goal_derived":
@@ -812,7 +847,7 @@ class IngestPipeline:
                 target_ctx, event.agent_invocation_completed, run_id
             )
         elif kind == "delegation_observed":
-            self._on_delegation_observed(target_ctx, event.delegation_observed, run_id)
+            await self._on_delegation_observed(target_ctx, event.delegation_observed, run_id)
         else:
             logger.debug(
                 "ignoring unknown goldfive event payload kind=%s on session_id=%s",
@@ -917,6 +952,37 @@ class IngestPipeline:
             created_at=created_at,
             planner_agent_id=ctx.agent_id,
         )
+        # Resolve each task's ``assignee_agent_id`` to a canonical
+        # agent-row id registered on this session (harmonograf#113).
+        # Goldfive planners emit the bare ADK agent name
+        # (``"coordinator_agent"``) while the harmonograf telemetry
+        # plugin registers per-ADK-agent rows with a compound id
+        # (``"<client_agent_id>:coordinator_agent"`` per harmonograf#74).
+        # Frontend surfaces that match task.assigneeAgentId against
+        # the registered agents list (GraphView pre-strip / ghost,
+        # Gantt task→agent lookup) silently fail under that mismatch,
+        # leaving the Plans checkbox toggling a no-op overlay and the
+        # Gantt pre-strip column empty despite valid plan data being
+        # in the DB. Resolving here lets downstream consumers keep
+        # their straightforward equality checks.
+        for task in stored.tasks:
+            bare = task.assignee_agent_id
+            if not bare:
+                continue
+            resolved = await self._store.find_agent_id_by_name(
+                ctx.session_id, bare
+            )
+            if resolved and resolved != bare:
+                task.assignee_agent_id = resolved
+        # Similarly resolve the planner_agent_id off the plan itself
+        # so the PlanRevisionBanner's "planner: X" attribution lands
+        # on a known agent row.
+        if stored.planner_agent_id:
+            resolved_planner = await self._store.find_agent_id_by_name(
+                ctx.session_id, stored.planner_agent_id
+            )
+            if resolved_planner and resolved_planner != stored.planner_agent_id:
+                stored.planner_agent_id = resolved_planner
         stored = await self._store.put_task_plan(stored)
         # Refresh the task index for span-to-task binding lookups on the
         # hot path. A re-emitted plan with the same id replaces previous
@@ -1252,17 +1318,47 @@ class IngestPipeline:
             completed_at=completed_at,
         )
 
-    def _on_delegation_observed(
+    async def _on_delegation_observed(
         self, ctx: StreamContext, payload: Any, run_id: str
     ) -> None:
         observed_at: Optional[float] = None
         if payload.HasField("observed_at"):
             observed_at = ts_to_float(payload.observed_at)
+        # Resolve from/to bare ADK names onto canonical agent-row ids
+        # (harmonograf#113). DelegationObserved events are emitted by
+        # goldfive's registry dispatch with the ADK agent.name strings,
+        # but the frontend's delegation arrow path matches fromAgentId
+        # / toAgentId against the registered agents list, which carries
+        # the telemetry-plugin's compound id format
+        # ``<client_id>:<adk_name>``. Without resolution the arrow's
+        # endpoint rows can't be found on the Gantt and the edge
+        # silently drops to nothing. Fall back to the raw name when no
+        # row is registered yet (rare race: DelegationObserved landing
+        # before the delegating agent's first span).
+        resolved_from = payload.from_agent
+        resolved_to = payload.to_agent
+        try:
+            f_id = await self._store.find_agent_id_by_name(
+                ctx.session_id, payload.from_agent
+            )
+            if f_id:
+                resolved_from = f_id
+            t_id = await self._store.find_agent_id_by_name(
+                ctx.session_id, payload.to_agent
+            )
+            if t_id:
+                resolved_to = t_id
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.debug(
+                "delegation agent resolve failed session_id=%s: %s",
+                ctx.session_id,
+                exc,
+            )
         self._bus.publish_delegation_observed(
             ctx.session_id,
             run_id,
-            from_agent=payload.from_agent,
-            to_agent=payload.to_agent,
+            from_agent=resolved_from,
+            to_agent=resolved_to,
             task_id=payload.task_id,
             invocation_id=payload.invocation_id,
             observed_at=observed_at,

--- a/server/harmonograf_server/storage/__init__.py
+++ b/server/harmonograf_server/storage/__init__.py
@@ -22,10 +22,12 @@ from harmonograf_server.storage.base import (
     TaskPlan,
     TaskStatus,
     ContextWindowSample,
+    GoldfiveEventRecord,
 )
 from harmonograf_server.storage.factory import make_store
 
 __all__ = [
+    "GoldfiveEventRecord",
     "Store",
     "Session",
     "Agent",

--- a/server/harmonograf_server/storage/base.py
+++ b/server/harmonograf_server/storage/base.py
@@ -215,6 +215,40 @@ class ContextWindowSample:
 
 
 @dataclass
+class GoldfiveEventRecord:
+    """Persisted record of one ``goldfive.v1.Event`` envelope.
+
+    The ingest pipeline fans goldfive events out to the SessionBus for
+    live subscribers but historically never wrote them to disk — the
+    Gantt / Trajectory views would repopulate on reconnect from the
+    derived ``task_plans`` / ``tasks`` / annotations tables, but the
+    raw event stream (DelegationObserved, PlanSubmitted, PlanRevised,
+    DriftDetected, AgentInvocationStarted/Completed, TaskStarted/
+    Progress/Completed/Failed/Blocked/Cancelled, RunStarted/Completed/
+    Aborted, GoalDerived) had nowhere to land. That broke forensic
+    replay of delegation edges / drift markers in the frontend after a
+    server restart and made post-hoc analysis impossible.
+
+    Schema kept deliberately narrow: the wire payload is stored
+    verbatim as bytes (``payload_bytes``) so the server doesn't have
+    to keep a parallel dataclass per payload variant; ``kind`` /
+    ``run_id`` / ``sequence`` are denormalized for the common "give me
+    every drift this session saw" query path. A server restart can
+    re-emit events onto the bus on WatchSession initial burst without
+    re-parsing the raw payload if the frontend doesn't need it —
+    the mirror registries (``delegations``, ``drifts``) are already
+    reconstructed from this row's kind-specific columns.
+    """
+
+    session_id: str
+    run_id: str
+    kind: str
+    sequence: int
+    recorded_at: float
+    payload_bytes: bytes = b""
+
+
+@dataclass
 class Stats:
     session_count: int
     agent_count: int
@@ -406,6 +440,39 @@ class Store(ABC):
         agent_id: Optional[str] = None,
         limit_per_agent: int = 200,
     ) -> list[ContextWindowSample]: ...
+
+    # goldfive events -----------------------------------------------------
+    @abstractmethod
+    async def append_goldfive_event(
+        self, record: GoldfiveEventRecord
+    ) -> None: ...
+
+    @abstractmethod
+    async def list_goldfive_events(
+        self,
+        session_id: str,
+        *,
+        kind: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list[GoldfiveEventRecord]: ...
+
+    # agent lookup helpers ------------------------------------------------
+    @abstractmethod
+    async def find_agent_id_by_name(
+        self, session_id: str, name: str
+    ) -> Optional[str]:
+        """Return the stored ``agents.id`` for the given (session, ADK name) or None.
+
+        Supports bug #113 — plans emit ``assignee_agent_id`` using the
+        bare ADK agent name (e.g. ``"coordinator_agent"``), but the
+        telemetry plugin registers agents with a per-ADK-agent id
+        (e.g. ``"<client_id>:coordinator_agent"``). Ingest calls this
+        to rewrite the plan's ``assignee_agent_id`` onto the canonical
+        per-ADK-agent id before storage so the frontend's agent-id
+        equality checks resolve. Returns None when no agent row
+        matches — caller keeps the bare name (degraded path).
+        """
+        ...
 
     # stats ----------------------------------------------------------------
     @abstractmethod

--- a/server/harmonograf_server/storage/memory.py
+++ b/server/harmonograf_server/storage/memory.py
@@ -29,6 +29,7 @@ from harmonograf_server.storage.base import (
     TaskPlan,
     TaskStatus,
     ContextWindowSample,
+    GoldfiveEventRecord,
 )
 
 
@@ -46,6 +47,11 @@ class InMemoryStore(Store):
         self._task_plans: dict[str, TaskPlan] = {}
         # session_id -> agent_id -> list[ContextWindowSample] (append-only).
         self._ctx_samples: dict[str, dict[str, list[ContextWindowSample]]] = {}
+        # session_id -> list[GoldfiveEventRecord] (append-only, in wire order).
+        # Keyed-by-tuple dedup is layered on top via ``_seen_gf_events``
+        # to match sqlite's PRIMARY KEY semantics under reconnect replay.
+        self._gf_events: dict[str, list[GoldfiveEventRecord]] = {}
+        self._seen_gf_events: set[tuple[str, str, int]] = set()
 
     async def start(self) -> None:
         return None
@@ -457,6 +463,57 @@ class InMemoryStore(Store):
                     out.extend(copy.deepcopy(s) for s in lst[-limit:])
             out.sort(key=lambda s: (s.agent_id, s.recorded_at))
             return out
+
+    async def append_goldfive_event(
+        self, record: GoldfiveEventRecord
+    ) -> None:
+        key = (record.session_id, record.run_id, int(record.sequence))
+        async with self._lock:
+            if key in self._seen_gf_events:
+                return
+            self._seen_gf_events.add(key)
+            self._gf_events.setdefault(record.session_id, []).append(
+                copy.deepcopy(record)
+            )
+
+    async def list_goldfive_events(
+        self,
+        session_id: str,
+        *,
+        kind: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list[GoldfiveEventRecord]:
+        async with self._lock:
+            lst = self._gf_events.get(session_id, [])
+            out = [copy.deepcopy(e) for e in lst]
+        if kind is not None:
+            out = [e for e in out if e.kind == kind]
+        out.sort(key=lambda e: (e.recorded_at, e.sequence))
+        if limit is not None:
+            out = out[: int(limit)]
+        return out
+
+    async def find_agent_id_by_name(
+        self, session_id: str, name: str
+    ) -> Optional[str]:
+        if not name or not session_id:
+            return None
+        async with self._lock:
+            # 1. exact id
+            if (session_id, name) in self._agents:
+                return name
+            # 2. exact name match
+            for (sid, aid), agent in self._agents.items():
+                if sid != session_id:
+                    continue
+                if agent.name == name:
+                    return aid
+            # 3. suffix match
+            suffix = f":{name}"
+            for (sid, aid), _ in self._agents.items():
+                if sid == session_id and aid.endswith(suffix):
+                    return aid
+        return None
 
     async def stats(self) -> Stats:
         async with self._lock:

--- a/server/harmonograf_server/storage/postgres.py
+++ b/server/harmonograf_server/storage/postgres.py
@@ -40,6 +40,7 @@ from harmonograf_server.storage.base import (
     AgentStatus,
     Annotation,
     ContextWindowSample,
+    GoldfiveEventRecord,
     PayloadMeta,
     PayloadRecord,
     Session,
@@ -212,6 +213,23 @@ class PostgresStore(Store):
         agent_id: Optional[str] = None,
         limit_per_agent: int = 200,
     ) -> list[ContextWindowSample]:
+        raise NotImplementedError(_NOT_IMPLEMENTED)
+
+    async def append_goldfive_event(self, record: GoldfiveEventRecord) -> None:
+        raise NotImplementedError(_NOT_IMPLEMENTED)
+
+    async def list_goldfive_events(
+        self,
+        session_id: str,
+        *,
+        kind: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list[GoldfiveEventRecord]:
+        raise NotImplementedError(_NOT_IMPLEMENTED)
+
+    async def find_agent_id_by_name(
+        self, session_id: str, name: str
+    ) -> Optional[str]:
         raise NotImplementedError(_NOT_IMPLEMENTED)
 
     async def stats(self) -> Stats:

--- a/server/harmonograf_server/storage/sqlite.py
+++ b/server/harmonograf_server/storage/sqlite.py
@@ -39,6 +39,7 @@ from harmonograf_server.storage.base import (
     TaskPlan,
     TaskStatus,
     ContextWindowSample,
+    GoldfiveEventRecord,
 )
 
 
@@ -176,6 +177,38 @@ CREATE TABLE IF NOT EXISTS payloads (
     summary TEXT NOT NULL DEFAULT '',
     path TEXT NOT NULL
 );
+
+-- harmonograf#113: goldfive event audit log.
+--
+-- The ingest pipeline historically only fanned goldfive events out to
+-- the SessionBus for live subscribers. Any downstream consumer that
+-- needed to replay events (frontend reconnect, forensic analysis,
+-- test-log inspection) had nothing to read back from disk because
+-- the events were never persisted. This table is the durable mirror.
+--
+-- (session_id, run_id, sequence) uniquely identifies an event within
+-- a run — goldfive's runner increments sequence monotonically per
+-- run_id, so the pair is effectively the wire-level identity. kind
+-- is a denormalized string (payload variant name, e.g.
+-- "delegation_observed") so the common "give me all drifts for this
+-- session" query path doesn't have to parse payload_bytes.
+--
+-- payload_bytes carries the serialized ``goldfive.v1.Event`` envelope
+-- verbatim so the server can re-emit it onto the bus or decode new
+-- fields after a schema bump without needing a new column.
+CREATE TABLE IF NOT EXISTS goldfive_events (
+    session_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    sequence INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    recorded_at REAL NOT NULL,
+    payload_bytes BLOB NOT NULL DEFAULT X'',
+    PRIMARY KEY (session_id, run_id, sequence)
+);
+CREATE INDEX IF NOT EXISTS idx_goldfive_events_session_kind
+    ON goldfive_events(session_id, kind);
+CREATE INDEX IF NOT EXISTS idx_goldfive_events_session_time
+    ON goldfive_events(session_id, recorded_at);
 """
 
 
@@ -1172,6 +1205,114 @@ class SqliteStore(Store):
             ]
             out.sort(key=lambda s: (s.agent_id, s.recorded_at))
             return out
+
+    # goldfive events ----------------------------------------------------
+    async def append_goldfive_event(
+        self, record: GoldfiveEventRecord
+    ) -> None:
+        async with self._lock:
+            # INSERT OR IGNORE: goldfive's runner emits each (run_id,
+            # sequence) exactly once, but a reconnect / replay race
+            # could re-deliver the same envelope. Idempotent-by-key
+            # matches ``_handle_span_start`` 's dedup semantics.
+            await self.db.execute(
+                """
+                INSERT OR IGNORE INTO goldfive_events
+                    (session_id, run_id, sequence, kind, recorded_at, payload_bytes)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.session_id,
+                    record.run_id,
+                    int(record.sequence),
+                    record.kind,
+                    record.recorded_at,
+                    record.payload_bytes or b"",
+                ),
+            )
+            await self.db.commit()
+
+    async def list_goldfive_events(
+        self,
+        session_id: str,
+        *,
+        kind: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list[GoldfiveEventRecord]:
+        async with self._lock:
+            q = (
+                "SELECT session_id, run_id, sequence, kind, recorded_at, payload_bytes "
+                "FROM goldfive_events WHERE session_id = ?"
+            )
+            args: list[Any] = [session_id]
+            if kind is not None:
+                q += " AND kind = ?"
+                args.append(kind)
+            q += " ORDER BY recorded_at ASC, sequence ASC"
+            if limit is not None:
+                q += " LIMIT ?"
+                args.append(int(limit))
+            async with self.db.execute(q, args) as cur:
+                rows = await cur.fetchall()
+        return [
+            GoldfiveEventRecord(
+                session_id=r["session_id"],
+                run_id=r["run_id"],
+                sequence=r["sequence"],
+                kind=r["kind"],
+                recorded_at=r["recorded_at"],
+                payload_bytes=bytes(r["payload_bytes"] or b""),
+            )
+            for r in rows
+        ]
+
+    # agent lookup helpers ----------------------------------------------
+    async def find_agent_id_by_name(
+        self, session_id: str, name: str
+    ) -> Optional[str]:
+        """Lookup (session, ADK name) → canonical agent_id.
+
+        Match precedence:
+          1. Exact ``agents.id`` match (caller already has the canonical id).
+          2. Exact ``agents.name`` match — the harmonograf#74 plugin
+             stamps ``name = <adk_agent_name>`` on per-ADK-agent rows.
+          3. Suffix match on ``agents.id`` (``...:<name>``) — tolerates
+             adk.agent.name cases where ``name`` got overwritten but the
+             id still encodes the ADK-agent-name suffix.
+
+        Returns None when no row matches. Single-row SELECT keyed on
+        ``session_id`` so the cost is bounded by the agent-registry
+        size (a few dozen rows in the worst case).
+        """
+        if not name or not session_id:
+            return None
+        async with self._lock:
+            # 1. exact id match
+            async with self.db.execute(
+                "SELECT id FROM agents WHERE session_id = ? AND id = ? LIMIT 1",
+                (session_id, name),
+            ) as cur:
+                row = await cur.fetchone()
+            if row is not None:
+                return row["id"]
+            # 2. exact name match
+            async with self.db.execute(
+                "SELECT id FROM agents WHERE session_id = ? AND name = ? LIMIT 1",
+                (session_id, name),
+            ) as cur:
+                row = await cur.fetchone()
+            if row is not None:
+                return row["id"]
+            # 3. suffix match on id
+            like = f"%:{name}"
+            async with self.db.execute(
+                "SELECT id FROM agents WHERE session_id = ? AND id LIKE ? LIMIT 1",
+                (session_id, like),
+            ) as cur:
+                row = await cur.fetchone()
+            if row is not None:
+                return row["id"]
+        return None
 
     # stats ---------------------------------------------------------------
     async def stats(self) -> Stats:

--- a/server/tests/test_goldfive_ingest.py
+++ b/server/tests/test_goldfive_ingest.py
@@ -1014,3 +1014,144 @@ async def test_registry_events_do_not_mutate_storage(pipeline, store):
     assert after is not None
     status_after = [(t.id, t.status) for t in after.tasks]
     assert status_before == status_after
+
+
+# ---- goldfive_events persistence (harmonograf#113) -----------------------
+
+
+@pytest.mark.asyncio
+async def test_every_goldfive_event_persists_to_store(pipeline, store):
+    """Every dispatched goldfive event lands in the audit log.
+
+    harmonograf#113: the ingest pipeline historically only fanned
+    events to the SessionBus. This test exercises a representative
+    sample (run_started, plan_submitted, delegation_observed,
+    drift_detected) and confirms each is retrievable via the store's
+    ``list_goldfive_events`` read path.
+    """
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+
+    events = [
+        (_make_event(sequence=0), "run_started"),
+        (_make_event(sequence=1), "plan_submitted"),
+        (_make_event(sequence=2), "delegation_observed"),
+        (_make_event(sequence=3), "drift_detected"),
+    ]
+    events[0][0].run_started.goal_summary = "go"
+    events[1][0].plan_submitted.plan.CopyFrom(_plan_pb(plan_id="p-gold"))
+    events[2][0].delegation_observed.from_agent = "agent_gf"
+    events[2][0].delegation_observed.to_agent = "sub"
+    events[3][0].drift_detected.detail = "stuck"
+
+    for evt, _kind in events:
+        await pipe.handle_message(_stream_ctx(), _wrap(evt))
+
+    stored = await store.list_goldfive_events("sess_gf")
+    stored_kinds = [r.kind for r in stored]
+    for _evt, kind in events:
+        assert kind in stored_kinds, (
+            f"expected {kind} persisted; got {stored_kinds}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_goldfive_event_persist_is_idempotent(pipeline, store):
+    """Re-delivering the same envelope is a no-op on the audit log."""
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+
+    evt = _make_event(sequence=7)
+    evt.run_started.goal_summary = "once"
+
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+
+    stored = await store.list_goldfive_events(
+        "sess_gf", kind="run_started"
+    )
+    assert len(stored) == 1
+
+
+@pytest.mark.asyncio
+async def test_plan_assignee_agent_id_resolves_from_bare_name(pipeline, store):
+    """A plan whose task.assignee is a bare ADK name resolves to the canonical id.
+
+    Under the harmonograf#74 per-agent attribution scheme, the
+    telemetry plugin registers agent rows with a compound id
+    (``<client_id>:<adk_name>``). Goldfive's planner emits
+    ``assignee_agent_id`` with the bare ADK name. The ingest pipeline
+    rewrites the bare name onto the canonical row id so the frontend
+    pre-strip / Plans overlay can resolve the task-to-agent link via
+    ordinary equality.
+    """
+    from harmonograf_server.storage import Agent, AgentStatus, Framework
+
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+    # Register an agent with the compound-id format the plugin uses.
+    canonical_id = "client-xyz:coordinator_agent"
+    await store.register_agent(
+        Agent(
+            id=canonical_id,
+            session_id="sess_gf",
+            name="coordinator_agent",
+            framework=Framework.ADK,
+            connected_at=1000.0,
+            last_heartbeat=1000.0,
+            status=AgentStatus.CONNECTED,
+        )
+    )
+
+    # Plan carries the bare ADK name on the task assignee field.
+    plan_pb = gt.Plan()
+    plan_pb.id = "p-assign"
+    plan_pb.run_id = "run-1"
+    plan_pb.summary = "assign test"
+    t = plan_pb.tasks.add()
+    t.id = "t1"
+    t.title = "first"
+    t.assignee_agent_id = "coordinator_agent"
+    t.status = gt.TASK_STATUS_PENDING
+
+    evt = _make_event()
+    evt.plan_submitted.plan.CopyFrom(plan_pb)
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+
+    stored = await store.get_task_plan("p-assign")
+    assert stored is not None
+    assert stored.tasks[0].assignee_agent_id == canonical_id
+
+
+@pytest.mark.asyncio
+async def test_delegation_observed_resolves_endpoint_agent_ids(pipeline, store):
+    """Bare from/to ADK names on DelegationObserved resolve to canonical ids."""
+    from harmonograf_server.storage import Agent, AgentStatus, Framework
+
+    pipe, bus, _ = pipeline
+    await _ensure_session(store)
+    for adk_name in ("coordinator_agent", "research_agent"):
+        await store.register_agent(
+            Agent(
+                id=f"client-abc:{adk_name}",
+                session_id="sess_gf",
+                name=adk_name,
+                framework=Framework.ADK,
+                connected_at=1000.0,
+                last_heartbeat=1000.0,
+                status=AgentStatus.CONNECTED,
+            )
+        )
+
+    sub = await bus.subscribe("sess_gf")
+    evt = _make_event()
+    evt.delegation_observed.from_agent = "coordinator_agent"
+    evt.delegation_observed.to_agent = "research_agent"
+    evt.delegation_observed.task_id = "t1"
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_DELEGATION_OBSERVED
+    assert delta.payload["from_agent"] == "client-abc:coordinator_agent"
+    assert delta.payload["to_agent"] == "client-abc:research_agent"


### PR DESCRIPTION
## Summary

Coordinated fix for a multi-layer observability regression. Session `dd188a0c-ba61-4fea-a671-8ade1915a83b` surfaces five independent symptoms that share one pipeline (ingest → persist → bus → UI), so they land together in one PR.

## Root causes (A-F from the bug report)

- **A. `spans.kind_string` NULL on every known-enum span** — `client/client.py::_resolve_kind` returned `""` for known enums; column stayed NULL for INVOCATION / LLM_CALL / TOOL_CALL, breaking SQL exports / filters. Fix: stamp the label for both known and CUSTOM kinds.
- **B. `goldfive_events` table never existed** — ingest only fanned events to the bus, never persisted. Fix: new `goldfive_events` table + `Store.append_goldfive_event` + idempotent INSERT OR IGNORE on (session_id, run_id, sequence). In-memory + postgres stub mirrored.
- **C. `span_links` empty** — the TRANSFER + LINK_INVOKED emit lived in `client/adk.py` deleted in Phase C (PR #9); never migrated to `telemetry_plugin.py`. Leaving the Gantt `drawLinks` fallback path dead — DelegationObserved (goldfive registry dispatch) already carries the cross-agent signal and the Gantt's `drawDelegations` / GraphView Method 3 consume it.
- **D. Duplicate coordinator_agent INVOCATION spans** — `goldfive.wrap`'s `GoldfiveADKAgent` propagates `name = inner.name`, so adk-web's outer Runner + goldfive's inner Runner both fire `before_run_callback` with the same agent name. Fix: telemetry plugin detects the wrapper by class name (`type(agent).__mro__` walk for `GoldfiveADKAgent`) and short-circuits — no wrapper span, `after_run` no-op, LLM calls route to the inner invocation unchanged. Class-name detection (not `isinstance`) keeps the client installable in ADK-only environments.
- **E + F. GraphView Plans checkbox no-op; Gantt pre-strip empty** — goldfive planners emit `task.assignee_agent_id = "coordinator_agent"` (bare ADK name). Telemetry plugin registers agents with compound id `<client_id>:coordinator_agent` per harmonograf#74. Frontend's equality-based agent index silently drops every task. Fix: ingest rewrites `assignee_agent_id` onto the canonical compound id via a new `Store.find_agent_id_by_name` (exact id → name → suffix). Delegation endpoints + planner_agent_id get the same rewrite.

## Test plan

- [x] `uv run pytest server/tests/` — 320 passed, 1 skipped
- [x] `uv run pytest client/tests/ --ignore client/tests/test_telemetry_plugin_dedup.py` — 248 passed, 3 skipped
- [x] `npx vitest run` — 279 passed (frontend)
- [x] New tests: `client/tests/test_telemetry_plugin_goldfive_wrap.py` (wrapper detection), new ingest tests for event persistence + agent-id resolution + delegation endpoint rewrite
- [ ] E2E: verify on a fresh `make demo` session that `span_links` populates via DelegationObserved path (follow-up if needed), `kind_string` populated, `goldfive_events` has rows, one INVOCATION per coordinator row, Plans checkbox toggles overlays, Gantt pre-strip shows strips