### PR TITLE
Show Reasoning section on Summary drawer tab

### DIFF
--- a/frontend/src/__tests__/components/Drawer.reasoning.test.tsx
+++ b/frontend/src/__tests__/components/Drawer.reasoning.test.tsx
@@ -16,7 +16,8 @@ vi.mock('../../rpc/hooks', () => ({
   usePayload: (digest: string | null) => usePayloadSpy(digest),
 }));
 
-import { ReasoningSection } from '../../components/shell/Drawer';
+import { ReasoningSection, SummaryTab } from '../../components/shell/Drawer';
+import type { Span } from '../../gantt/types';
 
 beforeEach(() => {
   usePayloadSpy.mockReset();
@@ -206,5 +207,86 @@ describe('ReasoningSection', () => {
     expect(screen.getByTestId('drawer-reasoning-toggle').textContent).toMatch(
       /^▸Reasoning$/,
     );
+  });
+});
+
+// --- SummaryTab integration ------------------------------------------------
+//
+// The Drawer defaults to the Summary tab when a user clicks a span. Prior to
+// this change the Reasoning section only lived under Task → Overview, leaving
+// users to conclude thinking capture was broken. These tests lock in the
+// behaviour that SummaryTab surfaces the ReasoningSection whenever the span
+// carries the relevant reasoning attributes.
+
+function makeSpan(overrides: Partial<Span> = {}): Span {
+  return {
+    id: 'span-1',
+    sessionId: 'sess-1',
+    agentId: 'agent-1',
+    parentSpanId: null,
+    kind: 'LLM_CALL',
+    status: 'COMPLETED',
+    name: 'llm-call',
+    startMs: 0,
+    endMs: 100,
+    links: [],
+    attributes: {},
+    payloadRefs: [],
+    error: null,
+    lane: 0,
+    replaced: false,
+    ...overrides,
+  };
+}
+
+describe('SummaryTab reasoning surfacing', () => {
+  it('renders the ReasoningSection when the span has has_reasoning and llm.reasoning set', () => {
+    const span = makeSpan({
+      attributes: {
+        has_reasoning: { kind: 'bool', value: true },
+        'llm.reasoning': {
+          kind: 'string',
+          value: 'chain of thought step one then step two',
+        },
+      },
+    });
+    render(<SummaryTab span={span} />);
+    // ReasoningSection is present by test id.
+    expect(screen.getByTestId('drawer-reasoning')).toBeTruthy();
+    // And opening it reveals the inline reasoning text.
+    fireEvent.click(screen.getByTestId('drawer-reasoning-toggle'));
+    expect(screen.getByTestId('drawer-reasoning-body').textContent).toContain(
+      'step one then step two',
+    );
+  });
+
+  it('does not render a ReasoningSection on spans without any reasoning signal', () => {
+    const span = makeSpan({
+      attributes: {
+        some_other_attr: { kind: 'string', value: 'nope' },
+      },
+    });
+    render(<SummaryTab span={span} />);
+    expect(screen.queryByTestId('drawer-reasoning')).toBeNull();
+  });
+
+  it('surfaces the INVOCATION reasoning_trail aggregate with a turn count', () => {
+    const span = makeSpan({
+      kind: 'INVOCATION',
+      attributes: {
+        has_reasoning: { kind: 'bool', value: true },
+        'llm.reasoning_trail': {
+          kind: 'string',
+          value: '[LLM call 1]\nfirst\n\n---\n\n[LLM call 2]\nsecond',
+        },
+        reasoning_call_count: { kind: 'int', value: 2n },
+      },
+    });
+    render(<SummaryTab span={span} />);
+    const toggle = screen.getByTestId('drawer-reasoning-toggle');
+    expect(toggle.textContent).toMatch(/Agent reasoning trail/);
+    expect(
+      screen.getByTestId('drawer-reasoning-call-count').textContent,
+    ).toBe('2 turns');
   });
 });

--- a/frontend/src/components/shell/Drawer.tsx
+++ b/frontend/src/components/shell/Drawer.tsx
@@ -326,6 +326,59 @@ function TaskSubtabButton({
   );
 }
 
+// Shared reader for the reasoning-related attributes a span can carry.
+// Extracted so both TaskOverviewPanel (Task → Overview subtab) and SummaryTab
+// (Summary tab) can surface ``<ReasoningSection />`` without duplicating the
+// attribute narrowing logic. Mirrors the attributes emitted by the goldfive
+// telemetry plugin: ``llm.reasoning`` (per LLM_CALL), ``llm.reasoning_trail``
+// (per INVOCATION aggregate, harmonograf#108), ``reasoning_call_count`` and
+// ``has_reasoning``. Large traces spill to a payload_ref with role="reasoning".
+function readReasoning(span: Span): {
+  inlineText: string | undefined;
+  payloadRef: PayloadRef | undefined;
+  callCount: number | undefined;
+  hasReasoningAttr: boolean;
+  isAggregate: boolean;
+  show: boolean;
+} {
+  const reasoningInline =
+    span.attributes['llm.reasoning']?.kind === 'string'
+      ? span.attributes['llm.reasoning'].value
+      : undefined;
+  const reasoningTrail =
+    span.attributes['llm.reasoning_trail']?.kind === 'string'
+      ? span.attributes['llm.reasoning_trail'].value
+      : undefined;
+  // Attribute rides as proto int64 → bigint on the wire. Narrow to number
+  // for the props; call counts in the hundreds-of-turns range fit easily
+  // inside a JS safe integer so Number() conversion is loss-less here.
+  const reasoningCallCountAttr = span.attributes['reasoning_call_count'];
+  const callCount =
+    reasoningCallCountAttr?.kind === 'int'
+      ? Number(reasoningCallCountAttr.value)
+      : undefined;
+  const hasReasoningAttr =
+    span.attributes['has_reasoning']?.kind === 'bool' &&
+    span.attributes['has_reasoning'].value === true;
+  const payloadRef = (span.payloadRefs ?? []).find((r) => r.role === 'reasoning');
+  const show = Boolean(
+    reasoningInline || reasoningTrail || payloadRef || hasReasoningAttr,
+  );
+  // Prefer the INVOCATION-level trail (agent-wide context) over a single
+  // LLM_CALL's reasoning. Both paths fall back to a payload_ref when the text
+  // is large enough to spill off the span attribute.
+  const inlineText = reasoningTrail ?? reasoningInline;
+  const isAggregate = Boolean(reasoningTrail) || callCount != null;
+  return {
+    inlineText,
+    payloadRef,
+    callCount,
+    hasReasoningAttr,
+    isAggregate,
+    show,
+  };
+}
+
 function TaskOverviewPanel({ span, sessionId }: { span: Span; sessionId: string | null }) {
   // harmonograf#110 / goldfive#205: resolve the bound task (if any) so the
   // panel can render a "Cancel reason" section when this span's task
@@ -352,31 +405,14 @@ function TaskOverviewPanel({ span, sessionId }: { span: Span; sessionId: string 
   const taskReport = (span.attributes['task_report']?.kind === 'string' ? span.attributes['task_report'].value : undefined);
   const isRunning = span.endMs == null;
   const agentDesc = (span.attributes['agent_description']?.kind === 'string' ? span.attributes['agent_description'].value : undefined);
-  // Per-LLM_CALL reasoning inline carrier (set by
-  // ``after_model_callback`` finalize for small reasoning).
-  const reasoningInline = (span.attributes['llm.reasoning']?.kind === 'string' ? span.attributes['llm.reasoning'].value : undefined);
-  // INVOCATION aggregate carrier (harmonograf#108). When the drawer opens
-  // on an agent row's INVOCATION span, this is the attribute that holds
-  // the concatenated chain-of-thought from every LLM_CALL child — the
-  // section was empty before the plugin started emitting this on
-  // after_run_callback.
-  const reasoningTrail = (span.attributes['llm.reasoning_trail']?.kind === 'string' ? span.attributes['llm.reasoning_trail'].value : undefined);
-  // Attribute rides as proto int64 → bigint on the wire. Narrow to number
-  // for the props; call counts in the hundreds-of-turns range fit easily
-  // inside a JS safe integer so Number() conversion is loss-less here.
-  const reasoningCallCountAttr = span.attributes['reasoning_call_count'];
-  const reasoningCallCount =
-    reasoningCallCountAttr?.kind === 'int'
-      ? Number(reasoningCallCountAttr.value)
-      : undefined;
-  const hasReasoningAttr = span.attributes['has_reasoning']?.kind === 'bool' && span.attributes['has_reasoning'].value;
-  const reasoningRef = (span.payloadRefs ?? []).find((r) => r.role === 'reasoning');
-  const showReasoning = Boolean(reasoningInline || reasoningTrail || reasoningRef || hasReasoningAttr);
-  // The inline text to hand to <ReasoningSection /> — prefer the
-  // INVOCATION-level trail (agent-wide context) over a single LLM_CALL's
-  // reasoning. Both paths fall back to a payload_ref when the text is
-  // large enough to spill off the span attribute.
-  const reasoningInlineText = reasoningTrail ?? reasoningInline;
+  const {
+    inlineText: reasoningInlineText,
+    payloadRef: reasoningRef,
+    callCount: reasoningCallCount,
+    hasReasoningAttr,
+    isAggregate: reasoningIsAggregate,
+    show: showReasoning,
+  } = readReasoning(span);
 
   return (
     <div style={{ padding: '12px 16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -447,7 +483,7 @@ function TaskOverviewPanel({ span, sessionId }: { span: Span; sessionId: string 
           inline={reasoningInlineText}
           payloadRef={reasoningRef}
           callCount={reasoningCallCount}
-          isAggregate={Boolean(reasoningTrail) || reasoningCallCount != null}
+          isAggregate={reasoningIsAggregate}
         />
       )}
 
@@ -1030,13 +1066,32 @@ function formatRevisionTime(ms: number): string {
 
 // --- Summary tab ------------------------------------------------------------
 
-function SummaryTab({ span }: { span: Span }) {
+export function SummaryTab({ span }: { span: Span }) {
   const durationMs =
     span.endMs !== null ? span.endMs - span.startMs : null;
   const entries = Object.entries(span.attributes);
+  // Render the reasoning section on Summary too so it isn't hidden behind the
+  // Task → Overview subtab (harmonograf: Reasoning was undiscoverable from the
+  // default drawer tab). This is additive — the TaskOverviewPanel still renders
+  // its own copy for users who navigate there.
+  const {
+    inlineText: reasoningInlineText,
+    payloadRef: reasoningRef,
+    callCount: reasoningCallCount,
+    isAggregate: reasoningIsAggregate,
+    show: showReasoning,
+  } = readReasoning(span);
 
   return (
     <div className="hg-drawer__section">
+      {showReasoning && (
+        <ReasoningSection
+          inline={reasoningInlineText}
+          payloadRef={reasoningRef}
+          callCount={reasoningCallCount}
+          isAggregate={reasoningIsAggregate}
+        />
+      )}
       <dl className="hg-drawer__meta">
         <dt>Status</dt>
         <dd>{span.status}</dd>


### PR DESCRIPTION
Drawer default-opens to Summary which was an attribute dump; Reasoning lived only on Task → Overview and was undiscoverable. Renders ReasoningSection on SummaryTab too.

## Summary
- Extract the reasoning-attribute reads (`llm.reasoning`, `llm.reasoning_trail`, `reasoning_call_count`, `has_reasoning`, `payloadRef` with `role="reasoning"`) into a shared `readReasoning(span)` helper.
- `SummaryTab` now renders `<ReasoningSection />` at the top of the panel when `readReasoning(span).show` is true. The existing `TaskOverviewPanel` render is preserved; this is additive.
- `SummaryTab` is exported so the test can mount it directly.

## Test plan
- [x] `pnpm test` in `frontend/` — 282 tests pass (includes three new SummaryTab-reasoning cases).
- [x] `pnpm lint` clean.
- [x] `pnpm exec tsc -b` clean.
- [ ] Manual smoke: click an INVOCATION span with captured thinking, confirm Reasoning appears on Summary without switching to Task → Overview.