### PR TITLE
Route 4 frontend has_thinking readers through hasThinking() helper

### DIFF
--- a/frontend/src/__tests__/components/CurrentTaskStrip.test.tsx
+++ b/frontend/src/__tests__/components/CurrentTaskStrip.test.tsx
@@ -186,14 +186,14 @@ describe('<CurrentTaskStrip />', () => {
     ).toBeNull();
   });
 
-  it('renders the thinking dot when an LLM_CALL has has_thinking=true', () => {
+  it('renders the thinking dot when an LLM_CALL has has_reasoning=true', () => {
     mockStore!.tasks.upsertPlan(
       plan('p1', [task('t1', 'RUNNING', 'Analyze logs', 'worker-7')]),
     );
     mockStore!.spans.append(
       span('s-llm', 'worker-7', 'LLM_CALL', 'gpt', {
         startMs: 100,
-        attributes: { has_thinking: { kind: 'bool', value: true } },
+        attributes: { has_reasoning: { kind: 'bool', value: true } },
       }),
     );
     render(<CurrentTaskStrip />);
@@ -202,14 +202,14 @@ describe('<CurrentTaskStrip />', () => {
     ).toBeTruthy();
   });
 
-  it('omits the thinking dot when has_thinking is false or absent', () => {
+  it('omits the thinking dot when has_reasoning is false or absent', () => {
     mockStore!.tasks.upsertPlan(
       plan('p1', [task('t1', 'RUNNING', 'Analyze logs', 'worker-7')]),
     );
     mockStore!.spans.append(
       span('s-llm', 'worker-7', 'LLM_CALL', 'gpt', {
         startMs: 100,
-        attributes: { has_thinking: { kind: 'bool', value: false } },
+        attributes: { has_reasoning: { kind: 'bool', value: false } },
       }),
     );
     render(<CurrentTaskStrip />);

--- a/frontend/src/components/LiveActivity/LiveActivityPanel.tsx
+++ b/frontend/src/components/LiveActivity/LiveActivityPanel.tsx
@@ -4,6 +4,7 @@ import { useSessionWatch, sessionIsInactive } from '../../rpc/hooks';
 import { colorForAgent } from '../../theme/agentColors';
 import { formatDuration } from '../../lib/format';
 import type { Span, AttributeValue } from '../../gantt/types';
+import { hasThinking as spanHasThinking } from '../../lib/thinking';
 import './LiveActivity.css';
 
 interface ActiveItem {
@@ -30,13 +31,6 @@ function attrToString(v: AttributeValue | undefined): string {
     default:
       return '';
   }
-}
-
-function attrToBool(v: AttributeValue | undefined): boolean {
-  if (!v) return false;
-  if (v.kind === 'bool') return v.value;
-  if (v.kind === 'string') return v.value.length > 0;
-  return false;
 }
 
 export function LiveActivityPanel() {
@@ -124,8 +118,7 @@ export function LiveActivityPanel() {
     const attrReport = attrToString(span.attributes['task_report']);
     const taskReport = attrReport || agent.taskReport || '';
     const hasThinking =
-      attrToBool(span.attributes['has_thinking']) ||
-      taskReport.startsWith('Thinking');
+      spanHasThinking(span) || taskReport.startsWith('Thinking');
     const elapsedMs = Math.max(0, nowRel - span.startMs);
     items.push({
       agentId,

--- a/frontend/src/components/shell/views/GraphView.tsx
+++ b/frontend/src/components/shell/views/GraphView.tsx
@@ -6,6 +6,7 @@ import { useSessionWatch, sendStatusQuery } from '../../../rpc/hooks';
 import { colorForAgent } from '../../../theme/agentColors';
 import type { Span, Task, TaskPlan } from '../../../gantt/types';
 import type { SessionStore } from '../../../gantt/index';
+import { hasThinking } from '../../../lib/thinking';
 import {
   DEFAULT_VIEWPORT,
   MIN_SCALE,
@@ -64,7 +65,9 @@ interface ActivationBox {
   endMs: number | null; // null = still running
   isRunning: boolean;
   spanId: string;      // for span lookup
-  thinking: boolean;   // true if has_thinking attribute set
+  thinking: boolean;   // true if lib/thinking.hasThinking(span) — honors
+                       // the has_reasoning bool flag stamped by the plugin
+                       // plus any reasoning text carrier (see #107).
 }
 
 interface SeqLayout {
@@ -307,10 +310,9 @@ function computeSequence(store: SessionStore): SeqLayout {
     if (s.kind !== 'INVOCATION') continue;
     const idx = colIdx.get(s.agentId);
     if (idx === undefined) continue;
-    const thinkingAttr = s.attributes?.['has_thinking'];
-    const thinking = thinkingAttr !== undefined && thinkingAttr !== null &&
-      (thinkingAttr.kind === 'bool' ? thinkingAttr.value === true :
-       thinkingAttr.kind === 'string' ? thinkingAttr.value === 'true' : false);
+    // Route through lib/thinking.hasThinking() so we honor both the
+    // has_reasoning bool flag and any reasoning text carrier (#107).
+    const thinking = hasThinking(s);
     activations.push({
       agentIdx: idx,
       startMs: s.startMs,

--- a/frontend/src/gantt/index.ts
+++ b/frontend/src/gantt/index.ts
@@ -4,6 +4,7 @@
 
 import type { Agent, ContextWindowSample, Task, TaskPlan, TaskStatus } from './types';
 import { SpanIndex, type DirtyRect } from './spatialIndex';
+import { hasThinking } from '../lib/thinking';
 
 export type { DirtyRect } from './spatialIndex';
 export { SpanIndex } from './spatialIndex';
@@ -691,7 +692,8 @@ export class SessionStore {
   //
   // When the task is RUNNING, the result is enriched with live context from
   // the span index: the most recent in-flight TOOL_CALL on the assignee agent
-  // and whether any in-flight LLM_CALL on that agent has `has_thinking=true`.
+  // and whether any in-flight LLM_CALL on that agent carries reasoning
+  // (per lib/thinking.hasThinking — has_reasoning flag or inline text).
   // These fields let the CurrentTaskStrip surface a tool badge and thinking
   // dot without the component having to crawl the span index itself.
   getCurrentTask(): {
@@ -743,8 +745,9 @@ export class SessionStore {
           inFlightTool = { name: span.name, startedAtMs: span.startMs };
         }
       } else if (span.kind === 'LLM_CALL') {
-        const attr = span.attributes['has_thinking'];
-        if (attr && attr.kind === 'bool' && attr.value) {
+        // Route through lib/thinking.hasThinking() so we honor both the
+        // has_reasoning bool flag and any reasoning text carrier (#107).
+        if (hasThinking(span)) {
           isThinking = true;
         }
       }

--- a/frontend/src/gantt/renderer.ts
+++ b/frontend/src/gantt/renderer.ts
@@ -24,6 +24,7 @@ import {
 import type { DelegationRecord, SessionStore } from './index';
 import type { SpanIndex, DirtyRect } from './spatialIndex';
 import type { Agent, ContextWindowSample, Span, SpanKind, Task, TaskStatus } from './types';
+import { hasThinking } from '../lib/thinking';
 import {
   GUTTER_WIDTH_PX,
   ROW_HEIGHT_FOCUSED_PX,
@@ -925,14 +926,13 @@ export class GanttRenderer {
           }
         }
         // Brain badge: any LLM_CALL with reasoning content (live or done).
-        // Gate on has_thinking=true to keep the test cheap (no string attr
-        // parse in the hot path) and skip narrow blocks where the badge
-        // would collide with the kind icon label.
-        if (s.kind === 'LLM_CALL' && width >= 14) {
-          const ht = s.attributes['has_thinking'];
-          if (ht && ht.kind === 'bool' && ht.value) {
-            brainBadges.push({ x: x1, y: laneTop, w: width, h: rectH });
-          }
+        // Route through lib/thinking.hasThinking() so we honor both the
+        // has_reasoning bool flag and any reasoning text carrier — the
+        // plugin stamps has_reasoning alongside llm.reasoning / trail
+        // (see harmonograf#107). Skip narrow blocks where the badge would
+        // collide with the kind icon label.
+        if (s.kind === 'LLM_CALL' && width >= 14 && hasThinking(s)) {
+          brainBadges.push({ x: x1, y: laneTop, w: width, h: rectH });
         }
         visibleCount++;
       }


### PR DESCRIPTION
Plugin emits has_reasoning; four sites still read has_thinking directly — brain badges / live-thinking chip / graph flag never fire. Route through lib/thinking.hasThinking() which handles both.

Sites fixed:
- `frontend/src/gantt/renderer.ts` — brain badge on LLM_CALL bars
- `frontend/src/gantt/index.ts` — per-row aggregate thinking flag
- `frontend/src/components/LiveActivity/LiveActivityPanel.tsx` — live-panel thinking chip
- `frontend/src/components/shell/views/GraphView.tsx` — GraphView node thinking flag

Tests:
- Updated two fixtures in `__tests__/components/CurrentTaskStrip.test.tsx` from `has_thinking` to `has_reasoning`.
- `pnpm test` → 279/279 pass.
- `pnpm run build` → clean.