### PR TITLE
Stamp hgraf.task_id + agent kind on every SpanStart

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -106,6 +106,49 @@ def _adk_session_id(ctx: Any) -> str:
     return str(sid)
 
 
+def _extract_current_task_id(ctx: Any) -> str:
+    """Read ``goldfive.current_task_id`` out of an ADK callback context's session.state.
+
+    Goldfive's ADK state-protocol mirror (``_adk_state_protocol``) stamps
+    ``goldfive.current_task_id`` onto ``session.state`` on every
+    ``before_run_callback`` — see goldfive issue #3. The server's ingest
+    and the frontend's Task tab both key Trajectory / dependency
+    rendering off a ``hgraf.task_id`` attribute on SpanStart frames; this
+    helper pulls the goldfive-side value out of whichever shape the
+    callback gives us (CallbackContext exposes ``session`` directly;
+    ToolContext does too; InvocationContext does as well).
+
+    ADK shallow-copies ``session.state`` into ``CallbackContext`` so
+    *writes* on the callback side don't propagate back — this is a
+    **read-only** use and the mirror has fired on ``before_run_callback``
+    by the time any before-agent/tool/model callback runs, so the read
+    sees the latest task id.
+
+    Returns ``""`` when the context is non-goldfive (no state key present),
+    malformed, or pre-plan — callers must treat that as a no-op and not
+    invent a task id.
+    """
+    if ctx is None:
+        return ""
+    session = _safe_attr(ctx, "session", None)
+    if session is None:
+        inv = _safe_attr(ctx, "_invocation_context", None)
+        if inv is not None:
+            session = _safe_attr(inv, "session", None)
+    if session is None:
+        return ""
+    state = _safe_attr(session, "state", None)
+    if state is None:
+        return ""
+    try:
+        value = state.get("goldfive.current_task_id", "")
+    except Exception:  # noqa: BLE001 — defensive: telemetry must not raise
+        return ""
+    if not value:
+        return ""
+    return str(value)
+
+
 def _serialize_args(args: Any) -> bytes | None:
     if args is None:
         return None
@@ -590,40 +633,88 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
     def _stamp_agent_attrs(
         self, per_agent_id: str, attrs: Optional[dict[str, Any]] = None
     ) -> Optional[dict[str, Any]]:
-        """Return span attributes augmented with ``hgraf.agent.*`` on first-sight.
+        """Return span attributes augmented with ``hgraf.agent.*``.
 
-        Only the FIRST span the server sees for a given
-        ``(session_id, per_agent_id)`` pair needs to carry the metadata
-        payload; subsequent spans inherit the agent row via
-        ``_ensure_route``'s auto-register and don't re-pay the cost.
-        The plugin tracks first-sight locally via ``_seen_agents``,
-        keyed on ``(session_id, per_agent_id)`` because the same
-        per-agent id can appear in multiple sessions over a plugin
-        lifetime (adk-web reuses the process across runs).
+        Contract (harmonograf#6):
 
-        Returns ``attrs`` unchanged (may be ``None``) for already-seen
-        agents so the hot span-emit path doesn't copy dicts for every
-        model / tool call.
+        * ``hgraf.agent.name`` and ``hgraf.agent.kind`` are stamped on
+          EVERY SpanStart emitted for a registered per-agent id. The
+          frontend's Gantt/Graph/Timeline boundSpanId binding and the
+          Task tab's Trajectory subtab key off these, and follow-up
+          user turns reuse an already-registered per-agent id — so
+          gating on first-sight caused the second INVOCATION span for
+          the same agent to ship without ``hgraf.agent.kind`` and the
+          row rendered as ``unknown`` (verified against session
+          ``9fa8d4cb-...``).
+        * ``hgraf.agent.parent_id`` and ``hgraf.agent.branch`` remain
+          first-sight only — the server harvests them into ``Agent.metadata``
+          on auto-register, and re-shipping them on every span would
+          bloat span-stream bytes without changing behavior.
+
+        The ``_seen_agents`` set still gates first-sight so parent/branch
+        ride only on the first span per ``(session_id, per_agent_id)``
+        pair.
+
+        Returns a *new* dict when any stamping happened so the caller's
+        ``attrs`` reference stays pristine; returns the input unchanged
+        (possibly ``None``) when ``per_agent_id`` is the client root,
+        which is registered via the Hello frame and must not carry
+        agent-row metadata.
         """
         if per_agent_id == str(self._client.agent_id):
             # The client root id is registered by the Hello frame —
             # never stamp hgraf.agent.* on spans landing on the root.
             return attrs
-        session_id = self._root_session_id or str(self._client.session_id or "")
-        key = (session_id, per_agent_id)
-        if key in self._seen_agents:
-            return attrs
-        self._seen_agents.add(key)
         meta = self._agent_metadata.get(per_agent_id, {})
         if not meta:
             # Degraded path: span was emitted before ``before_agent_callback``
             # populated the metadata cache. Stamp a name-only entry so the
-            # server still creates a row.
+            # server still creates a row. Kind is left off — the server's
+            # auto-register defaults it to ``unknown`` until a subsequent
+            # span carries the real metadata.
             meta = {"hgraf.agent.name": per_agent_id.split(":", 1)[-1]}
         merged: dict[str, Any] = dict(attrs or {})
-        # Caller-provided attrs win (don't clobber user metadata).
-        for k, v in meta.items():
-            merged.setdefault(k, v)
+        # Always-stamp keys: name + kind land on every SpanStart so the
+        # Task tab / boundSpanId pipeline works on follow-up turns.
+        for k in ("hgraf.agent.name", "hgraf.agent.kind"):
+            v = meta.get(k)
+            if v is not None:
+                merged.setdefault(k, v)
+        # First-sight keys: parent_id + branch ride only on the first
+        # span per (session_id, per_agent_id) pair.
+        session_id = self._root_session_id or str(self._client.session_id or "")
+        key = (session_id, per_agent_id)
+        if key not in self._seen_agents:
+            self._seen_agents.add(key)
+            for k in ("hgraf.agent.parent_id", "hgraf.agent.branch"):
+                v = meta.get(k)
+                if v is not None:
+                    merged.setdefault(k, v)
+        return merged or None
+
+    def _stamp_task_id(
+        self, ctx: Any, attrs: Optional[dict[str, Any]] = None
+    ) -> Optional[dict[str, Any]]:
+        """Augment ``attrs`` with ``hgraf.task_id`` when ``ctx`` is in a goldfive run.
+
+        Goldfive's ``_adk_state_protocol`` mirror writes
+        ``goldfive.current_task_id`` into ADK ``session.state`` on each
+        ``before_run_callback``. The server's ingest and the frontend's
+        Task tab / Gantt / Timeline / Graph views all key task binding
+        off a ``hgraf.task_id`` string attribute on SpanStart frames
+        (``hgraf.task_id`` drives ``collectThinkingForTask`` and
+        ``TaskRegistry.boundSpanId``). Nobody emits it today — fixing
+        that is harmonograf#3.
+
+        No-op for non-goldfive runs or pre-plan spans (state key absent
+        or empty). Never invents a value.
+        """
+        task_id = _extract_current_task_id(ctx)
+        if not task_id:
+            return attrs
+        merged: dict[str, Any] = dict(attrs or {})
+        # Caller-provided attrs win — tests / future stamps can override.
+        merged.setdefault("hgraf.task_id", task_id)
         return merged
 
     # ------------------------------------------------------------------
@@ -1145,6 +1236,7 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         # id so the Gantt puts this invocation on the right row.
         per_agent_id = self._register_agent_for_ctx(invocation_context)
         augmented_attrs = self._stamp_agent_attrs(per_agent_id, attrs)
+        augmented_attrs = self._stamp_task_id(invocation_context, augmented_attrs)
         sid = self._client.emit_span_start(
             kind=SpanKind.INVOCATION,
             name=name,
@@ -1352,6 +1444,7 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         per_agent_id = self._resolve_agent_id(callback_context)
         attrs: dict[str, Any] = {"llm.model": model} if model else {}
         augmented_attrs = self._stamp_agent_attrs(per_agent_id, attrs or None)
+        augmented_attrs = self._stamp_task_id(callback_context, augmented_attrs)
         sid = self._client.emit_span_start(
             kind=SpanKind.LLM_CALL,
             name=model or "llm_call",
@@ -1460,6 +1553,7 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         payload = _serialize_args(tool_args)
         per_agent_id = self._resolve_agent_id(tool_context)
         augmented_attrs = self._stamp_agent_attrs(per_agent_id, None)
+        augmented_attrs = self._stamp_task_id(tool_context, augmented_attrs)
         sid = self._client.emit_span_start(
             kind=SpanKind.TOOL_CALL,
             name=tool_name,

--- a/client/tests/test_telemetry_plugin_per_agent.py
+++ b/client/tests/test_telemetry_plugin_per_agent.py
@@ -375,12 +375,19 @@ async def test_first_span_stamps_hgraf_agent_attributes(
 
 
 @pytest.mark.asyncio
-async def test_second_span_from_same_agent_skips_hgraf_attrs(
+async def test_second_span_from_same_agent_still_carries_name_and_kind(
     plugin: HarmonografTelemetryPlugin, client: Client
 ) -> None:
-    """The hot path doesn't re-stamp hgraf.agent.* on every span."""
+    """Every SpanStart carries hgraf.agent.name + hgraf.agent.kind (harmonograf#6).
+
+    Follow-up user turns reuse an already-registered per-agent id; if
+    we gated these on first-sight, the second INVOCATION span arrived
+    without ``hgraf.agent.kind`` and the row rendered as ``unknown``
+    (verified against session 9fa8d4cb-...). Parent/branch remain
+    first-sight only — they're harvested into Agent.metadata once.
+    """
     research = Agent("research_agent")
-    cb = _CallbackContext("inv-1", ROOT_SESSION, research)
+    cb = _CallbackContext("inv-1", ROOT_SESSION, research, branch="root.research_agent")
     await plugin.before_agent_callback(agent=research, callback_context=cb)
     await plugin.before_tool_callback(
         tool=_Tool("t1"), tool_args={}, tool_context=cb
@@ -389,11 +396,16 @@ async def test_second_span_from_same_agent_skips_hgraf_attrs(
         tool=_Tool("t2"), tool_args={}, tool_context=cb
     )
     spans = _span_starts(client)
-    # First tool span has the hgraf.agent attrs; second does not.
     attrs1 = dict(spans[0].attributes or {})
     attrs2 = dict(spans[1].attributes or {})
-    assert "hgraf.agent.name" in attrs1
-    assert "hgraf.agent.name" not in attrs2
+    # Name + kind are always-stamp.
+    assert attrs1["hgraf.agent.name"].string_value == "research_agent"
+    assert attrs1["hgraf.agent.kind"].string_value == "llm"
+    assert attrs2["hgraf.agent.name"].string_value == "research_agent"
+    assert attrs2["hgraf.agent.kind"].string_value == "llm"
+    # Branch is first-sight: on attrs1 only.
+    assert "hgraf.agent.branch" in attrs1
+    assert "hgraf.agent.branch" not in attrs2
 
 
 @pytest.mark.asyncio
@@ -414,6 +426,47 @@ async def test_root_client_agent_id_never_gets_hgraf_stamps(
     assert spans[0].agent_id == CLIENT_AGENT_ID
     attrs = dict(spans[0].attributes or {})
     assert "hgraf.agent.name" not in attrs
+
+
+# ---------------------------------------------------------------------------
+# Follow-up turns: every SpanStart (including INVOCATION) stamps kind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_followup_invocation_on_registered_agent_stamps_kind(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Second INVOCATION SpanStart for an already-registered agent must
+    still carry hgraf.agent.kind (harmonograf#6).
+
+    Reproduces the session 9fa8d4cb-... bug: on a follow-up user turn,
+    before_run_callback fires again for the same coordinator; _seen_agents
+    suppression was hiding kind on that INVOCATION's SpanStart and the
+    frontend rendered the agent row as ``unknown``.
+    """
+    coord = Agent("coordinator")
+    # First turn: registers the coordinator.
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext("inv-1", ROOT_SESSION, coord)
+    )
+    await plugin.after_run_callback(
+        invocation_context=_InvocationContext("inv-1", ROOT_SESSION, coord)
+    )
+    # Second turn: SAME coordinator, fresh invocation id.
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext("inv-2", ROOT_SESSION, coord)
+    )
+    spans = _span_starts(client)
+    assert len(spans) == 2
+    attrs_first = dict(spans[0].attributes or {})
+    attrs_second = dict(spans[1].attributes or {})
+    # First turn carries name + kind.
+    assert attrs_first["hgraf.agent.name"].string_value == "coordinator"
+    assert attrs_first["hgraf.agent.kind"].string_value == "llm"
+    # Second turn MUST also carry name + kind — the fix.
+    assert attrs_second["hgraf.agent.name"].string_value == "coordinator"
+    assert attrs_second["hgraf.agent.kind"].string_value == "llm"
 
 
 # ---------------------------------------------------------------------------

--- a/client/tests/test_telemetry_plugin_task_id.py
+++ b/client/tests/test_telemetry_plugin_task_id.py
@@ -1,0 +1,307 @@
+"""Tests for ``hgraf.task_id`` SpanStart stamping (harmonograf#3).
+
+Goldfive mirrors ``goldfive.current_task_id`` into ADK's
+``session.state`` on every ``before_run_callback`` via
+``_adk_state_protocol``. The harmonograf server's ingest and the
+frontend's Task tab / Trajectory subtab, TaskRegistry.boundSpanId, and
+Gantt/Graph/Timeline dependency arrows ALL key off a ``hgraf.task_id``
+string attribute on SpanStart frames — but pre-fix nobody emitted it
+(verified: 0/44 spans in a fresh e2e session carried the attribute).
+
+This module verifies:
+
+* Every SpanStart (INVOCATION / LLM_CALL / TOOL_CALL) carries
+  ``hgraf.task_id`` when ``session.state['goldfive.current_task_id']``
+  is populated.
+* Absent / empty state key → no attribute stamped (non-goldfive runs,
+  pre-plan spans must not carry an invented id).
+* Task id flips between turns: the follow-up SpanStart carries the
+  NEW task id, not the cached first-turn value.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from harmonograf_client.buffer import EnvelopeKind
+from harmonograf_client.client import Client
+from harmonograf_client.telemetry_plugin import HarmonografTelemetryPlugin
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+ROOT_SESSION = "root-session-task-id"
+CLIENT_AGENT_ID = "client-root-agent-task-id"
+
+
+# ---------------------------------------------------------------------------
+# ADK-shaped stand-ins with session.state (mirrored by _adk_state_protocol)
+# ---------------------------------------------------------------------------
+
+
+class _Session:
+    def __init__(self, sid: str, state: dict[str, Any] | None = None) -> None:
+        self.id = sid
+        # ADK's ``Session.state`` is a MutableMapping; a plain dict
+        # duck-types for ``.get()`` which is what the plugin reads.
+        self.state = dict(state or {})
+
+
+class _BaseAgent:
+    def __init__(self, name: str, parent: Any = None) -> None:
+        self.name = name
+        self.parent_agent = parent
+
+
+class Agent(_BaseAgent):
+    """Class-name matches ADK's ``Agent``/``LlmAgent`` mapping."""
+
+
+class _InvocationContext:
+    def __init__(
+        self,
+        invocation_id: str,
+        session_id: str,
+        agent: Any,
+        state: dict[str, Any] | None = None,
+        branch: str = "",
+    ) -> None:
+        self.invocation_id = invocation_id
+        self.session = _Session(session_id, state)
+        self.agent = agent
+        self.branch = branch
+
+
+class _CallbackContext:
+    def __init__(
+        self,
+        invocation_id: str,
+        session_id: str,
+        agent: Any,
+        state: dict[str, Any] | None = None,
+        branch: str = "",
+    ) -> None:
+        self.invocation_id = invocation_id
+        # CallbackContext carries a *shallow copy* of the session.state
+        # in real ADK (see the memory pitfall
+        # "Verify plugin callback state handoff is read-readable"). For
+        # a read-only stamp we only need the snapshot to contain the
+        # key — which goldfive's mirror has populated by the time any
+        # before_* callback fires.
+        self.session = _Session(session_id, state)
+        self.branch = branch
+        self._invocation_context = _InvocationContext(
+            invocation_id, session_id, agent, state=state, branch=branch
+        )
+
+
+class _Tool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _LlmRequest:
+    def __init__(self, model: str = "mock/llm") -> None:
+        self.model = model
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="task-id-test",
+        agent_id=CLIENT_AGENT_ID,
+        session_id="home",
+        buffer_size=256,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def plugin(client: Client) -> HarmonografTelemetryPlugin:
+    return HarmonografTelemetryPlugin(client)
+
+
+def _span_starts(client: Client) -> list[Any]:
+    out: list[Any] = []
+    for env in client._events.drain():
+        if env.kind is EnvelopeKind.SPAN_START:
+            out.append(env.payload.span)
+    return out
+
+
+def _attr_string(span: Any, key: str) -> str | None:
+    attrs = dict(span.attributes or {})
+    val = attrs.get(key)
+    if val is None:
+        return None
+    return val.string_value
+
+
+# ---------------------------------------------------------------------------
+# Populated state → every SpanStart carries hgraf.task_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invocation_span_stamps_hgraf_task_id(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """before_run_callback INVOCATION SpanStart carries hgraf.task_id."""
+    coord = Agent("coordinator")
+    state = {"goldfive.current_task_id": "t1"}
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext(
+            "inv-1", ROOT_SESSION, coord, state=state
+        )
+    )
+    spans = _span_starts(client)
+    assert len(spans) == 1
+    assert _attr_string(spans[0], "hgraf.task_id") == "t1"
+
+
+@pytest.mark.asyncio
+async def test_tool_span_stamps_hgraf_task_id(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """before_tool_callback TOOL_CALL SpanStart carries hgraf.task_id."""
+    research = Agent("research_agent")
+    state = {"goldfive.current_task_id": "t2"}
+    cb = _CallbackContext("inv-1", ROOT_SESSION, research, state=state)
+    await plugin.before_agent_callback(agent=research, callback_context=cb)
+    await plugin.before_tool_callback(
+        tool=_Tool("read_file"), tool_args={"path": "a.md"}, tool_context=cb
+    )
+    spans = _span_starts(client)
+    tool_spans = [s for s in spans if s.name == "read_file"]
+    assert len(tool_spans) == 1
+    assert _attr_string(tool_spans[0], "hgraf.task_id") == "t2"
+
+
+@pytest.mark.asyncio
+async def test_model_span_stamps_hgraf_task_id(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """before_model_callback LLM_CALL SpanStart carries hgraf.task_id."""
+    coord = Agent("coordinator")
+    state = {"goldfive.current_task_id": "t3"}
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext(
+            "inv-1", ROOT_SESSION, coord, state=state
+        )
+    )
+    cb = _CallbackContext("inv-1", ROOT_SESSION, coord, state=state)
+    await plugin.before_agent_callback(agent=coord, callback_context=cb)
+    await plugin.before_model_callback(
+        callback_context=cb, llm_request=_LlmRequest("gpt-test")
+    )
+    spans = _span_starts(client)
+    # INVOCATION + LLM_CALL.
+    assert len(spans) == 2
+    assert _attr_string(spans[0], "hgraf.task_id") == "t3"
+    assert _attr_string(spans[1], "hgraf.task_id") == "t3"
+
+
+# ---------------------------------------------------------------------------
+# Absent / empty state → no attribute (non-goldfive runs, pre-plan spans)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_state_key_does_not_stamp_hgraf_task_id(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """No ``goldfive.current_task_id`` in state → no attribute; don't
+    invent a value, don't raise. Non-goldfive ADK apps must emit
+    cleanly without the attribute.
+    """
+    coord = Agent("coordinator")
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext(
+            "inv-1", ROOT_SESSION, coord, state={}
+        )
+    )
+    spans = _span_starts(client)
+    assert len(spans) == 1
+    assert _attr_string(spans[0], "hgraf.task_id") is None
+
+
+@pytest.mark.asyncio
+async def test_empty_state_value_does_not_stamp(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Empty-string value is treated identically to absence — pre-plan
+    spans (before goldfive has a task id to mirror) must not carry
+    ``hgraf.task_id=""``.
+    """
+    coord = Agent("coordinator")
+    state = {"goldfive.current_task_id": ""}
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext(
+            "inv-1", ROOT_SESSION, coord, state=state
+        )
+    )
+    spans = _span_starts(client)
+    assert _attr_string(spans[0], "hgraf.task_id") is None
+
+
+@pytest.mark.asyncio
+async def test_no_session_attr_does_not_raise(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Malformed ctx (no ``session``) must not raise — telemetry is
+    observability-only and must fail quietly."""
+
+    class _BareCtx:
+        invocation_id = "inv-1"
+        agent = Agent("bare")
+        branch = ""
+
+    # Real ADK always populates ``session`` on a runtime callback, but
+    # defensive paths matter: ``_safe_attr`` + early-return absorb both.
+    await plugin.before_run_callback(invocation_context=_BareCtx())
+    spans = _span_starts(client)
+    assert len(spans) == 1
+    assert _attr_string(spans[0], "hgraf.task_id") is None
+
+
+# ---------------------------------------------------------------------------
+# Follow-up turns: task id flips between tasks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_id_flips_between_turns(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Goldfive's mirror runs on EVERY before_run_callback, so
+    subsequent turns see a fresh (possibly different) task id. The
+    plugin reads per-callback — never caches — so the follow-up
+    SpanStart carries the NEW value.
+    """
+    coord = Agent("coordinator")
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext(
+            "inv-1", ROOT_SESSION, coord, state={"goldfive.current_task_id": "t1"}
+        )
+    )
+    await plugin.after_run_callback(
+        invocation_context=_InvocationContext(
+            "inv-1", ROOT_SESSION, coord, state={"goldfive.current_task_id": "t1"}
+        )
+    )
+    await plugin.before_run_callback(
+        invocation_context=_InvocationContext(
+            "inv-2", ROOT_SESSION, coord, state={"goldfive.current_task_id": "t2"}
+        )
+    )
+    spans = _span_starts(client)
+    assert len(spans) == 2
+    assert _attr_string(spans[0], "hgraf.task_id") == "t1"
+    assert _attr_string(spans[1], "hgraf.task_id") == "t2"


### PR DESCRIPTION
## Summary

Fix two span-attribution bugs that together broke the Task tab Trajectory subtab, Gantt/Graph/Timeline task binding, dependency arrows, and follow-up-turn agent rows.

### Issue #3 — `hgraf.task_id` never emitted

Goldfive mirrors `goldfive.current_task_id` into ADK `session.state` on every `before_run_callback` (via `_adk_state_protocol`). The server's ingest (`harmonograf_server/ingest.py`) and the frontend (`lib/thinking.ts:collectThinkingForTask`, `TaskRegistry.boundSpanId`) both key task binding off a `hgraf.task_id` string attribute on SpanStart frames — but nobody was emitting it. Verified: **0/44 spans** in the latest e2e session carried the attribute.

Fix: new `_stamp_task_id` helper reads `goldfive.current_task_id` off `callback_context` / `invocation_context` / `tool_context` `session.state` (read-only — ADK shallow-copies state into `CallbackContext`, so this consumes the mirror rather than writing) and augments span attributes with `hgraf.task_id`. Wired into `before_run_callback` (INVOCATION), `before_model_callback` (LLM_CALL), `before_tool_callback` (TOOL_CALL). Non-goldfive runs and pre-plan spans no-op cleanly — the helper never invents a task id.

### Issue #6 — follow-up INVOCATION missing `hgraf.agent.kind`

`_stamp_agent_attrs` gated ALL `hgraf.agent.*` keys on first-sight per `(session_id, per_agent_id)`. Follow-up user turns reuse the same coordinator's per-agent id, so the second INVOCATION SpanStart arrived without `hgraf.agent.kind` and the frontend rendered the row as `unknown` (verified against session `9fa8d4cb-...`).

Fix: split `hgraf.agent.*` keys into two tiers:

- **Always-stamp**: `hgraf.agent.name` + `hgraf.agent.kind` on every SpanStart so the `boundSpanId` / Task tab / Trajectory pipeline works on follow-up turns.
- **First-sight only**: `hgraf.agent.parent_id` + `hgraf.agent.branch` — the server harvests them into `Agent.metadata` on auto-register, so re-shipping on every span would bloat span-stream bytes without changing behavior.

## Test plan

- [x] `test_telemetry_plugin_task_id.py` (new, 7 cases): INVOCATION / LLM_CALL / TOOL_CALL stamping; absent / empty state no-ops; malformed ctx tolerance; task id flips between turns.
- [x] `test_telemetry_plugin_per_agent.py` (updated + extended): second span still carries name+kind; new `test_followup_invocation_on_registered_agent_stamps_kind` reproduces the 9fa8d4cb-... bug and verifies the fix.
- [x] Full client test suite: **265 passed** (`uv run --extra e2e pytest client/tests/`).
- [ ] Manual e2e: run `adk web` + goldfive, open Task tab, verify Trajectory populates and the second-turn agent row renders `llm` not `unknown`.