### PR TITLE
Replay persisted delegation_observed events on WatchSession burst

### DIFF
--- a/server/harmonograf_server/rpc/frontend.py
+++ b/server/harmonograf_server/rpc/frontend.py
@@ -358,6 +358,68 @@ class FrontendServicerMixin:
                     pb_sample.recorded_at.CopyFrom(ra)
                 yield frontend_pb2.SessionUpdate(context_window_sample=pb_sample)
 
+            # 4d. DelegationObserved — replay persisted delegation events so
+            # the Agent Graph / Gantt delegation arrows reappear on
+            # reconnect or for clients that open the view after the
+            # orchestrator already emitted the events. Without this,
+            # delegations only land on live bus subscribers — a viewer
+            # that joins late sees the agent lifelines (from span replay)
+            # but no arrows between them.
+            #
+            # The persisted payload_bytes carry the *raw* bare ADK agent
+            # names (ingest persists verbatim before resolving), so we
+            # re-run find_agent_id_by_name here to rewrite bare → compound
+            # ids. This matches the live path in
+            # IngestPipeline._on_delegation_observed.
+            try:
+                delegation_events = await self._store.list_goldfive_events(
+                    session_id, kind="delegation_observed"
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("list_goldfive_events(delegation_observed) failed: %s", exc)
+                delegation_events = []
+            for rec in delegation_events:
+                try:
+                    ev = goldfive_events_pb2.Event()
+                    ev.ParseFromString(rec.payload_bytes)
+                except Exception as exc:  # noqa: BLE001 — proto edge cases
+                    logger.debug(
+                        "delegation_observed replay parse failed session_id=%s seq=%s: %s",
+                        session_id,
+                        rec.sequence,
+                        exc,
+                    )
+                    continue
+                d = ev.delegation_observed
+                resolved_from = d.from_agent
+                resolved_to = d.to_agent
+                try:
+                    f_id = await self._store.find_agent_id_by_name(
+                        session_id, d.from_agent
+                    )
+                    if f_id:
+                        resolved_from = f_id
+                    t_id = await self._store.find_agent_id_by_name(
+                        session_id, d.to_agent
+                    )
+                    if t_id:
+                        resolved_to = t_id
+                except Exception as exc:  # noqa: BLE001 — defensive
+                    logger.debug(
+                        "delegation_observed replay resolve failed session_id=%s: %s",
+                        session_id,
+                        exc,
+                    )
+                ev.delegation_observed.from_agent = resolved_from
+                ev.delegation_observed.to_agent = resolved_to
+                # Stamp emitted_at from observed_at so the frontend's
+                # observedAtMs calculation (which reads Event.emitted_at)
+                # lines up with the Gantt timeline — same invariant as
+                # the live delta path in _delta_to_session_update.
+                if d.HasField("observed_at"):
+                    ev.emitted_at.CopyFrom(d.observed_at)
+                yield frontend_pb2.SessionUpdate(goldfive_event=ev)
+
             # 5. Burst complete marker
             yield frontend_pb2.SessionUpdate(
                 burst_complete=frontend_pb2.InitialBurstComplete(

--- a/server/tests/test_frontend_rpcs.py
+++ b/server/tests/test_frontend_rpcs.py
@@ -343,6 +343,92 @@ async def test_watch_session_replays_persisted_plan_as_goldfive_events(
     assert live_run_completed == "done"
 
 
+@pytest.mark.asyncio
+async def test_watch_session_replays_persisted_delegation_observed(harness, stub):
+    """Initial burst must replay persisted delegation_observed events with
+    bare ADK names rewritten to canonical compound agent ids so the Agent
+    Graph view draws arrows on reconnect. Regression: persist path stored
+    events verbatim (bare names), but WatchSession never re-emitted them
+    — only live bus subscribers ever saw delegations, so any client that
+    opened the view late got lifelines with no arrows between them."""
+
+    from goldfive.v1 import events_pb2 as goldfive_events_pb2
+    from harmonograf_server.storage import GoldfiveEventRecord
+
+    store = harness["store"]
+    now = time.time()
+    await _seed_session(
+        store, session_id="sess_gf_d", n_spans=0, start=now - 10
+    )
+    # Register the two ADK agents under compound ids so bare → compound
+    # resolution on replay has targets.
+    for adk_name in ("coordinator_agent", "research_agent"):
+        await store.register_agent(
+            Agent(
+                id=f"client-xyz:{adk_name}",
+                session_id="sess_gf_d",
+                name=adk_name,
+                framework=Framework.ADK,
+                connected_at=now - 9,
+                last_heartbeat=now - 9,
+                status=AgentStatus.CONNECTED,
+            )
+        )
+
+    # Persist a delegation_observed event exactly as the ingest pipeline
+    # would — raw proto bytes, bare ADK names in the payload.
+    ev = goldfive_events_pb2.Event(run_id="run-d")
+    ev.delegation_observed.from_agent = "coordinator_agent"
+    ev.delegation_observed.to_agent = "research_agent"
+    ev.delegation_observed.task_id = "t-del"
+    ev.delegation_observed.invocation_id = "inv-del"
+    ev.delegation_observed.observed_at.seconds = int(now - 5)
+    await store.append_goldfive_event(
+        GoldfiveEventRecord(
+            session_id="sess_gf_d",
+            run_id="run-d",
+            sequence=1,
+            kind="delegation_observed",
+            recorded_at=now - 5,
+            payload_bytes=ev.SerializeToString(),
+        )
+    )
+
+    req = frontend_pb2.WatchSessionRequest(session_id="sess_gf_d")
+    call = stub.WatchSession(req)
+
+    delegations: list = []
+
+    async def consumer():
+        async for upd in call:
+            which = upd.WhichOneof("kind")
+            if which == "goldfive_event":
+                payload = upd.goldfive_event.WhichOneof("payload")
+                if payload == "delegation_observed":
+                    delegations.append(upd.goldfive_event)
+            elif which == "burst_complete":
+                break
+
+    await asyncio.wait_for(consumer(), timeout=5.0)
+    call.cancel()
+
+    assert len(delegations) == 1, (
+        f"expected one replayed delegation_observed event, got {len(delegations)}"
+    )
+    replayed = delegations[0].delegation_observed
+    assert replayed.from_agent == "client-xyz:coordinator_agent", (
+        f"expected bare → compound rewrite on from_agent, got {replayed.from_agent!r}"
+    )
+    assert replayed.to_agent == "client-xyz:research_agent", (
+        f"expected bare → compound rewrite on to_agent, got {replayed.to_agent!r}"
+    )
+    assert replayed.task_id == "t-del"
+    assert replayed.invocation_id == "inv-del"
+    # emitted_at must be stamped from observed_at so the frontend's
+    # observedAtMs calculation lines up with the Gantt timeline.
+    assert delegations[0].emitted_at.seconds == int(now - 5)
+
+
 # ---- GetPayload -----------------------------------------------------------
 
 


### PR DESCRIPTION
## Root cause

Agent Graph view rendered 7 agent lifelines plus the "No agent interactions detected yet" header because `store.delegations` was empty even though `goldfive_events` in the DB had three `delegation_observed` rows for the session.

The ingest pipeline persists every goldfive event verbatim (raw `payload_bytes`) **before** dispatching it to the per-kind handler, then `_on_delegation_observed` rewrites the bare ADK names to canonical `"<client_id>:<adk_name>"` ids and publishes onto the bus. Live subscribers get correctly-resolved deltas; late joiners (reconnect, or a view opened after the event was emitted) get nothing — `WatchSession`'s initial burst replayed persisted plans, drifts, and context-window samples but had no case for `delegation_observed`.

Net effect: the data was on disk, but the wire protocol never surfaced it to any client that wasn't already subscribed when the event landed.

## Fix

Add a fourth replay step to `WatchSession` that:

- lists persisted `delegation_observed` records via `list_goldfive_events(session_id, kind='delegation_observed')`
- parses each `payload_bytes` back into `goldfive.v1.Event`
- rewrites `from_agent` / `to_agent` from bare ADK names to compound ids via `find_agent_id_by_name` (same path the live handler uses, needed because the persisted payload is pre-resolution)
- stamps `emitted_at` from `observed_at` so the frontend's `observedAtMs` calculation aligns with the Gantt timeline, matching `_delta_to_session_update`
- yields each as a `SessionUpdate(goldfive_event=...)` before the burst_complete marker

No frontend changes — the `goldfiveEvent.ts` dispatcher already routes `delegationObserved` into `store.delegations`, which is what `GraphView`'s Method 3 arrow pass reads.

## Test plan

- [x] `server/tests/test_frontend_rpcs.py::test_watch_session_replays_persisted_delegation_observed` — persist a delegation event with bare names, assert the burst delivers it with compound ids and intact task/invocation fields plus a correct `emitted_at`.
- [x] Full `server/tests/` suite (322 tests) passes.
- [x] `pnpm lint` clean.