### PR TITLE
Stop TrajectoryView from drowning in UNSPECIFIED drift markers

### DIFF
--- a/frontend/src/__tests__/components/TrajectoryView.emptyRev.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.emptyRev.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * Regression test for the "Trajectory view is empty when a session has
+ * a plan + task events + a drift storm" bug.
+ *
+ * Repro snapshot: a live session with a single rev-0 plan, no refines yet,
+ * real task_started/task_completed updates, and *tens of thousands* of
+ * UNSPECIFIED-kind drifts (a known goldfive status-query bug emits these
+ * spuriously). Before the fix, the TrajectoryView Ribbon rendered a
+ * <button> for every drift — 50k buttons under `flex-wrap: wrap` paved
+ * the viewport with a giant grid of dots and pushed the DAG off-screen,
+ * so the operator saw nothing useful.
+ *
+ * The fix has three parts tested here:
+ *   1. UNSPECIFIED-kind drifts (kind === '') are filtered out up-front so
+ *      they never reach the ribbon.
+ *   2. Legitimate drifts are capped per rev with a "+N more" chip so a
+ *      dense legitimate-drift window can't break layout either.
+ *   3. The DAG, task-delta list, and plan header still render normally
+ *      against real task data even with no refines yet (vm.revs.length >
+ *      0 from rev 0 alone).
+ */
+
+import { render, screen } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { SessionStore } from '../../gantt/index';
+import type { Task, TaskPlan } from '../../gantt/types';
+
+vi.mock('../../components/shell/views/views.css', () => ({}));
+
+let mockStore = new SessionStore();
+const mockSessionId: string | null = 'sess-traj';
+
+vi.mock('../../rpc/hooks', () => ({
+  useSessionWatch: () => ({
+    store: mockStore,
+    connected: true,
+    initialBurstComplete: true,
+    error: null,
+    sessionStatus: 'LIVE' as const,
+    lastEventAtMs: Date.now(),
+  }),
+  getSessionStore: () => mockStore,
+}));
+
+const uiStoreState = {
+  currentSessionId: mockSessionId,
+  selectSpan: vi.fn(),
+};
+vi.mock('../../state/uiStore', () => ({
+  useUiStore: <T,>(selector: (s: typeof uiStoreState) => T) =>
+    selector(uiStoreState),
+}));
+
+// Minimal annotation store stub — no annotations for this session so the
+// intervention list naturally collapses to empty. Subscribe is a no-op.
+vi.mock('../../state/annotationStore', () => ({
+  useAnnotationStore: Object.assign(
+    () => ({ list: () => [] }),
+    {
+      getState: () => ({ list: () => [] }),
+      subscribe: () => () => {},
+    },
+  ),
+}));
+
+import { TrajectoryView } from '../../components/shell/views/TrajectoryView';
+
+function mkTask(id: string, status: Task['status'], title = id): Task {
+  return {
+    id,
+    title,
+    description: `desc for ${id}`,
+    assigneeAgentId: 'agent-a',
+    status,
+    predictedStartMs: 0,
+    predictedDurationMs: 0,
+    boundSpanId: '',
+    cancelReason: '',
+  };
+}
+
+function mkPlan(tasks: Task[]): TaskPlan {
+  return {
+    id: 'plan-0',
+    invocationSpanId: 'inv-0',
+    plannerAgentId: 'planner-agent',
+    createdAtMs: 0,
+    summary: 'Two-slide solar panel presentation',
+    tasks,
+    edges: [
+      { fromTaskId: 't1', toTaskId: 't2' },
+      { fromTaskId: 't2', toTaskId: 't3' },
+    ],
+    revisionReason: '',
+    revisionIndex: 0,
+  };
+}
+
+beforeEach(() => {
+  mockStore = new SessionStore();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('<TrajectoryView /> with only rev 0 + drift storm', () => {
+  it('renders the plan, DAG nodes, and task-delta for a session with no refines', () => {
+    // Seed a rev-0 plan with 3 tasks in realistic statuses.
+    const plan = mkPlan([
+      mkTask('t1', 'COMPLETED', 'Research'),
+      mkTask('t2', 'RUNNING', 'Draft'),
+      mkTask('t3', 'CANCELLED', 'Verify'),
+    ]);
+    // t3 needs a cancelReason for the delta section to surface it.
+    plan.tasks[2].cancelReason = 'superseded_by_revision';
+    mockStore.tasks.upsertPlan(plan);
+
+    render(<TrajectoryView />);
+
+    // Header + rev chip show.
+    expect(screen.getByText('Trajectory')).toBeInTheDocument();
+
+    // Ribbon rendered.
+    expect(screen.getByTestId('trajectory-ribbon')).toBeInTheDocument();
+    expect(screen.getByTestId('rev-segment-0')).toBeInTheDocument();
+    // Summary text from the plan surfaces.
+    expect(
+      screen.getByText(/Two-slide solar panel presentation/),
+    ).toBeInTheDocument();
+
+    // DAG renders each task as a node with its stable testid.
+    expect(screen.getByTestId('trajectory-dag')).toBeInTheDocument();
+    expect(screen.getByTestId('task-node-t1')).toBeInTheDocument();
+    expect(screen.getByTestId('task-node-t2')).toBeInTheDocument();
+    expect(screen.getByTestId('task-node-t3')).toBeInTheDocument();
+
+    // Task-delta lists the one CANCELLED task with its reason.
+    expect(screen.getByTestId('trajectory-task-delta')).toBeInTheDocument();
+    const cancelRow = screen.getByTestId('task-delta-row-t3');
+    expect(cancelRow).toHaveTextContent('superseded_by_revision');
+  });
+
+  it('drops UNSPECIFIED-kind drifts from the ribbon entirely', () => {
+    const plan = mkPlan([mkTask('t1', 'RUNNING')]);
+    mockStore.tasks.upsertPlan(plan);
+
+    // Simulate the status-query storm: 200 drifts with no kind at all.
+    // The real reproducer has 50k, 200 is enough to prove the filter
+    // kicks in without slowing the test.
+    for (let i = 0; i < 200; i++) {
+      mockStore.drifts.append({
+        kind: '',
+        severity: '',
+        detail: `status_query ${i}`,
+        taskId: 't1',
+        agentId: 'agent-a',
+        recordedAtMs: i,
+        annotationId: '',
+        driftId: `noise-${i}`,
+      });
+    }
+
+    render(<TrajectoryView />);
+
+    // No drift markers at all (every drift was unspec). No "+N more" chip
+    // either, since the filter drops these before the cap applies.
+    expect(screen.queryAllByTestId(/^drift-marker-/)).toHaveLength(0);
+    expect(screen.queryByTestId('drift-more-0')).not.toBeInTheDocument();
+
+    // Task node still renders — the ribbon never blocked it.
+    expect(screen.getByTestId('task-node-t1')).toBeInTheDocument();
+  });
+
+  it('caps legitimate drifts per rev and shows a +N summary chip', () => {
+    const plan = mkPlan([mkTask('t1', 'RUNNING')]);
+    mockStore.tasks.upsertPlan(plan);
+
+    // 60 real drifts (well above the 24 cap). Mix of severities so the
+    // ranker has something to work on.
+    const severities = ['info', 'warning', 'critical'] as const;
+    for (let i = 0; i < 60; i++) {
+      mockStore.drifts.append({
+        kind: 'looping_reasoning',
+        severity: severities[i % 3],
+        detail: `d${i}`,
+        taskId: 't1',
+        agentId: 'agent-a',
+        recordedAtMs: i,
+        annotationId: '',
+        driftId: `drift-${i}`,
+      });
+    }
+
+    render(<TrajectoryView />);
+
+    const markers = screen.queryAllByTestId(/^drift-marker-/);
+    // Capped at RIBBON_MAX_MARKERS_PER_REV (24).
+    expect(markers.length).toBeLessThanOrEqual(24);
+    // Summary chip surfaces the trimmed remainder (60 - 24 = 36).
+    const more = screen.getByTestId('drift-more-0');
+    expect(more).toHaveTextContent('+36');
+  });
+
+  it('keeps the DAG visible even when the session has a mixed drift storm', () => {
+    // This is the exact repro of the live bug: rev-0 plan, real task
+    // statuses, a handful of legit drifts, and a firehose of UNSPECIFIED
+    // noise. The DAG + task markers must still render.
+    const plan = mkPlan([
+      mkTask('t1', 'COMPLETED'),
+      mkTask('t2', 'RUNNING'),
+      mkTask('t3', 'PENDING'),
+    ]);
+    mockStore.tasks.upsertPlan(plan);
+
+    // 2 legitimate drifts.
+    mockStore.drifts.append({
+      kind: 'looping_reasoning',
+      severity: 'warning',
+      detail: 'legit',
+      taskId: 't2',
+      agentId: 'agent-a',
+      recordedAtMs: 1,
+      annotationId: '',
+      driftId: 'legit-1',
+    });
+    mockStore.drifts.append({
+      kind: 'user_steer',
+      severity: 'info',
+      detail: 'operator nudge',
+      taskId: 't2',
+      agentId: 'agent-a',
+      recordedAtMs: 2,
+      annotationId: 'ann-1',
+      driftId: 'legit-2',
+    });
+    // 500 UNSPECIFIED drifts from the status-query bug.
+    for (let i = 0; i < 500; i++) {
+      mockStore.drifts.append({
+        kind: '',
+        severity: '',
+        detail: 'noise',
+        taskId: '',
+        agentId: 'agent-a',
+        recordedAtMs: 3 + i,
+        annotationId: '',
+        driftId: `n-${i}`,
+      });
+    }
+
+    render(<TrajectoryView />);
+
+    // DAG + every task still there.
+    expect(screen.getByTestId('task-node-t1')).toBeInTheDocument();
+    expect(screen.getByTestId('task-node-t2')).toBeInTheDocument();
+    expect(screen.getByTestId('task-node-t3')).toBeInTheDocument();
+
+    // Exactly the two legitimate drift markers, no noise.
+    const markers = screen.queryAllByTestId(/^drift-marker-/);
+    expect(markers).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -42,6 +42,55 @@ const SEVERITY_COLOR: Record<string, string> = {
 // model-authored drifts.
 const STEER_KINDS = new Set(['user_steer', 'user_cancel', 'user_pause']);
 
+// Upper bound on how many drift markers a single rev can render in the ribbon.
+// goldfive can emit thousands of DRIFT_KIND_UNSPECIFIED drifts in a single
+// session from misbehaving status-query paths; rendering a button per drift
+// (flex-wrap) produces a wall of dots that pushes the DAG off-screen and
+// freezes the browser. We keep the first N by severity+recency and render a
+// "+M more" summary chip for the remainder. Empty-kind drifts are dropped
+// entirely — goldfiveEvent.ts maps DRIFT_KIND_UNSPECIFIED → ''.
+const RIBBON_MAX_MARKERS_PER_REV = 24;
+
+// Filter out drifts whose kind is unknown/unspecified. These are inherently
+// noise for the trajectory ribbon — the upstream taxonomy mapper already
+// folds DRIFT_KIND_UNSPECIFIED to empty string (rpc/goldfiveEvent.ts
+// driftKindToString). Keeps a single filter site so a future "show raw"
+// affordance can flip it per-view.
+function isRenderableDrift(d: DriftRecord): boolean {
+  return !!(d.kind && d.kind.length > 0);
+}
+
+// Severity rank used when we have to trim a long drift list down to a
+// bounded window: critical > warning > info > unspec. Within a rank we
+// keep the most recent by recordedAtMs so the operator still sees the
+// trailing activity of a dense session.
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 3,
+  warning: 2,
+  info: 1,
+  '': 0,
+};
+
+function selectTopDrifts(
+  drifts: readonly DriftRecord[],
+  max: number,
+): { shown: DriftRecord[]; hidden: number } {
+  if (drifts.length <= max) {
+    return { shown: [...drifts], hidden: 0 };
+  }
+  const ranked = [...drifts].sort((a, b) => {
+    const sa = SEVERITY_RANK[a.severity] ?? 0;
+    const sb = SEVERITY_RANK[b.severity] ?? 0;
+    if (sa !== sb) return sb - sa;
+    return b.recordedAtMs - a.recordedAtMs;
+  });
+  const shown = ranked.slice(0, max);
+  // Present in chronological order so the ribbon still reads left-to-right
+  // even after we trimmed by severity.
+  shown.sort((a, b) => a.recordedAtMs - b.recordedAtMs);
+  return { shown, hidden: drifts.length - max };
+}
+
 // ── View model ─────────────────────────────────────────────────────────────
 
 interface TrajectoryViewModel {
@@ -83,7 +132,12 @@ function buildViewModel(store: SessionStore | null): TrajectoryViewModel {
   // for labeling / compare affordances; the trajectory view itself treats
   // every rev uniformly regardless of its plan_id.
   const primaryId = combined[0]?.id ?? plans[0].id;
-  const drifts = [...store.drifts.list()];
+  // Drop UNSPECIFIED-kind drifts up-front. Goldfive emits tens of thousands
+  // of these from a misbehaving status-query path; rendering them in the
+  // ribbon buries the DAG under a wall of dots and freezes the browser.
+  // They carry no actionable information (no kind, no severity → the
+  // ribbon marker would have no color or tooltip anyway).
+  const drifts = store.drifts.list().filter(isRenderableDrift);
   const driftsByRev: DriftRecord[][] = combined.map(() => []);
   for (const d of drifts) {
     let idx = 0;
@@ -491,26 +545,51 @@ function Ribbon(props: RibbonProps) {
               </span>
             </button>
             <div className="hg-traj__markers">
-              {drifts.map((d) => {
-                const isSteer = STEER_KINDS.has(d.kind);
-                return (
-                  <button
-                    key={`drift-${d.seq}`}
-                    className="hg-traj__marker"
-                    type="button"
-                    data-steer={isSteer}
-                    data-severity={d.severity || undefined}
-                    title={`${d.kind}${d.severity ? ` (${d.severity})` : ''}${d.detail ? `: ${d.detail}` : ''}`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      props.onSelectDrift(d.seq);
-                    }}
-                    data-testid={`drift-marker-${d.seq}`}
-                  >
-                    {isSteer ? '★' : '●'}
-                  </button>
+              {(() => {
+                // Cap markers per rev so a pathological drift storm (goldfive
+                // can emit thousands in one session) can't overflow the ribbon
+                // and push the DAG off-screen. UNSPECIFIED-kind drifts are
+                // already dropped in buildViewModel — this cap only kicks in
+                // when there are still more legitimate drifts than the ribbon
+                // can readably display.
+                const { shown, hidden } = selectTopDrifts(
+                  drifts,
+                  RIBBON_MAX_MARKERS_PER_REV,
                 );
-              })}
+                return (
+                  <>
+                    {shown.map((d) => {
+                      const isSteer = STEER_KINDS.has(d.kind);
+                      return (
+                        <button
+                          key={`drift-${d.seq}`}
+                          className="hg-traj__marker"
+                          type="button"
+                          data-steer={isSteer}
+                          data-severity={d.severity || undefined}
+                          title={`${d.kind}${d.severity ? ` (${d.severity})` : ''}${d.detail ? `: ${d.detail}` : ''}`}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            props.onSelectDrift(d.seq);
+                          }}
+                          data-testid={`drift-marker-${d.seq}`}
+                        >
+                          {isSteer ? '★' : '●'}
+                        </button>
+                      );
+                    })}
+                    {hidden > 0 && (
+                      <span
+                        className="hg-traj__marker--more"
+                        data-testid={`drift-more-${i}`}
+                        title={`${hidden} more drift${hidden === 1 ? '' : 's'} not shown (ranked by severity + recency)`}
+                      >
+                        +{hidden}
+                      </span>
+                    )}
+                  </>
+                );
+              })()}
             </div>
           </div>
         );

--- a/frontend/src/components/shell/views/views.css
+++ b/frontend/src/components/shell/views/views.css
@@ -385,6 +385,23 @@ a.hg-settings__value:hover {
   background: rgba(255, 255, 255, 0.06);
   border-color: currentColor;
 }
+.hg-traj__marker--more {
+  /* +N summary chip — informational only, never a button. Sits inline with
+     the real markers so a trimmed ribbon still reads as one row instead of
+     wrapping into a grid. */
+  color: #8d9199;
+  font-size: 11px;
+  line-height: 1.4;
+  padding: 0 6px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  white-space: nowrap;
+  cursor: default;
+}
+.hg-traj__marker--more:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: transparent;
+}
 
 /* Split layout: DAG on the left, detail on the right */
 


### PR DESCRIPTION
## Summary

- **Root cause.** The Ribbon rendered a `<button>` per drift inside a `flex-wrap: wrap` container. A sibling goldfive bug can emit tens of thousands of `DRIFT_KIND_UNSPECIFIED` events per session, which produced a viewport-filling grid of empty dots that pushed the DAG, intervention list, and task-delta off-screen (and stalled the render loop). The view rendered "plan title + REV 0 + wall of dots + footer" with no visible task cards.
- **Fix (local to TrajectoryView).**
  1. `buildViewModel` filters drifts whose kind is `''` (the upstream mapper already normalises `DRIFT_KIND_UNSPECIFIED → ''`). They carry no actionable info and never reach any downstream path.
  2. The ribbon caps markers at `RIBBON_MAX_MARKERS_PER_REV = 24`, ranked by severity + recency, and shows a `+N more` summary chip for the remainder. Dense but legitimate drift windows can't break layout either.
  3. DAG, intervention list, and task-delta are untouched — they render normally on rev 0 with real task data, which is exactly what they always should have done when the ribbon wasn't hogging the viewport.

Scope is intentionally small: the upstream drift-storm (33k–50k noise drifts from a broken status-query path) is a separate bug being fixed in parallel. This PR just makes the Trajectory view robust to it.

## Test plan

- [x] New `TrajectoryView.emptyRev.test.tsx` covers the repro exactly:
  - rev-0-only session renders plan header, ribbon segment, DAG nodes, task-delta row + cancel reason;
  - 200 UNSPECIFIED drifts produce 0 markers and no `+N` chip;
  - 60 legit drifts are capped at 24 markers with a `+36` chip;
  - rev-0 plan + 2 legit drifts + 500 noise drifts still renders every task node and exactly 2 markers.
- [x] `pnpm test` in `frontend/` — 286 / 286 pass.
- [x] `pnpm lint` in `frontend/` — clean.
- [x] `pnpm exec tsc -b --noEmit` — clean.