### PR TITLE
Read live Session state for hgraf.task_id (fix CallbackContext shallow-copy regression)

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -106,35 +106,13 @@ def _adk_session_id(ctx: Any) -> str:
     return str(sid)
 
 
-def _extract_current_task_id(ctx: Any) -> str:
-    """Read ``goldfive.current_task_id`` out of an ADK callback context's session.state.
+def _read_task_id_from_session(session: Any) -> str:
+    """Pull ``goldfive.current_task_id`` out of an ADK ``Session``-like object.
 
-    Goldfive's ADK state-protocol mirror (``_adk_state_protocol``) stamps
-    ``goldfive.current_task_id`` onto ``session.state`` on every
-    ``before_run_callback`` — see goldfive issue #3. The server's ingest
-    and the frontend's Task tab both key Trajectory / dependency
-    rendering off a ``hgraf.task_id`` attribute on SpanStart frames; this
-    helper pulls the goldfive-side value out of whichever shape the
-    callback gives us (CallbackContext exposes ``session`` directly;
-    ToolContext does too; InvocationContext does as well).
-
-    ADK shallow-copies ``session.state`` into ``CallbackContext`` so
-    *writes* on the callback side don't propagate back — this is a
-    **read-only** use and the mirror has fired on ``before_run_callback``
-    by the time any before-agent/tool/model callback runs, so the read
-    sees the latest task id.
-
-    Returns ``""`` when the context is non-goldfive (no state key present),
-    malformed, or pre-plan — callers must treat that as a no-op and not
-    invent a task id.
+    Pure helper: takes whatever ``session`` object the caller resolved
+    and reads ``.state['goldfive.current_task_id']``. Empty / missing /
+    malformed → ``""``. Never raises — telemetry is observability-only.
     """
-    if ctx is None:
-        return ""
-    session = _safe_attr(ctx, "session", None)
-    if session is None:
-        inv = _safe_attr(ctx, "_invocation_context", None)
-        if inv is not None:
-            session = _safe_attr(inv, "session", None)
     if session is None:
         return ""
     state = _safe_attr(session, "state", None)
@@ -147,6 +125,50 @@ def _extract_current_task_id(ctx: Any) -> str:
     if not value:
         return ""
     return str(value)
+
+
+def _extract_current_task_id(ctx: Any) -> str:
+    """Read ``goldfive.current_task_id`` out of an ADK callback context's session.state.
+
+    Goldfive's ADK state-protocol mirror (``_adk_state_protocol``) stamps
+    ``goldfive.current_task_id`` onto ``session.state`` on every
+    ``before_run_callback`` — see goldfive issue #3. The server's ingest
+    and the frontend's Task tab both key Trajectory / dependency
+    rendering off a ``hgraf.task_id`` attribute on SpanStart frames; this
+    helper pulls the goldfive-side value out of whichever shape the
+    callback gives us (CallbackContext exposes ``session`` directly;
+    ToolContext does too; InvocationContext does as well).
+
+    .. warning::
+
+       ADK's ``CallbackContext`` captures a **shallow copy** of
+       ``invocation_context.session.state`` at the moment the callback
+       context is constructed (see ``ReadonlyContext`` / ``CallbackContext``
+       in google.adk). Writes made to ``session.state`` *after* that
+       snapshot (e.g. goldfive's mirror on ``before_run_callback`` when
+       another plugin's ``before_run_callback`` has already minted the
+       CallbackContext used for a child model/tool callback) do NOT
+       flow back into the stale snapshot.
+
+       Prefer :meth:`HarmonografTelemetryPlugin._resolve_live_session`
+       + :func:`_read_task_id_from_session` in the plugin's own code
+       paths — this free function is the degraded legacy path kept for
+       callers who have no plugin instance handy (and for the ``session``
+       attribute resolve below which will still be correct when the
+       caller is an ``InvocationContext`` rather than a CallbackContext).
+
+    Returns ``""`` when the context is non-goldfive (no state key present),
+    malformed, or pre-plan — callers must treat that as a no-op and not
+    invent a task id.
+    """
+    if ctx is None:
+        return ""
+    session = _safe_attr(ctx, "session", None)
+    if session is None:
+        inv = _safe_attr(ctx, "_invocation_context", None)
+        if inv is not None:
+            session = _safe_attr(inv, "session", None)
+    return _read_task_id_from_session(session)
 
 
 def _serialize_args(args: Any) -> bytes | None:
@@ -479,6 +501,37 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         # :meth:`_register_agent_for_ctx`.
         self._agent_metadata: dict[str, dict[str, str]] = {}
 
+        # Live ADK Session cache keyed by ``invocation_id``
+        # (harmonograf#117 / goldfive state-handoff pitfall).
+        #
+        # ``CallbackContext`` holds a SHALLOW COPY of
+        # ``invocation_context.session.state`` taken at construction
+        # time. Goldfive's ADK state-protocol mirror writes
+        # ``goldfive.current_task_id`` onto the live
+        # ``invocation_context.session`` on ``before_run_callback`` —
+        # CallbackContexts already minted for child before_model /
+        # before_tool / before_agent callbacks don't see those writes.
+        # Pre-fix symptom: only 1/21 spans in a run carried
+        # ``hgraf.task_id``, breaking Gantt task→span edges and the
+        # Task-tab Trajectory subtab (``bound_span_id`` was NULL on
+        # 6/7 tasks of a verified failing session).
+        #
+        # Fix: cache the live ``invocation_context.session`` on
+        # ``before_run_callback`` keyed by ``invocation_id``; every
+        # subsequent before_* callback reads task_id from the cached
+        # LIVE session instead of the stale CallbackContext snapshot.
+        # IMPORTANT: we cache the *session object*, not the task_id
+        # string — goldfive's mirror may run AFTER harmonograf's
+        # ``before_run_callback`` (plugin ordering is not contractual),
+        # so the task_id value we'd read at stash time can be stale.
+        # Reading ``session.state`` at child-callback time sees the
+        # latest mirror write regardless of plugin ordering.
+        #
+        # Cleaned up in ``after_run_callback`` / ``on_cancellation`` /
+        # ``on_run_end`` so long-lived plugin instances don't retain
+        # references to dead ADK sessions.
+        self._live_sessions: dict[str, Any] = {}
+
     @property
     def client(self) -> Client:
         return self._client
@@ -692,6 +745,51 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
                     merged.setdefault(k, v)
         return merged or None
 
+    def _resolve_live_session(self, ctx: Any) -> Any:
+        """Return the live ADK Session for ``ctx`` — never the shallow copy.
+
+        ADK's ``CallbackContext`` (and ``ToolContext``, which extends it)
+        constructs with a shallow copy of ``invocation_context.session.state``
+        at the moment the callback context is created. Later writes to
+        the live ``invocation_context.session.state`` — e.g. goldfive's
+        state-protocol mirror stamping ``goldfive.current_task_id`` on
+        ``before_run_callback`` — are invisible to an already-minted
+        CallbackContext.
+
+        Resolution order:
+
+        1. Cache hit on ``_live_sessions[invocation_id]`` (populated by
+           :meth:`before_run_callback`, which receives the real
+           ``InvocationContext``).
+        2. ``ctx._invocation_context.session`` — on a CallbackContext
+           this IS the live session, not a copy (the copy is only of
+           ``state``, not of the enclosing Session object; on ADK
+           versions where the whole Session is copied the cache still
+           wins via step 1).
+        3. ``ctx.session`` — fallback for ``InvocationContext`` callers
+           directly, or unit-test harnesses that skip
+           ``before_run_callback``. This branch is the legacy
+           shallow-copy path; it's the last resort and only wrong for
+           the exact regression this method exists to fix.
+
+        Returns ``None`` when ``ctx`` has no resolvable session at all
+        (malformed harness, no ADK wiring). Callers must treat ``None``
+        as "no task id available" and not raise.
+        """
+        if ctx is None:
+            return None
+        inv_id = str(_safe_attr(ctx, "invocation_id", "") or "")
+        if inv_id:
+            cached = self._live_sessions.get(inv_id)
+            if cached is not None:
+                return cached
+        inv = _safe_attr(ctx, "_invocation_context", None)
+        if inv is not None:
+            live = _safe_attr(inv, "session", None)
+            if live is not None:
+                return live
+        return _safe_attr(ctx, "session", None)
+
     def _stamp_task_id(
         self, ctx: Any, attrs: Optional[dict[str, Any]] = None
     ) -> Optional[dict[str, Any]]:
@@ -703,13 +801,21 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         Task tab / Gantt / Timeline / Graph views all key task binding
         off a ``hgraf.task_id`` string attribute on SpanStart frames
         (``hgraf.task_id`` drives ``collectThinkingForTask`` and
-        ``TaskRegistry.boundSpanId``). Nobody emits it today — fixing
-        that is harmonograf#3.
+        ``TaskRegistry.boundSpanId``).
+
+        CRITICAL: reads from the LIVE session resolved via
+        :meth:`_resolve_live_session`, not from the CallbackContext's
+        shallow-copied state. See the ``_live_sessions`` cache
+        docstring in ``__init__`` for the full pitfall write-up —
+        pre-fix, only 1/21 spans in a run carried ``hgraf.task_id``
+        because CallbackContexts minted before goldfive's mirror write
+        served stale snapshots.
 
         No-op for non-goldfive runs or pre-plan spans (state key absent
         or empty). Never invents a value.
         """
-        task_id = _extract_current_task_id(ctx)
+        session = self._resolve_live_session(ctx)
+        task_id = _read_task_id_from_session(session)
         if not task_id:
             return attrs
         merged: dict[str, Any] = dict(attrs or {})
@@ -990,6 +1096,12 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         # cancelled invocation without touching concurrent siblings.
         self._agent_stash.pop(invocation_id, None)
 
+        # Drop the live-session cache entry for the cancelled
+        # invocation. Mirrors the cleanup in ``after_run_callback`` —
+        # on a cancel that bypasses after_run_callback, this is the
+        # only place the entry gets released.
+        self._live_sessions.pop(invocation_id, None)
+
         # If the cancelled invocation was the cached ROOT, release the
         # root-session cache and tear down the per-session control sub.
         # Without this, a subsequent run after a user cancel would still
@@ -1149,6 +1261,13 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         # plugin instances.
         self._reasoning_trails.clear()
 
+        # Drop any remaining live-session references so the plugin
+        # doesn't pin ADK sessions after the run exits. Normal path
+        # already popped per-invocation in ``after_run_callback`` /
+        # ``_close_stale_spans_for_invocation``; this final sweep
+        # handles ADK flows that skip those hooks.
+        self._live_sessions.clear()
+
     # ------------------------------------------------------------------
     # Invocation lifecycle
     # ------------------------------------------------------------------
@@ -1181,6 +1300,23 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         agent = _safe_attr(invocation_context, "agent")
         name = str(_safe_attr(agent, "name", "") or "invocation")
         adk_sid = _adk_session_id(invocation_context)
+
+        # Stash the LIVE ADK Session keyed by invocation_id so child
+        # before_model / before_tool / before_agent callbacks can read
+        # ``goldfive.current_task_id`` from the live session.state
+        # instead of the stale CallbackContext shallow copy. See the
+        # ``_live_sessions`` docstring in ``__init__`` for the
+        # shallow-copy pitfall this fixes (harmonograf#117).
+        #
+        # We stash the session OBJECT, not the task_id VALUE — goldfive's
+        # mirror plugin writes on ``before_run_callback`` too and its
+        # relative ordering vs ours is not contractual, so reading
+        # ``session.state`` lazily at child-callback time is the only
+        # way to guarantee we see the post-mirror value.
+        if inv_id:
+            live_session = _safe_attr(invocation_context, "session", None)
+            if live_session is not None:
+                self._live_sessions[inv_id] = live_session
 
         # Root-invocation detection (harmonograf#65 / goldfive#161).
         # The first ``before_run_callback`` we see with no cached root
@@ -1254,6 +1390,12 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         if self._maybe_disable_as_duplicate(invocation_context):
             return
         inv_id = str(_safe_attr(invocation_context, "invocation_id", "") or "")
+        # Drop the live-session cache entry for this invocation
+        # regardless of the short-circuit below — we never want to keep
+        # a reference to a dead ADK session across invocations. Pairs
+        # with the cache seed in ``before_run_callback``.
+        if inv_id:
+            self._live_sessions.pop(inv_id, None)
         # Goldfive.wrap wrapper short-circuit (harmonograf#113). The
         # matching ``before_run_callback`` opened no span for this
         # invocation_id, so this after_run is a no-op. Dropping the

--- a/client/tests/test_telemetry_plugin_task_id.py
+++ b/client/tests/test_telemetry_plugin_task_id.py
@@ -305,3 +305,216 @@ async def test_task_id_flips_between_turns(
     assert len(spans) == 2
     assert _attr_string(spans[0], "hgraf.task_id") == "t1"
     assert _attr_string(spans[1], "hgraf.task_id") == "t2"
+
+
+# ---------------------------------------------------------------------------
+# Shallow-copy regression (harmonograf#117)
+# ---------------------------------------------------------------------------
+#
+# Regression: ADK's CallbackContext holds a SHALLOW COPY of
+# invocation_context.session.state at the moment the CallbackContext is
+# built. Goldfive's _adk_state_protocol mirror writes
+# ``goldfive.current_task_id`` onto the LIVE session.state on
+# before_run_callback. If the mirror fires AFTER harmonograf's
+# before_run_callback (plugin ordering is not contractual) — or if the
+# CallbackContext for a child before_model / before_tool was minted
+# before the mirror write — the stale snapshot does NOT see the update.
+#
+# DB-verified symptom on session 0f4959c9-798e-44b8-8cc2-ab049d0bb415:
+# 21 spans total, only 1 carried hgraf.task_id. Task-tab Trajectory
+# subtab was empty; Gantt task→span edges broken; 6/7 tasks' bound_span_id
+# was NULL. The one span that DID carry it was the LLM_CALL that happened
+# to fire close enough to the mirror write to see the value.
+#
+# Fix: cache the LIVE invocation_context.session on before_run_callback
+# keyed by invocation_id; every child callback reads task_id from the
+# cached live session at CALLBACK TIME so it sees the latest mirror
+# write regardless of plugin ordering.
+
+
+class _LiveSession:
+    """Session stand-in shared between an InvocationContext and N
+    CallbackContexts so tests can verify the plugin reads from the
+    LIVE object — writes to the live session must be visible to
+    already-minted CallbackContexts through the plugin's resolver."""
+
+    def __init__(self, sid: str, state: dict[str, Any] | None = None) -> None:
+        self.id = sid
+        self.state = dict(state or {})
+
+
+class _SharedSessionInvocationContext:
+    def __init__(
+        self,
+        invocation_id: str,
+        agent: Any,
+        live_session: _LiveSession,
+        branch: str = "",
+    ) -> None:
+        self.invocation_id = invocation_id
+        self.session = live_session  # THE live session — shared
+        self.agent = agent
+        self.branch = branch
+
+
+class _StaleCopyCallbackContext:
+    """CallbackContext that mimics ADK's real shallow-copy semantics.
+
+    ``self.session.state`` is a snapshot taken at construction time;
+    later writes to the LIVE session (held separately by the
+    InvocationContext passed in) DO NOT propagate to ``self.session.state``.
+    This is the exact shape that broke ``_extract_current_task_id``
+    pre-fix.
+    """
+
+    def __init__(
+        self,
+        invocation_context: _SharedSessionInvocationContext,
+        live_session: _LiveSession,
+    ) -> None:
+        self.invocation_id = invocation_context.invocation_id
+        self.branch = invocation_context.branch
+        # CRITICAL: snapshot the state dict — no shared reference.
+        self.session = _Session(
+            live_session.id, state=dict(live_session.state)
+        )
+        # CallbackContext still holds a ref to the live InvocationContext,
+        # which in turn holds a ref to the LIVE session. The plugin's
+        # resolver walks through this path when the cache misses; when
+        # the cache is seeded (normal flow) it takes precedence.
+        self._invocation_context = invocation_context
+
+
+@pytest.mark.asyncio
+async def test_live_session_write_after_callback_context_mint_is_visible(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Simulate the exact production pitfall:
+
+    1. before_run_callback fires → plugin caches the live session.
+    2. A CallbackContext for a child before_model is minted, snapshotting
+       state = {} (the mirror hasn't written yet).
+    3. Goldfive's mirror writes ``goldfive.current_task_id = "t-late"``
+       onto the LIVE session.state (AFTER the CallbackContext was minted).
+    4. before_model_callback fires with the stale CallbackContext.
+
+    Expected: the LLM_CALL SpanStart carries ``hgraf.task_id = "t-late"``
+    — read from the cached live session, NOT the stale snapshot on
+    ``callback_context.session.state``.
+
+    Pre-fix: the plugin read ``callback_context.session.state`` which
+    was empty, so the LLM_CALL SpanStart had no ``hgraf.task_id`` at
+    all — the exact DB-verified regression this test locks down.
+    """
+    coord = Agent("coordinator")
+    live = _LiveSession(ROOT_SESSION, state={})  # empty at run-start
+    inv_ctx = _SharedSessionInvocationContext("inv-late", coord, live)
+
+    # (1) Seed the plugin's live-session cache.
+    await plugin.before_run_callback(invocation_context=inv_ctx)
+
+    # (2) Child CallbackContext is minted here — snapshots empty state.
+    cb = _StaleCopyCallbackContext(inv_ctx, live)
+    # Sanity-check the harness: the snapshot on the CallbackContext is
+    # divorced from subsequent live writes.
+    assert cb.session.state.get("goldfive.current_task_id", "") == ""
+
+    # (3) Goldfive's mirror writes LATE on the LIVE session.
+    live.state["goldfive.current_task_id"] = "t-late"
+    # The stale snapshot still shows empty — this is the pitfall.
+    assert cb.session.state.get("goldfive.current_task_id", "") == ""
+
+    # (4) before_model_callback reads the LIVE session via the cache.
+    await plugin.before_model_callback(
+        callback_context=cb, llm_request=_LlmRequest("gpt-live")
+    )
+    spans = _span_starts(client)
+    llm_spans = [s for s in spans if s.name == "gpt-live"]
+    assert len(llm_spans) == 1
+    assert _attr_string(llm_spans[0], "hgraf.task_id") == "t-late", (
+        "Regression: plugin read CallbackContext shallow-copy instead of "
+        "live session. Every child span loses hgraf.task_id when goldfive's "
+        "mirror write lands after the CallbackContext is minted."
+    )
+
+
+@pytest.mark.asyncio
+async def test_live_session_write_visible_to_before_tool_callback(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """Same pitfall, TOOL_CALL path. TOOL_CALL spans dominate a typical
+    run (6/7 cases in the verified regression) so a separate lock-down
+    test here guards the tool path explicitly."""
+    research = Agent("research_agent")
+    live = _LiveSession(ROOT_SESSION, state={})
+    inv_ctx = _SharedSessionInvocationContext("inv-tool", research, live)
+
+    await plugin.before_run_callback(invocation_context=inv_ctx)
+    cb = _StaleCopyCallbackContext(inv_ctx, live)
+    # Late mirror write — AFTER the CallbackContext was minted.
+    live.state["goldfive.current_task_id"] = "t-tool"
+
+    await plugin.before_tool_callback(
+        tool=_Tool("read_file"), tool_args={"path": "a.md"}, tool_context=cb
+    )
+    spans = _span_starts(client)
+    tool_spans = [s for s in spans if s.name == "read_file"]
+    assert len(tool_spans) == 1
+    assert _attr_string(tool_spans[0], "hgraf.task_id") == "t-tool"
+
+
+@pytest.mark.asyncio
+async def test_live_session_cache_cleared_after_run(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """The live-session cache must not retain references across runs.
+    after_run_callback pops the entry keyed by invocation_id.
+    """
+    coord = Agent("coordinator")
+    live = _LiveSession(ROOT_SESSION, state={"goldfive.current_task_id": "t1"})
+    inv_ctx = _SharedSessionInvocationContext("inv-cleanup", coord, live)
+
+    await plugin.before_run_callback(invocation_context=inv_ctx)
+    assert "inv-cleanup" in plugin._live_sessions
+
+    await plugin.after_run_callback(invocation_context=inv_ctx)
+    assert "inv-cleanup" not in plugin._live_sessions
+
+
+@pytest.mark.asyncio
+async def test_live_session_cache_cleared_on_cancellation(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """on_cancellation clears the live-session cache for the cancelled
+    invocation. Without this, the plugin would pin the ADK session
+    across cancelled runs."""
+    coord = Agent("coordinator")
+    live = _LiveSession(ROOT_SESSION, state={"goldfive.current_task_id": "t1"})
+    inv_ctx = _SharedSessionInvocationContext("inv-cancel", coord, live)
+
+    await plugin.before_run_callback(invocation_context=inv_ctx)
+    assert "inv-cancel" in plugin._live_sessions
+
+    plugin.on_cancellation("inv-cancel")
+    assert "inv-cancel" not in plugin._live_sessions
+
+
+@pytest.mark.asyncio
+async def test_live_session_cache_cleared_on_run_end(
+    plugin: HarmonografTelemetryPlugin, client: Client
+) -> None:
+    """on_run_end sweeps any leftover live-session entries so long-lived
+    plugin instances don't accumulate references."""
+    coord = Agent("coordinator")
+    live_a = _LiveSession(ROOT_SESSION, state={"goldfive.current_task_id": "t1"})
+    live_b = _LiveSession(ROOT_SESSION, state={"goldfive.current_task_id": "t2"})
+    await plugin.before_run_callback(
+        invocation_context=_SharedSessionInvocationContext("inv-a", coord, live_a)
+    )
+    await plugin.before_run_callback(
+        invocation_context=_SharedSessionInvocationContext("inv-b", coord, live_b)
+    )
+    assert len(plugin._live_sessions) == 2
+
+    plugin.on_run_end()
+    assert plugin._live_sessions == {}


### PR DESCRIPTION
## Summary

PR #115 added `hgraf.task_id` stamping via `_extract_current_task_id(ctx)`
that reads `callback_context.session.state['goldfive.current_task_id']`.
ADK's `CallbackContext` is constructed with a **shallow copy** of
`invocation_context.session.state` at construction time — writes made to
the live `session.state` after that snapshot DO NOT flow back.

Goldfive's `_adk_state_protocol` mirror plugin writes
`goldfive.current_task_id` onto the LIVE session on `before_run_callback`.
Plugin ordering is not contractual, so CallbackContexts minted for child
before_model / before_tool callbacks before the mirror write serve a
stale (often empty) snapshot.

**DB-verified regression** (session `0f4959c9-798e-44b8-8cc2-ab049d0bb415`):
21 spans total, only 1 carried `hgraf.task_id`. The one that did was the
LLM_CALL that fired close enough to the mirror write to see the value.
Downstream: `bound_span_id` NULL on 6/7 tasks, Gantt task→span edges
broken, Task-tab Trajectory subtab empty.

## Fix

Cache the LIVE `invocation_context.session` on `before_run_callback`,
keyed by `invocation_id`. Every child before_* callback resolves task_id
via the cached live session at CALLBACK TIME, so it sees the latest
mirror write regardless of plugin ordering.

- Cache the SESSION OBJECT, not the task_id VALUE — stashing the value at
  `before_run_callback` time would still lose the race when harmonograf's
  `before_run_callback` runs before goldfive's mirror.
- `_resolve_live_session(ctx)` prefers the cache, falls back to
  `ctx._invocation_context.session`, then to `ctx.session` — graceful
  degradation for unit-test harnesses and non-goldfive runs.
- Cleanup hooks: `after_run_callback` / `on_cancellation` /
  `on_run_end` all pop / clear the cache so long-lived plugin instances
  don't retain references to dead ADK sessions.

Scope: `client/harmonograf_client/telemetry_plugin.py` only. The free
function `_extract_current_task_id` stays in place as a legacy degraded
path (kept for direct InvocationContext callers); the plugin's own call
sites now route through `_resolve_live_session` +
`_read_task_id_from_session`.

## Test plan

- [x] New test `test_live_session_write_after_callback_context_mint_is_visible`
  reproduces the exact pitfall — snapshot empty at CallbackContext mint,
  live write lands after, `before_model_callback` must still stamp the
  late value. Locks down the LLM_CALL regression.
- [x] New test `test_live_session_write_visible_to_before_tool_callback`
  — same pattern on the TOOL_CALL path (dominated the DB-verified failure:
  TOOL_CALLs were 6/7 of the orphaned spans).
- [x] Three new cleanup tests covering `after_run_callback`,
  `on_cancellation`, `on_run_end` — cache must not retain entries.
- [x] All 270 client tests pass (`uv run --extra e2e pytest client/tests/`).
- [x] All 89 `test_telemetry_plugin*.py` tests pass.