### PR TITLE
Fix STATUS_QUERY polling thrash in GraphView (useEffect dep instability)

### DIFF
--- a/frontend/src/__tests__/components/GraphView.statusQueryPolling.test.tsx
+++ b/frontend/src/__tests__/components/GraphView.statusQueryPolling.test.tsx
@@ -1,0 +1,218 @@
+// Regression test for the STATUS_QUERY polling thrash bug in
+// components/shell/views/GraphView.tsx.
+//
+// The offending useEffect was intended to fire sendStatusQuery once on
+// mount and then every 8s while there are running agents. In practice,
+// its dependency array included `layout.agentIds` and
+// `layout.activations` — both derived from a memo keyed on `tick`, so
+// both got fresh array identities every store tick (~60Hz during a
+// busy run). That caused the effect to re-run on every render,
+// firing the initial `poll()` again each time → ~222 sendStatusQuery
+// calls/sec observed in production, 50k+ DB rows in under 4 minutes.
+//
+// This test mounts <GraphView /> with one running agent, fires 20
+// store-subscription ticks in quick succession, and asserts
+// sendStatusQuery was called at most once (the initial poll) — NOT
+// 20+ times. It also verifies that when the set of running agents
+// actually changes, we DO fire an extra immediate poll.
+
+import { act, render } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { SessionStore } from '../../gantt/index';
+import type { Agent, Span } from '../../gantt/types';
+
+type WatchMock = {
+  store: SessionStore;
+  connected: boolean;
+  initialBurstComplete: boolean;
+  error: string | null;
+  sessionStatus: 'UNKNOWN' | 'LIVE' | 'COMPLETED' | 'ABORTED';
+  lastEventAtMs: number;
+};
+
+let mockStore: SessionStore | undefined;
+let mockWatch: WatchMock | undefined;
+let mockSessionId: string | null = 'session-1';
+const sendStatusQueryMock = vi.fn().mockResolvedValue('');
+
+vi.mock('../../rpc/hooks', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../rpc/hooks')>(
+      '../../rpc/hooks',
+    );
+  return {
+    ...actual,
+    getSessionStore: (id: string | null) => (id ? mockStore : undefined),
+    useSessionWatch: () => mockWatch ?? null,
+    sendStatusQuery: (...args: unknown[]) => sendStatusQueryMock(...args),
+  };
+});
+
+vi.mock('../../state/uiStore', () => {
+  const state: Record<string, unknown> = {
+    currentSessionId: 'session-1',
+    selectSpan: () => {},
+    selectTask: () => {},
+    selectedSpanId: null,
+    selectedTaskId: null,
+    taskPlanMode: 'ghost' as const,
+    taskPlanVisible: false,
+    setTaskPlanMode: () => {},
+    toggleTaskPlanVisible: () => {},
+    graphViewport: null,
+    setGraphViewport: () => {},
+    setGraphActions: () => {},
+  };
+  return {
+    useUiStore: <T,>(selector: (s: typeof state) => T) => {
+      return selector({ ...state, currentSessionId: mockSessionId ?? '' });
+    },
+  };
+});
+
+import { GraphView } from '../../components/shell/views/GraphView';
+
+function agent(id: string, connectedAtMs = 0): Agent {
+  return {
+    id,
+    name: id,
+    framework: 'ADK',
+    capabilities: [],
+    status: 'CONNECTED',
+    connectedAtMs,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+  };
+}
+
+function invocationSpan(
+  id: string,
+  agentId: string,
+  startMs: number,
+  endMs: number | null,
+): Span {
+  return {
+    id,
+    sessionId: 'session-1',
+    agentId,
+    parentSpanId: null,
+    kind: 'INVOCATION',
+    name: `${agentId}-inv`,
+    status: endMs === null ? 'RUNNING' : 'COMPLETED',
+    startMs,
+    endMs,
+    lane: 0,
+    attributes: {},
+    payloadRefs: [],
+    links: [],
+    replaced: false,
+    error: null,
+  };
+}
+
+describe('<GraphView /> STATUS_QUERY polling stability', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sendStatusQueryMock.mockClear();
+    mockStore = new SessionStore();
+    mockSessionId = 'session-1';
+    mockStore.agents.upsert(agent('coordinator', 1));
+    mockStore.agents.upsert(agent('worker', 2));
+    // One open (running) INVOCATION on 'worker'.
+    mockStore.spans.append(invocationSpan('sp-worker-1', 'worker', 1_000, null));
+    mockWatch = {
+      store: mockStore,
+      connected: true,
+      initialBurstComplete: true,
+      error: null,
+      sessionStatus: 'LIVE',
+      lastEventAtMs: 0,
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    mockStore = undefined;
+    mockWatch = undefined;
+  });
+
+  it('does not re-poll on every store-subscription tick when the running set is unchanged', () => {
+    render(<GraphView />);
+    // Initial mount: one immediate poll for the single running agent.
+    const initialCalls = sendStatusQueryMock.mock.calls.length;
+    expect(initialCalls).toBe(1);
+    expect(sendStatusQueryMock.mock.calls[0][1]).toBe('worker');
+
+    // Simulate 20 store ticks that do NOT change the running agent set
+    // (just bumping activity/status — exactly the kind of churn
+    // delegation events, context series appends, or per-frame nowMs
+    // updates produce in a live session). Each emit happens in its
+    // own act() so React commits a render between them, which is what
+    // a real live session produces (subscribe callbacks fire one at a
+    // time across microtasks).
+    for (let i = 0; i < 20; i++) {
+      act(() => {
+        mockStore!.agents.setActivityAndStuck(
+          'coordinator',
+          `beat-${i}`,
+          false,
+        );
+      });
+    }
+
+    // The effect's deps must be stable enough that it does NOT re-run
+    // on every tick. Without the fix, we'd see ~21 calls (1 initial +
+    // 20 re-mounts firing poll() again). With the fix, we see exactly
+    // the initial call.
+    expect(sendStatusQueryMock.mock.calls.length).toBe(initialCalls);
+  });
+
+  it('fires an extra immediate poll when the running-agent set actually changes', () => {
+    render(<GraphView />);
+    expect(sendStatusQueryMock.mock.calls.length).toBe(1);
+
+    // A second agent goes running — set changed, effect re-runs, new
+    // immediate poll fires for BOTH currently-running agents.
+    act(() => {
+      mockStore!.spans.append(
+        invocationSpan('sp-coord-1', 'coordinator', 2_000, null),
+      );
+    });
+
+    // After the set-change, one more poll cycle fires. That cycle
+    // iterates the current running set (both agents now), so we
+    // expect 1 (initial) + 2 (second cycle, one per running agent)
+    // = 3 total.
+    expect(sendStatusQueryMock.mock.calls.length).toBe(3);
+    const polledAgents = sendStatusQueryMock.mock.calls.map((c) => c[1]);
+    expect(polledAgents).toContain('worker');
+    expect(polledAgents).toContain('coordinator');
+  });
+
+  it('keeps polling on the 8s interval (does not disable the auto-poll feature)', () => {
+    render(<GraphView />);
+    expect(sendStatusQueryMock.mock.calls.length).toBe(1);
+
+    // Advance 8s — exactly one interval tick.
+    act(() => {
+      vi.advanceTimersByTime(8_000);
+    });
+    expect(sendStatusQueryMock.mock.calls.length).toBe(2);
+
+    // Advance another 8s — another tick.
+    act(() => {
+      vi.advanceTimersByTime(8_000);
+    });
+    expect(sendStatusQueryMock.mock.calls.length).toBe(3);
+  });
+});

--- a/frontend/src/components/shell/views/GraphView.tsx
+++ b/frontend/src/components/shell/views/GraphView.tsx
@@ -643,27 +643,48 @@ export function GraphView() {
     [watch.store, selectSpan],
   );
 
-  // Auto-poll STATUS_QUERY for agents with running activations
+  // Auto-poll STATUS_QUERY for agents with running activations.
+  //
+  // The list of running agent ids is derived fresh on every store tick
+  // (because `layout` churns with `tick`), so we can't depend on
+  // `layout.agentIds` / `layout.activations` directly — their array
+  // identities change every render and would re-run this effect at
+  // ~60Hz during a busy run, firing sendStatusQuery() once per tick
+  // (see harmonograf GraphView status-query thrash: ~222 downstream
+  // events/sec observed in production). Instead, derive a stable
+  // scalar signature from the *set* of running agent ids and depend on
+  // that: the effect only re-runs when the set actually changes, and
+  // the polling loop ticks on its own 8s schedule in between.
+  const runningAgentIds = useMemo(
+    () =>
+      layout.agentIds.filter((_agentId, idx) =>
+        layout.activations.some((a) => a.agentIdx === idx && a.isRunning),
+      ),
+    [layout],
+  );
+  const runningAgentSig = useMemo(
+    () => [...runningAgentIds].sort().join('|'),
+    [runningAgentIds],
+  );
+  const runningAgentIdsRef = useRef<string[]>(runningAgentIds);
+  runningAgentIdsRef.current = runningAgentIds;
+
   useEffect(() => {
-    if (!sessionId || layout.agentIds.length === 0) return;
-
-    const runningAgentIds = layout.agentIds.filter((_agentId, idx) =>
-      layout.activations.some((a) => a.agentIdx === idx && a.isRunning)
-    );
-
-    if (runningAgentIds.length === 0) return;
+    if (!sessionId || runningAgentSig === '') return;
 
     const poll = () => {
-      for (const agentId of runningAgentIds) {
+      const ids = runningAgentIdsRef.current;
+      for (const agentId of ids) {
         sendStatusQuery(sessionId, agentId).catch(() => {});
       }
     };
 
-    // Fire once immediately, then every 8 seconds
+    // Fire once immediately on mount / whenever the running-agent set
+    // actually changes, then every 8 seconds.
     poll();
     const interval = setInterval(poll, 8000);
     return () => clearInterval(interval);
-  }, [sessionId, layout.agentIds, layout.activations]);
+  }, [sessionId, runningAgentSig]);
 
   if (!sessionId) {
     return (


### PR DESCRIPTION
## Summary

- `GraphView`'s auto-poll `useEffect` (lines 647-666) listed `layout.agentIds` and `layout.activations` as deps. Both came out of a `useMemo` keyed on the `tick` counter that bumps on every store subscription (spans / agents / tasks / delegations), so both got fresh array identities on every render.
- Net effect: the effect re-ran on every store tick (~60Hz during a busy run), firing `sendStatusQuery()` immediately each time. Production repro: **50,212 control requests in 226 seconds (~222 downstream events/sec)** from a single 3-agent session — DB pollution + UI choke.
- Fix: derive a stable scalar signature (sorted-join of running-agent ids) and depend on that string. Stash the current list in a `useRef` so the interval callback reads the latest without re-binding on identity churn. Effect now only re-runs when the running-agent **set** actually changes, preserving the intended "fire once immediately + every 8s" cadence with an extra immediate poll on real set-changes.

## Mechanism (before)

```tsx
const layout = useMemo(() => computeSequence(watch.store), [watch.store, tick]);
// ^ fresh object every time tick bumps (~60Hz in a live run)

useEffect(() => {
  // ... build runningAgentIds from layout.activations ...
  poll();                                    // fires immediately
  const interval = setInterval(poll, 8000);
  return () => clearInterval(interval);
}, [sessionId, layout.agentIds, layout.activations]);
// ^ fresh array identities every tick → cleanup + re-run every tick
//   → immediate poll() fires every render → ~60+ polls/sec
```

## Fix

- `runningAgentIds` is memoized off `layout`.
- `runningAgentSig = [...runningAgentIds].sort().join('|')` is memoized off `runningAgentIds`. When the set is unchanged, the string is identical and the effect's dep array stays stable.
- Current list is mirrored into a ref so the 8s-interval callback reads the latest ids without the effect needing to re-subscribe.

## Test plan

- [x] Added `frontend/src/__tests__/components/GraphView.statusQueryPolling.test.tsx`:
  - Mount with 1 running agent, fire 20 store ticks that don't change the set, assert `sendStatusQuery` called exactly once. Without the fix, this test observes **21** calls (1 initial + 20 tick-triggered re-polls) — confirms the exact mechanism.
  - Verifies a real set-change (second agent goes running) triggers one additional immediate poll covering both agents.
  - Verifies the 8s interval still fires (feature preserved).
- [x] `pnpm test` (frontend): **285/285 pass**
- [x] `pnpm lint` clean
- [x] `pnpm build` clean