### PR TITLE
Ingest-time task→span binding via agent-id correlation (retire attribute dependency)

### DIFF
--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -217,6 +217,17 @@ class IngestPipeline:
         # attributes without a full table scan on every span start.
         self._task_index: dict[str, dict[str, str]] = {}
 
+        # Pending task→span binding intents (harmonograf#122). Keyed by
+        # (session_id, canonical_agent_id) so a ``task_started`` that
+        # arrives before the INVOCATION span for its assignee can be
+        # fulfilled when the span lands. Each entry is a list of
+        # (plan_id, task_id) waiting on an INVOCATION span for that
+        # agent. Drained as soon as a matching span starts; bounded in
+        # practice by concurrent-tasks-per-agent which is tiny.
+        self._pending_task_bindings: dict[
+            tuple[str, str], list[tuple[str, str]]
+        ] = {}
+
         # Per-session ring of recent DriftDetected events. Frontend
         # replays these on WatchSession initial burst so synthetic-actor
         # rows (user / goldfive) and trajectory drift markers survive
@@ -416,6 +427,18 @@ class IngestPipeline:
         )
         stored = await self._store.append_span(span)
         self._bus.publish_span_start(stored)
+
+        # harmonograf#122: server-side task→span binding. When an
+        # INVOCATION span starts, fulfill any pending binding intents
+        # for its (session, agent) pair so tasks whose ``task_started``
+        # arrived before their agent's span land on the right
+        # ``bound_span_id``. The attribute-based path below stays as a
+        # secondary signal on leaf spans — it binds correctly on the
+        # narrow timing window where the client's state mirror wins,
+        # but the PRIMARY binding is now agent-id correlation at
+        # ingest (see ``_on_task_started``).
+        if stored.kind == SpanKind.INVOCATION:
+            await self._drain_pending_bindings_for_span(stored)
 
         # Proactive task report via span attribute.
         if pb_span.attributes:
@@ -999,8 +1022,27 @@ class IngestPipeline:
     async def _on_task_started(
         self, ctx: StreamContext, payload: Any, run_id: str
     ) -> None:
+        # harmonograf#122: correlate task→INVOCATION span at ingest
+        # time. Resolve the task's ``assignee_agent_id`` to the
+        # canonical (per-ADK-agent) id registered on this session,
+        # then find a RUNNING INVOCATION span for that agent. If the
+        # span hasn't arrived yet (possible under stream ordering),
+        # stash a pending binding intent so ``_handle_span_start``
+        # can fulfill it when the span lands. This replaces the
+        # fragile client-side ``hgraf.task_id`` attribute path, which
+        # mis-binds under the AgentTool sub-Runner state-handoff bug
+        # (harmonograf#119): only 1/19 spans carry the attribute in a
+        # fresh run, so the attribute path is kept as a fallback but
+        # cannot be the sole source of truth.
+        bound_span_id = await self._resolve_invocation_span_for_task(
+            ctx.session_id, payload.task_id
+        )
         await self._apply_goldfive_task_status(
-            ctx, payload.task_id, TaskStatus.RUNNING, run_id=run_id
+            ctx,
+            payload.task_id,
+            TaskStatus.RUNNING,
+            run_id=run_id,
+            bound_span_id=bound_span_id,
         )
 
     def _on_task_progress(
@@ -1070,6 +1112,7 @@ class IngestPipeline:
         *,
         run_id: str,
         cancel_reason: str = "",
+        bound_span_id: Optional[str] = None,
     ) -> None:
         if not task_id:
             logger.debug(
@@ -1101,7 +1144,11 @@ class IngestPipeline:
             )
             return
         updated = await self._store.update_task_status(
-            plan_id, task_id, status, cancel_reason=cancel_reason
+            plan_id,
+            task_id,
+            status,
+            bound_span_id=bound_span_id,
+            cancel_reason=cancel_reason,
         )
         if updated is not None:
             self._bus.publish_task_status(ctx.session_id, plan_id, updated)
@@ -1363,6 +1410,148 @@ class IngestPipeline:
             invocation_id=payload.invocation_id,
             observed_at=observed_at,
         )
+
+    async def _resolve_invocation_span_for_task(
+        self, session_id: str, task_id: str
+    ) -> Optional[str]:
+        """Return the span id of the INVOCATION that should bind to ``task_id``.
+
+        harmonograf#122: looks up the task's ``assignee_agent_id``,
+        resolves it to the canonical agent-row id
+        (``find_agent_id_by_name`` — bare ADK name → compound id per
+        harmonograf#111 / #113), and scans stored spans for an
+        INVOCATION owned by that agent. Preference order:
+
+          1. RUNNING INVOCATION with the latest ``start_time`` (the
+             agent is actively executing — the usual case).
+          2. Most recently started INVOCATION regardless of status.
+             Covers late-arriving ``task_started`` after the
+             invocation already closed (rare, but observed when the
+             coordinator reports task deltas out of band).
+
+        Returns None if the plan/task is unknown, the assignee is
+        missing, or no matching span has been ingested yet. In that
+        case ``_on_task_started`` stashes a pending binding intent
+        that ``_handle_span_start`` fulfills when the span lands.
+        Returning None also covers the pre-#122 behavior where
+        ``_on_task_started`` did not set ``bound_span_id`` at all, so
+        this is strictly additive.
+        """
+        if not task_id:
+            return None
+        task = await self._lookup_task(session_id, task_id)
+        if task is None or not task.assignee_agent_id:
+            return None
+        canonical = await self._store.find_agent_id_by_name(
+            session_id, task.assignee_agent_id
+        ) or task.assignee_agent_id
+        span_id = await self._find_invocation_span_for_agent(
+            session_id, canonical
+        )
+        if span_id is None:
+            # Stash a pending binding intent keyed by the canonical
+            # agent id so ``_handle_span_start`` can fulfill it when
+            # the INVOCATION span arrives.
+            plan_id = self._task_index.get(session_id, {}).get(task_id)
+            if plan_id is not None:
+                self._pending_task_bindings.setdefault(
+                    (session_id, canonical), []
+                ).append((plan_id, task_id))
+        return span_id
+
+    async def _lookup_task(
+        self, session_id: str, task_id: str
+    ) -> Optional[Any]:
+        """Fetch the ``Task`` row for ``(session_id, task_id)`` or None.
+
+        Uses the in-memory ``_task_index`` to find the owning plan and
+        falls back to a storage scan if the index is cold (pipeline
+        restart mid-session).
+        """
+        plan_id = self._task_index.get(session_id, {}).get(task_id)
+        if plan_id is None:
+            plans = await self._store.list_task_plans_for_session(session_id)
+            for p in plans:
+                for t in p.tasks:
+                    if t.id == task_id:
+                        self._task_index.setdefault(session_id, {})[
+                            task_id
+                        ] = p.id
+                        return t
+            return None
+        plan = await self._store.get_task_plan(plan_id)
+        if plan is None:
+            return None
+        for t in plan.tasks:
+            if t.id == task_id:
+                return t
+        return None
+
+    async def _find_invocation_span_for_agent(
+        self, session_id: str, agent_id: str
+    ) -> Optional[str]:
+        """Return the id of the INVOCATION span to bind to this agent.
+
+        Scans spans for ``(session_id, agent_id)`` and picks the best
+        INVOCATION candidate: RUNNING with the latest ``start_time``,
+        else the most recently started INVOCATION (any status). Only
+        INVOCATION spans are considered — the UI renders task boxes on
+        agent lifelines which live on INVOCATION spans; binding a
+        TOOL_CALL / LLM_CALL here would fight the attribute-based leaf
+        binding on the same task row.
+        """
+        if not session_id or not agent_id:
+            return None
+        spans = await self._store.get_spans(session_id, agent_id=agent_id)
+        running: list[Span] = []
+        any_invocation: list[Span] = []
+        for sp in spans:
+            if sp.kind != SpanKind.INVOCATION:
+                continue
+            any_invocation.append(sp)
+            if sp.status == SpanStatus.RUNNING:
+                running.append(sp)
+        pool = running or any_invocation
+        if not pool:
+            return None
+        pool.sort(key=lambda s: s.start_time, reverse=True)
+        return pool[0].id
+
+    async def _drain_pending_bindings_for_span(self, span: Span) -> None:
+        """Fulfill any task-binding intents waiting on ``span``'s agent.
+
+        harmonograf#122: called from ``_handle_span_start`` after an
+        INVOCATION span is persisted. Any ``task_started`` event that
+        fired BEFORE this span landed left a pending-binding record
+        keyed by ``(session_id, canonical_agent_id)``; we drain the
+        list and stamp ``bound_span_id`` on each task. Runs under the
+        same lock-free regime as the rest of the ingest hot path
+        because the entries are append-only from one ingest thread
+        and each drain pops its key.
+        """
+        key = (span.session_id, span.agent_id)
+        pending = self._pending_task_bindings.pop(key, None)
+        if not pending:
+            return
+        for plan_id, task_id in pending:
+            # Preserve whatever status the task currently holds — the
+            # span might land after the task already transitioned
+            # terminal (task_completed can arrive before the
+            # INVOCATION's span_start under odd stream orderings).
+            # We only want to set bound_span_id; use the task's own
+            # status as the "no-op" value for update_task_status.
+            current = await self._lookup_task(span.session_id, task_id)
+            status = current.status if current is not None else TaskStatus.RUNNING
+            updated = await self._store.update_task_status(
+                plan_id,
+                task_id,
+                status,
+                bound_span_id=span.id,
+            )
+            if updated is not None:
+                self._bus.publish_task_status(
+                    span.session_id, plan_id, updated
+                )
 
     async def _bind_task_to_span(
         self,

--- a/server/tests/test_ingest_task_binding.py
+++ b/server/tests/test_ingest_task_binding.py
@@ -1,0 +1,482 @@
+"""Tests for ingest-time task→span binding (harmonograf#122).
+
+Before #122 the only path from a planned task to the INVOCATION span
+that executed it was a client-stamped ``hgraf.task_id`` span attribute.
+That attribute relied on ADK's ``CallbackContext.state`` round-tripping
+the current task id through sub-Runner sessions; goldfive's sub-Runner
+mirror writes ``goldfive.current_task_id`` in ``before_run_callback``
+while the binding reconciler runs during ``before_agent_callback``, so
+the attribute lands on at most 1/19 spans in a representative run
+(empirical measurement on 2026-04-22).
+
+The new design correlates by agent id at ingest time: when
+``task_started(task_id=T)`` arrives, the server reads the task's
+``assignee_agent_id`` (already resolved to the canonical per-ADK-agent
+id at plan ingest — harmonograf#113), finds an INVOCATION span owned
+by that agent, and stamps ``bound_span_id`` on the task. If the span
+hasn't arrived yet (stream ordering), a pending-binding intent queues
+up and ``_handle_span_start`` fulfills it when the span lands.
+
+These tests drive the ingest pipeline with synthetic
+``TelemetryUp.span_start`` + ``TelemetryUp.goldfive_event`` messages
+and assert the resulting ``bound_span_id`` on the stored task. The
+attribute-based path from harmonograf#72 stays enabled and is NOT
+exercised here — see ``test_goldfive_ingest.py`` for those tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from goldfive.pb.goldfive.v1 import events_pb2 as ge
+from goldfive.pb.goldfive.v1 import types_pb2 as gt
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from harmonograf_server.bus import SessionBus
+from harmonograf_server.ingest import IngestPipeline, StreamContext
+from harmonograf_server.pb import telemetry_pb2, types_pb2
+from harmonograf_server.storage import (
+    Agent,
+    AgentStatus,
+    Framework,
+    Session,
+    SessionStatus,
+    TaskStatus,
+    make_store,
+)
+
+
+# ---- fixtures ------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def store():
+    s = make_store("memory")
+    await s.start()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+@pytest_asyncio.fixture
+async def pipeline(store):
+    bus = SessionBus()
+    pipe = IngestPipeline(store, bus, now_fn=lambda: 1_000_000.0)
+    yield pipe, bus, store
+
+
+SESSION_ID = "sess_bind"
+STREAM_AGENT = "client-xyz"
+
+
+def _stream_ctx(
+    session_id: str = SESSION_ID, agent_id: str = STREAM_AGENT
+) -> StreamContext:
+    return StreamContext(
+        stream_id="str_test",
+        agent_id=agent_id,
+        session_id=session_id,
+        connected_at=1000.0,
+        last_heartbeat=1000.0,
+        seen_routes={(session_id, agent_id)},
+    )
+
+
+def _ts(sec: float) -> Timestamp:
+    t = Timestamp()
+    t.seconds = int(sec)
+    t.nanos = int((sec - int(sec)) * 1e9)
+    return t
+
+
+def _span_start_msg(
+    *,
+    span_id: str,
+    agent_id: str,
+    session_id: str = SESSION_ID,
+    kind=types_pb2.SPAN_KIND_INVOCATION,
+    start: float = 100.0,
+    name: str = "invocation",
+) -> telemetry_pb2.TelemetryUp:
+    span = types_pb2.Span(
+        id=span_id,
+        session_id=session_id,
+        agent_id=agent_id,
+        kind=kind,
+        status=types_pb2.SPAN_STATUS_RUNNING,
+        name=name,
+    )
+    span.start_time.CopyFrom(_ts(start))
+    return telemetry_pb2.TelemetryUp(
+        span_start=telemetry_pb2.SpanStart(span=span)
+    )
+
+
+def _make_event(**kwargs) -> ge.Event:
+    evt = ge.Event()
+    evt.event_id = kwargs.get("event_id", "e1")
+    evt.run_id = kwargs.get("run_id", "run-1")
+    evt.sequence = kwargs.get("sequence", 0)
+    return evt
+
+
+def _wrap_gf(event: ge.Event) -> telemetry_pb2.TelemetryUp:
+    return telemetry_pb2.TelemetryUp(goldfive_event=event)
+
+
+def _plan_event(
+    *,
+    plan_id: str,
+    task_id: str,
+    assignee_bare_name: str,
+    sequence: int = 0,
+    event_id: str = "e-plan",
+) -> ge.Event:
+    evt = _make_event(event_id=event_id, sequence=sequence)
+    plan = evt.plan_submitted.plan
+    plan.id = plan_id
+    plan.run_id = "run-1"
+    plan.summary = "bind plan"
+    t = plan.tasks.add()
+    t.id = task_id
+    t.title = task_id
+    t.assignee_agent_id = assignee_bare_name
+    t.status = gt.TASK_STATUS_PENDING
+    return evt
+
+
+def _task_started_event(
+    *, task_id: str, sequence: int = 1, event_id: str = "e-ts"
+) -> ge.Event:
+    evt = _make_event(event_id=event_id, sequence=sequence)
+    evt.task_started.task_id = task_id
+    return evt
+
+
+async def _ensure_session(store) -> None:
+    await store.create_session(
+        Session(
+            id=SESSION_ID,
+            title=SESSION_ID,
+            created_at=1.0,
+            status=SessionStatus.LIVE,
+        )
+    )
+
+
+async def _register_agent(store, *, canonical_id: str, name: str) -> None:
+    await store.register_agent(
+        Agent(
+            id=canonical_id,
+            session_id=SESSION_ID,
+            name=name,
+            framework=Framework.ADK,
+            connected_at=1000.0,
+            last_heartbeat=1000.0,
+            status=AgentStatus.CONNECTED,
+        )
+    )
+
+
+# ---- tests ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_span_then_task_started_binds_immediately(pipeline, store):
+    """SpanStart(INVOCATION, agent=A) → task_started(T, assignee=A)
+    → task.bound_span_id == that span id.
+
+    This is the common ordering: the sub-agent's INVOCATION opens
+    first (its ``before_run_callback`` emits SpanStart), then the
+    coordinator's planner fires ``task_started`` for the task
+    assigned to that sub-agent.
+    """
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+    canonical = "client-xyz:research_agent"
+    await _register_agent(store, canonical_id=canonical, name="research_agent")
+
+    # Plan assigns t1 to research_agent (bare name — matches what
+    # goldfive's planner emits; ingest rewrites to canonical).
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(
+            _plan_event(
+                plan_id="p1",
+                task_id="t1",
+                assignee_bare_name="research_agent",
+            )
+        ),
+    )
+
+    # INVOCATION span lands first, owned by the canonical agent id.
+    await pipe.handle_message(
+        _stream_ctx(),
+        _span_start_msg(span_id="inv-1", agent_id=canonical, start=100.0),
+    )
+
+    # Now task_started fires.
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(_task_started_event(task_id="t1")),
+    )
+
+    plan = await store.get_task_plan("p1")
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.status == TaskStatus.RUNNING
+    assert t1.bound_span_id == "inv-1", (
+        "task_started should bind to the RUNNING INVOCATION span"
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_started_then_span_binds_on_span_arrival(pipeline, store):
+    """task_started arrives BEFORE the INVOCATION span — binding
+    deferred until ``_handle_span_start`` sees the matching agent."""
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+    canonical = "client-xyz:research_agent"
+    await _register_agent(store, canonical_id=canonical, name="research_agent")
+
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(
+            _plan_event(
+                plan_id="p1",
+                task_id="t1",
+                assignee_bare_name="research_agent",
+            )
+        ),
+    )
+
+    # task_started before the span lands — binding stashed.
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(_task_started_event(task_id="t1")),
+    )
+
+    plan = await store.get_task_plan("p1")
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.status == TaskStatus.RUNNING
+    assert t1.bound_span_id == "", "no binding yet — span hasn't arrived"
+
+    # Now the INVOCATION span lands — pending binding fulfilled.
+    await pipe.handle_message(
+        _stream_ctx(),
+        _span_start_msg(span_id="inv-1", agent_id=canonical, start=110.0),
+    )
+
+    plan = await store.get_task_plan("p1")
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.bound_span_id == "inv-1", (
+        "late-arriving INVOCATION span should fulfill pending binding"
+    )
+
+
+@pytest.mark.asyncio
+async def test_multi_agent_tasks_do_not_cross_bind(pipeline, store):
+    """Two agents, two tasks — each task binds to its own agent's
+    INVOCATION, never to the other's."""
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+    agent_a = "client-xyz:research_agent"
+    agent_b = "client-xyz:summarizer_agent"
+    await _register_agent(store, canonical_id=agent_a, name="research_agent")
+    await _register_agent(store, canonical_id=agent_b, name="summarizer_agent")
+
+    # Plan with two tasks, each assigned to a different agent.
+    plan_evt = _make_event(event_id="e-plan", sequence=0)
+    plan = plan_evt.plan_submitted.plan
+    plan.id = "p1"
+    plan.run_id = "run-1"
+    plan.summary = "two-agent plan"
+    t1 = plan.tasks.add()
+    t1.id = "t1"
+    t1.title = "research"
+    t1.assignee_agent_id = "research_agent"
+    t1.status = gt.TASK_STATUS_PENDING
+    t2 = plan.tasks.add()
+    t2.id = "t2"
+    t2.title = "summarize"
+    t2.assignee_agent_id = "summarizer_agent"
+    t2.status = gt.TASK_STATUS_PENDING
+    await pipe.handle_message(_stream_ctx(), _wrap_gf(plan_evt))
+
+    # Two INVOCATION spans, one per agent.
+    await pipe.handle_message(
+        _stream_ctx(),
+        _span_start_msg(span_id="inv-a", agent_id=agent_a, start=100.0),
+    )
+    await pipe.handle_message(
+        _stream_ctx(),
+        _span_start_msg(span_id="inv-b", agent_id=agent_b, start=101.0),
+    )
+
+    # Start both tasks.
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(_task_started_event(task_id="t1", sequence=1, event_id="e-s1")),
+    )
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(_task_started_event(task_id="t2", sequence=2, event_id="e-s2")),
+    )
+
+    plan_row = await store.get_task_plan("p1")
+    t1_row = next(t for t in plan_row.tasks if t.id == "t1")
+    t2_row = next(t for t in plan_row.tasks if t.id == "t2")
+    assert t1_row.bound_span_id == "inv-a"
+    assert t2_row.bound_span_id == "inv-b"
+
+
+@pytest.mark.asyncio
+async def test_leaf_spans_do_not_satisfy_invocation_binding(pipeline, store):
+    """Only INVOCATION spans participate in ingest binding. A
+    TOOL_CALL / LLM_CALL for the same agent must not be picked.
+
+    This protects the existing attribute-based leaf binding path
+    (harmonograf#72) which binds leaf spans to their executing task;
+    the two paths must not fight over ``bound_span_id``.
+    """
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+    canonical = "client-xyz:research_agent"
+    await _register_agent(store, canonical_id=canonical, name="research_agent")
+
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(
+            _plan_event(
+                plan_id="p1",
+                task_id="t1",
+                assignee_bare_name="research_agent",
+            )
+        ),
+    )
+
+    # Only a TOOL_CALL span (no INVOCATION) — the ingest path should
+    # queue a pending binding that is NEVER fulfilled by this span.
+    await pipe.handle_message(
+        _stream_ctx(),
+        _span_start_msg(
+            span_id="tc-1",
+            agent_id=canonical,
+            kind=types_pb2.SPAN_KIND_TOOL_CALL,
+            start=100.0,
+            name="tool_x",
+        ),
+    )
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(_task_started_event(task_id="t1")),
+    )
+
+    plan = await store.get_task_plan("p1")
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.status == TaskStatus.RUNNING
+    assert t1.bound_span_id == "", (
+        "TOOL_CALL must not satisfy INVOCATION binding"
+    )
+
+    # Now an INVOCATION lands for the same agent — binding fulfilled.
+    await pipe.handle_message(
+        _stream_ctx(),
+        _span_start_msg(span_id="inv-1", agent_id=canonical, start=110.0),
+    )
+    plan = await store.get_task_plan("p1")
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.bound_span_id == "inv-1"
+
+
+@pytest.mark.asyncio
+async def test_binding_resolves_bare_name_via_find_agent_id_by_name(
+    pipeline, store
+):
+    """The plan's ``assignee_agent_id`` is rewritten from the bare ADK
+    name to the canonical compound id at plan ingest (harmonograf#113).
+    The binding path must agree with that resolution."""
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+    canonical = "client-xyz:research_agent"
+    await _register_agent(store, canonical_id=canonical, name="research_agent")
+
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(
+            _plan_event(
+                plan_id="p1",
+                task_id="t1",
+                assignee_bare_name="research_agent",
+            )
+        ),
+    )
+
+    plan = await store.get_task_plan("p1")
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.assignee_agent_id == canonical, (
+        "plan ingest should resolve bare ADK name → canonical id"
+    )
+
+    await pipe.handle_message(
+        _stream_ctx(),
+        _span_start_msg(span_id="inv-1", agent_id=canonical, start=100.0),
+    )
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(_task_started_event(task_id="t1")),
+    )
+
+    plan = await store.get_task_plan("p1")
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.bound_span_id == "inv-1"
+
+
+@pytest.mark.asyncio
+async def test_binding_preserves_existing_status_on_late_span(pipeline, store):
+    """If the INVOCATION span lands AFTER task_completed (an odd but
+    possible ordering under mixed stream timing), the late binding
+    must not downgrade the task's terminal status back to RUNNING —
+    it should stamp ``bound_span_id`` while leaving status at
+    COMPLETED."""
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+    canonical = "client-xyz:research_agent"
+    await _register_agent(store, canonical_id=canonical, name="research_agent")
+
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(
+            _plan_event(
+                plan_id="p1",
+                task_id="t1",
+                assignee_bare_name="research_agent",
+            )
+        ),
+    )
+    # task_started → task_completed without the span having arrived.
+    await pipe.handle_message(
+        _stream_ctx(),
+        _wrap_gf(_task_started_event(task_id="t1")),
+    )
+    completed = _make_event(sequence=2, event_id="e-c")
+    completed.task_completed.task_id = "t1"
+    await pipe.handle_message(_stream_ctx(), _wrap_gf(completed))
+
+    plan = await store.get_task_plan("p1")
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.status == TaskStatus.COMPLETED
+    assert t1.bound_span_id == ""
+
+    # Span lands last — binding must not clobber COMPLETED.
+    await pipe.handle_message(
+        _stream_ctx(),
+        _span_start_msg(span_id="inv-1", agent_id=canonical, start=100.0),
+    )
+
+    plan = await store.get_task_plan("p1")
+    t1 = next(t for t in plan.tasks if t.id == "t1")
+    assert t1.status == TaskStatus.COMPLETED, (
+        "late binding must preserve terminal status"
+    )
+    assert t1.bound_span_id == "inv-1"


### PR DESCRIPTION
## Summary

Binds planned tasks to their executing INVOCATION span at **ingest time** by correlating on ``assignee_agent_id``, replacing the fragile client-stamped ``hgraf.task_id`` span attribute as the source of truth.

## Why

The attribute-based path stamps ``hgraf.task_id`` on spans by reading ``goldfive.current_task_id`` from ADK's ``CallbackContext.state``. That state crosses an AgentTool-spawned sub-Runner boundary with its own ``Session``: goldfive's state mirror writes ``current_task_id`` in ``before_run_callback``, but the task reconciler runs during ``before_agent_callback``, so the attribute lands on at most **1/19 spans** in a representative run (empirical measurement 2026-04-22). harmonograf#119 plugged the shallow-copy pitfall but did not fix the sub-Runner session handoff — only the narrow timing window where the mirror wins leaves the one stamped span.

The server already has everything it needs to correlate directly:
- ``task_started(task_id=T)`` with T's ``assignee_agent_id`` resolved to the canonical per-ADK-agent id (harmonograf#113) at plan ingest
- INVOCATION spans per agent from the span stream
- ``find_agent_id_by_name`` helper for bare ↔ compound resolution (harmonograf#111)

## Design

1. On ``task_started(T)``: read T's ``assignee_agent_id``, resolve via ``find_agent_id_by_name``, scan for a RUNNING INVOCATION span owned by that agent, stamp ``bound_span_id``.
2. If the span hasn't arrived yet (stream ordering): stash a pending intent keyed by ``(session_id, canonical_agent_id)``.
3. On ``_handle_span_start`` for an INVOCATION span: drain pending intents for its ``(session, agent)`` pair.
4. Late-arriving spans preserve an already-terminal task status (task_completed before the span no longer gets downgraded to RUNNING).

Only INVOCATION spans participate in ingest binding; TOOL_CALL / LLM_CALL don't, so the existing attribute-based leaf binding (which runs on ``_TASK_BINDING_SPAN_KINDS``) and the new wrapper binding do not fight over the same column. The attribute path stays as a secondary signal.

Proto / wire format / client telemetry plugin: unchanged.

## Test plan

- [x] New ``server/tests/test_ingest_task_binding.py`` (6 tests):
  - span-first then task_started → binds immediately
  - task_started first, then late-arriving span → binds when span lands
  - multi-agent two-task plan → no cross-binding
  - TOOL_CALL for same agent does NOT satisfy INVOCATION binding
  - bare ADK name resolves via ``find_agent_id_by_name`` to canonical id
  - late span after ``task_completed`` stamps ``bound_span_id`` without downgrading status
- [x] Full server suite: ``uv run pytest server/tests/`` — **327 passed, 1 skipped** (the skip is pre-existing ``test_task_plans.py`` Phase-A gate)
- [ ] Manual verification on a fresh run: expect the 1/19 → 19/19 bindings improvement the frontend Task/Graph/Trajectory views should pick up automatically via ``task.boundSpanId``