### PR TITLE
Dedup DelegationRegistry by invocation_id to prevent double-arrow rendering

### DIFF
--- a/frontend/src/__tests__/gantt/delegations.test.ts
+++ b/frontend/src/__tests__/gantt/delegations.test.ts
@@ -107,6 +107,167 @@ describe('DelegationRegistry', () => {
     reg.clear();
     expect(fn).not.toHaveBeenCalled();
   });
+
+  // Dedup suite — harmonograf#117's WatchSession double-delivers the same
+  // DelegationObserved event during the initial-burst-vs-live-stream race,
+  // which surfaced as two ↪↪ arrows per delegation in Agent Graph view.
+  describe('dedup', () => {
+    it('appending the same (from, to, invocationId) twice yields length 1', () => {
+      const reg = new DelegationRegistry();
+      const fn = vi.fn();
+      reg.subscribe(fn);
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: 't-1',
+        invocationId: 'inv-dup',
+        observedAtMs: 1000,
+      });
+      // Second copy with the same invocation id — even if observedAtMs drifts
+      // across the replay/live split, it must be treated as a duplicate.
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: 't-1',
+        invocationId: 'inv-dup',
+        observedAtMs: 1237,
+      });
+      expect(reg.list()).toHaveLength(1);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('two distinct delegations are both kept', () => {
+      const reg = new DelegationRegistry();
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: 't-1',
+        invocationId: 'inv-1',
+        observedAtMs: 1000,
+      });
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_b',
+        taskId: 't-2',
+        invocationId: 'inv-2',
+        observedAtMs: 1100,
+      });
+      expect(reg.list()).toHaveLength(2);
+    });
+
+    it('same invocationId with different toAgentId is distinct', () => {
+      // A coordinator can reuse an invocation id across two AgentTool fan-outs
+      // in pathological setups; the to-agent disambiguates.
+      const reg = new DelegationRegistry();
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: '',
+        invocationId: 'inv-shared',
+        observedAtMs: 1000,
+      });
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_b',
+        taskId: '',
+        invocationId: 'inv-shared',
+        observedAtMs: 1000,
+      });
+      expect(reg.list()).toHaveLength(2);
+    });
+
+    it('empty invocationId + same timestamp is treated as a duplicate', () => {
+      // Fallback path for older goldfive versions that don't stamp
+      // invocation_id on DelegationObserved.
+      const reg = new DelegationRegistry();
+      const fn = vi.fn();
+      reg.subscribe(fn);
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: '',
+        invocationId: '',
+        observedAtMs: 500,
+      });
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: '',
+        invocationId: '',
+        observedAtMs: 500,
+      });
+      expect(reg.list()).toHaveLength(1);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('empty invocationId + different timestamps is distinct', () => {
+      const reg = new DelegationRegistry();
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: '',
+        invocationId: '',
+        observedAtMs: 500,
+      });
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: '',
+        invocationId: '',
+        observedAtMs: 600,
+      });
+      expect(reg.list()).toHaveLength(2);
+    });
+
+    it('duplicate append does not advance seq', () => {
+      const reg = new DelegationRegistry();
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: '',
+        invocationId: 'inv-1',
+        observedAtMs: 100,
+      });
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: '',
+        invocationId: 'inv-1',
+        observedAtMs: 100,
+      });
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_b',
+        taskId: '',
+        invocationId: 'inv-2',
+        observedAtMs: 200,
+      });
+      const list = reg.list();
+      expect(list).toHaveLength(2);
+      expect(list[0].seq).toBe(0);
+      expect(list[1].seq).toBe(1);
+    });
+
+    it('clear resets dedup state so same invocationId can be re-appended', () => {
+      const reg = new DelegationRegistry();
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: '',
+        invocationId: 'inv-1',
+        observedAtMs: 100,
+      });
+      reg.clear();
+      reg.append({
+        fromAgentId: 'coord',
+        toAgentId: 'sub_a',
+        taskId: '',
+        invocationId: 'inv-1',
+        observedAtMs: 100,
+      });
+      expect(reg.list()).toHaveLength(1);
+    });
+  });
 });
 
 describe('SessionStore.delegations integration', () => {

--- a/frontend/src/gantt/index.ts
+++ b/frontend/src/gantt/index.ts
@@ -598,12 +598,25 @@ export class DelegationRegistry {
   private delegations: DelegationRecord[] = [];
   private listeners = new Set<() => void>();
   private nextSeq = 0;
+  // Dedup key set — harmonograf#117's WatchSession can deliver the same
+  // DelegationObserved event via both the initial-burst replay of persisted
+  // events AND the live bus publish during the subscription-setup race,
+  // which previously caused two ↪↪ arrows to render per delegation. The key
+  // is (fromAgentId|toAgentId|invocationId) when an invocationId is present
+  // (unique per delegation), else a timestamp-based fallback for older
+  // goldfive versions that don't set invocation_id.
+  private seen = new Set<string>();
 
   list(): readonly DelegationRecord[] {
     return this.delegations;
   }
 
   append(d: Omit<DelegationRecord, 'seq'>): void {
+    const key = d.invocationId
+      ? `${d.fromAgentId}|${d.toAgentId}|inv:${d.invocationId}`
+      : `${d.fromAgentId}|${d.toAgentId}|ts:${d.observedAtMs}`;
+    if (this.seen.has(key)) return;
+    this.seen.add(key);
     this.delegations.push({ ...d, seq: this.nextSeq++ });
     this.emit();
   }
@@ -612,6 +625,7 @@ export class DelegationRegistry {
     if (this.delegations.length === 0) return;
     this.delegations = [];
     this.nextSeq = 0;
+    this.seen.clear();
     this.emit();
   }
 


### PR DESCRIPTION
## Symptom

User reports **"two ↪↪ per delegation"** in the Agent Graph view — every single delegation renders two identical forward-delegation arrows.

## Root cause

`WatchSession` (introduced in harmonograf#117) delivers each persisted `DelegationObserved` event via two paths:

1. **Initial-burst replay** of the persisted event log on subscription open.
2. **Live-bus publish** that begins as soon as the subscription is wired.

During the subscription-setup race (also on reconnects and page revisits), the same delegation lands on the client twice. `DelegationRegistry.append` in `frontend/src/gantt/index.ts` was unconditionally pushing every incoming record, so `store.delegations` ended up with two copies.

`GraphView`'s existing `coveredPairs` dedup is keyed on `(fromId, toId, round(observedMs/500))`. That papers over most double-delivery, but when the replay and live copies' `observedAtMs` values straddle the 500ms bucket boundary, both copies slip through and both arrows render — which is how this bug escaped.

## Fix

Dedup at the source, inside `DelegationRegistry.append`:

- Primary key: `(fromAgentId, toAgentId, invocationId)` — ADK `invocation_id` is unique per delegation.
- Fallback key (for older goldfive versions that don't stamp `invocation_id`): `(fromAgentId, toAgentId, observedAtMs)`.
- Duplicate appends are dropped silently — `seq` does not advance and subscribers do not fire, so no spurious re-renders.
- `clear()` wipes the dedup set alongside the list.

`GraphView`'s `coveredPairs` is intentionally left in place as a belt-and-suspenders second line of defense. Server replay logic is untouched.

## Scope

- `frontend/src/gantt/index.ts` — `DelegationRegistry.append` + `clear`
- `frontend/src/__tests__/gantt/delegations.test.ts` — new `dedup` describe block

## Test plan

- [x] `pnpm test` in `frontend/` — 31 files, 296 tests passing.
- [x] New dedup cases cover: same `(from, to, invocationId)` is length 1 with one emit; distinct delegations kept; empty `invocationId` + same ts is a duplicate; empty `invocationId` + different ts is distinct; duplicate append does not advance `seq`; `clear()` resets dedup state.