### PR TITLE
Gantt: re-render brain badges when has_reasoning arrives via stream update

### DIFF
--- a/frontend/src/__tests__/gantt/brainBadges.test.ts
+++ b/frontend/src/__tests__/gantt/brainBadges.test.ts
@@ -1,0 +1,189 @@
+// Regression for the brain-badge-not-rendering bug: the Gantt renderer
+// must re-evaluate hasThinking(span) every frame so that when a reasoning
+// attribute arrives via stream (as an UpdatedSpan or the SPAN_UPDATE we
+// now emit just before SPAN_END), the next drawBlocks pass picks it up
+// and renders the 🧠 badge. See harmonograf#[this PR].
+//
+// The renderer requires a 2D canvas context; jsdom doesn't provide one,
+// so we stub getContext with a Proxy that no-ops every method. The test
+// only inspects `renderer.lastBrainBadgeCount`, which drawBlocks writes
+// at the end of the pass — pixel output doesn't matter.
+
+import { describe, expect, it } from 'vitest';
+import { GanttRenderer } from '../../gantt/renderer';
+import { SessionStore } from '../../gantt/index';
+import type { Span } from '../../gantt/types';
+
+function stubCtx(): CanvasRenderingContext2D {
+  // A Proxy that swallows every property access. Methods return the
+  // proxy itself so chained calls like ctx.save().beginPath() still work,
+  // and property reads return sensible defaults where the renderer
+  // actually reads back.
+  const handler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'canvas') return { width: 1200, height: 400 };
+      if (prop === 'globalAlpha') return 1;
+      if (prop === 'measureText') return () => ({ width: 10 });
+      // Everything else — fillRect, clearRect, save, restore, beginPath,
+      // clip, setLineDash, etc. — is a no-op function.
+      return () => undefined;
+    },
+    set() {
+      return true;
+    },
+  };
+  return new Proxy({}, handler) as CanvasRenderingContext2D;
+}
+
+function stubCanvas(): HTMLCanvasElement {
+  const el = document.createElement('canvas');
+  el.width = 1200;
+  el.height = 400;
+  // getContext returns null in jsdom; swap in the stub.
+  (el as unknown as { getContext: () => CanvasRenderingContext2D }).getContext =
+    () => stubCtx();
+  return el;
+}
+
+function mkLlmSpan(overrides: Partial<Span> = {}): Span {
+  return {
+    id: 'sp-llm',
+    sessionId: 'sess',
+    agentId: 'agent-a',
+    parentSpanId: null,
+    kind: 'LLM_CALL',
+    name: 'gemini-2.0',
+    status: 'RUNNING',
+    startMs: 1_000,
+    endMs: null,
+    lane: 0,
+    attributes: {},
+    payloadRefs: [],
+    links: [],
+    replaced: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('GanttRenderer brain badges — stream update reactivity', () => {
+  it('renders a brain badge when has_reasoning arrives on an already-placed LLM_CALL', () => {
+    const store = new SessionStore();
+    // Stamp an agent so queryAgent has a row to walk. Name + framework are
+    // unused by drawBlocks beyond painting labels (which the ctx stub
+    // swallows), so minimal shape is fine.
+    store.agents.upsert({
+      id: 'agent-a',
+      name: 'agent-a',
+      framework: 'ADK',
+      status: 'CONNECTED',
+      capabilities: [],
+      connectedAtMs: 0,
+      currentActivity: '',
+      stuck: false,
+      taskReport: '',
+      taskReportAt: 0,
+      metadata: {},
+    });
+    // Span starts WITHOUT reasoning attributes — the common case where
+    // the client hasn't yet run after_model_callback.
+    const span = mkLlmSpan({ startMs: 1_000, endMs: 5_000, status: 'COMPLETED' });
+    store.spans.append(span);
+
+    const renderer = new GanttRenderer(store);
+    const bg = stubCanvas();
+    const blocks = stubCanvas();
+    const overlay = stubCanvas();
+    renderer.attach(bg, blocks, overlay);
+    renderer.resize(1200, 200, 1);
+
+    // Position the viewport so the span sits comfortably inside and is
+    // rendered wide enough to clear the width>=14 gate (the badge is
+    // skipped on narrow bars to avoid colliding with the kind icon).
+    renderer.setViewport({
+      endMs: 10_000,
+      windowMs: 10_000,
+      liveFollow: false,
+      replay: false,
+    });
+
+    // First frame: no reasoning attributes → no badge.
+    // drawBlocks is private; drive it via the public frame path by
+    // triggering a dirty + calling the internal frame handler. Because
+    // rAF is async in jsdom, we sidestep it by calling the private
+    // drawBlocks directly through the typed escape hatch — this is the
+    // same approach existing tests use for _seedDelegationLayoutsForTesting.
+    (renderer as unknown as { drawBlocks: () => void }).drawBlocks();
+    expect(renderer.lastBrainBadgeCount).toBe(0);
+
+    // Now simulate the stream update: the server's SPAN_UPDATE delta
+    // arrives with has_reasoning=true + llm.reasoning. The rpc hook
+    // mutates the existing span's attributes in place, then calls
+    // store.spans.update — mirroring that here.
+    const existing = store.spans.get('sp-llm')!;
+    existing.attributes['has_reasoning'] = { kind: 'bool', value: true };
+    existing.attributes['llm.reasoning'] = {
+      kind: 'string',
+      value: 'i thought carefully',
+    };
+    store.spans.update(existing);
+
+    // Next frame: renderer must re-scan hasThinking and emit the badge.
+    (renderer as unknown as { drawBlocks: () => void }).drawBlocks();
+    expect(renderer.lastBrainBadgeCount).toBe(1);
+
+    renderer.detach();
+  });
+
+  it('renders a brain badge when only llm.reasoning_trail arrives (no has_reasoning flag)', () => {
+    // Covers the INVOCATION-span path where the plugin stamps the
+    // aggregated trail but hasThinking() falls back to attribute text
+    // when the has_reasoning bool is missing.
+    const store = new SessionStore();
+    store.agents.upsert({
+      id: 'agent-a',
+      name: 'agent-a',
+      framework: 'ADK',
+      status: 'CONNECTED',
+      capabilities: [],
+      connectedAtMs: 0,
+      currentActivity: '',
+      stuck: false,
+      taskReport: '',
+      taskReportAt: 0,
+      metadata: {},
+    });
+    const span = mkLlmSpan({
+      id: 'sp-llm-2',
+      startMs: 1_000,
+      endMs: 5_000,
+      status: 'COMPLETED',
+    });
+    store.spans.append(span);
+
+    const renderer = new GanttRenderer(store);
+    renderer.attach(stubCanvas(), stubCanvas(), stubCanvas());
+    renderer.resize(1200, 200, 1);
+    renderer.setViewport({
+      endMs: 10_000,
+      windowMs: 10_000,
+      liveFollow: false,
+      replay: false,
+    });
+
+    (renderer as unknown as { drawBlocks: () => void }).drawBlocks();
+    expect(renderer.lastBrainBadgeCount).toBe(0);
+
+    const existing = store.spans.get('sp-llm-2')!;
+    existing.attributes['llm.reasoning_trail'] = {
+      kind: 'string',
+      value: '[LLM call 1] thought',
+    };
+    store.spans.update(existing);
+
+    (renderer as unknown as { drawBlocks: () => void }).drawBlocks();
+    expect(renderer.lastBrainBadgeCount).toBe(1);
+
+    renderer.detach();
+  });
+});

--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -585,12 +585,25 @@ class IngestPipeline:
         ended = await self._store.end_span(msg.span_id, end_time, status, error=error)
         if ended is None:
             return
-        if msg.attributes or len(msg.payload_refs):
+        had_end_attrs = bool(msg.attributes) or bool(len(msg.payload_refs))
+        if had_end_attrs:
             attrs = attr_map_to_dict(msg.attributes) if msg.attributes else None
             payload_kwargs = _payload_ref_kwargs(msg.payload_refs)
             ended = await self._store.update_span(
                 msg.span_id, attributes=attrs, **payload_kwargs
             ) or ended
+            # The frontend-facing EndedSpan proto does not carry attributes
+            # (it only carries span_id/end_time/status/error/payload_refs).
+            # When the client stamps reasoning/tooling attributes on the
+            # same SpanEnd message (e.g. HarmonografTelemetryPlugin's
+            # after_model_callback adding ``has_reasoning`` + ``llm.reasoning``
+            # on top of the terminal transition), the renderer would never
+            # see those attrs on the live stream — only on a page reload that
+            # refetches from storage. Publish a SPAN_UPDATE delta first so
+            # the frontend's updatedSpan handler merges the attributes in
+            # place before the EndedSpan arrives and flips status to terminal.
+            # See harmonograf#[this PR].
+            self._bus.publish_span_update(ended)
         self._bus.publish_span_end(ended)
 
         # Task completion is driven EXCLUSIVELY by explicit client

--- a/server/tests/test_ingest_extensive.py
+++ b/server/tests/test_ingest_extensive.py
@@ -216,6 +216,61 @@ async def test_span_end_for_unknown_span_is_noop(pipeline):
     await pipeline.handle_message(ctx, _span_end("ghost"))
 
 
+async def test_span_end_with_attributes_publishes_update_before_end(pipeline, store):
+    """SpanEnd messages may carry terminal attributes (e.g. the telemetry
+    plugin's ``after_model_callback`` stamps ``has_reasoning`` +
+    ``llm.reasoning`` alongside the SpanEnd). The frontend-facing
+    ``EndedSpan`` proto omits attributes, so the live stream would drop them
+    unless we also publish a SPAN_UPDATE so the client's updatedSpan handler
+    can merge them in place. Regression for the brain-badge-not-rendering
+    bug (harmonograf#[this PR])."""
+    ctx, _ = await pipeline.handle_hello(_hello(session_id="sess_end_attrs"))
+    sub = await pipeline.bus.subscribe("sess_end_attrs")
+    await pipeline.handle_message(
+        ctx, _span_msg("sp1", session_id="sess_end_attrs", kind=types_pb2.SPAN_KIND_LLM_CALL)
+    )
+
+    # SpanEnd carrying reasoning attributes — mirrors what the client
+    # telemetry plugin emits when after_model_callback fires.
+    se = telemetry_pb2.SpanEnd(span_id="sp1", status=types_pb2.SPAN_STATUS_COMPLETED)
+    se.end_time.CopyFrom(_ts(110.0))
+    se.attributes["has_reasoning"].bool_value = True
+    se.attributes["llm.reasoning"].string_value = "i thought about it"
+    await pipeline.handle_message(ctx, telemetry_pb2.TelemetryUp(span_end=se))
+
+    # Attributes persisted.
+    stored = await store.get_span("sp1")
+    assert stored.attributes.get("has_reasoning") is True
+    assert stored.attributes.get("llm.reasoning") == "i thought about it"
+
+    # Bus deltas include both SPAN_UPDATE and SPAN_END, in that order.
+    delta_kinds: list[str] = []
+    while not sub.queue.empty():
+        delta_kinds.append(sub.queue.get_nowait().kind)
+    update_idx = delta_kinds.index(DELTA_SPAN_UPDATE)
+    end_idx = delta_kinds.index(DELTA_SPAN_END)
+    assert update_idx < end_idx, (
+        f"SPAN_UPDATE must precede SPAN_END so the frontend can merge "
+        f"terminal attributes before status flips; got deltas={delta_kinds}"
+    )
+
+
+async def test_span_end_without_attributes_only_publishes_end(pipeline, store):
+    """The SPAN_UPDATE-before-SPAN_END path is only required when SpanEnd
+    carries attributes. A bare SpanEnd (no attrs, no payload_refs) must
+    continue to publish a single SPAN_END delta."""
+    ctx, _ = await pipeline.handle_hello(_hello(session_id="sess_bare_end"))
+    sub = await pipeline.bus.subscribe("sess_bare_end")
+    await pipeline.handle_message(ctx, _span_msg("sp1", session_id="sess_bare_end"))
+    await pipeline.handle_message(ctx, _span_end("sp1", end=110.0))
+
+    delta_kinds: list[str] = []
+    while not sub.queue.empty():
+        delta_kinds.append(sub.queue.get_nowait().kind)
+    assert delta_kinds.count(DELTA_SPAN_END) == 1
+    assert DELTA_SPAN_UPDATE not in delta_kinds
+
+
 async def test_span_update_status_and_attributes(pipeline, store):
     ctx, _ = await pipeline.handle_hello(_hello(session_id="sess_upd"))
     await pipeline.handle_message(ctx, _span_msg("sp1"))


### PR DESCRIPTION
## Bug (browser-verified)

LLM_CALL span bars on the Gantt are supposed to carry a 🧠 badge in the top-right corner when the span has reasoning (harmonograf#107/#108/#114). In a representative live session, 9 of 19 LLM_CALL spans had `has_reasoning=true` and `llm.reasoning` stamped on them server-side — but zero brain badges rendered during live viewing. A hard page reload populated them correctly, which narrowed the failure to the **live-stream delivery path**, not persistence or the renderer.

## Root cause

The client's `HarmonografTelemetryPlugin.after_model_callback` stamps `has_reasoning` + `llm.reasoning` (and `llm.reasoning_trail` for the INVOCATION aggregate) on the **SpanEnd** telemetry message. The server's `_handle_span_end` writes those attributes to storage (so reload works) and then publishes a `SPAN_END` bus delta. `_delta_to_session_update` maps `DELTA_SPAN_END` → `EndedSpan` proto, which has no `attributes` field — it only carries `span_id`, `end_time`, `status`, `error`, `payload_refs`. The attributes were silently dropped from the live stream.

The renderer side was fine the whole time: `drawBlocks` re-evaluates `hasThinking(span)` on every frame for every visible span. It just never saw the attributes because they never arrived.

## Fix

In `IngestPipeline._handle_span_end`, when the incoming SpanEnd carries attributes (or payload_refs), publish a `SPAN_UPDATE` bus delta immediately before the `SPAN_END`. The existing `UpdatedSpan` proto already carries attributes, and the frontend's `updatedSpan` handler already mutates the existing Span's attributes in place and emits a dirty rect — the renderer picks up the new `has_reasoning` flag on the next frame and paints the badge.

Deliberately surgical:
- no proto change (EndedSpan stays as-is)
- no store change
- no renderer change (drawBlocks was already re-scanning every frame)
- no additional chatter on bare SpanEnds (the update is only emitted when attrs or payload_refs are present on the incoming SpanEnd)

## Test plan

Server regression tests in `test_ingest_extensive.py`:
- [x] `test_span_end_with_attributes_publishes_update_before_end` — seeds a SpanEnd with `has_reasoning=true` + `llm.reasoning="..."`, asserts the bus emits `SPAN_UPDATE` before `SPAN_END` and that both attributes land in storage.
- [x] `test_span_end_without_attributes_only_publishes_end` — pins the no-attrs fast path so bare SpanEnds don't amplify delta chatter.

Frontend regression test in `frontend/src/__tests__/gantt/brainBadges.test.ts`:
- [x] Places an LLM_CALL span with no reasoning attrs → `drawBlocks` → asserts `lastBrainBadgeCount === 0`.
- [x] Mutates the same span's attributes in place (`has_reasoning=true`, `llm.reasoning=...`) + calls `store.spans.update` → `drawBlocks` → asserts `lastBrainBadgeCount === 1`.
- [x] Second case covers the INVOCATION-span trail path (`llm.reasoning_trail` without `has_reasoning` bool).

Runs:
- [x] `uv run pytest` in `server/` — 329 passed, 1 skipped
- [x] `pnpm test` in `frontend/` — 291 passed
- [x] `pnpm lint` in `frontend/` — clean