### PR TITLE
Interventions timeline: accurate placement + dynamic axis scaling

### DIFF
--- a/frontend/src/__tests__/components/InterventionsTimeline.test.tsx
+++ b/frontend/src/__tests__/components/InterventionsTimeline.test.tsx
@@ -1,9 +1,17 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { InterventionsTimeline } from '../../components/Interventions/InterventionsTimeline';
 import type { InterventionRow } from '../../lib/interventions';
 
 vi.mock('../../components/Interventions/InterventionsTimeline.css', () => ({}));
+
+// Parse SVG transform="translate(x, y)" and return cx.
+function cxOf(el: Element): number {
+  const t = el.getAttribute('transform') || '';
+  const m = t.match(/translate\(([-\d.]+),\s*([-\d.]+)\)/);
+  if (!m) throw new Error(`no translate in ${t}`);
+  return parseFloat(m[1]);
+}
 
 function row(over: Partial<InterventionRow>): InterventionRow {
   return {
@@ -232,5 +240,145 @@ describe('<InterventionsTimeline />', () => {
     const wrapper = screen.getByTestId('interventions-timeline');
     expect(wrapper.style.width).toBe('800px');
     expect(wrapper.style.maxWidth).toBe('800px');
+  });
+
+  // --- accurate placement + dynamic axis scaling -------------------------
+  //
+  // Regression coverage for the user-reported bug: a drift/steer that
+  // fired 7 minutes into a 10-minute session was rendering at the 0m
+  // end of the strip because the caller passed a per-plan window where
+  // row.atMs == startMs. The strip now receives a session-wide axis
+  // (startMs=0, endMs=session_now) so markers land at their real
+  // session-relative fraction across the strip.
+
+  it('places a 10-minute-in marker at ~70% of a 10-minute strip', () => {
+    // startMs=0, endMs=10m, drift at 7m → cx should be ~70% across the
+    // usable strip (minus STRIP_PAD_X padding on each side).
+    const width = 400;
+    render(
+      <InterventionsTimeline
+        rows={[
+          row({ key: 'd', atMs: 7 * 60_000, source: 'drift', kind: 'LOOPING' }),
+        ]}
+        startMs={0}
+        endMs={10 * 60_000}
+        width={width}
+        _liveTickMs={0}
+      />,
+    );
+    const marker = screen.getByTestId('intervention-marker-d');
+    const cx = cxOf(marker);
+    // With STRIP_PAD_X=14 on each side: cx = 14 + 0.7 * (400 - 28) = 14 + 260.4 = 274.4
+    // Allow ±2px slack for rounding / future minor spacing tweaks.
+    expect(cx).toBeGreaterThan(272);
+    expect(cx).toBeLessThan(277);
+    // Crucially: NOT at the 0m end.
+    expect(cx).toBeGreaterThan(width * 0.5);
+  });
+
+  it('places a 30-minute-in marker at ~50% of a 1-hour strip', () => {
+    const width = 600;
+    render(
+      <InterventionsTimeline
+        rows={[
+          row({ key: 's', atMs: 30 * 60_000, source: 'user', kind: 'STEER' }),
+        ]}
+        startMs={0}
+        endMs={60 * 60_000}
+        width={width}
+        _liveTickMs={0}
+      />,
+    );
+    const marker = screen.getByTestId('intervention-marker-s');
+    const cx = cxOf(marker);
+    // 14 + 0.5 * (600 - 28) = 14 + 286 = 300
+    expect(cx).toBeGreaterThan(298);
+    expect(cx).toBeLessThan(302);
+  });
+
+  // --- axis tick scaling -------------------------------------------------
+
+  it('generates minute-step axis ticks across a 5-minute span', () => {
+    render(
+      <InterventionsTimeline
+        rows={[]}
+        startMs={0}
+        endMs={5 * 60_000}
+        width={500}
+        _liveTickMs={0}
+      />,
+    );
+    // pickTickStepMs picks 60s for spans ≤ 10m → 6 ticks at 0, 1, 2, 3, 4, 5 min.
+    const labels = screen
+      .getAllByTestId(/^axis-tick-\d+$/)
+      .map((g) => g.textContent);
+    expect(labels).toContain('0m');
+    expect(labels).toContain('1m');
+    expect(labels).toContain('2m');
+    expect(labels).toContain('5m');
+  });
+
+  // --- live axis tracking ------------------------------------------------
+  //
+  // A live session has session.ended_at == null and the parent advances
+  // endMs to track "now". With fake timers we can verify the snapshot
+  // advances on the coarse live tick so markers re-place against the
+  // growing span.
+
+  describe('live axis (fake timers)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('advances the strip span when the live tick fires, re-placing markers', () => {
+      const rows = [
+        row({ key: 'u', atMs: 5 * 60_000, source: 'user', kind: 'STEER' }),
+      ];
+      const width = 400;
+      // Start: session only 10 minutes in. Marker at 5m → 50%.
+      const { rerender } = render(
+        <InterventionsTimeline
+          rows={rows}
+          startMs={0}
+          endMs={10 * 60_000}
+          width={width}
+          _liveTickMs={1000}
+        />,
+      );
+      const beforeCx = cxOf(screen.getByTestId('intervention-marker-u'));
+      // Expect ~ center.
+      expect(beforeCx).toBeGreaterThan(width * 0.45);
+      expect(beforeCx).toBeLessThan(width * 0.55);
+
+      // Session grows to 20 minutes — parent re-renders with a wider
+      // endMs. Before the live tick fires the snapshot is still 10m,
+      // so marker x hasn't moved yet (stable-anchor invariant).
+      rerender(
+        <InterventionsTimeline
+          rows={rows}
+          startMs={0}
+          endMs={20 * 60_000}
+          width={width}
+          _liveTickMs={1000}
+        />,
+      );
+      expect(cxOf(screen.getByTestId('intervention-marker-u'))).toBeCloseTo(
+        beforeCx,
+        0,
+      );
+
+      // Now advance the timer past the 1s tick. The snapshot pulls in
+      // the new endMs (20m), and the 5m marker slides to ~25%.
+      act(() => {
+        vi.advanceTimersByTime(1500);
+      });
+      const afterCx = cxOf(screen.getByTestId('intervention-marker-u'));
+      expect(afterCx).toBeLessThan(beforeCx); // moved left as span grew
+      expect(afterCx).toBeGreaterThan(width * 0.2);
+      expect(afterCx).toBeLessThan(width * 0.3);
+    });
   });
 });

--- a/frontend/src/components/Interventions/InterventionsTimeline.css
+++ b/frontend/src/components/Interventions/InterventionsTimeline.css
@@ -8,12 +8,15 @@
   flex-direction: column;
   gap: 4px;
   padding: 0;
-  /* Cap the strip's rendered width so sparse markers don't get smeared
-     across an over-wide Gantt pane. Matches the default viewBox width the
-     component uses to lay out markers (#107). Parents that need a wider
-     strip can pass an explicit `width` prop; that overrides max-width
-     via the inline style on the wrapper. */
-  max-width: 480px;
+  /* Let the strip fill its container — the axis now spans the whole
+     session (GanttView passes session-relative startMs/endMs), so
+     honest horizontal scaling matters more than capping width. A
+     generous cap remains so pathologically wide panes don't produce
+     vast empty space between sparse markers; it's much larger than
+     the old 480px so typical Gantt widths get full horizontal range.
+     Parents that want an exact width still pass the `width` prop,
+     which overrides this cap via inline style. */
+  max-width: 1600px;
   font:
     11px/1.3 var(--md-sys-typescale-body-small-font, system-ui, sans-serif);
   color: var(--md-sys-color-on-surface-variant, #9da3b4);

--- a/frontend/src/components/shell/views/GanttView.tsx
+++ b/frontend/src/components/shell/views/GanttView.tsx
@@ -150,6 +150,35 @@ export function GanttView() {
   const interventions = store
     ? deriveInterventionsFromStore(store, allAnnotations)
     : [];
+
+  // Session-wide axis for the InterventionsTimeline strips. Every
+  // intervention's `atMs` is session-relative (see lib/interventions.ts),
+  // so the strip's window must run from 0 (session start) to the
+  // effective "now" for the session — otherwise markers that fired well
+  // into the session land at the 0m end of a narrow per-plan window
+  // (user report: diamond pinned to 0m despite event ~7m in).
+  //
+  // For a live session we track `store.nowMs`; for a completed/aborted
+  // one we fall back to the max observed activity time across
+  // interventions, plans, and nowMs so the axis doesn't collapse if
+  // nowMs wasn't advanced past the final event.
+  const MIN_SESSION_SPAN_MS = 60_000; // 1 minute floor so a brand-new strip still has axis room
+  const sessionStartMs = 0;
+  const isLive =
+    watch?.sessionStatus === 'LIVE' || watch?.sessionStatus === 'UNKNOWN';
+  const observedMaxMs = store
+    ? Math.max(
+        0,
+        store.nowMs || 0,
+        ...interventions.map((r) => r.atMs),
+        ...plans.map((p) => p.createdAtMs),
+      )
+    : 0;
+  const sessionEndMs = Math.max(
+    isLive && store ? store.nowMs || observedMaxMs : observedMaxMs,
+    MIN_SESSION_SPAN_MS,
+  );
+
   const agentNameFor = (id: string): string =>
     store?.agents.get(id)?.name ?? id;
   // Resolve the assignee's canonical color only if the agent is registered on
@@ -358,13 +387,11 @@ export function GanttView() {
                         ? (plan.revisionIndex ?? 0) === row.planRevisionIndex
                         : (plan.revisionIndex ?? 0) === 0,
                   )}
-                  startMs={plan.createdAtMs}
-                  endMs={Math.max(
-                    plan.createdAtMs + 1,
-                    ...plan.tasks.map(
-                      (t) => plan.createdAtMs + (t.predictedDurationMs || 0),
-                    ),
-                  )}
+                  // Session-wide axis, not per-plan. All row.atMs values
+                  // are session-relative so the strip must span the
+                  // whole session for marker placement to be honest.
+                  startMs={sessionStartMs}
+                  endMs={sessionEndMs}
                   revs={plans}
                   onJumpToRevision={undefined}
                 />


### PR DESCRIPTION
## Symptom

User report (screenshot verified): in the Gantt view's `InterventionsTimeline` strip, a drift/steer marker that occurred well into the session was rendering at the `0m` end of the strip, and the strip's horizontal axis was short/compressed and didn't scale with how much time had elapsed.

## Root cause

`GanttView` passed a **per-plan** window to the strip:

```tsx
startMs={plan.createdAtMs}
endMs={Math.max(plan.createdAtMs + 1, ...plan.tasks.map(t => plan.createdAtMs + (t.predictedDurationMs || 0)))}
```

For a revised plan created at t=7m, `startMs = 7m`. But `row.atMs` is **session-relative** (see `lib/interventions.ts`), so for revision rev1 with `startMs=7m` the event mapped to `tNorm = (atMs - 7m) / span` — which clamped to 0 when the triggering event preceded revision creation. Every per-plan strip also had a tiny, task-duration-derived span; neither strip was honest about session wall-clock time.

## Fix

- `GanttView` computes a **session-wide** axis once per render and passes the same `startMs=0, endMs=sessionNow` to every strip.
- `endMs` tracks `store.nowMs` for live sessions (status `LIVE` / `UNKNOWN`) and the max observed activity (`nowMs` or any row/plan `atMs`) for completed ones, with a 60 s floor so a brand-new session still has axis room.
- Marker placement is now `(atMs - 0) / sessionEndMs` — honest and proportional across the strip.
- CSS `max-width` cap raised from 480 px → 1600 px so typical Gantt panes get full horizontal range instead of smearing 10-min and 1-hour sessions into the same 480-px box. Explicit `width` props still override the cap.

## Data-shape changes

None. The `InterventionRow` shape is unchanged; only the axis props that `GanttView` passes to `<InterventionsTimeline>` changed.

## Preserved behaviour

Diamond glyphs, popover-on-click, cluster collapse, jump-to-revision affordance, and the stable-anchor invariant under hover re-renders (#74) all still work.

## Test plan

- [x] New regression: 7m drift in a 10m session renders at ~70 % of strip width.
- [x] New regression: 30m steer in a 1h session renders at ~50 %.
- [x] New regression: 5m span generates `0m / 1m / 2m / 3m / 4m / 5m` axis ticks.
- [x] New regression: live session (fake timers) — advancing the 1 s live tick pulls the growing `endMs` into the stable-anchor snapshot; marker slides left as span grows.
- [x] `pnpm test` → 302 tests pass.
- [x] `pnpm run build` → clean.
- [x] `pnpm run lint` → clean.