### PR TITLE
Canonicalize agent ids at the sink boundary (single form end-to-end)

### DIFF
--- a/client/harmonograf_client/sink.py
+++ b/client/harmonograf_client/sink.py
@@ -11,6 +11,38 @@ Module identity: harmonograf's generated ``telemetry_pb2`` imports
 ``goldfive.v1.events_pb2`` via the same module grafted onto ``goldfive.pb``,
 so ``TelemetryUp.goldfive_event`` shares its class with whatever goldfive's
 runner produces. No serialize/parse round-trip is required.
+
+Agent-id canonicalization (harmonograf#125)
+------------------------------------------
+Goldfive emits two forms of agent identity:
+
+* **Bare**: the ADK ``agent.name`` string, e.g. ``coordinator_agent`` —
+  present on ``DelegationObserved.from_agent`` / ``.to_agent``,
+  ``AgentInvocationStarted.agent_name``, ``DriftDetected.current_agent_id``,
+  and ``Task.assignee_agent_id`` inside plan events. Goldfive has no
+  knowledge of who is wrapping it, so it cannot emit anything richer.
+* **Compound**: ``<client_id>:<bare_name>``, e.g.
+  ``presentation-orchestrated-abc123:coordinator_agent`` — the canonical
+  agent-row id the :class:`HarmonografTelemetryPlugin` stamps on every
+  ``SpanStart`` as ``span.agent_id``, and the row key the frontend uses for
+  Gantt lanes, lifelines, and delegation-arrow endpoints.
+
+Before harmonograf#125 the server did best-effort bare→compound rewrites on
+ingest and burst replay (``find_agent_id_by_name``), but a race between a
+``DelegationObserved`` landing and the target agent's first span registering
+leaked bare names onto live subscribers — producing the "transfer arrows
+missing until refresh" symptom (#111, #117).
+
+The fix: canonicalize at the source, before the event leaves the client
+process. After this sink runs, every event on the wire carries compound ids
+only; the server stores them verbatim and the frontend renders them
+verbatim.
+
+Rewrite rules:
+  * non-empty + no ``:`` already present (idempotent — already-compound ids
+    pass through untouched).
+  * applies to every agent-identity field across the event oneof; fields
+    not present on a particular payload are simply skipped.
 """
 
 from __future__ import annotations
@@ -50,9 +82,13 @@ class HarmonografSink:
         ``emit`` is declared async to satisfy ``goldfive.EventSink`` but does
         no IO itself — the push is a constant-time, thread-safe buffer append
         that the transport's send loop drains.
+
+        Before push, every agent-identity field on ``event_pb`` is rewritten
+        bare→compound (see module docstring).
         """
         if self._closed:
             return
+        self._canonicalize_agent_ids(event_pb)
         self._client.emit_goldfive_event(event_pb)
 
     async def close(self) -> None:
@@ -64,3 +100,78 @@ class HarmonografSink:
         runner do not raise.
         """
         self._closed = True
+
+    # ------------------------------------------------------------------
+    # Canonicalization
+    # ------------------------------------------------------------------
+
+    def _compound(self, bare: str) -> str:
+        """Return the compound id for ``bare``, or ``bare`` itself if it's
+        empty or already compound.
+
+        A value is considered "already compound" if it contains a ``:`` —
+        this keeps the rewrite idempotent so re-emitting an event (e.g. on
+        a sink that wraps another sink) doesn't produce
+        ``client:client:agent`` double-prefixing.
+        """
+        if not bare:
+            return bare
+        if ":" in bare:
+            return bare
+        return f"{self._client.agent_id}:{bare}"
+
+    def _rewrite_field(self, msg: Any, field_name: str) -> None:
+        """Canonicalize ``msg.<field_name>`` in-place if the field exists
+        and is non-empty. Silently no-ops on messages that don't carry the
+        field — keeps the dispatch table declarative across event types."""
+        current = getattr(msg, field_name, None)
+        if not isinstance(current, str) or not current:
+            return
+        canonical = self._compound(current)
+        if canonical != current:
+            setattr(msg, field_name, canonical)
+
+    def _canonicalize_agent_ids(self, event_pb: Any) -> None:
+        """Rewrite every agent-identity field on ``event_pb`` bare→compound.
+
+        Dispatches on the oneof payload case. Fields covered:
+
+        * ``DelegationObserved.from_agent`` / ``.to_agent``
+        * ``AgentInvocationStarted.agent_name``
+        * ``AgentInvocationCompleted.agent_name``
+        * ``DriftDetected.current_agent_id``
+        * ``PlanSubmitted.plan.tasks[*].assignee_agent_id``
+        * ``PlanRevised.plan.tasks[*].assignee_agent_id``
+
+        Unknown / unset oneof cases are a no-op — the wire is unchanged.
+        """
+        which = event_pb.WhichOneof("payload") if hasattr(event_pb, "WhichOneof") else None
+        if not which:
+            return
+
+        if which == "delegation_observed":
+            d = event_pb.delegation_observed
+            self._rewrite_field(d, "from_agent")
+            self._rewrite_field(d, "to_agent")
+        elif which == "agent_invocation_started":
+            self._rewrite_field(event_pb.agent_invocation_started, "agent_name")
+        elif which == "agent_invocation_completed":
+            self._rewrite_field(event_pb.agent_invocation_completed, "agent_name")
+        elif which == "drift_detected":
+            self._rewrite_field(event_pb.drift_detected, "current_agent_id")
+        elif which == "plan_submitted":
+            self._canonicalize_plan(event_pb.plan_submitted.plan)
+        elif which == "plan_revised":
+            self._canonicalize_plan(event_pb.plan_revised.plan)
+        # RunStarted, GoalDerived, Task{Started,Progress,Completed,Failed,
+        # Blocked,Cancelled}, RunCompleted, RunAborted, Conversation*,
+        # Approval* — none carry an agent-identity string field on the proto
+        # as of goldfive v1 (events.proto at 7b8ab49). They pass through
+        # untouched.
+
+    def _canonicalize_plan(self, plan: Any) -> None:
+        """Rewrite every ``task.assignee_agent_id`` on ``plan`` bare→compound."""
+        if plan is None:
+            return
+        for task in plan.tasks:
+            self._rewrite_field(task, "assignee_agent_id")

--- a/client/tests/test_sink_canonicalization.py
+++ b/client/tests/test_sink_canonicalization.py
@@ -1,0 +1,289 @@
+"""Tests for agent-id canonicalization at the HarmonografSink boundary.
+
+Issue history
+-------------
+Before harmonograf#125 the server rewrote bare ADK agent names
+(``coordinator_agent``) onto the telemetry-plugin's compound row keys
+(``client-xyz:coordinator_agent``) at ingest via
+``find_agent_id_by_name``. That rewrite raced with the target agent's
+first-span registration: a DelegationObserved landing before the
+sub-agent's SpanStart resolved to the bare name (no row matched), and
+the frontend then couldn't bind the arrow endpoint to a lifeline.
+Symptom: "transfer arrows missing until refresh" (#111, #117).
+
+The fix moves the rewrite to the source: :class:`HarmonografSink`
+canonicalizes every agent-identity field on every goldfive event
+before it leaves the client process. After that, the wire carries
+compound ids only; ingest and replay are verbatim.
+
+These tests pin the invariant by driving the sink directly and
+asserting the payload landing on the client's ring buffer is already
+compound.
+"""
+
+from __future__ import annotations
+
+import pytest
+from goldfive.pb.goldfive.v1 import events_pb2 as ge
+from goldfive.pb.goldfive.v1 import types_pb2 as gt
+
+from harmonograf_client.buffer import EnvelopeKind
+from harmonograf_client.client import Client
+from harmonograf_client.sink import HarmonografSink
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+CLIENT_AGENT_ID = "presentation-orchestrated-9b2b3a9c7289"
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="presentation",
+        agent_id=CLIENT_AGENT_ID,
+        session_id="sess-canon",
+        framework="ADK",
+        buffer_size=32,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def sink(client: Client) -> HarmonografSink:
+    return HarmonografSink(client)
+
+
+def _drain(client: Client) -> list:
+    return list(client._events.drain())
+
+
+def _make_event(which: str) -> ge.Event:
+    evt = ge.Event()
+    evt.event_id = f"e-{which}"
+    evt.run_id = "run-1"
+    evt.sequence = 0
+    return evt
+
+
+# ---- DelegationObserved ---------------------------------------------------
+
+
+class TestDelegationObserved:
+    @pytest.mark.asyncio
+    async def test_bare_from_to_rewritten_to_compound(
+        self, sink: HarmonografSink, client: Client
+    ):
+        evt = _make_event("delegation")
+        evt.delegation_observed.from_agent = "coordinator_agent"
+        evt.delegation_observed.to_agent = "research_agent"
+        await sink.emit(evt)
+
+        env = _drain(client)[0]
+        d = env.payload.delegation_observed
+        assert d.from_agent == f"{CLIENT_AGENT_ID}:coordinator_agent"
+        assert d.to_agent == f"{CLIENT_AGENT_ID}:research_agent"
+
+    @pytest.mark.asyncio
+    async def test_already_compound_is_idempotent(
+        self, sink: HarmonografSink, client: Client
+    ):
+        """Re-emitting a compound id must not double-prefix."""
+        evt = _make_event("delegation")
+        evt.delegation_observed.from_agent = f"{CLIENT_AGENT_ID}:coordinator_agent"
+        evt.delegation_observed.to_agent = "other-client:some_agent"
+        await sink.emit(evt)
+
+        env = _drain(client)[0]
+        d = env.payload.delegation_observed
+        # Home-client's own agent stays as-is (contains ':' → already compound).
+        assert d.from_agent == f"{CLIENT_AGENT_ID}:coordinator_agent"
+        # Foreign compound ids are preserved verbatim too — the sink
+        # does NOT rewrite them to the home client's prefix.
+        assert d.to_agent == "other-client:some_agent"
+
+    @pytest.mark.asyncio
+    async def test_empty_fields_left_alone(
+        self, sink: HarmonografSink, client: Client
+    ):
+        evt = _make_event("delegation")
+        # Leave from/to empty — e.g. a goldfive variant that didn't
+        # populate them. No empty → ``<client>:`` rewrite.
+        await sink.emit(evt)
+
+        env = _drain(client)[0]
+        d = env.payload.delegation_observed
+        assert d.from_agent == ""
+        assert d.to_agent == ""
+
+
+# ---- AgentInvocationStarted / Completed -----------------------------------
+
+
+class TestAgentInvocation:
+    @pytest.mark.asyncio
+    async def test_started_bare_rewritten(
+        self, sink: HarmonografSink, client: Client
+    ):
+        evt = _make_event("inv-start")
+        evt.agent_invocation_started.agent_name = "coordinator_agent"
+        evt.agent_invocation_started.task_id = "t1"
+        evt.agent_invocation_started.invocation_id = "inv-1"
+        await sink.emit(evt)
+
+        env = _drain(client)[0]
+        payload = env.payload.agent_invocation_started
+        assert payload.agent_name == f"{CLIENT_AGENT_ID}:coordinator_agent"
+        # Non-agent fields untouched.
+        assert payload.task_id == "t1"
+        assert payload.invocation_id == "inv-1"
+
+    @pytest.mark.asyncio
+    async def test_completed_bare_rewritten(
+        self, sink: HarmonografSink, client: Client
+    ):
+        evt = _make_event("inv-done")
+        evt.agent_invocation_completed.agent_name = "research_agent"
+        evt.agent_invocation_completed.invocation_id = "inv-2"
+        await sink.emit(evt)
+
+        env = _drain(client)[0]
+        payload = env.payload.agent_invocation_completed
+        assert payload.agent_name == f"{CLIENT_AGENT_ID}:research_agent"
+
+
+# ---- DriftDetected ---------------------------------------------------------
+
+
+class TestDriftDetected:
+    @pytest.mark.asyncio
+    async def test_current_agent_id_bare_rewritten(
+        self, sink: HarmonografSink, client: Client
+    ):
+        evt = _make_event("drift")
+        evt.drift_detected.kind = gt.DRIFT_KIND_TOOL_ERROR
+        evt.drift_detected.severity = gt.DRIFT_SEVERITY_WARNING
+        evt.drift_detected.current_agent_id = "research_agent"
+        evt.drift_detected.current_task_id = "t-work"
+        await sink.emit(evt)
+
+        env = _drain(client)[0]
+        d = env.payload.drift_detected
+        assert d.current_agent_id == f"{CLIENT_AGENT_ID}:research_agent"
+        # Non-agent fields untouched.
+        assert d.current_task_id == "t-work"
+
+    @pytest.mark.asyncio
+    async def test_empty_current_agent_id_left_alone(
+        self, sink: HarmonografSink, client: Client
+    ):
+        """Drifts minted without a current agent (e.g. goal-drift at
+        plan time) must not grow a stray ``<client>:`` prefix."""
+        evt = _make_event("drift-noagent")
+        evt.drift_detected.kind = gt.DRIFT_KIND_GOAL_DRIFT
+        evt.drift_detected.severity = gt.DRIFT_SEVERITY_INFO
+        # current_agent_id left empty.
+        await sink.emit(evt)
+
+        env = _drain(client)[0]
+        assert env.payload.drift_detected.current_agent_id == ""
+
+
+# ---- PlanSubmitted / PlanRevised -------------------------------------------
+
+
+class TestPlanCanonicalization:
+    @pytest.mark.asyncio
+    async def test_plan_submitted_task_assignees_rewritten(
+        self, sink: HarmonografSink, client: Client
+    ):
+        evt = _make_event("plan")
+        plan = evt.plan_submitted.plan
+        plan.id = "p1"
+        plan.run_id = "run-1"
+        t1 = plan.tasks.add()
+        t1.id = "t1"
+        t1.assignee_agent_id = "coordinator_agent"
+        t2 = plan.tasks.add()
+        t2.id = "t2"
+        t2.assignee_agent_id = "research_agent"
+        t3 = plan.tasks.add()
+        t3.id = "t3"
+        # Unassigned task — empty stays empty.
+        await sink.emit(evt)
+
+        env = _drain(client)[0]
+        tasks = list(env.payload.plan_submitted.plan.tasks)
+        assert tasks[0].assignee_agent_id == f"{CLIENT_AGENT_ID}:coordinator_agent"
+        assert tasks[1].assignee_agent_id == f"{CLIENT_AGENT_ID}:research_agent"
+        assert tasks[2].assignee_agent_id == ""
+
+    @pytest.mark.asyncio
+    async def test_plan_revised_task_assignees_rewritten(
+        self, sink: HarmonografSink, client: Client
+    ):
+        evt = _make_event("plan-rev")
+        plan = evt.plan_revised.plan
+        plan.id = "p1"
+        plan.run_id = "run-1"
+        plan.revision_index = 1
+        t1 = plan.tasks.add()
+        t1.id = "t1"
+        t1.assignee_agent_id = "coordinator_agent"
+        await sink.emit(evt)
+
+        env = _drain(client)[0]
+        tasks = list(env.payload.plan_revised.plan.tasks)
+        assert tasks[0].assignee_agent_id == f"{CLIENT_AGENT_ID}:coordinator_agent"
+
+    @pytest.mark.asyncio
+    async def test_plan_assignee_idempotent_on_compound(
+        self, sink: HarmonografSink, client: Client
+    ):
+        evt = _make_event("plan-compound")
+        plan = evt.plan_submitted.plan
+        plan.id = "p1"
+        plan.run_id = "run-1"
+        t1 = plan.tasks.add()
+        t1.id = "t1"
+        t1.assignee_agent_id = f"{CLIENT_AGENT_ID}:coordinator_agent"
+        await sink.emit(evt)
+
+        env = _drain(client)[0]
+        tasks = list(env.payload.plan_submitted.plan.tasks)
+        assert tasks[0].assignee_agent_id == f"{CLIENT_AGENT_ID}:coordinator_agent"
+
+
+# ---- Pass-through events (no agent-id fields) -----------------------------
+
+
+class TestPassThrough:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "setup,kind",
+        [
+            (lambda e: e.run_started.SetInParent(), "run_started"),
+            (lambda e: e.task_started.SetInParent(), "task_started"),
+            (lambda e: e.task_completed.SetInParent(), "task_completed"),
+            (lambda e: e.run_completed.SetInParent(), "run_completed"),
+            (lambda e: e.approval_requested.SetInParent(), "approval_requested"),
+        ],
+    )
+    async def test_events_without_agent_fields_untouched(
+        self, sink: HarmonografSink, client: Client, setup, kind: str
+    ):
+        """Payload kinds that carry no agent-identity string field pass
+        through the sink unchanged. Sanity: no exception, and the
+        envelope kind matches."""
+        evt = _make_event(kind)
+        setup(evt)
+        await sink.emit(evt)
+
+        env = _drain(client)[0]
+        assert env.kind is EnvelopeKind.GOLDFIVE_EVENT
+        assert env.payload.WhichOneof("payload") == kind

--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -988,37 +988,12 @@ class IngestPipeline:
             created_at=created_at,
             planner_agent_id=ctx.agent_id,
         )
-        # Resolve each task's ``assignee_agent_id`` to a canonical
-        # agent-row id registered on this session (harmonograf#113).
-        # Goldfive planners emit the bare ADK agent name
-        # (``"coordinator_agent"``) while the harmonograf telemetry
-        # plugin registers per-ADK-agent rows with a compound id
-        # (``"<client_agent_id>:coordinator_agent"`` per harmonograf#74).
-        # Frontend surfaces that match task.assigneeAgentId against
-        # the registered agents list (GraphView pre-strip / ghost,
-        # Gantt task→agent lookup) silently fail under that mismatch,
-        # leaving the Plans checkbox toggling a no-op overlay and the
-        # Gantt pre-strip column empty despite valid plan data being
-        # in the DB. Resolving here lets downstream consumers keep
-        # their straightforward equality checks.
-        for task in stored.tasks:
-            bare = task.assignee_agent_id
-            if not bare:
-                continue
-            resolved = await self._store.find_agent_id_by_name(
-                ctx.session_id, bare
-            )
-            if resolved and resolved != bare:
-                task.assignee_agent_id = resolved
-        # Similarly resolve the planner_agent_id off the plan itself
-        # so the PlanRevisionBanner's "planner: X" attribution lands
-        # on a known agent row.
-        if stored.planner_agent_id:
-            resolved_planner = await self._store.find_agent_id_by_name(
-                ctx.session_id, stored.planner_agent_id
-            )
-            if resolved_planner and resolved_planner != stored.planner_agent_id:
-                stored.planner_agent_id = resolved_planner
+        # Task ``assignee_agent_id`` fields arrive already-compound from the
+        # client-side sink (harmonograf#125). The bare→compound resolve loop
+        # that used to live here is no longer needed — wire is authoritative.
+        # ``planner_agent_id`` is ``ctx.agent_id`` (set in
+        # ``goldfive_pb_plan_to_storage`` above), which is the stream's Hello
+        # agent_id — always the compound client-root id. No rewrite needed.
         stored = await self._store.put_task_plan(stored)
         # Refresh the task index for span-to-task binding lookups on the
         # hot path. A re-emitted plan with the same id replaces previous
@@ -1384,41 +1359,20 @@ class IngestPipeline:
         observed_at: Optional[float] = None
         if payload.HasField("observed_at"):
             observed_at = ts_to_float(payload.observed_at)
-        # Resolve from/to bare ADK names onto canonical agent-row ids
-        # (harmonograf#113). DelegationObserved events are emitted by
-        # goldfive's registry dispatch with the ADK agent.name strings,
-        # but the frontend's delegation arrow path matches fromAgentId
-        # / toAgentId against the registered agents list, which carries
-        # the telemetry-plugin's compound id format
-        # ``<client_id>:<adk_name>``. Without resolution the arrow's
-        # endpoint rows can't be found on the Gantt and the edge
-        # silently drops to nothing. Fall back to the raw name when no
-        # row is registered yet (rare race: DelegationObserved landing
-        # before the delegating agent's first span).
-        resolved_from = payload.from_agent
-        resolved_to = payload.to_agent
-        try:
-            f_id = await self._store.find_agent_id_by_name(
-                ctx.session_id, payload.from_agent
-            )
-            if f_id:
-                resolved_from = f_id
-            t_id = await self._store.find_agent_id_by_name(
-                ctx.session_id, payload.to_agent
-            )
-            if t_id:
-                resolved_to = t_id
-        except Exception as exc:  # noqa: BLE001 — defensive
-            logger.debug(
-                "delegation agent resolve failed session_id=%s: %s",
-                ctx.session_id,
-                exc,
-            )
+        # Compound agent ids are canonicalized at the client-side sink
+        # boundary (harmonograf#125 / HarmonografSink._canonicalize_agent_ids),
+        # so ``payload.from_agent`` / ``.to_agent`` arrive already in the
+        # ``<client_id>:<adk_name>`` form the frontend indexes against.
+        # The old bare→compound rewrite that used to live here (#111 / #113)
+        # was race-prone — ``find_agent_id_by_name`` returned the bare name
+        # verbatim when DelegationObserved landed before the target agent's
+        # first span registered, leaking bare names onto live subscribers.
+        # Store and publish verbatim now; the wire is authoritative.
         self._bus.publish_delegation_observed(
             ctx.session_id,
             run_id,
-            from_agent=resolved_from,
-            to_agent=resolved_to,
+            from_agent=payload.from_agent,
+            to_agent=payload.to_agent,
             task_id=payload.task_id,
             invocation_id=payload.invocation_id,
             observed_at=observed_at,
@@ -1429,11 +1383,10 @@ class IngestPipeline:
     ) -> Optional[str]:
         """Return the span id of the INVOCATION that should bind to ``task_id``.
 
-        harmonograf#122: looks up the task's ``assignee_agent_id``,
-        resolves it to the canonical agent-row id
-        (``find_agent_id_by_name`` — bare ADK name → compound id per
-        harmonograf#111 / #113), and scans stored spans for an
-        INVOCATION owned by that agent. Preference order:
+        harmonograf#122: looks up the task's ``assignee_agent_id`` (now
+        sink-canonicalized to compound id per harmonograf#125) and scans
+        stored spans for an INVOCATION owned by that agent. Preference
+        order:
 
           1. RUNNING INVOCATION with the latest ``start_time`` (the
              agent is actively executing — the usual case).
@@ -1455,9 +1408,9 @@ class IngestPipeline:
         task = await self._lookup_task(session_id, task_id)
         if task is None or not task.assignee_agent_id:
             return None
-        canonical = await self._store.find_agent_id_by_name(
-            session_id, task.assignee_agent_id
-        ) or task.assignee_agent_id
+        # assignee_agent_id is already compound (sink-canonicalized per
+        # harmonograf#125); no bare→compound resolve needed here.
+        canonical = task.assignee_agent_id
         span_id = await self._find_invocation_span_for_agent(
             session_id, canonical
         )

--- a/server/harmonograf_server/rpc/frontend.py
+++ b/server/harmonograf_server/rpc/frontend.py
@@ -366,11 +366,14 @@ class FrontendServicerMixin:
             # that joins late sees the agent lifelines (from span replay)
             # but no arrows between them.
             #
-            # The persisted payload_bytes carry the *raw* bare ADK agent
-            # names (ingest persists verbatim before resolving), so we
-            # re-run find_agent_id_by_name here to rewrite bare → compound
-            # ids. This matches the live path in
-            # IngestPipeline._on_delegation_observed.
+            # Post-harmonograf#125, persisted payloads carry compound
+            # agent ids verbatim — the HarmonografSink canonicalizes on
+            # emit, so ingest stores already-compound strings. No
+            # bare→compound rewrite runs here. For forward-compat with
+            # any stored rows we may have forgotten to wipe, unknown
+            # bare-name rows remain readable but render on whichever
+            # lifeline happens to match — a legacy-data hazard the user
+            # has accepted (wipe DB between runs).
             try:
                 delegation_events = await self._store.list_goldfive_events(
                     session_id, kind="delegation_observed"
@@ -391,27 +394,6 @@ class FrontendServicerMixin:
                     )
                     continue
                 d = ev.delegation_observed
-                resolved_from = d.from_agent
-                resolved_to = d.to_agent
-                try:
-                    f_id = await self._store.find_agent_id_by_name(
-                        session_id, d.from_agent
-                    )
-                    if f_id:
-                        resolved_from = f_id
-                    t_id = await self._store.find_agent_id_by_name(
-                        session_id, d.to_agent
-                    )
-                    if t_id:
-                        resolved_to = t_id
-                except Exception as exc:  # noqa: BLE001 — defensive
-                    logger.debug(
-                        "delegation_observed replay resolve failed session_id=%s: %s",
-                        session_id,
-                        exc,
-                    )
-                ev.delegation_observed.from_agent = resolved_from
-                ev.delegation_observed.to_agent = resolved_to
                 # Stamp emitted_at from observed_at so the frontend's
                 # observedAtMs calculation (which reads Event.emitted_at)
                 # lines up with the Gantt timeline — same invariant as

--- a/server/harmonograf_server/storage/base.py
+++ b/server/harmonograf_server/storage/base.py
@@ -456,24 +456,6 @@ class Store(ABC):
         limit: Optional[int] = None,
     ) -> list[GoldfiveEventRecord]: ...
 
-    # agent lookup helpers ------------------------------------------------
-    @abstractmethod
-    async def find_agent_id_by_name(
-        self, session_id: str, name: str
-    ) -> Optional[str]:
-        """Return the stored ``agents.id`` for the given (session, ADK name) or None.
-
-        Supports bug #113 — plans emit ``assignee_agent_id`` using the
-        bare ADK agent name (e.g. ``"coordinator_agent"``), but the
-        telemetry plugin registers agents with a per-ADK-agent id
-        (e.g. ``"<client_id>:coordinator_agent"``). Ingest calls this
-        to rewrite the plan's ``assignee_agent_id`` onto the canonical
-        per-ADK-agent id before storage so the frontend's agent-id
-        equality checks resolve. Returns None when no agent row
-        matches — caller keeps the bare name (degraded path).
-        """
-        ...
-
     # stats ----------------------------------------------------------------
     @abstractmethod
     async def stats(self) -> Stats: ...

--- a/server/harmonograf_server/storage/memory.py
+++ b/server/harmonograf_server/storage/memory.py
@@ -493,28 +493,6 @@ class InMemoryStore(Store):
             out = out[: int(limit)]
         return out
 
-    async def find_agent_id_by_name(
-        self, session_id: str, name: str
-    ) -> Optional[str]:
-        if not name or not session_id:
-            return None
-        async with self._lock:
-            # 1. exact id
-            if (session_id, name) in self._agents:
-                return name
-            # 2. exact name match
-            for (sid, aid), agent in self._agents.items():
-                if sid != session_id:
-                    continue
-                if agent.name == name:
-                    return aid
-            # 3. suffix match
-            suffix = f":{name}"
-            for (sid, aid), _ in self._agents.items():
-                if sid == session_id and aid.endswith(suffix):
-                    return aid
-        return None
-
     async def stats(self) -> Stats:
         async with self._lock:
             payload_bytes = sum(rec.meta.size for rec in self._payloads.values())

--- a/server/harmonograf_server/storage/postgres.py
+++ b/server/harmonograf_server/storage/postgres.py
@@ -227,10 +227,5 @@ class PostgresStore(Store):
     ) -> list[GoldfiveEventRecord]:
         raise NotImplementedError(_NOT_IMPLEMENTED)
 
-    async def find_agent_id_by_name(
-        self, session_id: str, name: str
-    ) -> Optional[str]:
-        raise NotImplementedError(_NOT_IMPLEMENTED)
-
     async def stats(self) -> Stats:
         raise NotImplementedError(_NOT_IMPLEMENTED)

--- a/server/harmonograf_server/storage/sqlite.py
+++ b/server/harmonograf_server/storage/sqlite.py
@@ -1266,54 +1266,6 @@ class SqliteStore(Store):
             for r in rows
         ]
 
-    # agent lookup helpers ----------------------------------------------
-    async def find_agent_id_by_name(
-        self, session_id: str, name: str
-    ) -> Optional[str]:
-        """Lookup (session, ADK name) → canonical agent_id.
-
-        Match precedence:
-          1. Exact ``agents.id`` match (caller already has the canonical id).
-          2. Exact ``agents.name`` match — the harmonograf#74 plugin
-             stamps ``name = <adk_agent_name>`` on per-ADK-agent rows.
-          3. Suffix match on ``agents.id`` (``...:<name>``) — tolerates
-             adk.agent.name cases where ``name`` got overwritten but the
-             id still encodes the ADK-agent-name suffix.
-
-        Returns None when no row matches. Single-row SELECT keyed on
-        ``session_id`` so the cost is bounded by the agent-registry
-        size (a few dozen rows in the worst case).
-        """
-        if not name or not session_id:
-            return None
-        async with self._lock:
-            # 1. exact id match
-            async with self.db.execute(
-                "SELECT id FROM agents WHERE session_id = ? AND id = ? LIMIT 1",
-                (session_id, name),
-            ) as cur:
-                row = await cur.fetchone()
-            if row is not None:
-                return row["id"]
-            # 2. exact name match
-            async with self.db.execute(
-                "SELECT id FROM agents WHERE session_id = ? AND name = ? LIMIT 1",
-                (session_id, name),
-            ) as cur:
-                row = await cur.fetchone()
-            if row is not None:
-                return row["id"]
-            # 3. suffix match on id
-            like = f"%:{name}"
-            async with self.db.execute(
-                "SELECT id FROM agents WHERE session_id = ? AND id LIKE ? LIMIT 1",
-                (session_id, like),
-            ) as cur:
-                row = await cur.fetchone()
-            if row is not None:
-                return row["id"]
-        return None
-
     # stats ---------------------------------------------------------------
     async def stats(self) -> Stats:
         async with self._lock:

--- a/server/tests/test_frontend_rpcs.py
+++ b/server/tests/test_frontend_rpcs.py
@@ -345,12 +345,16 @@ async def test_watch_session_replays_persisted_plan_as_goldfive_events(
 
 @pytest.mark.asyncio
 async def test_watch_session_replays_persisted_delegation_observed(harness, stub):
-    """Initial burst must replay persisted delegation_observed events with
-    bare ADK names rewritten to canonical compound agent ids so the Agent
-    Graph view draws arrows on reconnect. Regression: persist path stored
-    events verbatim (bare names), but WatchSession never re-emitted them
-    — only live bus subscribers ever saw delegations, so any client that
-    opened the view late got lifelines with no arrows between them."""
+    """Initial burst must replay persisted delegation_observed events so
+    the Agent Graph view draws arrows on reconnect. Regression: persist
+    path stored events but WatchSession never re-emitted them — only live
+    bus subscribers ever saw delegations, so any client that opened the
+    view late got lifelines with no arrows between them.
+
+    Post-harmonograf#125, HarmonografSink canonicalizes bare → compound
+    ids at the sink boundary before events leave the client, so stored
+    payloads already carry compound ids. Replay forwards them verbatim
+    with no bare → compound rewrite in the burst path."""
 
     from goldfive.v1 import events_pb2 as goldfive_events_pb2
     from harmonograf_server.storage import GoldfiveEventRecord
@@ -360,8 +364,8 @@ async def test_watch_session_replays_persisted_delegation_observed(harness, stub
     await _seed_session(
         store, session_id="sess_gf_d", n_spans=0, start=now - 10
     )
-    # Register the two ADK agents under compound ids so bare → compound
-    # resolution on replay has targets.
+    # Register the two ADK agents under compound ids. (Not required for
+    # replay correctness post-#125 — included for realism.)
     for adk_name in ("coordinator_agent", "research_agent"):
         await store.register_agent(
             Agent(
@@ -375,11 +379,11 @@ async def test_watch_session_replays_persisted_delegation_observed(harness, stub
             )
         )
 
-    # Persist a delegation_observed event exactly as the ingest pipeline
-    # would — raw proto bytes, bare ADK names in the payload.
+    # Persist a delegation_observed event with the already-compound
+    # agent ids the sink produces.
     ev = goldfive_events_pb2.Event(run_id="run-d")
-    ev.delegation_observed.from_agent = "coordinator_agent"
-    ev.delegation_observed.to_agent = "research_agent"
+    ev.delegation_observed.from_agent = "client-xyz:coordinator_agent"
+    ev.delegation_observed.to_agent = "client-xyz:research_agent"
     ev.delegation_observed.task_id = "t-del"
     ev.delegation_observed.invocation_id = "inv-del"
     ev.delegation_observed.observed_at.seconds = int(now - 5)
@@ -417,10 +421,10 @@ async def test_watch_session_replays_persisted_delegation_observed(harness, stub
     )
     replayed = delegations[0].delegation_observed
     assert replayed.from_agent == "client-xyz:coordinator_agent", (
-        f"expected bare → compound rewrite on from_agent, got {replayed.from_agent!r}"
+        f"expected verbatim replay of from_agent, got {replayed.from_agent!r}"
     )
     assert replayed.to_agent == "client-xyz:research_agent", (
-        f"expected bare → compound rewrite on to_agent, got {replayed.to_agent!r}"
+        f"expected verbatim replay of to_agent, got {replayed.to_agent!r}"
     )
     assert replayed.task_id == "t-del"
     assert replayed.invocation_id == "inv-del"

--- a/server/tests/test_goldfive_ingest.py
+++ b/server/tests/test_goldfive_ingest.py
@@ -1075,22 +1075,17 @@ async def test_goldfive_event_persist_is_idempotent(pipeline, store):
 
 
 @pytest.mark.asyncio
-async def test_plan_assignee_agent_id_resolves_from_bare_name(pipeline, store):
-    """A plan whose task.assignee is a bare ADK name resolves to the canonical id.
+async def test_plan_assignee_agent_id_stored_verbatim(pipeline, store):
+    """Plan ingest stores ``assignee_agent_id`` verbatim.
 
-    Under the harmonograf#74 per-agent attribution scheme, the
-    telemetry plugin registers agent rows with a compound id
-    (``<client_id>:<adk_name>``). Goldfive's planner emits
-    ``assignee_agent_id`` with the bare ADK name. The ingest pipeline
-    rewrites the bare name onto the canonical row id so the frontend
-    pre-strip / Plans overlay can resolve the task-to-agent link via
-    ordinary equality.
+    Post-harmonograf#125, HarmonografSink canonicalizes bare → compound
+    at the sink boundary before the event leaves the client process.
+    Ingest no longer rewrites assignees — the wire is authoritative.
     """
     from harmonograf_server.storage import Agent, AgentStatus, Framework
 
     pipe, _bus, _ = pipeline
     await _ensure_session(store)
-    # Register an agent with the compound-id format the plugin uses.
     canonical_id = "client-xyz:coordinator_agent"
     await store.register_agent(
         Agent(
@@ -1104,7 +1099,7 @@ async def test_plan_assignee_agent_id_resolves_from_bare_name(pipeline, store):
         )
     )
 
-    # Plan carries the bare ADK name on the task assignee field.
+    # Plan carries the compound agent id (what the sink produces).
     plan_pb = gt.Plan()
     plan_pb.id = "p-assign"
     plan_pb.run_id = "run-1"
@@ -1112,7 +1107,7 @@ async def test_plan_assignee_agent_id_resolves_from_bare_name(pipeline, store):
     t = plan_pb.tasks.add()
     t.id = "t1"
     t.title = "first"
-    t.assignee_agent_id = "coordinator_agent"
+    t.assignee_agent_id = canonical_id
     t.status = gt.TASK_STATUS_PENDING
 
     evt = _make_event()
@@ -1125,8 +1120,14 @@ async def test_plan_assignee_agent_id_resolves_from_bare_name(pipeline, store):
 
 
 @pytest.mark.asyncio
-async def test_delegation_observed_resolves_endpoint_agent_ids(pipeline, store):
-    """Bare from/to ADK names on DelegationObserved resolve to canonical ids."""
+async def test_delegation_observed_stored_verbatim(pipeline, store):
+    """DelegationObserved endpoints flow through ingest verbatim.
+
+    Post-harmonograf#125, the HarmonografSink emits compound ids on
+    the wire; ingest publishes them to the bus without rewriting.
+    Regression guard against a server-side resolver sneaking back in
+    and re-introducing the #111 / #117 race surface.
+    """
     from harmonograf_server.storage import Agent, AgentStatus, Framework
 
     pipe, bus, _ = pipeline
@@ -1146,8 +1147,8 @@ async def test_delegation_observed_resolves_endpoint_agent_ids(pipeline, store):
 
     sub = await bus.subscribe("sess_gf")
     evt = _make_event()
-    evt.delegation_observed.from_agent = "coordinator_agent"
-    evt.delegation_observed.to_agent = "research_agent"
+    evt.delegation_observed.from_agent = "client-abc:coordinator_agent"
+    evt.delegation_observed.to_agent = "client-abc:research_agent"
     evt.delegation_observed.task_id = "t1"
     await pipe.handle_message(_stream_ctx(), _wrap(evt))
 

--- a/server/tests/test_ingest_task_binding.py
+++ b/server/tests/test_ingest_task_binding.py
@@ -11,11 +11,14 @@ the attribute lands on at most 1/19 spans in a representative run
 
 The new design correlates by agent id at ingest time: when
 ``task_started(task_id=T)`` arrives, the server reads the task's
-``assignee_agent_id`` (already resolved to the canonical per-ADK-agent
-id at plan ingest — harmonograf#113), finds an INVOCATION span owned
-by that agent, and stamps ``bound_span_id`` on the task. If the span
-hasn't arrived yet (stream ordering), a pending-binding intent queues
-up and ``_handle_span_start`` fulfills it when the span lands.
+``assignee_agent_id`` (already in the canonical compound
+``<client_id>:<adk_name>`` form thanks to HarmonografSink's
+sink-side canonicalization — harmonograf#125, replacing the server-
+side ``find_agent_id_by_name`` rewrite from #113), finds an
+INVOCATION span owned by that agent, and stamps ``bound_span_id`` on
+the task. If the span hasn't arrived yet (stream ordering), a
+pending-binding intent queues up and ``_handle_span_start`` fulfills
+it when the span lands.
 
 These tests drive the ingest pipeline with synthetic
 ``TelemetryUp.span_start`` + ``TelemetryUp.goldfive_event`` messages
@@ -129,10 +132,16 @@ def _plan_event(
     *,
     plan_id: str,
     task_id: str,
-    assignee_bare_name: str,
+    assignee_agent_id: str,
     sequence: int = 0,
     event_id: str = "e-plan",
 ) -> ge.Event:
+    """Build a PlanSubmitted event with one task.
+
+    ``assignee_agent_id`` is the compound ``<client_id>:<adk_name>`` form
+    that HarmonografSink stamps on the wire (harmonograf#125). Ingest
+    stores it verbatim; task→span binding looks it up by equality.
+    """
     evt = _make_event(event_id=event_id, sequence=sequence)
     plan = evt.plan_submitted.plan
     plan.id = plan_id
@@ -141,7 +150,7 @@ def _plan_event(
     t = plan.tasks.add()
     t.id = task_id
     t.title = task_id
-    t.assignee_agent_id = assignee_bare_name
+    t.assignee_agent_id = assignee_agent_id
     t.status = gt.TASK_STATUS_PENDING
     return evt
 
@@ -197,15 +206,16 @@ async def test_span_then_task_started_binds_immediately(pipeline, store):
     canonical = "client-xyz:research_agent"
     await _register_agent(store, canonical_id=canonical, name="research_agent")
 
-    # Plan assigns t1 to research_agent (bare name — matches what
-    # goldfive's planner emits; ingest rewrites to canonical).
+    # Plan assigns t1 to the canonical compound id — HarmonografSink
+    # canonicalizes bare → compound before the event hits the wire
+    # (harmonograf#125), so ingest sees compound values verbatim.
     await pipe.handle_message(
         _stream_ctx(),
         _wrap_gf(
             _plan_event(
                 plan_id="p1",
                 task_id="t1",
-                assignee_bare_name="research_agent",
+                assignee_agent_id=canonical,
             )
         ),
     )
@@ -245,7 +255,7 @@ async def test_task_started_then_span_binds_on_span_arrival(pipeline, store):
             _plan_event(
                 plan_id="p1",
                 task_id="t1",
-                assignee_bare_name="research_agent",
+                assignee_agent_id=canonical,
             )
         ),
     )
@@ -294,12 +304,12 @@ async def test_multi_agent_tasks_do_not_cross_bind(pipeline, store):
     t1 = plan.tasks.add()
     t1.id = "t1"
     t1.title = "research"
-    t1.assignee_agent_id = "research_agent"
+    t1.assignee_agent_id = agent_a
     t1.status = gt.TASK_STATUS_PENDING
     t2 = plan.tasks.add()
     t2.id = "t2"
     t2.title = "summarize"
-    t2.assignee_agent_id = "summarizer_agent"
+    t2.assignee_agent_id = agent_b
     t2.status = gt.TASK_STATUS_PENDING
     await pipe.handle_message(_stream_ctx(), _wrap_gf(plan_evt))
 
@@ -350,7 +360,7 @@ async def test_leaf_spans_do_not_satisfy_invocation_binding(pipeline, store):
             _plan_event(
                 plan_id="p1",
                 task_id="t1",
-                assignee_bare_name="research_agent",
+                assignee_agent_id=canonical,
             )
         ),
     )
@@ -390,12 +400,11 @@ async def test_leaf_spans_do_not_satisfy_invocation_binding(pipeline, store):
 
 
 @pytest.mark.asyncio
-async def test_binding_resolves_bare_name_via_find_agent_id_by_name(
-    pipeline, store
-):
-    """The plan's ``assignee_agent_id`` is rewritten from the bare ADK
-    name to the canonical compound id at plan ingest (harmonograf#113).
-    The binding path must agree with that resolution."""
+async def test_plan_ingest_stores_compound_assignee_verbatim(pipeline, store):
+    """Post-harmonograf#125 ingest does NOT rewrite ``assignee_agent_id``
+    — HarmonografSink canonicalizes to compound at the sink boundary, so
+    the field arrives compound and is stored verbatim. This test pins
+    that invariant: the value on the wire equals the value on disk."""
     pipe, _bus, _ = pipeline
     await _ensure_session(store)
     canonical = "client-xyz:research_agent"
@@ -407,7 +416,7 @@ async def test_binding_resolves_bare_name_via_find_agent_id_by_name(
             _plan_event(
                 plan_id="p1",
                 task_id="t1",
-                assignee_bare_name="research_agent",
+                assignee_agent_id=canonical,
             )
         ),
     )
@@ -415,7 +424,7 @@ async def test_binding_resolves_bare_name_via_find_agent_id_by_name(
     plan = await store.get_task_plan("p1")
     t1 = next(t for t in plan.tasks if t.id == "t1")
     assert t1.assignee_agent_id == canonical, (
-        "plan ingest should resolve bare ADK name → canonical id"
+        "ingest must store the compound assignee_agent_id verbatim"
     )
 
     await pipe.handle_message(
@@ -450,7 +459,7 @@ async def test_binding_preserves_existing_status_on_late_span(pipeline, store):
             _plan_event(
                 plan_id="p1",
                 task_id="t1",
-                assignee_bare_name="research_agent",
+                assignee_agent_id=canonical,
             )
         ),
     )


### PR DESCRIPTION
## The problem

Harmonograf has two agent-id forms in circulation:

- **Bare**: the ADK `agent.name` string, e.g. `coordinator_agent`. Goldfive emits these on `DelegationObserved.from_agent`/`.to_agent`, `AgentInvocationStarted.agent_name`, `DriftDetected.current_agent_id`, and every `Plan.Task.assignee_agent_id`.
- **Compound**: `<client_id>:<bare_name>`, e.g. `presentation-orchestrated-9b2b3a9c7289:coordinator_agent`. Stamped by `HarmonografTelemetryPlugin` on every `SpanStart` as `span.agent_id` — the canonical row key the frontend uses for Gantt lanes, lifelines, and delegation-arrow endpoints.

Prior PRs (#111, #117) plastered best-effort `find_agent_id_by_name` resolvers onto server ingest and WatchSession burst replay to upgrade bare → compound **after** the wire. That approach raced with the target agent's first-span registration: a `DelegationObserved` landing before the sub-agent's `SpanStart` resolved to the bare name (no row matched yet), leaking bare ids onto live bus subscribers. Symptom: transfer arrows missing on the Agent Graph / Gantt until refresh — hit on the live run that prompted this fix, and repeatedly across #111 / #117.

## The fix

Canonicalize at the **source**. `HarmonografSink._canonicalize_agent_ids` rewrites every agent-identity field on every goldfive `Event` before it leaves the client process. After this change:

- Wire carries compound ids only.
- Server ingest stores payloads verbatim (no more `find_agent_id_by_name` calls in `_on_delegation_observed`, plan ingest, or the binding resolver).
- WatchSession burst replay forwards verbatim (no more parallel resolution in `rpc/frontend.py`).
- Frontend renders verbatim — no fallback / suffix-match logic needed or added.
- The `find_agent_id_by_name` helper is **deleted** from every storage backend (base, memory, sqlite, postgres) since it has no remaining callers.

### Rewrite rules (sink)

- Applies to non-empty fields only.
- Skipped if the field already contains `:` (idempotent — already-compound ids pass through untouched, so wrapped sinks / replays don't double-prefix).

### Fields covered

- `DelegationObserved.from_agent` / `.to_agent`
- `AgentInvocationStarted.agent_name`
- `AgentInvocationCompleted.agent_name`
- `DriftDetected.current_agent_id`
- `PlanSubmitted.plan.tasks[*].assignee_agent_id`
- `PlanRevised.plan.tasks[*].assignee_agent_id`

## Test plan

- [x] `uv run --extra e2e pytest client/tests/` — 285 passed (includes 15 new cases in `test_sink_canonicalization.py` for all fields above plus idempotence, empty-field, and pass-through paths)
- [x] `uv run --extra e2e pytest server/tests/` — 329 passed, 1 skipped (updated tests pin compound-only verbatim forwarding; dropped tests that specifically exercised `find_agent_id_by_name`)
- [x] `pnpm -C frontend test` — 298 passed across 32 files
- [x] `pnpm -C frontend build && pnpm -C frontend lint` — clean

## Migration note

Stored `goldfive_events` rows from before this change carry bare names. User wipes DB between runs; fresh sessions are canonical from the first frame. If a pre-fix row is replayed without the old resolver, endpoints may render on whichever lifeline matches — an accepted legacy-data hazard (wipe to recover).