### PR TITLE
Fix delegation arrow alignment on live delivery (store absolute ts, compute at render time)

### DIFF
--- a/frontend/src/__tests__/rpc/goldfiveEvent.test.ts
+++ b/frontend/src/__tests__/rpc/goldfiveEvent.test.ts
@@ -570,6 +570,126 @@ describe('applyGoldfiveEvent', () => {
       expect(store.delegations.list()[0].observedAtMs).toBe(0);
     });
 
+    // harmonograf#127: live-path race — a delegation_observed dispatched
+    // BEFORE the 'session' SessionUpdate has seeded wallClockStartMs on
+    // the store. Ingest stamps observedAtAbsoluteMs from emitted_at but
+    // observedAtMs lands wall-clock-scale; when the session frame
+    // finally lands and rebaseRelativeTimestamps fires, observedAtMs
+    // must snap to the correct session-relative value so the Gantt /
+    // Graph delegation arrow lines up.
+    it('delegationObserved during the live-path race recovers after rebase', () => {
+      const store = new SessionStore();
+      // Pretend the session's wall-clock start is 2000ms epoch. The
+      // delegation fires at 5000ms epoch — expected relative = 3000.
+      // At ingest, though, wallClockStartMs hasn't been set, so the
+      // caller passes sessionStartMs=0 (mirroring hooks.ts when
+      // `origin` is still null).
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-del-race',
+          runId: 'run-1',
+          sequence: 0n,
+          emittedAt: create(TimestampSchema, { seconds: 5n, nanos: 0 }),
+          payload: {
+            case: 'delegationObserved',
+            value: create(DelegationObservedSchema, {
+              fromAgent: 'coordinator',
+              toAgent: 'researcher',
+              taskId: 't-1',
+              invocationId: 'inv-race',
+            }),
+          },
+        }),
+        store,
+        0, // sessionStartMs not yet known on the frontend
+      );
+
+      const preRebase = store.delegations.list();
+      expect(preRebase).toHaveLength(1);
+      // Pre-rebase the relative value is wall-clock-scale (5000 - 0),
+      // which would render miles off-axis on the Gantt timeline.
+      expect(preRebase[0].observedAtMs).toBe(5000);
+      // But the authoritative absolute ms is preserved.
+      expect(preRebase[0].observedAtAbsoluteMs).toBe(5000);
+
+      // Session frame finally lands — hooks.ts calls this to re-anchor
+      // any pre-session events on the live path.
+      store.rebaseRelativeTimestamps(2000);
+
+      const postRebase = store.delegations.list();
+      expect(postRebase).toHaveLength(1);
+      expect(postRebase[0].observedAtMs).toBe(3000);
+      // Absolute is invariant across rebases.
+      expect(postRebase[0].observedAtAbsoluteMs).toBe(5000);
+    });
+
+    // Regression for the refresh path: when the session frame DOES
+    // land first (burst replay order), ingest computes the right
+    // relative value directly, and a subsequent (idempotent) rebase
+    // with the same startMs is a no-op.
+    it('delegationObserved on the refresh path yields the same observedAtMs as the rebased live path', () => {
+      const store = new SessionStore();
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-del-refresh',
+          runId: 'run-1',
+          sequence: 0n,
+          emittedAt: create(TimestampSchema, { seconds: 5n, nanos: 0 }),
+          payload: {
+            case: 'delegationObserved',
+            value: create(DelegationObservedSchema, {
+              fromAgent: 'coordinator',
+              toAgent: 'researcher',
+              taskId: 't-1',
+              invocationId: 'inv-refresh',
+            }),
+          },
+        }),
+        store,
+        2000, // sessionStartMs already known (burst delivered session first)
+      );
+      expect(store.delegations.list()[0].observedAtMs).toBe(3000);
+
+      // Idempotent: rebasing with the same start must not shift anything.
+      store.rebaseRelativeTimestamps(2000);
+      expect(store.delegations.list()[0].observedAtMs).toBe(3000);
+    });
+
+    it('driftDetected during the live-path race recovers after rebase', () => {
+      const store = new SessionStore();
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev-drift-race',
+          runId: 'run-1',
+          sequence: 0n,
+          emittedAt: create(TimestampSchema, { seconds: 7n, nanos: 0 }),
+          payload: {
+            case: 'driftDetected',
+            value: create(DriftDetectedSchema, {
+              kind: DriftKind.BLOCKER,
+              severity: DriftSeverity.WARNING,
+              detail: 'race',
+              currentTaskId: 't-1',
+              currentAgentId: 'agent-a',
+              id: 'drift-race-1',
+            }),
+          },
+        }),
+        store,
+        0,
+      );
+
+      const pre = store.drifts.list();
+      expect(pre).toHaveLength(1);
+      expect(pre[0].recordedAtMs).toBe(7000);
+      expect(pre[0].recordedAtAbsoluteMs).toBe(7000);
+
+      store.rebaseRelativeTimestamps(3000);
+      const post = store.drifts.list();
+      expect(post[0].recordedAtMs).toBe(4000);
+      expect(post[0].recordedAtAbsoluteMs).toBe(7000);
+    });
+
     it('agentInvocationStarted is a no-op (telemetry plugin already emits INVOCATION spans)', () => {
       const store = new SessionStore();
       expect(() =>

--- a/frontend/src/gantt/index.ts
+++ b/frontend/src/gantt/index.ts
@@ -526,7 +526,17 @@ export interface DriftRecord {
   detail: string;
   taskId: string;
   agentId: string;
-  recordedAtMs: number;   // session-relative
+  // Session-relative ms — derived from recordedAtAbsoluteMs on ingest and
+  // refreshed by DriftRegistry.rebase(sessionStartMs) once the session's
+  // wall-clock start lands on the frontend. Readers consume this directly.
+  recordedAtMs: number;
+  // Authoritative wall-clock timestamp in ms (from Event.emitted_at).
+  // Stored separately so that if the 'session' update races the first
+  // drift event on the live path, we can recompute recordedAtMs correctly
+  // once the session start is known (harmonograf#127 — kills a whole
+  // class of session-relative-at-ingest races that would otherwise
+  // misalign drift markers on the Gantt / Trajectory timelines).
+  recordedAtAbsoluteMs: number;
   // Non-empty for USER_STEER / USER_CANCEL drifts minted by goldfive
   // from a ControlMessage carrying a bridge-supplied annotation_id
   // (goldfive#176). Used by the intervention deriver (harmonograf#75)
@@ -553,9 +563,46 @@ export class DriftRegistry {
     return this.drifts;
   }
 
-  append(d: Omit<DriftRecord, 'seq'>): void {
-    this.drifts.push({ ...d, seq: this.nextSeq++ });
+  append(
+    d: Omit<DriftRecord, 'seq' | 'recordedAtAbsoluteMs'> &
+      Partial<Pick<DriftRecord, 'recordedAtAbsoluteMs'>>,
+  ): void {
+    // Default absolute to relative for callers that haven't been migrated
+    // (older tests, synthetic fixtures). Rebase is a no-op when
+    // wallClockStartMs is 0, so these records retain their original
+    // recordedAtMs — matching pre-#127 semantics.
+    const recordedAtAbsoluteMs = d.recordedAtAbsoluteMs ?? d.recordedAtMs;
+    this.drifts.push({
+      ...d,
+      recordedAtAbsoluteMs,
+      seq: this.nextSeq++,
+    });
     this.emit();
+  }
+
+  // Recompute every drift's session-relative `recordedAtMs` from its
+  // authoritative `recordedAtAbsoluteMs` using the newly-known session
+  // start. Called from SessionStore.rebaseRelativeTimestamps when the
+  // 'session' SessionUpdate finally delivers `created_at` to the
+  // frontend — previously, a live-delivered DriftDetected that landed
+  // before the session update was recorded with a bogus wall-clock-scale
+  // recordedAtMs (sessionStartMs was still 0 at ingest) and the marker
+  // rendered miles off-axis on the Gantt / Trajectory timelines.
+  rebase(sessionStartMs: number): void {
+    if (this.drifts.length === 0) return;
+    let changed = false;
+    for (const d of this.drifts) {
+      // Records ingested before this PR (or with no absolute ms) fall back
+      // to whatever was stored — don't mutate so we don't regress legacy
+      // paths that already stored a usable relative ms.
+      if (!d.recordedAtAbsoluteMs) continue;
+      const next = d.recordedAtAbsoluteMs - sessionStartMs;
+      if (d.recordedAtMs !== next) {
+        d.recordedAtMs = next;
+        changed = true;
+      }
+    }
+    if (changed) this.emit();
   }
 
   clear(): void {
@@ -587,7 +634,19 @@ export interface DelegationRecord {
   toAgentId: string;       // sub-agent the coordinator delegated to
   taskId: string;          // empty when the host agent has no bound task
   invocationId: string;    // ADK invocation id for the delegation
-  observedAtMs: number;    // session-relative
+  // Session-relative ms. Derived from observedAtAbsoluteMs on ingest and
+  // refreshed by DelegationRegistry.rebase(sessionStartMs) once the
+  // session's wall-clock start lands. All renderers (Gantt delegation
+  // edge pass, GraphView arrow projection) read this field directly.
+  observedAtMs: number;
+  // Authoritative wall-clock ms from Event.emitted_at. Kept alongside
+  // the relative field so that live-delivered DelegationObserved events
+  // that arrive before the 'session' SessionUpdate (sessionStartMs=0 at
+  // ingest) can be re-anchored once the session start is known — the
+  // refresh-path replay worked only because the burst ordered the
+  // 'session' frame first, which set sessionStartMs before the first
+  // delegation_observed event was replayed. harmonograf#127.
+  observedAtAbsoluteMs: number;
 }
 
 // Delegation registry — in-memory list of DelegationObserved events received
@@ -611,14 +670,55 @@ export class DelegationRegistry {
     return this.delegations;
   }
 
-  append(d: Omit<DelegationRecord, 'seq'>): void {
+  append(
+    d: Omit<DelegationRecord, 'seq' | 'observedAtAbsoluteMs'> &
+      Partial<Pick<DelegationRecord, 'observedAtAbsoluteMs'>>,
+  ): void {
+    // Default absolute to relative for callers that haven't been migrated
+    // (older tests, synthetic fixtures). Rebase is a no-op when
+    // wallClockStartMs is 0, so these records keep their original
+    // observedAtMs — which matches pre-#127 behavior.
+    const observedAtAbsoluteMs = d.observedAtAbsoluteMs ?? d.observedAtMs;
     const key = d.invocationId
       ? `${d.fromAgentId}|${d.toAgentId}|inv:${d.invocationId}`
-      : `${d.fromAgentId}|${d.toAgentId}|ts:${d.observedAtMs}`;
+      : `${d.fromAgentId}|${d.toAgentId}|ts:${
+          // Prefer the absolute ms for the dedup fallback key so a
+          // record ingested before `sessionStartMs` lands (relative
+          // would be ~wall-clock scale) and the rebased same record
+          // (relative much smaller) still dedup.
+          observedAtAbsoluteMs || d.observedAtMs
+        }`;
     if (this.seen.has(key)) return;
     this.seen.add(key);
-    this.delegations.push({ ...d, seq: this.nextSeq++ });
+    this.delegations.push({
+      ...d,
+      observedAtAbsoluteMs,
+      seq: this.nextSeq++,
+    });
     this.emit();
+  }
+
+  // Recompute every delegation's session-relative `observedAtMs` from its
+  // authoritative `observedAtAbsoluteMs` using the newly-known session
+  // start. See harmonograf#127: on the live path, the first
+  // delegation_observed event can race the 'session' SessionUpdate that
+  // seeds `store.wallClockStartMs`; without this rebase, the delegation
+  // is permanently stamped with a wall-clock-scale observedAtMs and
+  // renders miles off-axis on the Gantt and GraphView. The refresh path
+  // happened to work because the server's initial burst orders the
+  // 'session' frame before any replayed delegation_observed.
+  rebase(sessionStartMs: number): void {
+    if (this.delegations.length === 0) return;
+    let changed = false;
+    for (const d of this.delegations) {
+      if (!d.observedAtAbsoluteMs) continue;
+      const next = d.observedAtAbsoluteMs - sessionStartMs;
+      if (d.observedAtMs !== next) {
+        d.observedAtMs = next;
+        changed = true;
+      }
+    }
+    if (changed) this.emit();
   }
 
   clear(): void {
@@ -771,6 +871,23 @@ export class SessionStore {
   // Session start timestamp (wall clock ms). startMs/endMs in spans are
   // session-relative, so this only matters for display formatting.
   wallClockStartMs = 0;
+
+  // Refresh every session-relative timestamp cached on a child registry
+  // so that records whose `*AtAbsoluteMs` was captured before
+  // `wallClockStartMs` landed (live-path race, harmonograf#127) pick up
+  // the now-correct session start. Today, only DriftRegistry and
+  // DelegationRegistry participate — spans carry absolute times on the
+  // wire and are relativized at ingest by `convertSpan`, which reads
+  // `origin.startMs` that the transport layer (rpc/hooks.ts) guards
+  // against by defaulting to the cached origin before subscribing.
+  //
+  // Idempotent: safe to call whenever `wallClockStartMs` changes,
+  // including on re-delivery of a 'session' SessionUpdate. Each
+  // registry short-circuits when nothing moves.
+  rebaseRelativeTimestamps(sessionStartMs: number): void {
+    this.drifts.rebase(sessionStartMs);
+    this.delegations.rebase(sessionStartMs);
+  }
 
   // Current wall-clock "now" relative to session start. Advanced by the
   // renderer each frame (or by the transport when paused).

--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -270,11 +270,14 @@ export function applyGoldfiveEvent(
     }
     case 'driftDetected': {
       const d = payload.value;
-      const emittedMs = event.emittedAt
-        ? Number(event.emittedAt.seconds) * 1000 +
-          Math.floor(event.emittedAt.nanos / 1_000_000) -
-          sessionStartMs
-        : 0;
+      // Store the authoritative wall-clock ms alongside the relative form.
+      // If the live-path delivery races the 'session' SessionUpdate that
+      // seeds `sessionStartMs`, the relative value here will be wall-clock
+      // scale (garbage) — SessionStore.rebaseRelativeTimestamps is called
+      // from the 'session' handler to rewrite it once the start is known.
+      // See DriftRecord.recordedAtAbsoluteMs and harmonograf#127.
+      const emittedAbsMs = tsToMsAbs(event.emittedAt);
+      const emittedMs = emittedAbsMs ? emittedAbsMs - sessionStartMs : 0;
       const kindStr = driftKindToString(d.kind as unknown as number);
       const sevStr = driftSeverityToString(d.severity as unknown as number);
       store.drifts.append({
@@ -284,6 +287,7 @@ export function applyGoldfiveEvent(
         taskId: d.currentTaskId,
         agentId: d.currentAgentId,
         recordedAtMs: emittedMs,
+        recordedAtAbsoluteMs: emittedAbsMs,
         // goldfive#176: user-control drifts carry the source annotation_id
         // so harmonograf#75's deduper can merge them into the annotation
         // row. Empty string for autonomous drifts.
@@ -333,18 +337,27 @@ export function applyGoldfiveEvent(
       // telemetry plugin only records as a generic TOOL_CALL span on the
       // coordinator row. Feed the registry; the Gantt renderer's delegation
       // edge pass synthesizes a cross-agent curve from each record.
+      //
+      // Store both the authoritative wall-clock ms and the relative form.
+      // harmonograf#127: on the live path, this event can arrive BEFORE the
+      // 'session' SessionUpdate has set `store.wallClockStartMs`, so
+      // `sessionStartMs` here is 0 and the naive subtract stamps the
+      // record with wall-clock-scale observedAtMs — which made the Gantt
+      // / Graph arrows land miles off-axis. The refresh path worked only
+      // because the server's initial burst orders 'session' first. When
+      // the 'session' case fires, hooks.ts now calls
+      // `store.rebaseRelativeTimestamps(startMs)` which walks the
+      // delegation registry and rewrites observedAtMs from the absolute.
       const d = payload.value;
-      const observedMs = event.emittedAt
-        ? Number(event.emittedAt.seconds) * 1000 +
-          Math.floor(event.emittedAt.nanos / 1_000_000) -
-          sessionStartMs
-        : 0;
+      const observedAbsMs = tsToMsAbs(event.emittedAt);
+      const observedMs = observedAbsMs ? observedAbsMs - sessionStartMs : 0;
       store.delegations.append({
         fromAgentId: d.fromAgent,
         toAgentId: d.toAgent,
         taskId: d.taskId,
         invocationId: d.invocationId,
         observedAtMs: observedMs,
+        observedAtAbsoluteMs: observedAbsMs,
       });
       return;
     }

--- a/frontend/src/rpc/hooks.ts
+++ b/frontend/src/rpc/hooks.ts
@@ -268,6 +268,20 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
               origin = { startMs };
               originCache.set(sessionId, origin);
               store.wallClockStartMs = startMs;
+              // harmonograf#127: any DriftDetected / DelegationObserved
+              // events that slipped in before this 'session' frame
+              // landed were stamped with a wall-clock-scale relative
+              // time (sessionStartMs was 0). Re-anchor them now that
+              // the session start is known so the Gantt / Graph
+              // delegation arrows and drift markers line up with the
+              // rest of the timeline (which converts span start/end on
+              // ingest via `origin`). Spans themselves don't need this
+              // pass because they never read a zero `origin` — the
+              // 'initialSpan' / 'newSpan' / 'endedSpan' arms all guard
+              // with `if (!origin) origin = { startMs: 0 }` then
+              // recompute, and the burst delivers the 'session' frame
+              // before any span frame.
+              store.rebaseRelativeTimestamps(startMs);
               const nextStatus = lifecycleFromPb(s.status);
               if (statusCache.get(sessionId) !== nextStatus) {
                 statusCache.set(sessionId, nextStatus);


### PR DESCRIPTION
## Summary

User-reported bug: delegation/transfer arrows in the Gantt and Agent Graph views are misaligned (x-axis / time coordinate) when a `delegation_observed` event is delivered via the live stream. A hard browser refresh — which triggers the WatchSession burst replay — produces correctly aligned arrows.

Root cause: on the live path, a `DelegationObserved` event can land on the WatchSession stream BEFORE the `'session'` `SessionUpdate` has seeded `store.wallClockStartMs`. `applyGoldfiveEvent` is then dispatched with `sessionStartMs=0` and the naive `emitted_at - sessionStartMs` subtract leaves the record with a wall-clock-scale `observedAtMs` — which the Gantt delegation-edge pass and GraphView arrow projection consume directly, rendering the arrow miles off-axis. Refresh masked the bug because the server's initial burst yields the `'session'` frame first, so `sessionStartMs` was already populated by the time the delegation reached the dispatcher.

Fix: store the authoritative wall-clock ms (`observedAtAbsoluteMs`) alongside the relative form on `DelegationRecord`, and call a new `SessionStore.rebaseRelativeTimestamps(startMs)` from the `'session'` arm in `rpc/hooks.ts` to recompute `observedAtMs = absolute - startMs` for every cached record. Idempotent — re-delivery of a `'session'` frame with the same `startMs` is a no-op.

Applied the same absolute-ts + rebase treatment to `DriftRecord`, which has the identical pattern (drift markers on the Trajectory and synthetic-goldfive-actor row suffered the same race).

Skimmed the other `goldfive_event` cases:
- `approvalRequested` also subtracts `sessionStartMs` at ingest but writes into `useApprovalsStore` (zustand, keyed by `target_id`) rather than a gantt registry. No UI component positions the approval by `requestedAtMs` on a timeline, so left alone — can be addressed separately if needed.
- `planSubmitted` / `planRevised` use `sessionStartMs` for `createdAtMs` but plans are delivered after the `'session'` frame in both paths (burst and live), so they don't hit the race.

Registry `append(...)` signatures accept callers that haven't been migrated to pass `*AtAbsoluteMs` — defaults to the relative value — so synthetic test fixtures continue to work unchanged and rebase is a no-op for stores where `wallClockStartMs` stays 0.

- Bug: delegation arrow misaligned on live delivery because `sessionStartMs` was 0 at ingest
- Fix: store absolute `emitted_at` ms; rebase relative ms when session start lands
- Applied to drift records too (same class of bug)

## Test plan

- [x] `pnpm test` in `frontend/` — 305 passed (3 new tests added)
  - `delegationObserved during the live-path race recovers after rebase`
  - `delegationObserved on the refresh path yields the same observedAtMs as the rebased live path`
  - `driftDetected during the live-path race recovers after rebase`
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] Manual verification in browser: live run with a coordinator → sub-agent delegation; arrow x-coordinate must match the refresh-path arrow