### PR TITLE
Anchor delegation arrow endpoints to INVOCATION bar Y, not lane midline

### DIFF
--- a/frontend/src/__tests__/gantt/delegationAnchor.test.ts
+++ b/frontend/src/__tests__/gantt/delegationAnchor.test.ts
@@ -1,0 +1,303 @@
+// Regression for the off-center delegation arrow bug: the endpoints must
+// anchor to the INVOCATION bar's Y (sub-lane 0 center), NOT the row's
+// vertical midline. On a ROW_HEIGHT_PX=56 row the bar center sits ~18px
+// above the row midline, and the user observed the arrow floating that
+// gap away from the bar on the live path. Refresh happened to mask the
+// same math because the burst orders spans ahead of delegations, but
+// both paths should land on the bar now.
+//
+// We drive drawBlocks (private) through the typed escape hatch used by
+// brainBadges.test.ts. The renderer needs a canvas 2D context; jsdom
+// doesn't ship one, so we stub it with a no-op Proxy and inspect the
+// cached DelegationEdgeLayout the draw pass populates.
+
+import { describe, expect, it } from 'vitest';
+import { GanttRenderer } from '../../gantt/renderer';
+import { SessionStore } from '../../gantt/index';
+import {
+  ROW_HEIGHT_PX,
+  SUB_LANE_HEIGHT_PX,
+  TOP_MARGIN_PX,
+} from '../../gantt/viewport';
+import type { Span } from '../../gantt/types';
+
+function stubCtx(): CanvasRenderingContext2D {
+  const handler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'canvas') return { width: 1200, height: 400 };
+      if (prop === 'globalAlpha') return 1;
+      if (prop === 'measureText') return () => ({ width: 10 });
+      return () => undefined;
+    },
+    set() {
+      return true;
+    },
+  };
+  return new Proxy({}, handler) as CanvasRenderingContext2D;
+}
+
+function stubCanvas(): HTMLCanvasElement {
+  const el = document.createElement('canvas');
+  el.width = 1200;
+  el.height = 400;
+  (el as unknown as { getContext: () => CanvasRenderingContext2D }).getContext =
+    () => stubCtx();
+  return el;
+}
+
+function mkAgent(store: SessionStore, id: string): void {
+  store.agents.upsert({
+    id,
+    name: id,
+    framework: 'ADK',
+    status: 'CONNECTED',
+    capabilities: [],
+    connectedAtMs: 0,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+  });
+}
+
+function mkSpan(overrides: Partial<Span> & { id: string; agentId: string }): Span {
+  return {
+    sessionId: 'sess',
+    parentSpanId: null,
+    kind: 'INVOCATION',
+    name: 'run',
+    status: 'RUNNING',
+    startMs: 0,
+    endMs: null,
+    lane: 0,
+    attributes: {},
+    payloadRefs: [],
+    links: [],
+    replaced: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+// Re-derive the same lane-0 center the renderer uses. Keeping this in the
+// test (rather than importing the renderer's private helper) documents the
+// contract: the INVOCATION bar's Y is a function of row.top + lane math,
+// NOT row midline.
+function expectedInvocationCenter(rowTop: number, rowHeight: number): number {
+  const laneH = Math.max(SUB_LANE_HEIGHT_PX, Math.floor(rowHeight / 3));
+  const laneTop = rowTop + 2;
+  const laneBot = Math.min(rowTop + rowHeight - 2, laneTop + laneH - 2);
+  const rectH = Math.max(6, laneBot - laneTop);
+  return laneTop + rectH / 2;
+}
+
+function drawBlocks(renderer: GanttRenderer): void {
+  (renderer as unknown as { drawBlocks: () => void }).drawBlocks();
+}
+
+describe('GanttRenderer delegation anchor (harmonograf#129)', () => {
+  it('anchors endpoints to the INVOCATION bar center, not the row midline', () => {
+    const store = new SessionStore();
+    mkAgent(store, 'coord');
+    mkAgent(store, 'sub');
+
+    // Coordinator INVOCATION is wide, sub-agent INVOCATION starts at the
+    // delegation moment and runs past it. Both sit at sub-lane 0.
+    store.spans.append(
+      mkSpan({
+        id: 'inv-coord',
+        agentId: 'coord',
+        startMs: 0,
+        endMs: 10_000,
+        status: 'COMPLETED',
+      }),
+    );
+    store.spans.append(
+      mkSpan({
+        id: 'inv-sub',
+        agentId: 'sub',
+        startMs: 1_000,
+        endMs: 8_000,
+        status: 'COMPLETED',
+      }),
+    );
+
+    store.delegations.append({
+      fromAgentId: 'coord',
+      toAgentId: 'sub',
+      taskId: 't-1',
+      invocationId: 'inv-1',
+      observedAtMs: 1_000,
+    });
+
+    const r = new GanttRenderer(store);
+    r.attach(stubCanvas(), stubCanvas(), stubCanvas());
+    r.resize(1200, 200, 1);
+    r.setViewport({
+      endMs: 10_000,
+      windowMs: 10_000,
+      liveFollow: false,
+      replay: false,
+    });
+    drawBlocks(r);
+
+    const edges = r._delegationLayoutsForTesting();
+    expect(edges).toHaveLength(1);
+    const e = edges[0];
+
+    // Rows are laid out top-down: coord first, sub second.
+    const coordTop = TOP_MARGIN_PX;
+    const subTop = TOP_MARGIN_PX + ROW_HEIGHT_PX;
+
+    const coordBarY = expectedInvocationCenter(coordTop, ROW_HEIGHT_PX);
+    const subBarY = expectedInvocationCenter(subTop, ROW_HEIGHT_PX);
+    const coordRowMid = coordTop + ROW_HEIGHT_PX / 2;
+    const subRowMid = subTop + ROW_HEIGHT_PX / 2;
+
+    // The old (buggy) behavior anchored at row midline. Assert we moved
+    // off it — and specifically landed on the bar.
+    expect(e.srcY).toBe(coordBarY);
+    expect(e.tgtY).toBe(subBarY);
+    expect(e.srcY).not.toBe(coordRowMid);
+    expect(e.tgtY).not.toBe(subRowMid);
+
+    r.detach();
+  });
+
+  it('lane-0 fallback holds when the target INVOCATION has not arrived yet (live path)', () => {
+    // Reproduces the race the screenshot captured: coordinator's
+    // INVOCATION is live, delegation observed, but the sub-agent's
+    // INVOCATION span hasn't been reported yet. The arrow must still
+    // land where the bar *will* be drawn once it arrives (sub-lane 0),
+    // not at the row midline.
+    const store = new SessionStore();
+    mkAgent(store, 'coord');
+    mkAgent(store, 'sub');
+
+    store.spans.append(
+      mkSpan({
+        id: 'inv-coord',
+        agentId: 'coord',
+        startMs: 0,
+        endMs: null,
+        status: 'RUNNING',
+      }),
+    );
+
+    store.delegations.append({
+      fromAgentId: 'coord',
+      toAgentId: 'sub',
+      taskId: 't-1',
+      invocationId: 'inv-1',
+      observedAtMs: 500,
+    });
+
+    const r = new GanttRenderer(store);
+    r.attach(stubCanvas(), stubCanvas(), stubCanvas());
+    r.resize(1200, 200, 1);
+    r.setViewport({
+      endMs: 10_000,
+      windowMs: 10_000,
+      liveFollow: false,
+      replay: false,
+    });
+    drawBlocks(r);
+
+    const edges = r._delegationLayoutsForTesting();
+    expect(edges).toHaveLength(1);
+    const e = edges[0];
+
+    const subTop = TOP_MARGIN_PX + ROW_HEIGHT_PX;
+    const subBarY = expectedInvocationCenter(subTop, ROW_HEIGHT_PX);
+    const subRowMid = subTop + ROW_HEIGHT_PX / 2;
+
+    expect(e.tgtY).toBe(subBarY);
+    expect(e.tgtY).not.toBe(subRowMid);
+
+    r.detach();
+  });
+
+  it('anchors correctly on a row with multiple active sub-lanes', () => {
+    // Sub-agent has an INVOCATION at lane 0 plus overlapping LLM_CALL /
+    // TOOL_CALL spans packed onto lane 1 and lane 2 — the bar Y is
+    // still lane-0 center, regardless of how many concurrent children
+    // are stacked alongside it.
+    const store = new SessionStore();
+    mkAgent(store, 'coord');
+    mkAgent(store, 'sub');
+
+    store.spans.append(
+      mkSpan({
+        id: 'inv-coord',
+        agentId: 'coord',
+        startMs: 0,
+        endMs: 10_000,
+        status: 'COMPLETED',
+      }),
+    );
+    store.spans.append(
+      mkSpan({
+        id: 'inv-sub',
+        agentId: 'sub',
+        startMs: 1_000,
+        endMs: 8_000,
+        status: 'COMPLETED',
+      }),
+    );
+    // Two concurrent children. packLanes() would put them on lane 1 and
+    // lane 2. We pre-assign here because the store doesn't auto-pack.
+    store.spans.append(
+      mkSpan({
+        id: 'llm-1',
+        agentId: 'sub',
+        kind: 'LLM_CALL',
+        startMs: 1_500,
+        endMs: 3_500,
+        lane: 1,
+        status: 'COMPLETED',
+      }),
+    );
+    store.spans.append(
+      mkSpan({
+        id: 'tool-1',
+        agentId: 'sub',
+        kind: 'TOOL_CALL',
+        startMs: 1_500,
+        endMs: 3_500,
+        lane: 2,
+        status: 'COMPLETED',
+      }),
+    );
+
+    store.delegations.append({
+      fromAgentId: 'coord',
+      toAgentId: 'sub',
+      taskId: 't-1',
+      invocationId: 'inv-1',
+      observedAtMs: 1_000,
+    });
+
+    const r = new GanttRenderer(store);
+    r.attach(stubCanvas(), stubCanvas(), stubCanvas());
+    r.resize(1200, 200, 1);
+    r.setViewport({
+      endMs: 10_000,
+      windowMs: 10_000,
+      liveFollow: false,
+      replay: false,
+    });
+    drawBlocks(r);
+
+    const edges = r._delegationLayoutsForTesting();
+    expect(edges).toHaveLength(1);
+    const e = edges[0];
+
+    const subTop = TOP_MARGIN_PX + ROW_HEIGHT_PX;
+    const subBarY = expectedInvocationCenter(subTop, ROW_HEIGHT_PX);
+
+    expect(e.tgtY).toBe(subBarY);
+
+    r.detach();
+  });
+});

--- a/frontend/src/gantt/renderer.ts
+++ b/frontend/src/gantt/renderer.ts
@@ -117,6 +117,23 @@ interface FrameMetrics {
   sampleCount: number;
 }
 
+// Shared row/lane → Y math. Used by drawBlocks, drawLinks, and drawDelegations
+// so a span's rendered Y center matches the arrow anchors exactly. Keep in
+// sync with the inline `laneTop = row.top + 2 + lane * laneH` formula used by
+// the block draw pass.
+interface RowLayoutLite {
+  top: number;
+  height: number;
+}
+function laneCenterY(row: RowLayoutLite, lane: number): number {
+  const laneIdx = lane >= 0 ? lane : 0;
+  const laneH = Math.max(SUB_LANE_HEIGHT_PX, Math.floor(row.height / 3));
+  const laneTop = row.top + 2 + laneIdx * laneH;
+  const laneBot = Math.min(row.top + row.height - 2, laneTop + laneH - 2);
+  const rectH = Math.max(6, laneBot - laneTop);
+  return laneTop + rectH / 2;
+}
+
 // Icons drawn when a block is wide enough. Single-char glyphs keep the fast
 // path cheap — no font atlas needed at 11sp.
 const KIND_ICON: Record<SpanKind, string> = {
@@ -1076,13 +1093,8 @@ export class GanttRenderer {
       rowLayout.set(agent.id, { top: y, height: rowH, centerY: y + rowH / 2 });
       y += rowH;
     }
-    const spanCenterY = (s: Span, row: RowLayout): number => {
-      const laneH = Math.max(SUB_LANE_HEIGHT_PX, Math.floor(row.height / 3));
-      const laneTop = row.top + 2 + (s.lane >= 0 ? s.lane : 0) * laneH;
-      const laneBot = Math.min(row.top + row.height - 2, laneTop + laneH - 2);
-      const rectH = Math.max(6, laneBot - laneTop);
-      return laneTop + rectH / 2;
-    };
+    const spanCenterY = (s: Span, row: RowLayout): number =>
+      laneCenterY(row, s.lane);
 
     const dataLeft = GUTTER_WIDTH_PX + 10;
     const dataRight = w;
@@ -1175,15 +1187,50 @@ export class GanttRenderer {
     const agents = this.store.agents.list;
     if (agents.length === 0) return;
 
-    // Row-center lookup — delegation anchors are row-centered rather than
-    // lane-specific because there's no originating span bar to point at.
-    const rowCenterY = new Map<string, number>();
+    // Row layout lookup — we need top+height per agent so we can anchor the
+    // delegation endpoints to the INVOCATION bar's Y (sub-lane 0 math),
+    // NOT the row midline. On a 3-sub-lane row the INVOCATION bar sits at
+    // ~row.top+10 while the midline is at row.top+28, so anchoring to
+    // midline leaves the arrow floating below the bar (harmonograf#129).
+    type RowLayout = { top: number; height: number; centerY: number };
+    const rowLayout = new Map<string, RowLayout>();
     let y = TOP_MARGIN_PX;
     for (const agent of agents) {
       const rowH = this.rowHeight(agent.id);
-      rowCenterY.set(agent.id, y + rowH / 2);
+      rowLayout.set(agent.id, { top: y, height: rowH, centerY: y + rowH / 2 });
       y += rowH;
     }
+
+    // Finds the INVOCATION span to anchor the arrow endpoint to on a
+    // given agent row at `atMs`. Prefers a span active at `atMs`; falls
+    // back to the most recent INVOCATION that ended before `atMs`, and
+    // finally to lane-0 math (same visual position the INVOCATION bar
+    // will occupy once it arrives) so the arrow stays stable on the live
+    // path even before the target row's INVOCATION span is reported.
+    const anchorY = (agentId: string, atMs: number): number | undefined => {
+      const row = rowLayout.get(agentId);
+      if (!row) return undefined;
+      const pad = Math.max(this.viewport.windowMs * 0.5, 1);
+      const scratch: Span[] = [];
+      this.store.spans.queryAgent(agentId, atMs - pad, atMs + pad, scratch);
+      let active: Span | undefined;
+      let mostRecentCompleted: Span | undefined;
+      for (const s of scratch) {
+        if (s.kind !== 'INVOCATION') continue;
+        if (s.startMs > atMs) continue;
+        const end = s.endMs ?? Number.POSITIVE_INFINITY;
+        if (end >= atMs) {
+          // Active at atMs — strongest match, prefer the latest-started
+          // one if multiple overlap (rare: invocation spans usually don't
+          // stack on a single row).
+          if (!active || s.startMs > active.startMs) active = s;
+        } else if (!mostRecentCompleted || s.startMs > mostRecentCompleted.startMs) {
+          mostRecentCompleted = s;
+        }
+      }
+      const chosen = active ?? mostRecentCompleted;
+      return laneCenterY(row, chosen ? chosen.lane : 0);
+    };
 
     const dataLeft = GUTTER_WIDTH_PX + 10;
     const dataRight = w;
@@ -1199,8 +1246,8 @@ export class GanttRenderer {
       if (d.observedAtMs < vs - margin || d.observedAtMs > ve + margin) {
         continue;
       }
-      const srcY = rowCenterY.get(d.fromAgentId);
-      const tgtY = rowCenterY.get(d.toAgentId);
+      const srcY = anchorY(d.fromAgentId, d.observedAtMs);
+      const tgtY = anchorY(d.toAgentId, d.observedAtMs);
       if (srcY === undefined || tgtY === undefined) continue;
       const x = msToPx(this.viewport, w, d.observedAtMs);
       if (x < dataLeft || x > dataRight) continue;


### PR DESCRIPTION
## Symptom

Zoomed-in Gantt (between two agent lanes) showed delegation dashed curves arriving at the correct agent *lane* (right row) but landing a few pixels *above/off* the INVOCATION bar rather than on its visual center. Refresh appeared to produce a clean render; live delivery made the off-center endpoint obvious.

## Root cause

`drawDelegations` anchored both endpoints to `y + rowH / 2` — the row's vertical midline. On a `ROW_HEIGHT_PX = 56` row with 3 sub-lanes (`laneH = max(14, floor(56/3)) = 18`), the INVOCATION bar's center sits at `row.top + 10` while the row midline sits at `row.top + 28`. That baked in an ~18px gap between the arrow endpoint and the bar it was pointing at, regardless of sub-lane count. Under live build-up, spans landing on lanes 1 / 2 during the session visibly amplified how "off" the arrow looked because more pixels of row separated the midline anchor from the bar at the top.

## Fix

- Extract `laneCenterY(row, lane)` as a module-level helper so the block draw pass, `drawLinks`, and `drawDelegations` share one Y-placement formula.
- In `drawDelegations`, look up the INVOCATION span active on each side's agent at `d.observedAtMs` (fall back to the most recent completed INVOCATION, then to lane-0 math) and anchor the arrow to that bar's center via `laneCenterY`.
- The lane-0 fallback handles the live-path race where `observedAtMs` precedes the target's INVOCATION SPAN_START — the arrow lands where the bar *will* be painted so there's no pop when the span arrives.

Pure renderer-side fix. No backend / goldfive changes. X coordinate and curvature are untouched.

## Test plan

- [x] `pnpm test` — 310 tests pass across 33 files.
- [x] `tsc --noEmit` — clean.
- [x] New regression test `frontend/src/__tests__/gantt/delegationAnchor.test.ts` seeds coordinator + sub-agent INVOCATION spans (and in one case concurrent LLM_CALL / TOOL_CALL sub-lane fillers) and asserts both endpoints land on `laneCenterY(row, 0)` and specifically NOT on `row.top + rowHeight / 2`.
- [x] Covers the live-path race: target's INVOCATION not yet reported — lane-0 fallback keeps the endpoint stable.
- [ ] Visual check in the frontend with a live + refresh side-by-side on a real delegated session.