### PR TITLE
InterventionsTimeline: session-wide shared axis + collapse-when-empty toggle

### DIFF
--- a/frontend/src/__tests__/components/InterventionsTimeline.test.tsx
+++ b/frontend/src/__tests__/components/InterventionsTimeline.test.tsx
@@ -52,9 +52,29 @@ describe('<InterventionsTimeline />', () => {
     expect(gold.getAttribute('data-source')).toBe('goldfive');
   });
 
-  it('shows the empty-state hint when there are no rows', () => {
+  it('collapses to a single toggle when there are no rows, and reveals the hint on click', () => {
     render(<InterventionsTimeline rows={[]} startMs={0} endMs={10} />);
+    // Collapsed by default — the empty hint is NOT in the DOM.
+    expect(screen.queryByText(/No interventions recorded/i)).toBeNull();
+    const toggle = screen.getByTestId('interventions-timeline-toggle');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(toggle.textContent).toMatch(/Interventions \(0\)/);
+    // Expand — hint + axis become visible.
+    fireEvent.click(toggle);
     expect(screen.getByText(/No interventions recorded/i)).toBeTruthy();
+    expect(screen.getByTestId('interventions-timeline-toggle').getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('renders the axis inline (no toggle) when there is at least one row', () => {
+    render(
+      <InterventionsTimeline
+        rows={[row({ key: 'u1', atMs: 100, source: 'user', kind: 'STEER' })]}
+        startMs={0}
+        endMs={60_000}
+      />,
+    );
+    expect(screen.queryByTestId('interventions-timeline-toggle')).toBeNull();
+    expect(screen.getByTestId('intervention-marker-u1')).toBeTruthy();
   });
 
   it('opens an expandable card with outcome + body when a marker is clicked', () => {
@@ -362,6 +382,8 @@ describe('<InterventionsTimeline />', () => {
         _liveTickMs={0}
       />,
     );
+    // Empty-row strip collapses by default — expand before checking axis.
+    fireEvent.click(screen.getByTestId('interventions-timeline-toggle'));
     // pickTickStepMs picks 60s for spans ≤ 10m → 6 ticks at 0, 1, 2, 3, 4, 5 min.
     const labels = screen
       .getAllByTestId(/^axis-tick-\d+$/)

--- a/frontend/src/components/Interventions/InterventionsTimeline.css
+++ b/frontend/src/components/Interventions/InterventionsTimeline.css
@@ -8,17 +8,16 @@
   flex-direction: column;
   gap: 4px;
   padding: 0;
-  /* Cap the strip width so it stays visually proportional to the
-     plan DAG above it rather than stretching to the full page. The
-     960px cap covers a typical ~6-stage DAG (SIDE_PADDING*2 +
-     stages*COLUMN_WIDTH ≈ 864px) plus slack for wider plans. The
-     earlier #125 fix switched to a session-wide axis so markers land
-     at the correct (atMs - startMs)/elapsedMs fraction; that math is
-     preserved — only the strip's horizontal footprint is bounded.
-     Parents that want an exact width pass the `width` prop, which
-     overrides this cap via inline style (e.g. GanttView flows the
-     measured plan-DAG width down so the strip and DAG line up). */
-  max-width: 960px;
+  /* Act as a session-wide time axis shared with the Gantt canvas above,
+     not column-aligned to a single plan's DAG. Stretches to the
+     container width but caps at 1280px so it doesn't sprawl across
+     ultrawide monitors — the strip's content (a few tick labels +
+     small glyphs) reads as empty when smeared across 2500+px.
+     Parents that want an exact width can still pass the `width` prop,
+     which overrides via inline style (tests pin a deterministic
+     viewBox that way). */
+  width: 100%;
+  max-width: 1280px;
   font:
     11px/1.3 var(--md-sys-typescale-body-small-font, system-ui, sans-serif);
   color: var(--md-sys-color-on-surface-variant, #9da3b4);
@@ -128,6 +127,39 @@
   font-size: 10px;
   font-style: italic;
   color: var(--md-sys-color-on-surface-variant, #9da3b4);
+}
+
+/* --- Collapse toggle (empty-state) -------------------------------------- */
+/* Shown only when rows.length === 0. Lets the user un-collapse the strip so
+   they can still see the axis for the currently-loaded time window. Sized
+   to occupy one text line so an empty strip costs ~18px instead of ~62px. */
+
+.hg-interventions-strip__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 6px;
+  background: transparent;
+  border: 0;
+  color: var(--md-sys-color-on-surface-variant, #9da3b4);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  letter-spacing: 0.2px;
+  opacity: 0.75;
+  align-self: flex-start;
+}
+
+.hg-interventions-strip__toggle:hover {
+  opacity: 1;
+  color: var(--md-sys-color-on-surface, #e2e2e9);
+}
+
+.hg-interventions-strip__toggle-caret {
+  display: inline-block;
+  width: 10px;
+  text-align: center;
+  font-size: 10px;
 }
 
 /* --- Popover (hover + pinned) ------------------------------------------ */

--- a/frontend/src/components/Interventions/InterventionsTimeline.tsx
+++ b/frontend/src/components/Interventions/InterventionsTimeline.tsx
@@ -303,6 +303,15 @@ export function InterventionsTimeline({
   const [hoverKey, setHoverKey] = useState<string | null>(null);
   const [pinnedKey, setPinnedKey] = useState<string | null>(null);
 
+  // Empty-state collapse. When no interventions have been recorded the
+  // strip folds down to a single-line caret to avoid wasting ~50px of
+  // vertical space per plan on an axis with nothing on it. The user can
+  // still un-collapse to see the axis if they want to sanity-check the
+  // time window. Once rows arrive the strip always renders.
+  const isEmpty = rows.length === 0;
+  const [userExpandedWhenEmpty, setUserExpandedWhenEmpty] = useState(false);
+  const isExpanded = !isEmpty || userExpandedWhenEmpty;
+
   // Default width for the SVG viewBox + marker math when no explicit
   // `width` prop is passed. Matches the CSS max-width cap (960px) so
   // cluster thresholds (a fraction of actualWidth) are consistent with
@@ -388,6 +397,8 @@ export function InterventionsTimeline({
       ref={rootRef}
       className="hg-interventions-strip"
       data-testid="interventions-timeline"
+      data-empty={isEmpty ? 'true' : 'false'}
+      data-expanded={isExpanded ? 'true' : 'false'}
       style={
         width
           ? // Explicit width overrides the CSS max-width cap so callers that
@@ -396,135 +407,153 @@ export function InterventionsTimeline({
           : { width: '100%' }
       }
     >
-      <svg
-        className="hg-interventions-strip__svg"
-        width="100%"
-        height={STRIP_HEIGHT}
-        viewBox={`0 0 ${actualWidth} ${STRIP_HEIGHT}`}
-        preserveAspectRatio="none"
-      >
-        {/* Rule */}
-        <line
-          className="hg-interventions-strip__rule"
-          x1={STRIP_PAD_X}
-          y1={MARKER_Y}
-          x2={actualWidth - STRIP_PAD_X}
-          y2={MARKER_Y}
-        />
-
-        {/* Axis ticks */}
-        {axisTicks.map((tick, i) => {
-          const tNorm = Math.min(1, Math.max(0, (tick.atMs - startMs) / span));
-          const x = STRIP_PAD_X + tNorm * (actualWidth - STRIP_PAD_X * 2);
-          return (
-            <g
-              key={`tick-${i}`}
-              className="hg-interventions-strip__tick"
-              data-testid={`axis-tick-${i}`}
-            >
-              <line
-                className="hg-interventions-strip__tick-mark"
-                x1={x}
-                y1={MARKER_Y - 2}
-                x2={x}
-                y2={MARKER_Y + 2}
-              />
-              <text
-                className="hg-interventions-strip__tick-label"
-                x={x}
-                y={AXIS_Y + 6}
-                textAnchor="middle"
-              >
-                {tick.label}
-              </text>
-            </g>
-          );
-        })}
-
-        {/* Markers / clusters */}
-        {clusters.map((cluster) => {
-          if (cluster.rows.length === 1) {
-            const row = cluster.rows[0];
-            const isActive = activeKey === row.key;
-            const isNew = newlyAdded.has(row.key);
-            return (
-              <Marker
-                key={row.key}
-                row={row}
-                cx={cluster.cx}
-                cy={MARKER_Y}
-                selected={isActive}
-                isNew={isNew}
-                onMouseEnter={() => {
-                  if (!pinnedKey) setHoverKey(row.key);
-                }}
-                onMouseLeave={() => {
-                  if (!pinnedKey) setHoverKey(null);
-                }}
-                onClick={() =>
-                  setPinnedKey((k) => (k === row.key ? null : row.key))
-                }
-              />
-            );
-          }
-          // Cluster badge
-          const representativeKey = cluster.rows[0].key;
-          const isActive = cluster.rows.some((r) => r.key === activeKey);
-          return (
-            <ClusterBadge
-              key={`cluster:${representativeKey}`}
-              cluster={cluster}
-              cx={cluster.cx}
-              cy={MARKER_Y}
-              selected={isActive}
-              onMouseEnter={() => {
-                if (!pinnedKey) setHoverKey(representativeKey);
-              }}
-              onMouseLeave={() => {
-                if (!pinnedKey) setHoverKey(null);
-              }}
-              onClick={() =>
-                setPinnedKey((k) =>
-                  cluster.rows.some((r) => r.key === k)
-                    ? null
-                    : representativeKey,
-                )
-              }
+      {isEmpty && (
+        <button
+          type="button"
+          className="hg-interventions-strip__toggle"
+          data-testid="interventions-timeline-toggle"
+          aria-expanded={isExpanded}
+          onClick={() => setUserExpandedWhenEmpty((v) => !v)}
+        >
+          <span className="hg-interventions-strip__toggle-caret" aria-hidden="true">
+            {isExpanded ? '▾' : '▸'}
+          </span>
+          <span>Interventions (0)</span>
+        </button>
+      )}
+      {isExpanded && (
+        <>
+          <svg
+            className="hg-interventions-strip__svg"
+            width="100%"
+            height={STRIP_HEIGHT}
+            viewBox={`0 0 ${actualWidth} ${STRIP_HEIGHT}`}
+            preserveAspectRatio="none"
+          >
+            {/* Rule */}
+            <line
+              className="hg-interventions-strip__rule"
+              x1={STRIP_PAD_X}
+              y1={MARKER_Y}
+              x2={actualWidth - STRIP_PAD_X}
+              y2={MARKER_Y}
             />
-          );
-        })}
-      </svg>
 
-      {/* Deterministic popover — positioned relative to the marker's cx in
-          the strip's coord space (not the cursor). */}
-      {activeCluster && activeRow && activeCluster.rows.length === 1 && (
-        <InterventionPopover
-          row={activeRow}
-          revs={revs}
-          anchorXPct={(activeCluster.cx / actualWidth) * 100}
-          pinned={pinnedKey !== null}
-          onClose={closePopover}
-          onJumpToRevision={onJumpToRevision}
-        />
-      )}
-      {activeCluster && activeCluster.rows.length > 1 && (
-        <ClusterPopover
-          cluster={activeCluster}
-          anchorXPct={(activeCluster.cx / actualWidth) * 100}
-          pinned={pinnedKey !== null}
-          revs={revs}
-          onClose={closePopover}
-          onJumpToRevision={onJumpToRevision}
-          onRowSelect={(key) => {
-            setPinnedKey(key);
-            setHoverKey(key);
-          }}
-        />
-      )}
-      {rows.length === 0 && (
-        <div className="hg-interventions-strip__empty">
-          No interventions recorded.
-        </div>
+            {/* Axis ticks */}
+            {axisTicks.map((tick, i) => {
+              const tNorm = Math.min(1, Math.max(0, (tick.atMs - startMs) / span));
+              const x = STRIP_PAD_X + tNorm * (actualWidth - STRIP_PAD_X * 2);
+              return (
+                <g
+                  key={`tick-${i}`}
+                  className="hg-interventions-strip__tick"
+                  data-testid={`axis-tick-${i}`}
+                >
+                  <line
+                    className="hg-interventions-strip__tick-mark"
+                    x1={x}
+                    y1={MARKER_Y - 2}
+                    x2={x}
+                    y2={MARKER_Y + 2}
+                  />
+                  <text
+                    className="hg-interventions-strip__tick-label"
+                    x={x}
+                    y={AXIS_Y + 6}
+                    textAnchor="middle"
+                  >
+                    {tick.label}
+                  </text>
+                </g>
+              );
+            })}
+
+            {/* Markers / clusters */}
+            {clusters.map((cluster) => {
+              if (cluster.rows.length === 1) {
+                const row = cluster.rows[0];
+                const isActive = activeKey === row.key;
+                const isNew = newlyAdded.has(row.key);
+                return (
+                  <Marker
+                    key={row.key}
+                    row={row}
+                    cx={cluster.cx}
+                    cy={MARKER_Y}
+                    selected={isActive}
+                    isNew={isNew}
+                    onMouseEnter={() => {
+                      if (!pinnedKey) setHoverKey(row.key);
+                    }}
+                    onMouseLeave={() => {
+                      if (!pinnedKey) setHoverKey(null);
+                    }}
+                    onClick={() =>
+                      setPinnedKey((k) => (k === row.key ? null : row.key))
+                    }
+                  />
+                );
+              }
+              // Cluster badge
+              const representativeKey = cluster.rows[0].key;
+              const isActive = cluster.rows.some((r) => r.key === activeKey);
+              return (
+                <ClusterBadge
+                  key={`cluster:${representativeKey}`}
+                  cluster={cluster}
+                  cx={cluster.cx}
+                  cy={MARKER_Y}
+                  selected={isActive}
+                  onMouseEnter={() => {
+                    if (!pinnedKey) setHoverKey(representativeKey);
+                  }}
+                  onMouseLeave={() => {
+                    if (!pinnedKey) setHoverKey(null);
+                  }}
+                  onClick={() =>
+                    setPinnedKey((k) =>
+                      cluster.rows.some((r) => r.key === k)
+                        ? null
+                        : representativeKey,
+                    )
+                  }
+                />
+              );
+            })}
+          </svg>
+
+          {/* Deterministic popover — positioned relative to the marker's cx
+              in the strip's coord space (not the cursor). */}
+          {activeCluster && activeRow && activeCluster.rows.length === 1 && (
+            <InterventionPopover
+              row={activeRow}
+              revs={revs}
+              anchorXPct={(activeCluster.cx / actualWidth) * 100}
+              pinned={pinnedKey !== null}
+              onClose={closePopover}
+              onJumpToRevision={onJumpToRevision}
+            />
+          )}
+          {activeCluster && activeCluster.rows.length > 1 && (
+            <ClusterPopover
+              cluster={activeCluster}
+              anchorXPct={(activeCluster.cx / actualWidth) * 100}
+              pinned={pinnedKey !== null}
+              revs={revs}
+              onClose={closePopover}
+              onJumpToRevision={onJumpToRevision}
+              onRowSelect={(key) => {
+                setPinnedKey(key);
+                setHoverKey(key);
+              }}
+            />
+          )}
+          {isEmpty && (
+            <div className="hg-interventions-strip__empty">
+              No interventions recorded.
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/shell/views/GanttView.tsx
+++ b/frontend/src/components/shell/views/GanttView.tsx
@@ -6,7 +6,7 @@ import { useUiStore, type TaskPlanMode } from '../../../state/uiStore';
 import { useSessionWatch } from '../../../rpc/hooks';
 import { colorForAgent } from '../../../theme/agentColors';
 import type { Task, TaskPlan, TaskStatus } from '../../../gantt/types';
-import { TaskStagesGraph, computePlanDagWidth } from '../../TaskStages/TaskStagesGraph';
+import { TaskStagesGraph } from '../../TaskStages/TaskStagesGraph';
 import { InterventionsTimeline } from '../../Interventions/InterventionsTimeline';
 import { deriveInterventionsFromStore } from '../../../lib/interventions';
 import { useAnnotationStore } from '../../../state/annotationStore';
@@ -162,7 +162,14 @@ export function GanttView() {
   // one we fall back to the max observed activity time across
   // interventions, plans, and nowMs so the axis doesn't collapse if
   // nowMs wasn't advanced past the final event.
-  const MIN_SESSION_SPAN_MS = 60_000; // 1 minute floor so a brand-new strip still has axis room
+  //
+  // Floor matches the Gantt canvas's default viewport window (5 min) so
+  // the intervention strip's ticks render at the same minute cadence as
+  // the Gantt above it. Without this floor, a brand-new 30-second
+  // session would tick at 10s on the strip while the Gantt ticks at 1m,
+  // and the user has to mentally re-map tick labels when glancing from
+  // one to the other.
+  const MIN_SESSION_SPAN_MS = 5 * 60_000; // 5 minutes — matches Gantt default viewport
   const sessionStartMs = 0;
   const isLive =
     watch?.sessionStatus === 'LIVE' || watch?.sessionStatus === 'UNKNOWN';
@@ -387,19 +394,15 @@ export function GanttView() {
                         ? (plan.revisionIndex ?? 0) === row.planRevisionIndex
                         : (plan.revisionIndex ?? 0) === 0,
                   )}
-                  // Session-wide axis, not per-plan. All row.atMs values
-                  // are session-relative so the strip must span the
-                  // whole session for marker placement to be honest.
+                  // Session-wide axis so the strip acts as a proper time
+                  // axis shared with the Gantt above, rather than
+                  // column-aligning to this plan's DAG. All row.atMs
+                  // values are session-relative; the strip stretches to
+                  // the container width (no explicit `width` prop) so
+                  // markers land at the same fraction of horizontal
+                  // space as the equivalent time on the Gantt canvas.
                   startMs={sessionStartMs}
                   endMs={sessionEndMs}
-                  // Visually align the strip to the plan DAG directly
-                  // above it. Without this, the strip would stretch to
-                  // the CSS max-width cap (~960px) on wide panes even
-                  // when the DAG itself is narrower (e.g. a 3-stage
-                  // plan at ~444px), leaving a lone marker floating
-                  // far right of an otherwise empty strip. Zero-width
-                  // plans (empty/loading) fall through to the CSS cap.
-                  width={computePlanDagWidth(plan) || undefined}
                   revs={plans}
                   onJumpToRevision={undefined}
                 />


### PR DESCRIPTION
## Summary
- **Shared axis with the Gantt canvas above.** Drop the per-DAG width clamp; strip stretches to container width (capped at 1280px so it doesn't sprawl on ultrawide monitors). Raise session-span floor from 1 min to 5 min so tick cadence matches the Gantt's default viewport — no more 30s ticks on the strip next to 1m ticks on the Gantt for the same time.
- **Collapse-when-empty toggle.** An empty strip folds to a single-line caret (~18px) instead of 60px of axis-with-nothing. The user can still un-collapse by clicking the caret to see the axis for the current time window.

Addresses two points from the UX review of the intervention strip:
- "why is the intervention timeline only as wide as the length of the DAG above it" → stage alignment was visually coincidental; stages are topological, not temporal.
- "the intervention timeline looks very stretched out and ugly. it is poorly spaced" → empty strips no longer eat 60px × N plans; full-width strips no longer smear a lone cluster across 2500+px.

## Test plan
- [ ] `pnpm vitest run src/__tests__/components/InterventionsTimeline.test.tsx` — 16/16 pass locally
- [ ] Open a session with 0 interventions → strip is a single-line `▸ Interventions (0)` caret under each plan
- [ ] Click the caret → axis expands, "No interventions recorded." visible
- [ ] Open a session with interventions → strip renders inline (no toggle); markers land at the same time-fraction as the equivalent time on the Gantt above
- [ ] Resize the browser: strip stretches to fill the task panel width, caps around 1280px on ultrawide