### PR TITLE
fix(frontend): seed agents registry from plan assignees

### DIFF
--- a/frontend/src/__tests__/gantt/agentRegistrySeed.test.ts
+++ b/frontend/src/__tests__/gantt/agentRegistrySeed.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AgentRegistry,
+  PLACEHOLDER_AGENT_FLAG,
+  bareAgentName,
+} from '../../gantt/index';
+import type { Agent } from '../../gantt/types';
+
+// Coverage for the plan-seeded agent rows added in harmonograf#133 (closes
+// the display-time resolver falling back to the raw compound id when an
+// agent is listed in the plan but hasn't yet emitted a span).
+
+function realAgent(id: string, overrides: Partial<Agent> = {}): Agent {
+  return {
+    id,
+    name: id,
+    framework: 'ADK',
+    capabilities: [],
+    status: 'CONNECTED',
+    connectedAtMs: 1000,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('bareAgentName', () => {
+  it('strips everything up to and including the last colon', () => {
+    expect(bareAgentName('client-abc:reviewer_agent')).toBe('reviewer_agent');
+  });
+
+  it('only strips the last colon (nested prefixes collapse)', () => {
+    expect(bareAgentName('a:b:research_agent')).toBe('research_agent');
+  });
+
+  it('returns bare ids (no colon) unchanged', () => {
+    expect(bareAgentName('research_agent')).toBe('research_agent');
+  });
+
+  it('is a no-op on the empty string', () => {
+    expect(bareAgentName('')).toBe('');
+  });
+});
+
+describe('AgentRegistry.ensureAgent', () => {
+  it('inserts a placeholder row for an unknown agent id', () => {
+    const reg = new AgentRegistry();
+    const inserted = reg.ensureAgent(
+      'client:reviewer_agent',
+      'reviewer_agent',
+    );
+    expect(inserted).toBe(true);
+    const row = reg.get('client:reviewer_agent');
+    expect(row).toBeDefined();
+    expect(row!.name).toBe('reviewer_agent');
+    expect(row!.status).toBe('DISCONNECTED');
+    expect(row!.framework).toBe('UNKNOWN');
+    expect(row!.metadata[PLACEHOLDER_AGENT_FLAG]).toBe('1');
+  });
+
+  it('is idempotent — a second ensureAgent call is a no-op', () => {
+    const reg = new AgentRegistry();
+    reg.ensureAgent('client:reviewer_agent', 'reviewer_agent');
+    const after1 = reg.get('client:reviewer_agent');
+    const inserted2 = reg.ensureAgent(
+      'client:reviewer_agent',
+      'reviewer_agent',
+    );
+    expect(inserted2).toBe(false);
+    expect(reg.get('client:reviewer_agent')).toBe(after1);
+    expect(reg.size).toBe(1);
+  });
+
+  it('does not clobber a pre-existing real agent row', () => {
+    const reg = new AgentRegistry();
+    const real = realAgent('client:research_agent', {
+      name: 'research_agent',
+      framework: 'ADK',
+      status: 'CONNECTED',
+      taskReport: 'live summary',
+      metadata: { 'harmonograf.execution_mode': 'sequential' },
+    });
+    reg.upsert(real);
+    const inserted = reg.ensureAgent(
+      'client:research_agent',
+      'research_agent',
+    );
+    expect(inserted).toBe(false);
+    const row = reg.get('client:research_agent')!;
+    expect(row.status).toBe('CONNECTED');
+    expect(row.framework).toBe('ADK');
+    expect(row.taskReport).toBe('live summary');
+    expect(row.metadata[PLACEHOLDER_AGENT_FLAG]).toBeUndefined();
+    expect(row.metadata['harmonograf.execution_mode']).toBe('sequential');
+  });
+
+  it('ignores the empty agent id', () => {
+    const reg = new AgentRegistry();
+    expect(reg.ensureAgent('', '')).toBe(false);
+    expect(reg.size).toBe(0);
+  });
+
+  it('fires the subscribe callback on first insertion only', () => {
+    const reg = new AgentRegistry();
+    const fn = vi.fn();
+    reg.subscribe(fn);
+    reg.ensureAgent('client:a', 'a');
+    reg.ensureAgent('client:a', 'a');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AgentRegistry.upsert clears the placeholder marker', () => {
+  it('drops the placeholder flag when a real row lands', () => {
+    const reg = new AgentRegistry();
+    reg.ensureAgent('client:reviewer_agent', 'reviewer_agent');
+    expect(reg.get('client:reviewer_agent')!.metadata[PLACEHOLDER_AGENT_FLAG]).toBe(
+      '1',
+    );
+    reg.upsert(
+      realAgent('client:reviewer_agent', { name: 'reviewer_agent' }),
+    );
+    const row = reg.get('client:reviewer_agent')!;
+    expect(row.status).toBe('CONNECTED');
+    expect(row.framework).toBe('ADK');
+    expect(row.metadata[PLACEHOLDER_AGENT_FLAG]).toBeUndefined();
+  });
+
+  it('preserves unrelated metadata keys across the upsert merge', () => {
+    const reg = new AgentRegistry();
+    reg.ensureAgent('client:a', 'a');
+    // Simulate some later code stashing a key on the placeholder row
+    // (today nothing does, but the merge should be additive either way).
+    reg.get('client:a')!.metadata['other.custom_key'] = 'keep-me';
+    reg.upsert(
+      realAgent('client:a', {
+        name: 'a',
+        metadata: { 'harmonograf.execution_mode': 'parallel' },
+      }),
+    );
+    const row = reg.get('client:a')!;
+    expect(row.metadata['other.custom_key']).toBe('keep-me');
+    expect(row.metadata['harmonograf.execution_mode']).toBe('parallel');
+    expect(row.metadata[PLACEHOLDER_AGENT_FLAG]).toBeUndefined();
+  });
+});

--- a/frontend/src/__tests__/rpc/goldfiveEventAgentSeed.test.ts
+++ b/frontend/src/__tests__/rpc/goldfiveEventAgentSeed.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { SessionStore, PLACEHOLDER_AGENT_FLAG } from '../../gantt/index';
+import { applyGoldfiveEvent } from '../../rpc/goldfiveEvent';
+import {
+  EventSchema,
+  PlanSubmittedSchema,
+  PlanRevisedSchema,
+} from '../../pb/goldfive/v1/events_pb';
+import {
+  PlanSchema,
+  TaskSchema,
+  TaskStatus,
+  DriftKind,
+  DriftSeverity,
+} from '../../pb/goldfive/v1/types_pb';
+
+// Integration coverage for harmonograf#133: seeding the agent registry
+// from plan content so tasks whose assignee hasn't emitted a span yet
+// still resolve to a bare display name instead of the raw compound id.
+
+const CLIENT = 'presentation-orchestrated-9b2b3a9c7289';
+
+function pbTask(id: string, bareAgent: string) {
+  return create(TaskSchema, {
+    id,
+    title: `task ${id}`,
+    description: '',
+    // Assignee id comes off the wire in its compound form (the canonical
+    // storage form — see HarmonografSink._compound on the client side).
+    assigneeAgentId: `${CLIENT}:${bareAgent}`,
+    status: TaskStatus.PENDING,
+    predictedStartMs: 0n,
+    predictedDurationMs: 0n,
+  });
+}
+
+function pbPlan(
+  id: string,
+  entries: Array<[string, string]>,
+  revisionIndex = 0,
+) {
+  return create(PlanSchema, {
+    id,
+    runId: 'run-1',
+    summary: `plan ${id}`,
+    tasks: entries.map(([tid, bare]) => pbTask(tid, bare)),
+    edges: [],
+    revisionReason: '',
+    revisionKind: DriftKind.UNSPECIFIED,
+    revisionSeverity: DriftSeverity.UNSPECIFIED,
+    revisionIndex,
+  });
+}
+
+describe('planSubmitted seeds the agent registry from task assignees', () => {
+  it('creates a placeholder row for every unique assignee, keyed by compound id', () => {
+    const store = new SessionStore();
+    const event = create(EventSchema, {
+      eventId: 'ev-seed',
+      runId: 'run-1',
+      sequence: 0n,
+      payload: {
+        case: 'planSubmitted',
+        value: create(PlanSubmittedSchema, {
+          plan: pbPlan('p1', [
+            ['t1', 'research_agent'],
+            ['t2', 'reviewer_agent'],
+            ['t3', 'debugger_agent'],
+          ]),
+        }),
+      },
+    });
+
+    applyGoldfiveEvent(event, store, 0);
+
+    // All three rows exist under their compound ids — that is what
+    // `task.assigneeAgentId` lookup on the resolver side uses.
+    expect(store.agents.size).toBe(3);
+    for (const bare of ['research_agent', 'reviewer_agent', 'debugger_agent']) {
+      const row = store.agents.get(`${CLIENT}:${bare}`);
+      expect(row, `agent row for ${bare}`).toBeDefined();
+      expect(row!.name).toBe(bare);
+      expect(row!.metadata[PLACEHOLDER_AGENT_FLAG]).toBe('1');
+    }
+  });
+
+  it('standard registry-lookup resolver now returns bare names', () => {
+    const store = new SessionStore();
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-seed-2',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'planSubmitted',
+          value: create(PlanSubmittedSchema, {
+            plan: pbPlan('p1', [
+              ['t1', 'research_agent'],
+              ['t2', 'reviewer_agent'],
+            ]),
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+
+    // This matches GanttView.agentNameFor / DelegationTooltip resolvers:
+    // `store.agents.get(id)?.name ?? id`. Before #133 this would have
+    // returned the raw compound wire id.
+    const resolve = (id: string) => store.agents.get(id)?.name ?? id;
+    expect(resolve(`${CLIENT}:research_agent`)).toBe('research_agent');
+    expect(resolve(`${CLIENT}:reviewer_agent`)).toBe('reviewer_agent');
+  });
+
+  it('planRevised also seeds newly-announced agents', () => {
+    const store = new SessionStore();
+    // Initial plan assigns t1/t2 to research + reviewer.
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-init',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'planSubmitted',
+          value: create(PlanSubmittedSchema, {
+            plan: pbPlan('p1', [
+              ['t1', 'research_agent'],
+              ['t2', 'reviewer_agent'],
+            ]),
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+    expect(store.agents.size).toBe(2);
+
+    // Revision introduces a third task assigned to an unseen agent.
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-rev',
+        runId: 'run-1',
+        sequence: 1n,
+        payload: {
+          case: 'planRevised',
+          value: create(PlanRevisedSchema, {
+            plan: pbPlan(
+              'p1',
+              [
+                ['t1', 'research_agent'],
+                ['t2', 'reviewer_agent'],
+                ['t3', 'verify_agent'],
+              ],
+              1,
+            ),
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+
+    expect(store.agents.get(`${CLIENT}:verify_agent`)?.name).toBe(
+      'verify_agent',
+    );
+    expect(store.agents.size).toBe(3);
+  });
+
+  it('skips tasks with an empty assignee (no synthetic empty-id row)', () => {
+    const store = new SessionStore();
+    const taskWithoutAssignee = create(TaskSchema, {
+      id: 't1',
+      title: 'unassigned',
+      description: '',
+      assigneeAgentId: '',
+      status: TaskStatus.PENDING,
+      predictedStartMs: 0n,
+      predictedDurationMs: 0n,
+    });
+    const plan = create(PlanSchema, {
+      id: 'p1',
+      runId: 'run-1',
+      summary: '',
+      tasks: [taskWithoutAssignee, pbTask('t2', 'research_agent')],
+      edges: [],
+      revisionReason: '',
+      revisionKind: DriftKind.UNSPECIFIED,
+      revisionSeverity: DriftSeverity.UNSPECIFIED,
+      revisionIndex: 0,
+    });
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: { case: 'planSubmitted', value: create(PlanSubmittedSchema, { plan }) },
+      }),
+      store,
+      0,
+    );
+    expect(store.agents.size).toBe(1);
+    expect(store.agents.get('')).toBeUndefined();
+    expect(store.agents.get(`${CLIENT}:research_agent`)).toBeDefined();
+  });
+});

--- a/frontend/src/components/shell/CurrentTaskStrip.tsx
+++ b/frontend/src/components/shell/CurrentTaskStrip.tsx
@@ -3,6 +3,7 @@ import { useUiStore } from '../../state/uiStore';
 import { getSessionStore } from '../../rpc/hooks';
 import type { ExecutionMode, Task, TaskStatus } from '../../gantt/types';
 import { readExecutionMode } from '../../gantt/types';
+import { bareAgentName } from '../../gantt/index';
 
 const STATUS_CLASS: Record<TaskStatus, string> = {
   UNSPECIFIED: 'hg-strip__chip--pending',
@@ -71,6 +72,14 @@ export function CurrentTaskStrip() {
     ? store?.agents.get(task.assigneeAgentId)
     : undefined;
   const mode = readExecutionMode(assignee);
+  // Display preference: the registry name (bare) when present, else
+  // derive the bare form directly from the compound id. Final fallback
+  // is the raw id itself so we never render "undefined" when the id is
+  // an empty string (the outer truthy-guard already skips that branch,
+  // but be defensive). See harmonograf#133.
+  const assigneeDisplay = task.assigneeAgentId
+    ? assignee?.name || bareAgentName(task.assigneeAgentId) || task.assigneeAgentId
+    : '';
 
   return (
     <div
@@ -96,7 +105,7 @@ export function CurrentTaskStrip() {
       )}
       {task.assigneeAgentId && (
         <span className="hg-strip__agent" title={`assigned to ${task.assigneeAgentId}`}>
-          {task.assigneeAgentId}
+          {assigneeDisplay}
           {isThinking && (
             <span
               className="hg-strip__thinking"

--- a/frontend/src/components/shell/Drawer.tsx
+++ b/frontend/src/components/shell/Drawer.tsx
@@ -22,6 +22,7 @@ import type {
   LinkRelation,
 } from '../../gantt/types';
 import type { PlanDiff, PlanRevision } from '../../gantt';
+import { bareAgentName } from '../../gantt';
 import { parseRevisionReason } from '../../gantt/driftKinds';
 import { formatDuration } from '../../lib/format';
 import { OrchestrationTimeline } from '../OrchestrationTimeline/OrchestrationTimeline';
@@ -235,7 +236,11 @@ function CurrentTaskSection({
       )}
       {task.assigneeAgentId && (
         <div className="hg-drawer__current-task-agent">
-          <code>{task.assigneeAgentId}</code>
+          <code title={task.assigneeAgentId}>
+            {store?.agents.get(task.assigneeAgentId)?.name ||
+              bareAgentName(task.assigneeAgentId) ||
+              task.assigneeAgentId}
+          </code>
         </div>
       )}
     </div>

--- a/frontend/src/components/shell/views/GraphView.tsx
+++ b/frontend/src/components/shell/views/GraphView.tsx
@@ -6,6 +6,7 @@ import { useSessionWatch, sendStatusQuery } from '../../../rpc/hooks';
 import { colorForAgent } from '../../../theme/agentColors';
 import type { Span, Task, TaskPlan } from '../../../gantt/types';
 import type { SessionStore } from '../../../gantt/index';
+import { bareAgentName } from '../../../gantt/index';
 import { hasThinking } from '../../../lib/thinking';
 import {
   DEFAULT_VIEWPORT,
@@ -1714,8 +1715,17 @@ export function GraphView() {
             <div style={{ opacity: 0.8, marginBottom: 4 }}>
               {hoveredTask.task.description || <em>No description</em>}
             </div>
-            <div style={{ fontSize: 10, opacity: 0.7 }}>
-              Assignee: {hoveredTask.task.assigneeAgentId || '(unassigned)'}
+            <div
+              style={{ fontSize: 10, opacity: 0.7 }}
+              title={hoveredTask.task.assigneeAgentId || undefined}
+            >
+              Assignee:{' '}
+              {hoveredTask.task.assigneeAgentId
+                ? watch.store?.agents.get(hoveredTask.task.assigneeAgentId)
+                    ?.name ||
+                  bareAgentName(hoveredTask.task.assigneeAgentId) ||
+                  hoveredTask.task.assigneeAgentId
+                : '(unassigned)'}
             </div>
             <div style={{ fontSize: 10, opacity: 0.7 }}>
               Status: {hoveredTask.task.status}

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -8,6 +8,7 @@ import type {
   DriftRecord,
   SessionStore,
 } from '../../../gantt/index';
+import { bareAgentName } from '../../../gantt/index';
 import { useAnnotationStore } from '../../../state/annotationStore';
 import {
   deriveInterventionsFromStore,
@@ -481,6 +482,7 @@ export function TrajectoryView() {
                   const task = currentRev.tasks.find((t) => t.id === taskId);
                   if (task?.boundSpanId) selectSpan(task.boundSpanId);
                 }}
+                store={store}
               />
               <DetailPane
                 selection={selection}
@@ -608,6 +610,10 @@ interface DagProps {
   delegations: DelegationRecord[];
   selection: Selection;
   onSelectTask: (taskId: string) => void;
+  // Optional session handle used only to resolve the assignee agent's
+  // bare display name. Passing null preserves the previous fallback
+  // (strip the compound prefix; else render the raw id).
+  store: SessionStore | null;
 }
 
 function buildDriftsByTaskId(
@@ -649,6 +655,7 @@ function DagPane(props: DagProps) {
     delegations,
     selection,
     onSelectTask,
+    store,
   } = props;
   const layout = plan ? layoutDag(plan) : null;
   const driftsByTaskId = buildDriftsByTaskId(driftsOnRev);
@@ -768,7 +775,14 @@ function DagPane(props: DagProps) {
                 </text>
                 <text className="hg-traj__node-sub" x={16} y={42}>
                   {t.status.toLowerCase()}
-                  {t.assigneeAgentId ? ` · ${truncate(t.assigneeAgentId, 14)}` : ''}
+                  {t.assigneeAgentId
+                    ? ` · ${truncate(
+                        store?.agents.get(t.assigneeAgentId)?.name ||
+                          bareAgentName(t.assigneeAgentId) ||
+                          t.assigneeAgentId,
+                        14,
+                      )}`
+                    : ''}
                 </text>
                 {drifts.length > 0 && (
                   <g transform={`translate(${n.w - 14}, 14)`}>
@@ -992,7 +1006,13 @@ function DetailPane(props: DetailPaneProps) {
         {t.description && <p className="hg-traj__detail-desc">{t.description}</p>}
         <dl className="hg-traj__detail-meta">
           <dt>assignee</dt>
-          <dd>{t.assigneeAgentId || '—'}</dd>
+          <dd title={t.assigneeAgentId || undefined}>
+            {t.assigneeAgentId
+              ? store?.agents.get(t.assigneeAgentId)?.name ||
+                bareAgentName(t.assigneeAgentId) ||
+                t.assigneeAgentId
+              : '—'}
+          </dd>
           <dt>bound span</dt>
           <dd>{t.boundSpanId ? t.boundSpanId.slice(0, 8) : '—'}</dd>
           {span && (

--- a/frontend/src/gantt/index.ts
+++ b/frontend/src/gantt/index.ts
@@ -22,6 +22,29 @@ export type {
   TaskStatus,
 } from './types';
 
+// Metadata key used to mark an agent row as a placeholder — seeded from
+// plan content (task.assignee_agent_id) before any real span has landed
+// for that agent. The renderer does NOT style placeholders differently
+// today, but consumers can branch on this marker if they need to (e.g.
+// a dimmer lane header, a "not yet active" tooltip).
+//
+// Value is "1" when the row originated from plan seeding and has never
+// been upgraded by a real telemetry upsert. As soon as a real agent row
+// (Hello / AgentsListed / span-emission path) lands, AgentRegistry.upsert
+// clobbers the placeholder and the flag is dropped.
+export const PLACEHOLDER_AGENT_FLAG = 'harmonograf.announced_only';
+
+// Strip a compound agent id (`<client>:<bare>`) down to its bare form
+// by lopping off everything up to and including the last `":"`. Matches
+// the inverse of `HarmonografSink._compound()` on the client side — a
+// bare id (no `:`) is returned unchanged, as is the empty string.
+export function bareAgentName(agentId: string): string {
+  if (!agentId) return agentId;
+  const idx = agentId.lastIndexOf(':');
+  if (idx < 0) return agentId;
+  return agentId.slice(idx + 1);
+}
+
 // Registry of agents in a session. Order is join time (stable) — doc 04 §5.1.
 export class AgentRegistry {
   private agents: Agent[] = [];
@@ -49,13 +72,73 @@ export class AgentRegistry {
   upsert(agent: Agent): void {
     const existing = this.byId.get(agent.id);
     if (existing) {
+      // A real upsert (span-emission / Hello / AgentsListed) always wins
+      // over a placeholder — drop the placeholder marker so downstream
+      // consumers stop treating this row as "announced but unobserved".
+      // Preserve metadata keys the caller didn't supply so metadata set
+      // by plan seeding (none today besides the flag) isn't silently
+      // dropped.
+      const prevMeta = existing.metadata ?? {};
+      const nextMeta = { ...prevMeta, ...(agent.metadata ?? {}) };
+      delete nextMeta[PLACEHOLDER_AGENT_FLAG];
       Object.assign(existing, agent);
+      existing.metadata = nextMeta;
     } else {
       this.byId.set(agent.id, agent);
       this.agents.push(agent);
       this.agents.sort((a, b) => a.connectedAtMs - b.connectedAtMs);
     }
     this.emit();
+  }
+
+  // Upsert a minimal placeholder row for an agent announced on the wire
+  // (today: via task.assignee_agent_id on a PlanSubmitted / PlanRevised)
+  // but not yet observed via any span, Hello, or AgentsListed frame.
+  //
+  // Idempotent: a second call with the same args is a no-op. When the
+  // row already exists and is NOT a placeholder (i.e. a real upsert has
+  // landed), this method leaves it entirely alone — plan seeding must
+  // never clobber authoritative agent metadata (connection status,
+  // framework, capabilities, task reports, …).
+  //
+  // Returns `true` when a new placeholder was inserted, `false` when a
+  // pre-existing row was left untouched. Callers typically ignore the
+  // return; it's exposed for tests.
+  ensureAgent(agentId: string, bareName: string): boolean {
+    if (!agentId) return false;
+    const existing = this.byId.get(agentId);
+    if (existing) {
+      // Leave real rows alone. Also leave existing placeholders alone —
+      // the name we'd derive is a pure function of the id, so re-seeding
+      // with the same inputs would be a no-op write anyway.
+      return false;
+    }
+    const placeholder: Agent = {
+      id: agentId,
+      name: bareName || agentId,
+      framework: 'UNKNOWN',
+      capabilities: [],
+      // DISCONNECTED is the cleanest existing status for "announced but
+      // not yet observed" — a real CONNECTED frame upgrades it via
+      // upsert() (which also strips the placeholder flag).
+      status: 'DISCONNECTED',
+      // connectedAtMs drives row ordering. 0 sorts to the top alongside
+      // any other placeholders; real agents with a real connect time
+      // will sort in below once they land.
+      connectedAtMs: 0,
+      currentActivity: '',
+      stuck: false,
+      taskReport: '',
+      taskReportAt: 0,
+      metadata: {
+        [PLACEHOLDER_AGENT_FLAG]: '1',
+      },
+    };
+    this.byId.set(agentId, placeholder);
+    this.agents.push(placeholder);
+    this.agents.sort((a, b) => a.connectedAtMs - b.connectedAtMs);
+    this.emit();
+    return true;
   }
 
   setStatus(id: string, status: Agent['status']): void {

--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -10,6 +10,7 @@
 // existing gantt stores without introducing any new store concepts.
 
 import type { SessionStore } from '../gantt/index';
+import { bareAgentName } from '../gantt/index';
 import type { Span, SpanKind, TaskPlan, Task, TaskStatus } from '../gantt/types';
 import type {
   Plan as GoldfivePlan,
@@ -198,7 +199,20 @@ export function applyGoldfiveEvent(
     case 'planRevised': {
       const plan = payload.value.plan;
       if (plan) {
-        store.tasks.upsertPlan(convertGoldfivePlan(plan, sessionStartMs));
+        const converted = convertGoldfivePlan(plan, sessionStartMs);
+        store.tasks.upsertPlan(converted);
+        // harmonograf#133: seed the agent registry from plan content so
+        // tasks whose assignee hasn't emitted a span yet still resolve
+        // to a bare display name (e.g. `reviewer_agent`) instead of the
+        // raw compound id (`<client>:reviewer_agent`). The registry was
+        // previously populated only as spans arrived; agents listed in
+        // the plan but not yet invoked had no row, so every display
+        // resolver fell back to rendering the compound wire id.
+        for (const task of converted.tasks) {
+          const id = task.assigneeAgentId;
+          if (!id) continue;
+          store.agents.ensureAgent(id, bareAgentName(id));
+        }
       }
       return;
     }


### PR DESCRIPTION
## Summary

Task assignees in the frontend were rendered inconsistently — sometimes as the bare agent name (`reviewer_agent`), sometimes as the raw compound wire id (`presentation-orchestrated-9b2b3a9c7289:reviewer_agent`) — within the same plan. The data layer was fine: every assignee in the DB is compound with the same `<client>:` prefix. The inconsistency was entirely display-time: the registry-lookup resolver (`store.agents.get(id)?.name ?? id`) fell back to the raw id whenever an assignee hadn't yet emitted a span, because `AgentRegistry` was populated **only** by span emission.

Concrete before/after on a live session where the coordinator delegated to research, review, and debug roles:

| Task                 | Assignee on the wire                                  | Before                                                                 | After              |
| -------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------- | ------------------ |
| `deep_research`      | `presentation-orchestrated-…:research_agent`          | `research_agent` (span already emitted → registry populated)           | `research_agent`   |
| `coordinator_plan`   | `presentation-orchestrated-…:coordinator_agent`       | `coordinator_agent`                                                    | `coordinator_agent`|
| `review_accuracy`    | `presentation-orchestrated-…:reviewer_agent`          | `presentation-orchestrated-9b2b3a9c7289:reviewer_agent` (no span yet)  | `reviewer_agent`   |
| `verify_slide_count` | `presentation-orchestrated-…:reviewer_agent`          | `presentation-orchestrated-9b2b3a9c7289:reviewer_agent` (no span yet)  | `reviewer_agent`   |
| `debug_build`        | `presentation-orchestrated-…:debugger_agent`          | `presentation-orchestrated-9b2b3a9c7289:debugger_agent` (no span yet)  | `debugger_agent`   |

## Fix

- `AgentRegistry.ensureAgent(id, bareName)` — new idempotent upsert that inserts a minimal placeholder row (`status: 'DISCONNECTED'`, `framework: 'UNKNOWN'`, `metadata['harmonograf.announced_only'] = '1'`). Never clobbers a pre-existing row. When a real span / Hello / AgentsListed frame later lands, `AgentRegistry.upsert` overwrites the placeholder and strips the placeholder-flag — so downstream consumers (today: none) can branch on `placeholder vs real`.
- `bareAgentName(id)` — new helper that mirrors the inverse of `HarmonografSink._compound()`: strip everything up to and including the last `":"`.
- `rpc/goldfiveEvent.ts` — the `planSubmitted` / `planRevised` branch now iterates `plan.tasks` after upserting and calls `ensureAgent(task.assigneeAgentId, bareAgentName(...))` for each non-empty assignee.
- Display sites that rendered `task.assigneeAgentId` directly (CurrentTaskStrip, Drawer current-task footer, TrajectoryView DAG sub text + DetailPane, GraphView task tooltip) now route through the registry-first resolver with a `bareAgentName` fallback — so even if seeding somehow gets skipped on a refresh-replay race, we render `reviewer_agent` instead of the compound wire id.

Out of scope (per brief): visual treatment of placeholder rows; DB/proto/server changes; the `DelegationTooltip` / `delegationHitTest` / `interventions` / `goldfiveEvent` test-file edits reserved for #134.

## Test plan

- [x] `pnpm -C frontend test --run` — 306 → 321 tests, all green (15 new: 9 `ensureAgent` unit cases, 4 integration cases across `planSubmitted` + `planRevised` seeding, 2 `bareAgentName` edge cases)
- [x] `pnpm -C frontend tsc -b` — clean apart from the 4 pre-existing errors in test files reserved for #134
- [x] `pnpm -C frontend lint` on touched files — clean (the 2 pre-existing lint findings in TaskStagesGraph.tsx / GanttView.tsx are on main before this branch; out of scope)
- [ ] Manual verify against a live session: spin up a coordinator run where `reviewer_agent` is listed in the plan but the first review task hasn't started yet; confirm the task row reads `reviewer_agent`, not `<client>:reviewer_agent`.

## Surprising finding

Span emission was the **only** registry seed path in the frontend. The `AgentsListed` and `Hello` frames are wired into `rpc/hooks.ts` for real delivery, but nothing else in the gantt/ tree seeded synthetically — the synthetic `user` / `goldfive` actors in `goldfiveEvent.ts` were the closest prior art (they use `agents.upsert(...)` directly for drift attribution). Adding `ensureAgent` as a distinct method kept the existing `upsert` contract (write-through, clobber-on-re-upsert) intact while giving plan ingestion a non-clobbering entry point.