### PR TITLE
feat(ui): goldfive lane + user lane + steering arrows + richer intervention detail

### DIFF
--- a/frontend/src/__tests__/components/TrajectoryView.steering.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.steering.test.tsx
@@ -1,0 +1,316 @@
+/**
+ * harmonograf#196: TrajectoryView surfaces goldfive's steering moves.
+ *
+ *   1. Steering arrow — a dashed goldfive-colored arrow draws from a
+ *      small "g5" gutter node on the DAG's left edge to the target
+ *      task node when a PlanRevised carries a target agent.
+ *   2. User gutter — a "u" node renders when a RunStarted event
+ *      produced a user-goal span; drawn only on rev 0 so later refine
+ *      panes don't accumulate stale user arrows.
+ *   3. Intervention detail panel — clicking a drift marker surfaces
+ *      Trigger / Steering / Target sections (testid-guarded).
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { SessionStore } from '../../gantt/index';
+import type { Span, Task, TaskPlan } from '../../gantt/types';
+
+vi.mock('../../components/shell/views/views.css', () => ({}));
+
+let mockStore = new SessionStore();
+const mockSessionId: string | null = 'sess-traj';
+
+vi.mock('../../rpc/hooks', () => ({
+  useSessionWatch: () => ({
+    store: mockStore,
+    connected: true,
+    initialBurstComplete: true,
+    error: null,
+    sessionStatus: 'LIVE' as const,
+    lastEventAtMs: Date.now(),
+  }),
+  getSessionStore: () => mockStore,
+}));
+
+const uiStoreState = {
+  currentSessionId: mockSessionId,
+  selectSpan: vi.fn(),
+};
+vi.mock('../../state/uiStore', () => ({
+  useUiStore: <T,>(selector: (s: typeof uiStoreState) => T) =>
+    selector(uiStoreState),
+}));
+
+vi.mock('../../state/annotationStore', () => ({
+  useAnnotationStore: Object.assign(
+    () => ({ list: () => [] }),
+    {
+      getState: () => ({ list: () => [] }),
+      subscribe: () => () => {},
+    },
+  ),
+}));
+
+import { TrajectoryView } from '../../components/shell/views/TrajectoryView';
+
+function mkTask(
+  id: string,
+  status: Task['status'],
+  assignee = 'agent-a',
+  title = id,
+): Task {
+  return {
+    id,
+    title,
+    description: '',
+    assigneeAgentId: assignee,
+    status,
+    predictedStartMs: 0,
+    predictedDurationMs: 0,
+    boundSpanId: '',
+    cancelReason: '',
+  };
+}
+
+function mkPlan(
+  id: string,
+  tasks: Task[],
+  revisionIndex = 0,
+  revisionReason = '',
+  revisionKind = '',
+): TaskPlan {
+  return {
+    id,
+    invocationSpanId: `inv-${id}`,
+    plannerAgentId: 'planner-agent',
+    createdAtMs: 0,
+    summary: `plan ${id}`,
+    tasks,
+    edges: [],
+    revisionReason,
+    revisionKind,
+    revisionSeverity: 'warning',
+    revisionIndex,
+    triggerEventId: '',
+  };
+}
+
+// Minimal synth-span builder mirroring goldfiveEvent.synthesizeRefineSpan.
+function synthRefineSpan(
+  revisionIndex: number,
+  kind: string,
+  reason: string,
+  targetAgent: string,
+  atMs: number,
+): Span {
+  return {
+    id: `refine-${atMs}-${revisionIndex}`,
+    sessionId: mockSessionId ?? '',
+    agentId: '__goldfive__',
+    parentSpanId: null,
+    kind: 'CUSTOM',
+    status: 'COMPLETED',
+    name: `refine: ${kind}`,
+    startMs: atMs,
+    endMs: atMs,
+    links: [],
+    attributes: {
+      'refine.index': { kind: 'string', value: String(revisionIndex) },
+      'refine.kind': { kind: 'string', value: kind },
+      'refine.severity': { kind: 'string', value: 'warning' },
+      'refine.reason': { kind: 'string', value: reason },
+      'refine.target_agent_id': { kind: 'string', value: targetAgent },
+      'harmonograf.synthetic_span': { kind: 'bool', value: true },
+    },
+    payloadRefs: [],
+    error: null,
+    lane: -1,
+    replaced: false,
+  };
+}
+
+function synthUserGoalSpan(goal: string, atMs: number): Span {
+  return {
+    id: `user-goal-${atMs}`,
+    sessionId: mockSessionId ?? '',
+    agentId: '__user__',
+    parentSpanId: null,
+    kind: 'USER_MESSAGE',
+    status: 'COMPLETED',
+    name: goal,
+    startMs: atMs,
+    endMs: atMs,
+    links: [],
+    attributes: {
+      'user.goal_summary': { kind: 'string', value: goal },
+      'user.run_id': { kind: 'string', value: 'run-1' },
+      'harmonograf.synthetic_span': { kind: 'bool', value: true },
+    },
+    payloadRefs: [],
+    error: null,
+    lane: -1,
+    replaced: false,
+  };
+}
+
+beforeEach(() => {
+  mockStore = new SessionStore();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('<TrajectoryView /> steering arrow + user gutter + detail panel', () => {
+  it('draws a steering edge from goldfive to the target task when PlanRevised has a target', () => {
+    // rev 0
+    const rev0 = mkPlan('p1', [mkTask('t1', 'COMPLETED', 'agent-a')]);
+    mockStore.tasks.upsertPlan(rev0);
+    // rev 1 — add t2 assigned to agent-b; synth the refine span with
+    // target_agent_id = agent-b.
+    const rev1 = mkPlan(
+      'p1',
+      [mkTask('t1', 'COMPLETED', 'agent-a'), mkTask('t2', 'PENDING', 'agent-b')],
+      1,
+      'add verification',
+      'looping_reasoning',
+    );
+    mockStore.tasks.upsertPlan(rev1);
+    mockStore.agents.upsert({
+      id: '__goldfive__',
+      name: 'goldfive',
+      framework: 'CUSTOM',
+      capabilities: [],
+      status: 'CONNECTED',
+      connectedAtMs: 1,
+      currentActivity: '',
+      stuck: false,
+      taskReport: '',
+      taskReportAt: 0,
+      metadata: {},
+    });
+    mockStore.spans.append(
+      synthRefineSpan(1, 'looping_reasoning', 'add verification', 'agent-b', 5),
+    );
+
+    render(<TrajectoryView />);
+
+    // Steering edge present, pointing at t2 (the task assigned to agent-b).
+    expect(screen.getByTestId('trajectory-steer-edges')).toBeInTheDocument();
+    expect(screen.getByTestId('steer-edge-t2')).toBeInTheDocument();
+    // Goldfive gutter rendered.
+    expect(
+      screen.getByTestId('trajectory-goldfive-gutter'),
+    ).toBeInTheDocument();
+  });
+
+  it('does NOT draw a steering edge on rev 0 (no steering yet)', () => {
+    const rev0 = mkPlan('p1', [mkTask('t1', 'PENDING', 'agent-a')]);
+    mockStore.tasks.upsertPlan(rev0);
+    render(<TrajectoryView />);
+    expect(
+      screen.queryByTestId('trajectory-steer-edges'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('trajectory-goldfive-gutter'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the user gutter + user edge on rev 0 when a user-goal span is present', () => {
+    const rev0 = mkPlan('p1', [mkTask('t1', 'PENDING', 'agent-a')]);
+    mockStore.tasks.upsertPlan(rev0);
+    mockStore.agents.upsert({
+      id: '__user__',
+      name: 'user',
+      framework: 'CUSTOM',
+      capabilities: [],
+      status: 'CONNECTED',
+      connectedAtMs: 1,
+      currentActivity: '',
+      stuck: false,
+      taskReport: '',
+      taskReportAt: 0,
+      metadata: {},
+    });
+    mockStore.spans.append(synthUserGoalSpan('summarize the paper', 0));
+
+    render(<TrajectoryView />);
+    expect(screen.getByTestId('trajectory-user-gutter')).toBeInTheDocument();
+    expect(screen.getByTestId('trajectory-user-edge')).toBeInTheDocument();
+  });
+
+  it('intervention detail panel shows Trigger + Target when a drift is selected', () => {
+    const rev0 = mkPlan('p1', [mkTask('t1', 'RUNNING', 'agent-a')]);
+    mockStore.tasks.upsertPlan(rev0);
+    mockStore.drifts.append({
+      kind: 'looping_reasoning',
+      severity: 'warning',
+      detail: 'repeated tool calls',
+      taskId: 't1',
+      agentId: 'agent-a',
+      recordedAtMs: 10,
+      annotationId: '',
+      driftId: 'drift-1',
+    });
+
+    render(<TrajectoryView />);
+
+    // Click the drift marker — the only one on rev 0.
+    const marker = screen.getByTestId(/^drift-marker-/);
+    fireEvent.click(marker);
+
+    expect(screen.getByTestId('detail-drift')).toBeInTheDocument();
+    // Trigger section surfaces the drift detail.
+    const trigger = screen.getByTestId('detail-drift-trigger');
+    expect(trigger).toHaveTextContent('repeated tool calls');
+    // Target section surfaces agent-a.
+    const target = screen.getByTestId('detail-drift-target');
+    expect(target).toHaveTextContent('agent-a');
+  });
+
+  it('intervention detail panel composes Steering from a matching PlanRevised', () => {
+    // rev 0 + drift + rev 1 with triggerEventId = drift.driftId.
+    const rev0 = mkPlan('p1', [mkTask('t1', 'RUNNING', 'agent-a')]);
+    mockStore.tasks.upsertPlan(rev0);
+    mockStore.drifts.append({
+      kind: 'looping_reasoning',
+      severity: 'warning',
+      detail: 'loop',
+      taskId: 't1',
+      agentId: 'agent-a',
+      recordedAtMs: 10,
+      annotationId: '',
+      driftId: 'drift-42',
+    });
+    const rev1 = mkPlan(
+      'p1',
+      [mkTask('t1', 'RUNNING', 'agent-a'), mkTask('t2', 'PENDING', 'agent-b')],
+      1,
+      'add verification',
+      'looping_reasoning',
+    );
+    rev1.triggerEventId = 'drift-42';
+    mockStore.tasks.upsertPlan(rev1);
+    mockStore.spans.append(
+      synthRefineSpan(1, 'looping_reasoning', 'add verification', 'agent-b', 11),
+    );
+
+    render(<TrajectoryView />);
+
+    const marker = screen.getByTestId(/^drift-marker-/);
+    fireEvent.click(marker);
+
+    const steering = screen.getByTestId('detail-drift-steering');
+    expect(steering).toHaveTextContent('add verification');
+    const target = screen.getByTestId('detail-drift-target');
+    // Refine's target_agent_id wins over drift's current_agent_id.
+    expect(target).toHaveTextContent('agent-b');
+  });
+});

--- a/frontend/src/__tests__/lib/interventionDetail.test.ts
+++ b/frontend/src/__tests__/lib/interventionDetail.test.ts
@@ -1,0 +1,346 @@
+// harmonograf#196 — intervention detail resolver.
+//
+// Verifies Trigger / Steering / Target composition given a drift + plan
+// rev + SessionStore, and that forward-compat fields (trigger_input,
+// refine input/output summaries, target agent) surface when present.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { TimestampSchema } from '@bufbuild/protobuf/wkt';
+import { SessionStore } from '../../gantt/index';
+import { applyGoldfiveEvent } from '../../rpc/goldfiveEvent';
+import {
+  EventSchema,
+  PlanSubmittedSchema,
+  PlanRevisedSchema,
+  DriftDetectedSchema,
+} from '../../pb/goldfive/v1/events_pb';
+import {
+  PlanSchema,
+  TaskSchema,
+  DriftKind,
+  DriftSeverity,
+  TaskStatus,
+} from '../../pb/goldfive/v1/types_pb';
+import {
+  resolveDriftDetail,
+  resolvePlanRevisionDetail,
+  resolveTaskCancelDetail,
+} from '../../lib/interventionDetail';
+import type { Task, TaskPlan } from '../../gantt/types';
+
+function pbTask(id: string, agent = 'agent-a') {
+  return create(TaskSchema, {
+    id,
+    title: `task ${id}`,
+    description: '',
+    assigneeAgentId: agent,
+    status: TaskStatus.PENDING,
+    predictedStartMs: 0n,
+    predictedDurationMs: 0n,
+  });
+}
+
+function pbPlan(id: string, taskIds: string[], revisionIndex = 0) {
+  return create(PlanSchema, {
+    id,
+    runId: 'run-1',
+    summary: `plan ${id}`,
+    tasks: taskIds.map((t) => pbTask(t)),
+    edges: [],
+    revisionReason: '',
+    revisionKind: DriftKind.UNSPECIFIED,
+    revisionSeverity: DriftSeverity.UNSPECIFIED,
+    revisionIndex,
+  });
+}
+
+function ts(seconds: number) {
+  return create(TimestampSchema, { seconds: BigInt(seconds), nanos: 0 });
+}
+
+describe('interventionDetail', () => {
+  let store: SessionStore;
+  beforeEach(() => {
+    store = new SessionStore();
+  });
+
+  it('resolveDriftDetail surfaces drift detail + drift target', () => {
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev',
+        runId: 'run-1',
+        sequence: 0n,
+        emittedAt: ts(30),
+        payload: {
+          case: 'driftDetected',
+          value: create(DriftDetectedSchema, {
+            kind: DriftKind.LOOPING_REASONING,
+            severity: DriftSeverity.WARNING,
+            detail: 'repeated tool calls',
+            currentTaskId: 't1',
+            currentAgentId: 'agent-a',
+            id: 'drift-1',
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+
+    const drifts = store.drifts.list();
+    expect(drifts).toHaveLength(1);
+    const detail = resolveDriftDetail(drifts[0], [], store);
+    expect(detail.trigger).toBe('repeated tool calls');
+    expect(detail.targetAgentId).toBe('agent-a');
+    expect(detail.targetTaskId).toBe('t1');
+    expect(detail.steering).toBe('');
+  });
+
+  it('resolveDriftDetail composes steering when a PlanRevised was triggered by the drift', () => {
+    // Emit drift first (id=drift-X). Emit a plan rev whose triggerEventId
+    // matches the drift id.
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-init',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'planSubmitted',
+          value: create(PlanSubmittedSchema, { plan: pbPlan('p1', ['t1']) }),
+        },
+      }),
+      store,
+      0,
+    );
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-drift',
+        runId: 'run-1',
+        sequence: 1n,
+        emittedAt: ts(30),
+        payload: {
+          case: 'driftDetected',
+          value: create(DriftDetectedSchema, {
+            kind: DriftKind.LOOPING_REASONING,
+            severity: DriftSeverity.WARNING,
+            detail: 'agent looping',
+            currentTaskId: 't1',
+            currentAgentId: 'agent-a',
+            id: 'drift-42',
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+    const rev = pbPlan('p1', ['t1', 't2'], 1);
+    rev.revisionReason = 'add verification step';
+    rev.revisionKind = DriftKind.LOOPING_REASONING;
+    rev.revisionTriggerEventId = 'drift-42';
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-rev',
+        runId: 'run-1',
+        sequence: 2n,
+        emittedAt: ts(31),
+        payload: {
+          case: 'planRevised',
+          value: create(PlanRevisedSchema, {
+            plan: rev,
+            driftKind: DriftKind.LOOPING_REASONING,
+            reason: 'add verification step',
+            revisionIndex: 1,
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+
+    const drifts = store.drifts.list();
+    const plans: TaskPlan[] = [];
+    for (const live of store.tasks.listPlans()) {
+      for (const snap of store.tasks.allRevsForPlan(live.id)) plans.push(snap);
+    }
+    const detail = resolveDriftDetail(drifts[0], plans, store);
+    expect(detail.trigger).toContain('agent looping');
+    expect(detail.steering).toContain('add verification step');
+    expect(detail.targetAgentId).toBe('agent-a');
+  });
+
+  it('resolveDriftDetail merges trigger_input (post-merge) into the Trigger section', () => {
+    const d = create(DriftDetectedSchema, {
+      kind: DriftKind.LOOPING_REASONING,
+      severity: DriftSeverity.WARNING,
+      detail: 'loop',
+      currentTaskId: 't1',
+      currentAgentId: 'agent-a',
+      id: 'drift-5',
+    });
+    (d as unknown as Record<string, unknown>).triggerInput =
+      'three search calls in a row';
+
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev',
+        runId: 'run-1',
+        sequence: 0n,
+        emittedAt: ts(40),
+        payload: { case: 'driftDetected', value: d },
+      }),
+      store,
+      0,
+    );
+    const detail = resolveDriftDetail(store.drifts.list()[0], [], store);
+    expect(detail.trigger).toContain('loop');
+    expect(detail.trigger).toContain('three search calls');
+  });
+
+  it('resolveDriftDetail prefers refine.target_agent_id over drift.current_agent_id when present', () => {
+    // Drift blames agent-a; the subsequent refine rebinds steering to
+    // agent-b. The resolver should report agent-b as the steering target.
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-init',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'planSubmitted',
+          value: create(PlanSubmittedSchema, { plan: pbPlan('p1', ['t1']) }),
+        },
+      }),
+      store,
+      0,
+    );
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-drift',
+        runId: 'run-1',
+        sequence: 1n,
+        emittedAt: ts(30),
+        payload: {
+          case: 'driftDetected',
+          value: create(DriftDetectedSchema, {
+            kind: DriftKind.CONFABULATION_RISK,
+            severity: DriftSeverity.WARNING,
+            detail: 'loose claims',
+            currentTaskId: 't1',
+            currentAgentId: 'agent-a',
+            id: 'drift-9',
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+    const rev = pbPlan('p1', ['t1'], 1);
+    rev.revisionReason = 'tighten claims';
+    rev.revisionTriggerEventId = 'drift-9';
+    const prMsg = create(PlanRevisedSchema, {
+      plan: rev,
+      reason: 'tighten claims',
+      revisionIndex: 1,
+    });
+    (prMsg as unknown as Record<string, unknown>).targetAgentId = 'agent-b';
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-rev',
+        runId: 'run-1',
+        sequence: 2n,
+        emittedAt: ts(31),
+        payload: { case: 'planRevised', value: prMsg },
+      }),
+      store,
+      0,
+    );
+    const plans: TaskPlan[] = [];
+    for (const live of store.tasks.listPlans()) {
+      for (const snap of store.tasks.allRevsForPlan(live.id)) plans.push(snap);
+    }
+    const detail = resolveDriftDetail(store.drifts.list()[0], plans, store);
+    expect(detail.targetAgentId).toBe('agent-b');
+  });
+
+  it('resolvePlanRevisionDetail returns steering + target for a goldfive-authored rev', () => {
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-init',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'planSubmitted',
+          value: create(PlanSubmittedSchema, { plan: pbPlan('p1', ['t1']) }),
+        },
+      }),
+      store,
+      0,
+    );
+    const rev = pbPlan('p1', ['t1'], 1);
+    rev.revisionReason = 'cascade cancel upstream';
+    rev.revisionKind = DriftKind.UNSPECIFIED;
+    const prMsg = create(PlanRevisedSchema, {
+      plan: rev,
+      reason: 'cascade cancel upstream',
+      revisionIndex: 1,
+    });
+    (prMsg as unknown as Record<string, unknown>).targetAgentId = 'agent-c';
+    (prMsg as unknown as Record<string, unknown>).refineInputSummary = 'upstream failed';
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-rev',
+        runId: 'run-1',
+        sequence: 1n,
+        emittedAt: ts(100),
+        payload: { case: 'planRevised', value: prMsg },
+      }),
+      store,
+      0,
+    );
+    const plans: TaskPlan[] = [];
+    for (const live of store.tasks.listPlans()) {
+      for (const snap of store.tasks.allRevsForPlan(live.id)) plans.push(snap);
+    }
+    const revPlan = plans.find((p) => (p.revisionIndex ?? 0) === 1)!;
+    const detail = resolvePlanRevisionDetail(revPlan, store);
+    expect(detail.trigger).toBe('');
+    expect(detail.steering).toContain('cascade cancel upstream');
+    expect(detail.steering).toContain('upstream failed');
+    expect(detail.targetAgentId).toBe('agent-c');
+  });
+
+  it('resolveTaskCancelDetail surfaces cancel_reason as steering', () => {
+    const task: Task = {
+      id: 't1',
+      title: 'task 1',
+      description: '',
+      assigneeAgentId: 'agent-a',
+      status: 'CANCELLED',
+      predictedStartMs: 0,
+      predictedDurationMs: 0,
+      boundSpanId: '',
+      cancelReason: 'upstream_failed:t0',
+    };
+    const detail = resolveTaskCancelDetail(task);
+    expect(detail.steering).toBe('upstream_failed:t0');
+    expect(detail.targetAgentId).toBe('agent-a');
+    expect(detail.targetTaskId).toBe('t1');
+    expect(detail.trigger).toBe('');
+  });
+
+  it('resolveTaskCancelDetail returns empty on non-terminal tasks', () => {
+    const task: Task = {
+      id: 't1',
+      title: 'task 1',
+      description: '',
+      assigneeAgentId: 'agent-a',
+      status: 'RUNNING',
+      predictedStartMs: 0,
+      predictedDurationMs: 0,
+      boundSpanId: '',
+    };
+    const detail = resolveTaskCancelDetail(task);
+    expect(detail.steering).toBe('');
+    expect(detail.targetAgentId).toBe('');
+  });
+});

--- a/frontend/src/__tests__/rpc/goldfiveEventAgentSeed.test.ts
+++ b/frontend/src/__tests__/rpc/goldfiveEventAgentSeed.test.ts
@@ -165,7 +165,11 @@ describe('planSubmitted seeds the agent registry from task assignees', () => {
     expect(store.agents.get(`${CLIENT}:verify_agent`)?.name).toBe(
       'verify_agent',
     );
-    expect(store.agents.size).toBe(3);
+    // harmonograf#196: PlanRevised now synthesizes the goldfive actor row so
+    // the refine span has a lane to land on. Count the three plan-seeded
+    // rows directly rather than rely on size.
+    expect(store.agents.size).toBe(4);
+    expect(store.agents.get('__goldfive__')).toBeTruthy();
   });
 
   it('skips tasks with an empty assignee (no synthetic empty-id row)', () => {

--- a/frontend/src/__tests__/rpc/goldfiveEventLanes.test.ts
+++ b/frontend/src/__tests__/rpc/goldfiveEventLanes.test.ts
@@ -1,0 +1,389 @@
+// harmonograf#196: goldfive + user lane synthesis
+//
+// Verifies that ingest maps drift / plan-revised / run-started events onto
+// synthesized spans on the __goldfive__ / __user__ actor rows so the Gantt
+// and Trajectory views can render them as first-class activity.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { TimestampSchema } from '@bufbuild/protobuf/wkt';
+import { SessionStore } from '../../gantt/index';
+import { applyGoldfiveEvent } from '../../rpc/goldfiveEvent';
+import {
+  EventSchema,
+  PlanSubmittedSchema,
+  PlanRevisedSchema,
+  DriftDetectedSchema,
+  RunStartedSchema,
+} from '../../pb/goldfive/v1/events_pb';
+import {
+  PlanSchema,
+  TaskSchema,
+  DriftKind,
+  DriftSeverity,
+  TaskStatus,
+} from '../../pb/goldfive/v1/types_pb';
+import { GOLDFIVE_ACTOR_ID, USER_ACTOR_ID } from '../../theme/agentColors';
+
+function pbTask(id: string, agent = 'agent-a') {
+  return create(TaskSchema, {
+    id,
+    title: `task ${id}`,
+    description: '',
+    assigneeAgentId: agent,
+    status: TaskStatus.PENDING,
+    predictedStartMs: 0n,
+    predictedDurationMs: 0n,
+  });
+}
+
+function pbPlan(id: string, taskIds: string[], revisionIndex = 0) {
+  return create(PlanSchema, {
+    id,
+    runId: 'run-1',
+    summary: `plan ${id}`,
+    tasks: taskIds.map((t) => pbTask(t)),
+    edges: [],
+    revisionReason: '',
+    revisionKind: DriftKind.UNSPECIFIED,
+    revisionSeverity: DriftSeverity.UNSPECIFIED,
+    revisionIndex,
+  });
+}
+
+function ts(seconds: number) {
+  return create(TimestampSchema, { seconds: BigInt(seconds), nanos: 0 });
+}
+
+describe('goldfive lane synthesis (harmonograf#196)', () => {
+  let store: SessionStore;
+  beforeEach(() => {
+    store = new SessionStore();
+  });
+
+  it('planRevised synthesizes a refine span on the goldfive actor row', () => {
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-0',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'planSubmitted',
+          value: create(PlanSubmittedSchema, { plan: pbPlan('p1', ['t1']) }),
+        },
+      }),
+      store,
+      0,
+    );
+
+    const revised = pbPlan('p1', ['t1', 't2'], 1);
+    revised.revisionReason = 'loop detected';
+    revised.revisionKind = DriftKind.LOOPING_REASONING;
+    revised.revisionSeverity = DriftSeverity.WARNING;
+
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-rev',
+        runId: 'run-1',
+        sequence: 1n,
+        emittedAt: ts(60),
+        payload: {
+          case: 'planRevised',
+          value: create(PlanRevisedSchema, {
+            plan: revised,
+            driftKind: DriftKind.LOOPING_REASONING,
+            severity: DriftSeverity.WARNING,
+            reason: 'loop detected',
+            revisionIndex: 1,
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+
+    // Goldfive actor row exists.
+    expect(store.agents.get(GOLDFIVE_ACTOR_ID)).toBeTruthy();
+
+    // A refine span is stamped on the goldfive row.
+    const spans: Array<ReturnType<typeof store.spans.get>> = [];
+    store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans as never);
+    const refine = spans.find((s) => s && s.name.startsWith('refine:'));
+    expect(refine).toBeTruthy();
+    if (!refine) return;
+    expect(refine.agentId).toBe(GOLDFIVE_ACTOR_ID);
+    expect(refine.kind).toBe('CUSTOM');
+    expect(refine.attributes['refine.kind']).toEqual({
+      kind: 'string',
+      value: 'looping_reasoning',
+    });
+    expect(refine.attributes['refine.reason']).toEqual({
+      kind: 'string',
+      value: 'loop detected',
+    });
+    expect(refine.attributes['refine.index']).toEqual({
+      kind: 'string',
+      value: '1',
+    });
+  });
+
+  it('planSubmitted (rev 0) does NOT synthesize a refine span', () => {
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-0',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'planSubmitted',
+          value: create(PlanSubmittedSchema, { plan: pbPlan('p1', ['t1']) }),
+        },
+      }),
+      store,
+      0,
+    );
+    const spans: Array<ReturnType<typeof store.spans.get>> = [];
+    store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans as never);
+    expect(spans.filter((s) => s?.name.startsWith('refine:'))).toHaveLength(0);
+  });
+
+  it('runStarted synthesizes a USER_MESSAGE span on the user actor row carrying goal_summary', () => {
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-run',
+        runId: 'run-1',
+        sequence: 0n,
+        emittedAt: ts(0),
+        payload: {
+          case: 'runStarted',
+          value: create(RunStartedSchema, {
+            runId: 'run-1',
+            goalSummary: 'summarize the paper',
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+
+    expect(store.agents.get(USER_ACTOR_ID)).toBeTruthy();
+    const spans: Array<ReturnType<typeof store.spans.get>> = [];
+    store.spans.queryAgent(USER_ACTOR_ID, 0, 1_000_000, spans as never);
+    const userSpan = spans.find((s) => s?.kind === 'USER_MESSAGE' && s.name === 'summarize the paper');
+    expect(userSpan).toBeTruthy();
+    expect(userSpan?.attributes['user.goal_summary']).toEqual({
+      kind: 'string',
+      value: 'summarize the paper',
+    });
+  });
+
+  it('runStarted with an empty goal_summary skips span creation', () => {
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-run',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'runStarted',
+          value: create(RunStartedSchema, { runId: 'run-1', goalSummary: '' }),
+        },
+      }),
+      store,
+      0,
+    );
+    const spans: Array<ReturnType<typeof store.spans.get>> = [];
+    store.spans.queryAgent(USER_ACTOR_ID, 0, 1_000_000, spans as never);
+    expect(spans).toHaveLength(0);
+  });
+
+  it('driftDetected still synthesizes a goldfive-row span (pre-existing behaviour preserved)', () => {
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-drift',
+        runId: 'run-1',
+        sequence: 0n,
+        emittedAt: ts(30),
+        payload: {
+          case: 'driftDetected',
+          value: create(DriftDetectedSchema, {
+            kind: DriftKind.LOOPING_REASONING,
+            severity: DriftSeverity.WARNING,
+            detail: 'repeated tool calls',
+            currentTaskId: 't1',
+            currentAgentId: 'agent-a',
+            id: 'drift-1',
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+    const spans: Array<ReturnType<typeof store.spans.get>> = [];
+    store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans as never);
+    expect(spans).toHaveLength(1);
+    const drift = spans[0];
+    expect(drift?.name).toBe('looping_reasoning');
+    expect(drift?.attributes['drift.kind']).toEqual({
+      kind: 'string',
+      value: 'looping_reasoning',
+    });
+    expect(drift?.attributes['drift.target_agent_id']).toEqual({
+      kind: 'string',
+      value: 'agent-a',
+    });
+  });
+
+  it('user_steer drift lands on the user row (not the goldfive row)', () => {
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-user-drift',
+        runId: 'run-1',
+        sequence: 0n,
+        emittedAt: ts(10),
+        payload: {
+          case: 'driftDetected',
+          value: create(DriftDetectedSchema, {
+            kind: DriftKind.USER_STEER,
+            severity: DriftSeverity.INFO,
+            detail: 'please focus on section 2',
+            currentTaskId: 't1',
+            currentAgentId: 'agent-a',
+            annotationId: 'ann-1',
+            id: 'drift-2',
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+    const goldfive: Array<ReturnType<typeof store.spans.get>> = [];
+    store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, goldfive as never);
+    expect(goldfive).toHaveLength(0);
+    const user: Array<ReturnType<typeof store.spans.get>> = [];
+    store.spans.queryAgent(USER_ACTOR_ID, 0, 1_000_000, user as never);
+    expect(user).toHaveLength(1);
+    expect(user[0]?.kind).toBe('USER_MESSAGE');
+  });
+
+  it('forward-compat: PlanRevised with extra fields carries them onto the refine span', () => {
+    const revised = pbPlan('p1', ['t1'], 2);
+    // Simulate post-merge proto having the new fields by creating the
+    // PlanRevised message and injecting the extra keys directly on the
+    // object. The ingest path reads through `unknown` so this
+    // mimics what the regenerated stubs will produce.
+    const prMsg = create(PlanRevisedSchema, {
+      plan: revised,
+      driftKind: DriftKind.PLAN_DIVERGENCE,
+      severity: DriftSeverity.WARNING,
+      reason: 'divergence',
+      revisionIndex: 2,
+    });
+    (prMsg as unknown as Record<string, unknown>).targetAgentId = 'agent-a';
+    (prMsg as unknown as Record<string, unknown>).refineInputSummary =
+      'agent-a stuck on step 3';
+    (prMsg as unknown as Record<string, unknown>).refineOutputSummary =
+      'add step 4: verify';
+
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev',
+        runId: 'run-1',
+        sequence: 0n,
+        emittedAt: ts(40),
+        payload: { case: 'planRevised', value: prMsg },
+      }),
+      store,
+      0,
+    );
+
+    const spans: Array<ReturnType<typeof store.spans.get>> = [];
+    store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans as never);
+    const refine = spans.find((s) => s && s.name.startsWith('refine:'));
+    expect(refine?.attributes['refine.target_agent_id']).toEqual({
+      kind: 'string',
+      value: 'agent-a',
+    });
+    expect(refine?.attributes['refine.input_summary']).toEqual({
+      kind: 'string',
+      value: 'agent-a stuck on step 3',
+    });
+    expect(refine?.attributes['refine.output_summary']).toEqual({
+      kind: 'string',
+      value: 'add step 4: verify',
+    });
+  });
+
+  it('forward-compat: DriftDetected.trigger_input lands on the synthesized drift span', () => {
+    const d = create(DriftDetectedSchema, {
+      kind: DriftKind.LOOPING_REASONING,
+      severity: DriftSeverity.WARNING,
+      detail: 'repeated tool',
+      currentTaskId: 't1',
+      currentAgentId: 'agent-a',
+      id: 'drift-3',
+    });
+    (d as unknown as Record<string, unknown>).triggerInput =
+      'the agent has called search three times';
+
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev',
+        runId: 'run-1',
+        sequence: 0n,
+        emittedAt: ts(50),
+        payload: { case: 'driftDetected', value: d },
+      }),
+      store,
+      0,
+    );
+
+    const spans: Array<ReturnType<typeof store.spans.get>> = [];
+    store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans as never);
+    expect(spans[0]?.attributes['drift.trigger_input']).toEqual({
+      kind: 'string',
+      value: 'the agent has called search three times',
+    });
+  });
+
+  it('forward-compat: reasoningJudgeInvoked (unknown oneof case pre-merge) is tolerated', () => {
+    // Pre-merge stubs don't know this case. Build the event manually so
+    // the oneof `case` string is 'reasoningJudgeInvoked' and verify that
+    // applyGoldfiveEvent either handles it (post-merge) or simply no-ops
+    // (pre-merge) without crashing.
+    const event = create(EventSchema, {
+      eventId: 'ev',
+      runId: 'run-1',
+      sequence: 0n,
+      emittedAt: ts(20),
+    });
+    (event as unknown as Record<string, unknown>).payload = {
+      case: 'reasoningJudgeInvoked',
+      value: {
+        verdict: 'drift',
+        severity: 'warning',
+        reasoning: 'agent paraphrased the last turn',
+        currentAgentId: 'agent-a',
+        currentTaskId: 't1',
+      },
+    };
+
+    expect(() => applyGoldfiveEvent(event, store, 0)).not.toThrow();
+
+    // Post-merge path: if the switch case ran, a judge span landed.
+    // Pre-merge path: nothing happens (no assertion on span count, but
+    // the synthetic goldfive actor row is created on the judge branch).
+    const spans: Array<ReturnType<typeof store.spans.get>> = [];
+    store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans as never);
+    // If the branch ran (which it does — the switch uses the string
+    // compare directly), exactly one judge span lands.
+    const judge = spans.find((s) => s && s.name.startsWith('judge:'));
+    expect(judge).toBeTruthy();
+    expect(judge?.attributes['judge.verdict']).toEqual({
+      kind: 'string',
+      value: 'drift',
+    });
+    expect(judge?.attributes['judge.target_agent_id']).toEqual({
+      kind: 'string',
+      value: 'agent-a',
+    });
+  });
+});

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -1,8 +1,9 @@
 import './views.css';
+import type React from 'react';
 import { useEffect, useState } from 'react';
 import { useUiStore } from '../../../state/uiStore';
 import { useSessionWatch } from '../../../rpc/hooks';
-import type { Task, TaskEdge, TaskPlan, TaskStatus } from '../../../gantt/types';
+import type { Span, Task, TaskEdge, TaskPlan, TaskStatus } from '../../../gantt/types';
 import type {
   DelegationRecord,
   DriftRecord,
@@ -15,6 +16,10 @@ import {
   SOURCE_COLOR,
   type InterventionRow,
 } from '../../../lib/interventions';
+import {
+  resolveDriftDetail,
+  type InterventionDetail,
+} from '../../../lib/interventionDetail';
 
 // ── Palette ────────────────────────────────────────────────────────────────
 // Aligned with GanttView's status palette so a task's status reads the same
@@ -646,6 +651,80 @@ function buildDelegationsByTaskId(
   return m;
 }
 
+// harmonograf#196: which task on the current rev should the steering
+// arrow land on. Target priority:
+//   1. Post-merge goldfive stamps PlanRevised.target_agent_id — pick the
+//      first task on the rev whose assignee matches. When multiple
+//      tasks share an assignee, prefer the task still RUNNING or
+//      PENDING (the one the steering most likely applies to).
+//   2. Pre-merge fallback: the drift carried on the same trigger as the
+//      revision identifies a current_agent_id — goldfiveEvent.ts stamps
+//      that onto the synthesized refine span. Here we accept the plan's
+//      revisionKind as a hint when the explicit field is missing: no
+//      target → no steering arrow (we degrade gracefully).
+function findSteeringTargetTask(
+  plan: TaskPlan,
+  targetAgentId: string,
+): Task | null {
+  if (!targetAgentId) return null;
+  const matches = plan.tasks.filter((t) => t.assigneeAgentId === targetAgentId);
+  if (matches.length === 0) return null;
+  // Prefer an active task; otherwise the first task — keeps the arrow stable
+  // across status transitions.
+  const active = matches.find(
+    (t) => t.status === 'RUNNING' || t.status === 'PENDING',
+  );
+  return active ?? matches[0];
+}
+
+// Look up the synthesized "refine" span on the goldfive actor row for a
+// given plan revision. The synthesizer (rpc/goldfiveEvent.ts) stamps
+// `refine.index = String(revIdx)` so we can pick the exact rev even when
+// multiple refines land inside the same ms.
+function findRefineSpanForPlan(
+  store: SessionStore,
+  plan: TaskPlan,
+): Span | null {
+  const revIdx = plan.revisionIndex ?? 0;
+  if (revIdx <= 0) return null;
+  const scratch: Span[] = [];
+  // Match by `refine.index` on the goldfive row — the synth span's
+  // startMs is the event's emittedAt, not the plan's createdAt, so the
+  // time window has to be wide enough to tolerate clock skew.
+  store.spans.queryAgent('__goldfive__', 0, Number.POSITIVE_INFINITY, scratch);
+  for (const s of scratch) {
+    if (!s.name.startsWith('refine:')) continue;
+    const attr = s.attributes['refine.index'];
+    if (attr && attr.kind === 'string' && attr.value === String(revIdx)) {
+      return s;
+    }
+  }
+  return null;
+}
+
+function readRefineAttr(span: Span | null, key: string): string {
+  if (!span) return '';
+  const attr = span.attributes[key];
+  if (!attr || attr.kind !== 'string') return '';
+  return attr.value;
+}
+
+// The user-goal span is the USER_MESSAGE span the ingest synthesizer
+// stamps on the user actor row from RunStarted.goal_summary. There is at
+// most one per run; pick the earliest (earliest RunStarted).
+function findUserGoalSpan(store: SessionStore): Span | null {
+  const scratch: Span[] = [];
+  store.spans.queryAgent('__user__', 0, Number.POSITIVE_INFINITY, scratch);
+  let chosen: Span | null = null;
+  for (const s of scratch) {
+    if (s.kind !== 'USER_MESSAGE') continue;
+    const marker = s.attributes['user.goal_summary'];
+    if (!marker) continue;
+    if (!chosen || s.startMs < chosen.startMs) chosen = s;
+  }
+  return chosen;
+}
+
 function DagPane(props: DagProps) {
   const {
     plan,
@@ -664,6 +743,37 @@ function DagPane(props: DagProps) {
   if (!plan || !layout) {
     return <div className="hg-traj__dag hg-traj__dag--empty">No plan to render.</div>;
   }
+
+  // harmonograf#196 steering arrow: find the current rev's refine target
+  // and, if one exists, draw a distinct arrow from a small "goldfive"
+  // gutter node on the DAG's left edge to the matching task node. The
+  // target agent lives on the synthesized refine span the ingest layer
+  // stamps on the goldfive actor row at plan.createdAtMs.
+  const revIdx = plan.revisionIndex ?? 0;
+  const refineSpan = store && revIdx > 0 ? findRefineSpanForPlan(store, plan) : null;
+  const steerTargetAgent = refineSpan ? readRefineAttr(refineSpan, 'refine.target_agent_id') : '';
+  const steerKind = refineSpan ? readRefineAttr(refineSpan, 'refine.kind') : plan.revisionKind || '';
+  const steerReason = refineSpan ? readRefineAttr(refineSpan, 'refine.reason') : plan.revisionReason || '';
+  const steerTargetTask = steerTargetAgent
+    ? findSteeringTargetTask(plan, steerTargetAgent)
+    : null;
+  // Gutter node coordinates — small circles in the left margin of the
+  // DAG's SVG viewport. Chosen so they never overlap the first-layer
+  // task column (which starts at DAG_PAD + 0 = 24). The goldfive node
+  // sits mid-height (steering origin); the user node sits higher and
+  // points to the first layer-0 task (representing the RunStarted goal
+  // that seeded the plan).
+  const GOLDFIVE_NODE = { cx: 12, cy: layout.height / 2, r: 7 };
+  const USER_NODE = { cx: 12, cy: 16, r: 7 };
+
+  // User → first-task arrow: represents "this plan exists because the
+  // user asked for <goal>". Only drawn on the initial rev (rev 0) so
+  // rev 1+ panes don't accumulate a user arrow on every refine.
+  const userGoalSpan = store ? findUserGoalSpan(store) : null;
+  const userGoalSummary = userGoalSpan?.name || '';
+  const firstLayerTask = revIdx === 0
+    ? plan.tasks.find((t) => layout.nodeById.get(t.id)?.layer === 0) ?? null
+    : null;
 
   // Removed-task cards (only when in diff/compare mode). These sit to the right
   // of the DAG so the user can see what the refine dropped without corrupting
@@ -693,7 +803,166 @@ function DagPane(props: DagProps) {
           >
             <path d="M0,0 L10,5 L0,10 z" fill="#8d9199" />
           </marker>
+          {/* Distinct marker for steering edges so it reads different
+              from delegation at a glance — same shape, goldfive color. */}
+          <marker
+            id="traj-steer-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="9"
+            markerHeight="9"
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L10,5 L0,10 z" fill="#80deea" />
+          </marker>
+          {/* User-origin arrow: warm neutral so it reads distinctly from
+              both delegation (grey) and steering (goldfive-teal). */}
+          <marker
+            id="traj-user-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="9"
+            markerHeight="9"
+            orient="auto-start-reverse"
+          >
+            <path d="M0,0 L10,5 L0,10 z" fill="#d0bcff" />
+          </marker>
         </defs>
+
+        {/* user → first-layer task arrow: drawn only on rev 0. Represents
+            "this plan was seeded by the user's goal". */}
+        {firstLayerTask && userGoalSpan && (() => {
+          const targetNode = layout.nodeById.get(firstLayerTask.id);
+          if (!targetNode) return null;
+          const x1 = USER_NODE.cx + USER_NODE.r;
+          const y1 = USER_NODE.cy;
+          const x2 = targetNode.x;
+          const y2 = targetNode.y + targetNode.h / 2;
+          const mx = (x1 + x2) / 2;
+          const d = `M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}`;
+          return (
+            <g data-testid="trajectory-user-edge">
+              <path
+                d={d}
+                fill="none"
+                stroke="#d0bcff"
+                strokeWidth={1.5}
+                strokeDasharray="5,3"
+                opacity={0.7}
+                markerEnd="url(#traj-user-arrow)"
+              />
+              <title>{userGoalSummary ? `user goal: ${userGoalSummary}` : 'user goal'}</title>
+            </g>
+          );
+        })()}
+        {userGoalSpan && (
+          <g
+            className="hg-traj__user-gutter"
+            data-testid="trajectory-user-gutter"
+          >
+            <circle
+              cx={USER_NODE.cx}
+              cy={USER_NODE.cy}
+              r={USER_NODE.r}
+              fill="#d0bcff"
+              opacity={0.85}
+            />
+            <text
+              x={USER_NODE.cx}
+              y={USER_NODE.cy + 3}
+              textAnchor="middle"
+              fontSize={9}
+              fill="#0b0d12"
+              fontWeight={700}
+            >
+              u
+            </text>
+            <title>{userGoalSummary ? `user: ${userGoalSummary}` : 'user'}</title>
+          </g>
+        )}
+
+        {/* steering edges: goldfive gutter → target task. Rendered before
+            task edges so delegation / dependency arrows draw on top, but
+            the dashed goldfive color + the distinct marker keep it
+            readable. Only drawn on non-zero revs with a target. */}
+        {steerTargetTask && (
+          <g
+            className="hg-traj__steer-edges"
+            data-testid="trajectory-steer-edges"
+          >
+            {(() => {
+              const targetNode = layout.nodeById.get(steerTargetTask.id);
+              if (!targetNode) return null;
+              const x1 = GOLDFIVE_NODE.cx + GOLDFIVE_NODE.r;
+              const y1 = GOLDFIVE_NODE.cy;
+              const x2 = targetNode.x;
+              const y2 = targetNode.y + targetNode.h / 2;
+              const mx = (x1 + x2) / 2;
+              const d = `M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}`;
+              const label =
+                steerKind || steerReason || `rev ${plan.revisionIndex ?? 0}`;
+              return (
+                <g data-testid={`steer-edge-${steerTargetTask.id}`}>
+                  <path
+                    className="hg-traj__steer-edge"
+                    d={d}
+                    fill="none"
+                    stroke="#80deea"
+                    strokeWidth={1.5}
+                    strokeDasharray="5,3"
+                    opacity={0.75}
+                    markerEnd="url(#traj-steer-arrow)"
+                  />
+                  <text
+                    className="hg-traj__steer-label"
+                    x={(x1 + x2) / 2}
+                    y={(y1 + y2) / 2 - 4}
+                    textAnchor="middle"
+                    fontSize={10}
+                    fill="#80deea"
+                    opacity={0.9}
+                  >
+                    <title>
+                      {`goldfive steered ${steerTargetTask.assigneeAgentId || '(agent)'}` +
+                        (steerReason ? `\nreason: ${steerReason}` : '') +
+                        (steerKind ? `\nkind: ${steerKind}` : '')}
+                    </title>
+                    {truncate(label, 28)}
+                  </text>
+                </g>
+              );
+            })()}
+          </g>
+        )}
+
+        {/* goldfive gutter node: the origin of the steering arrow, only
+            rendered on revs that have a target to arrow to. */}
+        {steerTargetTask && (
+          <g
+            className="hg-traj__goldfive-gutter"
+            data-testid="trajectory-goldfive-gutter"
+          >
+            <circle
+              cx={GOLDFIVE_NODE.cx}
+              cy={GOLDFIVE_NODE.cy}
+              r={GOLDFIVE_NODE.r}
+              fill="#80deea"
+              opacity={0.85}
+            />
+            <text
+              x={GOLDFIVE_NODE.cx}
+              y={GOLDFIVE_NODE.cy + 3}
+              textAnchor="middle"
+              fontSize={9}
+              fill="#0b0d12"
+              fontWeight={700}
+            >
+              g5
+            </text>
+          </g>
+        )}
 
         {/* edges behind nodes */}
         <g className="hg-traj__edges">
@@ -1072,6 +1341,16 @@ function DetailPane(props: DetailPaneProps) {
         </aside>
       );
     }
+    // Resolve the richer intervention detail so the pane can surface
+    // Trigger / Steering / Target sections — the three questions a
+    // human operator asks at each drift marker: what did goldfive see,
+    // what did it do about it, and which agent got steered.
+    const plans = plan ? [plan] : [];
+    // Walk every rev visible through the selection context so cross-rev
+    // triggerEventId matches work (the trigger-event is stamped on the
+    // PlanRevised, not the drift row).
+    const allPlans = store ? collectAllPlanRevs(store) : plans;
+    const detail = resolveDriftDetail(d, allPlans, store);
     return (
       <aside className="hg-traj__detail" data-testid="detail-drift">
         <header>
@@ -1084,7 +1363,6 @@ function DetailPane(props: DetailPaneProps) {
             {d.severity || 'unspec'}
           </span>
         </header>
-        {d.detail && <p className="hg-traj__detail-desc">{d.detail}</p>}
         <dl className="hg-traj__detail-meta">
           <dt>observed</dt>
           <dd>{fmtTime(d.recordedAtMs)}</dd>
@@ -1093,10 +1371,118 @@ function DetailPane(props: DetailPaneProps) {
           <dt>agent</dt>
           <dd>{d.agentId || '—'}</dd>
         </dl>
+        <InterventionDetailSections detail={detail} store={store} />
       </aside>
     );
   }
   return null;
+}
+
+// Walk every plan in the store and gather every revision snapshot. The
+// resolver needs the full rev history because a drift's triggering
+// PlanRevised can live under any plan_id (goldfive often mints fresh
+// plan ids on refine — same behaviour the main VM builder guards
+// against).
+function collectAllPlanRevs(store: SessionStore): TaskPlan[] {
+  const out: TaskPlan[] = [];
+  const seen = new Set<TaskPlan>();
+  for (const live of store.tasks.listPlans()) {
+    for (const snap of store.tasks.allRevsForPlan(live.id)) {
+      if (seen.has(snap)) continue;
+      seen.add(snap);
+      out.push(snap);
+    }
+  }
+  return out;
+}
+
+// Trigger / Steering / Target panel (harmonograf#196). Each section is
+// hidden when its data is empty — so drift rows that have no matching
+// PlanRevised don't render an empty "Steering" block.
+function InterventionDetailSections({
+  detail,
+  store,
+}: {
+  detail: InterventionDetail;
+  store: SessionStore | null;
+}): React.ReactNode {
+  const agentName = (id: string): string => {
+    if (!id) return '';
+    return store?.agents.get(id)?.name || bareAgentName(id) || id;
+  };
+  return (
+    <section
+      className="hg-traj__detail-intervention"
+      data-testid="detail-drift-intervention"
+      aria-label="Intervention context"
+      style={{ marginTop: 10, fontSize: 12 }}
+    >
+      {detail.trigger && (
+        <DetailSection
+          label="Trigger"
+          body={detail.trigger}
+          testId="detail-drift-trigger"
+        />
+      )}
+      {detail.steering && (
+        <DetailSection
+          label="Steering"
+          body={detail.steering}
+          testId="detail-drift-steering"
+        />
+      )}
+      {detail.targetAgentId && (
+        <div
+          className="hg-traj__detail-target"
+          data-testid="detail-drift-target"
+          style={{ marginTop: 6, display: 'flex', gap: 6, alignItems: 'baseline' }}
+        >
+          <strong style={{ opacity: 0.65, textTransform: 'uppercase', fontSize: 10 }}>
+            Target
+          </strong>
+          <span title={detail.targetAgentId}>{agentName(detail.targetAgentId)}</span>
+          {detail.targetTaskId && (
+            <code style={{ opacity: 0.7, fontSize: 10 }}>{detail.targetTaskId}</code>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DetailSection({
+  label,
+  body,
+  testId,
+}: {
+  label: string;
+  body: string;
+  testId: string;
+}): React.ReactNode {
+  return (
+    <div
+      data-testid={testId}
+      style={{
+        marginTop: 6,
+        padding: '6px 8px',
+        background: 'rgba(255,255,255,0.03)',
+        borderRadius: 4,
+      }}
+    >
+      <strong
+        style={{
+          display: 'block',
+          fontSize: 10,
+          opacity: 0.65,
+          textTransform: 'uppercase',
+          marginBottom: 2,
+        }}
+      >
+        {label}
+      </strong>
+      <div style={{ whiteSpace: 'pre-wrap', fontFamily: 'inherit' }}>{body}</div>
+    </div>
+  );
 }
 
 function truncate(s: string, n: number): string {

--- a/frontend/src/lib/interventionDetail.ts
+++ b/frontend/src/lib/interventionDetail.ts
@@ -1,0 +1,191 @@
+// Intervention detail resolver (harmonograf#196).
+//
+// Given a drift record, a plan revision, or the task cancel-reason slot,
+// compute the three-part detail that the Trajectory DetailPane (and any
+// other intervention-aware UI) renders:
+//
+//   * trigger  — the input that triggered goldfive's detection
+//                (drift reasoning text / activity summary / detail)
+//   * steering — what goldfive published (refine-plan reason / cancel
+//                reason / inject-prompt text)
+//   * target   — the agent id goldfive's steering applies to
+//
+// Tree-agnostic: this helper never inspects kind vocabularies. New drift
+// or revision kinds emitted server-side surface correctly without code
+// changes. The shape mirrors the three sections the UI renders — the
+// view-layer is free to hide any section whose value is empty.
+//
+// Forward-compat with goldfive#feat/judge-observability-events:
+//   DriftDetected.trigger_input and PlanRevised.refine_input_summary /
+//   refine_output_summary / target_agent_id are read through the
+//   synthesized span attributes goldfiveEvent.ts stamps (absent today,
+//   present post-merge). We do NOT add optional fields to DriftRecord /
+//   TaskPlan themselves — pre-merge the stubs don't carry the values so
+//   there is nothing to wire. Post-merge the ingest layer fills the span
+//   attributes and this resolver surfaces them.
+
+import type { DriftRecord, SessionStore } from '../gantt/index';
+import type { Span, TaskPlan, Task } from '../gantt/types';
+
+export interface InterventionDetail {
+  // Section 1: what triggered goldfive's detection. For drifts this is
+  // the drift detail plus (post-merge) the trigger_input reasoning text.
+  // Empty string when neither is known — view callers should hide the
+  // section.
+  trigger: string;
+  // Section 2: what goldfive published as steering. For plan revisions
+  // this is the revision reason plus (post-merge) the refine input /
+  // output summaries. For task cancellations (selected from the delta
+  // list) this is the task.cancelReason. Empty string ⇒ not a steering.
+  steering: string;
+  // Section 3: target agent id. Derived from the drift's current_agent_id
+  // or (post-merge) PlanRevised.target_agent_id. Empty string when
+  // goldfive did not point at a specific agent.
+  targetAgentId: string;
+  // Target task id, when known. Surfaced alongside the agent in the
+  // detail pane so the "Target" section can link to the task lane too.
+  targetTaskId: string;
+}
+
+// Pull a string attribute off a Span, handling absent / wrong-kind gracefully.
+function readStringAttr(span: Span | null, key: string): string {
+  if (!span) return '';
+  const attr = span.attributes[key];
+  if (!attr) return '';
+  if (attr.kind !== 'string') return '';
+  return attr.value;
+}
+
+// Synthetic "refine" span minted by goldfiveEvent.synthesizeRefineSpan.
+// Matched by `refine.index == revisionIndex` — the most reliable key
+// since the synth span's startMs is the event's emittedAt (not the
+// plan's createdAt, which can differ by clock skew).
+function findRefineSpan(
+  store: SessionStore | null,
+  plan: TaskPlan,
+): Span | null {
+  if (!store) return null;
+  const revIdx = plan.revisionIndex ?? 0;
+  if (revIdx <= 0) return null;
+  const spans: Span[] = [];
+  store.spans.queryAgent(
+    '__goldfive__',
+    0,
+    Number.POSITIVE_INFINITY,
+    spans,
+  );
+  for (const s of spans) {
+    if (!s.name.startsWith('refine:')) continue;
+    if (readStringAttr(s, 'refine.index') === String(revIdx)) return s;
+  }
+  return null;
+}
+
+// Synthetic "drift" span minted by goldfiveEvent.synthesizeDriftSpan.
+function findDriftSpan(
+  store: SessionStore | null,
+  drift: DriftRecord,
+): Span | null {
+  if (!store) return null;
+  const actor = drift.kind && drift.kind.startsWith('user_') ? '__user__' : '__goldfive__';
+  const spans: Span[] = [];
+  store.spans.queryAgent(
+    actor,
+    drift.recordedAtMs - 5,
+    drift.recordedAtMs + 5,
+    spans,
+  );
+  for (const s of spans) {
+    if (
+      readStringAttr(s, 'drift.kind') === drift.kind &&
+      s.startMs === drift.recordedAtMs
+    ) {
+      return s;
+    }
+  }
+  return null;
+}
+
+// Resolve detail for a drift selection. Pairs the drift row with its
+// triggering PlanRevised (if any) by walking store.tasks' rev list for a
+// plan whose triggerEventId matches this drift's driftId. That lookup is
+// cheap — sessions have few plan revs — and keeps the resolver stateless.
+export function resolveDriftDetail(
+  drift: DriftRecord,
+  plans: readonly TaskPlan[],
+  store: SessionStore | null,
+): InterventionDetail {
+  const driftSpan = findDriftSpan(store, drift);
+  const triggerInput = readStringAttr(driftSpan, 'drift.trigger_input');
+  const triggerParts: string[] = [];
+  if (drift.detail) triggerParts.push(drift.detail);
+  if (triggerInput && triggerInput !== drift.detail) triggerParts.push(triggerInput);
+  // Find a plan rev triggered by this drift to compose the steering text.
+  // Tier-1 strict id match (see lib/interventions.ts).
+  const triggeredPlan = drift.driftId
+    ? plans.find((p) => p.triggerEventId === drift.driftId)
+    : undefined;
+  let steeringText = '';
+  let refineSpan: Span | null = null;
+  if (triggeredPlan) {
+    refineSpan = findRefineSpan(store, triggeredPlan);
+    const steeringParts: string[] = [];
+    if (triggeredPlan.revisionReason) steeringParts.push(triggeredPlan.revisionReason);
+    const inSum = readStringAttr(refineSpan, 'refine.input_summary');
+    const outSum = readStringAttr(refineSpan, 'refine.output_summary');
+    if (inSum) steeringParts.push(`input: ${inSum}`);
+    if (outSum) steeringParts.push(`output: ${outSum}`);
+    steeringText = steeringParts.join('\n\n');
+  }
+  // Target: prefer the refine span's target_agent_id (post-merge wire
+  // field), else the drift's current_agent_id, else empty.
+  const refineTarget = readStringAttr(refineSpan, 'refine.target_agent_id');
+  const targetAgentId = refineTarget || drift.agentId || '';
+  const targetTaskId = drift.taskId || '';
+  return {
+    trigger: triggerParts.join('\n\n'),
+    steering: steeringText,
+    targetAgentId,
+    targetTaskId,
+  };
+}
+
+// Resolve detail when a plan revision is selected directly (no drift).
+// Used for goldfive-authored revisions that have no preceding user /
+// drift row (cascade_cancel, refine_retry, etc).
+export function resolvePlanRevisionDetail(
+  plan: TaskPlan,
+  store: SessionStore | null,
+): InterventionDetail {
+  if ((plan.revisionIndex ?? 0) <= 0) {
+    return { trigger: '', steering: '', targetAgentId: '', targetTaskId: '' };
+  }
+  const refineSpan = findRefineSpan(store, plan);
+  const steeringParts: string[] = [];
+  if (plan.revisionReason) steeringParts.push(plan.revisionReason);
+  const inSum = readStringAttr(refineSpan, 'refine.input_summary');
+  const outSum = readStringAttr(refineSpan, 'refine.output_summary');
+  if (inSum) steeringParts.push(`input: ${inSum}`);
+  if (outSum) steeringParts.push(`output: ${outSum}`);
+  return {
+    trigger: '',
+    steering: steeringParts.join('\n\n'),
+    targetAgentId: readStringAttr(refineSpan, 'refine.target_agent_id'),
+    targetTaskId: '',
+  };
+}
+
+// Resolve detail for a task cancellation (terminal status + cancelReason).
+// Surfaced when the task-delta list row is selected; the "steering" text
+// is the structured cancel reason itself.
+export function resolveTaskCancelDetail(task: Task): InterventionDetail {
+  if (task.status !== 'CANCELLED' && task.status !== 'FAILED') {
+    return { trigger: '', steering: '', targetAgentId: '', targetTaskId: '' };
+  }
+  return {
+    trigger: '',
+    steering: task.cancelReason || '',
+    targetAgentId: task.assigneeAgentId || '',
+    targetTaskId: task.id,
+  };
+}

--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -68,9 +68,27 @@ function synthesizeDriftSpan(
   taskId: string,
   targetAgentId: string,
   recordedAtMs: number,
+  triggerInput?: string,
 ): void {
   const spanKind: SpanKind = actorId === USER_ACTOR_ID ? 'USER_MESSAGE' : 'CUSTOM';
   const id = `drift-${actorId}-${recordedAtMs}-${kind}`;
+  const attributes: Span['attributes'] = {
+    'drift.kind': { kind: 'string', value: kind },
+    'drift.severity': { kind: 'string', value: severity },
+    'drift.detail': { kind: 'string', value: detail },
+    'drift.target_task_id': { kind: 'string', value: taskId },
+    'drift.target_agent_id': { kind: 'string', value: targetAgentId },
+    'harmonograf.synthetic_span': { kind: 'bool', value: true },
+  };
+  // harmonograf#196 forward-compat: goldfive#feat/judge-observability-events
+  // adds DriftDetected.trigger_input — the reasoning snippet / activity
+  // summary that triggered the judge. Carry it on the synthesized span as
+  // a string attribute when present so the intervention detail panel can
+  // surface richer context post-submodule-bump. Attribute is simply absent
+  // (not empty-string) when the field is missing on the pre-merge wire.
+  if (triggerInput) {
+    attributes['drift.trigger_input'] = { kind: 'string', value: triggerInput };
+  }
   const span: Span = {
     id,
     sessionId: sessionId ?? '',
@@ -82,12 +100,159 @@ function synthesizeDriftSpan(
     startMs: recordedAtMs,
     endMs: recordedAtMs,
     links: [],
+    attributes,
+    payloadRefs: [],
+    error: null,
+    lane: -1,
+    replaced: false,
+  };
+  store.spans.append(span);
+}
+
+// Synthesize a "refine" span on the goldfive actor row for each PlanRevised
+// event so the Gantt + Trajectory views surface goldfive's decision-making
+// as first-class activity — not just an implicit new plan revision. Pairs
+// with the DriftDetected span (same row) and the forthcoming
+// ReasoningJudgeInvoked span (same row) to build a readable timeline of
+// orchestrator decisions.
+//
+// The span name reads `refine: <kind>` (or `refine: <reason prefix>`
+// if the drift kind is empty). Target agent / task attribution is pulled
+// from (a) the forward-compat ``targetAgentId`` field if present on the
+// generated stubs, otherwise (b) the revisionKind alone — which the UI
+// will treat as "refine with no explicit target" and skip the steering
+// arrow for.
+function synthesizeRefineSpan(
+  store: SessionStore,
+  sessionId: string | null,
+  revisionIndex: number,
+  revisionKind: string,
+  revisionSeverity: string,
+  revisionReason: string,
+  recordedAtMs: number,
+  targetAgentId: string,
+  refineInputSummary: string,
+  refineOutputSummary: string,
+): void {
+  const id = `refine-${recordedAtMs}-${revisionIndex}`;
+  const nameCore = revisionKind || 'refine';
+  const attributes: Span['attributes'] = {
+    'refine.index': { kind: 'string', value: String(revisionIndex) },
+    'refine.kind': { kind: 'string', value: revisionKind },
+    'refine.severity': { kind: 'string', value: revisionSeverity },
+    'refine.reason': { kind: 'string', value: revisionReason },
+    'refine.target_agent_id': { kind: 'string', value: targetAgentId },
+    'harmonograf.synthetic_span': { kind: 'bool', value: true },
+  };
+  if (refineInputSummary) {
+    attributes['refine.input_summary'] = {
+      kind: 'string',
+      value: refineInputSummary,
+    };
+  }
+  if (refineOutputSummary) {
+    attributes['refine.output_summary'] = {
+      kind: 'string',
+      value: refineOutputSummary,
+    };
+  }
+  const span: Span = {
+    id,
+    sessionId: sessionId ?? '',
+    agentId: GOLDFIVE_ACTOR_ID,
+    parentSpanId: null,
+    kind: 'CUSTOM',
+    status: 'COMPLETED',
+    name: `refine: ${nameCore}`,
+    startMs: recordedAtMs,
+    endMs: recordedAtMs,
+    links: [],
+    attributes,
+    payloadRefs: [],
+    error: null,
+    lane: -1,
+    replaced: false,
+  };
+  store.spans.append(span);
+}
+
+// Synthesize a USER_MESSAGE span on the user actor row for each RunStarted
+// event, carrying the goal summary as the span name. This is the best
+// pre-merge substitute for a dedicated conversation-turn event —
+// `RunStarted.goal_summary` is a single-line natural-language distillation
+// of what the user asked for. When a richer per-turn event ships later
+// the same row can absorb those too; the user-lane pattern already exists.
+function synthesizeUserGoalSpan(
+  store: SessionStore,
+  sessionId: string | null,
+  runId: string,
+  goalSummary: string,
+  recordedAtMs: number,
+): void {
+  if (!goalSummary) return;
+  const id = `user-goal-${runId || recordedAtMs}`;
+  const span: Span = {
+    id,
+    sessionId: sessionId ?? '',
+    agentId: USER_ACTOR_ID,
+    parentSpanId: null,
+    kind: 'USER_MESSAGE',
+    status: 'COMPLETED',
+    name: goalSummary,
+    startMs: recordedAtMs,
+    endMs: recordedAtMs,
+    links: [],
     attributes: {
-      'drift.kind': { kind: 'string', value: kind },
-      'drift.severity': { kind: 'string', value: severity },
-      'drift.detail': { kind: 'string', value: detail },
-      'drift.target_task_id': { kind: 'string', value: taskId },
-      'drift.target_agent_id': { kind: 'string', value: targetAgentId },
+      'user.goal_summary': { kind: 'string', value: goalSummary },
+      'user.run_id': { kind: 'string', value: runId },
+      'harmonograf.synthetic_span': { kind: 'bool', value: true },
+    },
+    payloadRefs: [],
+    error: null,
+    lane: -1,
+    replaced: false,
+  };
+  store.spans.append(span);
+}
+
+// Forward-compat: synthesize a "judge" span on the goldfive actor row
+// when a goldfive.v1.ReasoningJudgeInvoked event arrives. The stub may
+// not exist on the pre-merge submodule — callers guard the call path
+// with a string-case check on the oneof so a missing case does not crash
+// ingest. Once the submodule bumps the generated ``Event.payload.case``
+// union includes 'reasoningJudgeInvoked' and TS narrows automatically.
+function synthesizeJudgeSpan(
+  store: SessionStore,
+  sessionId: string | null,
+  verdict: string,
+  severity: string,
+  reasoning: string,
+  currentAgentId: string,
+  currentTaskId: string,
+  recordedAtMs: number,
+): void {
+  const id = `judge-${recordedAtMs}-${verdict || 'on_task'}`;
+  const name =
+    verdict && verdict !== 'on_task'
+      ? `judge: ${verdict}${severity ? ` (${severity})` : ''}`
+      : 'judge: on_task';
+  const span: Span = {
+    id,
+    sessionId: sessionId ?? '',
+    agentId: GOLDFIVE_ACTOR_ID,
+    parentSpanId: null,
+    kind: 'CUSTOM',
+    status: 'COMPLETED',
+    name,
+    startMs: recordedAtMs,
+    endMs: recordedAtMs,
+    links: [],
+    attributes: {
+      'judge.verdict': { kind: 'string', value: verdict },
+      'judge.severity': { kind: 'string', value: severity },
+      'judge.reasoning': { kind: 'string', value: reasoning },
+      'judge.target_agent_id': { kind: 'string', value: currentAgentId },
+      'judge.target_task_id': { kind: 'string', value: currentTaskId },
       'harmonograf.synthetic_span': { kind: 'bool', value: true },
     },
     payloadRefs: [],
@@ -214,6 +379,48 @@ export function applyGoldfiveEvent(
           store.agents.ensureAgent(id, bareAgentName(id));
         }
       }
+      // harmonograf#196 Gantt lane: synthesize a "refine: <kind>" span on
+      // the goldfive actor row for every PlanRevised event so the lane
+      // reads as a readable orchestrator timeline (drift → refine → judge)
+      // instead of only drift rows. Skip the initial plan (planSubmitted /
+      // revision_index == 0) — that's the baseline, not a steering move.
+      if (payload.case === 'planRevised') {
+        const pr = payload.value;
+        ensureSyntheticActor(store, GOLDFIVE_ACTOR_ID);
+        const emittedAbsMs = tsToMsAbs(event.emittedAt);
+        const emittedMs = emittedAbsMs ? emittedAbsMs - sessionStartMs : 0;
+        const revKind = driftKindToString(pr.driftKind as unknown as number);
+        const revSev = driftSeverityToString(pr.severity as unknown as number);
+        // Forward-compat reads: goldfive#feat/judge-observability-events
+        // adds PlanRevised.target_agent_id / refine_input_summary /
+        // refine_output_summary. Pre-merge these fields are undefined on
+        // the generated stubs, so read through `unknown` + a string guard
+        // instead of relying on TS to know about them. When the stubs
+        // regenerate with the new fields the reads land naturally.
+        const pru = pr as unknown as Record<string, unknown>;
+        const targetAgent =
+          typeof pru.targetAgentId === 'string' ? (pru.targetAgentId as string) : '';
+        const refineInput =
+          typeof pru.refineInputSummary === 'string'
+            ? (pru.refineInputSummary as string)
+            : '';
+        const refineOutput =
+          typeof pru.refineOutputSummary === 'string'
+            ? (pru.refineOutputSummary as string)
+            : '';
+        synthesizeRefineSpan(
+          store,
+          sessionId,
+          pr.revisionIndex,
+          revKind,
+          revSev,
+          pr.reason || '',
+          emittedMs,
+          targetAgent,
+          refineInput,
+          refineOutput,
+        );
+      }
       return;
     }
     case 'taskStarted':
@@ -318,6 +525,14 @@ export function applyGoldfiveEvent(
         ? USER_ACTOR_ID
         : GOLDFIVE_ACTOR_ID;
       ensureSyntheticActor(store, actorId);
+      // Forward-compat: goldfive#feat/judge-observability-events adds
+      // DriftDetected.trigger_input (the reasoning snippet / activity
+      // summary that produced the drift). Read through `unknown` + string
+      // guard so ingest stays green on the pre-merge submodule pin. Once
+      // the stubs regenerate the field lands naturally.
+      const du = d as unknown as Record<string, unknown>;
+      const triggerInput =
+        typeof du.triggerInput === 'string' ? (du.triggerInput as string) : '';
       synthesizeDriftSpan(
         store,
         sessionId,
@@ -328,11 +543,32 @@ export function applyGoldfiveEvent(
         d.currentTaskId,
         d.currentAgentId,
         emittedMs,
+        triggerInput,
       );
       return;
     }
+    case 'runStarted': {
+      // harmonograf#196 user lane: synthesize a USER_MESSAGE span on the
+      // user actor row carrying `goal_summary` — the pre-merge substitute
+      // for a per-turn user-prompt event. Once goldfive ships a dedicated
+      // ConversationTurn event with per-turn user text, the same row can
+      // absorb those too.
+      const r = payload.value;
+      if (r.goalSummary) {
+        ensureSyntheticActor(store, USER_ACTOR_ID);
+        const emittedAbsMs = tsToMsAbs(event.emittedAt);
+        const emittedMs = emittedAbsMs ? emittedAbsMs - sessionStartMs : 0;
+        synthesizeUserGoalSpan(
+          store,
+          sessionId,
+          r.runId || '',
+          r.goalSummary,
+          emittedMs,
+        );
+      }
+      return;
+    }
     case 'taskProgress':
-    case 'runStarted':
     case 'goalDerived':
     case 'runCompleted':
     case 'runAborted':
@@ -346,6 +582,45 @@ export function applyGoldfiveEvent(
     case 'agentInvocationStarted':
     case 'agentInvocationCompleted':
       return;
+    // harmonograf#196 forward-compat: goldfive#feat/judge-observability-events
+    // adds a `reasoningJudgeInvoked` oneof case (the orchestrator's LLM-as-
+    // judge fires on each reasoning step and classifies it on-task / drift).
+    // The case string is matched as a wide string because the generated
+    // union on the current submodule pin doesn't include it yet — once the
+    // submodule bumps the `payload.case` type narrows automatically and this
+    // branch becomes reachable through the normal switch.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    case 'reasoningJudgeInvoked' as any: {
+      ensureSyntheticActor(store, GOLDFIVE_ACTOR_ID);
+      const emittedAbsMs = tsToMsAbs(event.emittedAt);
+      const emittedMs = emittedAbsMs ? emittedAbsMs - sessionStartMs : 0;
+      const ju = payload.value as unknown as Record<string, unknown>;
+      const verdict = typeof ju.verdict === 'string' ? (ju.verdict as string) : '';
+      const severityRaw = ju.severity;
+      const severity =
+        typeof severityRaw === 'string'
+          ? severityRaw
+          : typeof severityRaw === 'number'
+            ? driftSeverityToString(severityRaw)
+            : '';
+      const reasoning =
+        typeof ju.reasoning === 'string' ? (ju.reasoning as string) : '';
+      const currentAgentId =
+        typeof ju.currentAgentId === 'string' ? (ju.currentAgentId as string) : '';
+      const currentTaskId =
+        typeof ju.currentTaskId === 'string' ? (ju.currentTaskId as string) : '';
+      synthesizeJudgeSpan(
+        store,
+        sessionId,
+        verdict,
+        severity,
+        reasoning,
+        currentAgentId,
+        currentTaskId,
+        emittedMs,
+      );
+      return;
+    }
     case 'delegationObserved': {
       // DelegationObserved carries the coordinator→sub_agent edge that the
       // telemetry plugin only records as a generic TOOL_CALL span on the


### PR DESCRIPTION
Closes #141.

## Summary

Four observability features so Gantt + Trajectory surface goldfive's decision-making instead of burying it in implicit plan revisions.

- **A. Goldfive lane (Gantt)** — PlanRevised now synthesizes `refine: <kind>` spans on the `__goldfive__` actor row. Forward-compat judge spans land on the same row once goldfive ships `ReasoningJudgeInvoked`.
- **B. Intervention detail panel** — new `lib/interventionDetail.ts` resolves `{ trigger, steering, targetAgentId, targetTaskId }` from a drift + plan rev history; Trajectory drift DetailPane renders the three labeled sections.
- **C. User lane** — RunStarted now synthesizes a `USER_MESSAGE` span on the `__user__` row carrying `goal_summary`. Trajectory DAG gains a small "u" gutter + dashed user→first-task edge on rev 0.
- **D. Steering arrow** — Trajectory DAG draws a dashed goldfive-teal arrow from a "g5" gutter node to the target agent's task node on revs > 0. Distinct marker + dash from the delegation edge.

## Screenshots

Will add after the goldfive `feat/judge-observability-events` PR lands and the submodule bumps — the fuller detail (`trigger_input`, `refine_input_summary/output_summary`, `target_agent_id`) is the motivating win and ships empty on the current submodule pin.

## Forward-compat with goldfive#feat/judge-observability-events

The parallel goldfive PR adds:

- `ReasoningJudgeInvoked` oneof case — ingest handles the string-case directly, tolerating its absence on the pre-merge submodule.
- `DriftDetected.trigger_input` — read through `unknown` + string guard; when present, stamps `drift.trigger_input` attr on the synth drift span and surfaces in the Trigger section.
- `PlanRevised.refine_input_summary` / `refine_output_summary` / `target_agent_id` — same pattern; surface in the Steering + Target sections when present, feed the steering arrow.

Pre-merge behaviour: features A (goldfive lane — drifts + refines) and B (drift detail + basic steering) ship fully; C (user lane — RunStarted goal) ships fully; D (steering arrow) ships when the drift's `current_agent_id` matches a task assignee (fallback path). Fuller detail + reliable target-agent arrow land automatically once the submodule bumps.

## What to look for in review

- `rpc/goldfiveEvent.ts`: new synthesizers (`synthesizeRefineSpan`, `synthesizeUserGoalSpan`, `synthesizeJudgeSpan`) + forward-compat `unknown` reads guarded by string checks. No hardcoded proto field access that would break when stubs regenerate.
- `lib/interventionDetail.ts`: tree-agnostic — never inspects kind vocabularies. Tier-1 strict-id merge via `triggerEventId`.
- `components/shell/views/TrajectoryView.tsx`: two new SVG gutter nodes + edge passes, three new DetailPane subsections. No changes to the existing delegation / dependency edge passes.

## Tests

321 → 342 (+21). `pnpm -C frontend test --run`, `pnpm -C frontend tsc -b`, `pnpm -C frontend lint` clean.

- `__tests__/rpc/goldfiveEventLanes.test.ts` (9): refine / user-goal / drift span synthesis + forward-compat extra-field reads + `reasoningJudgeInvoked` tolerance.
- `__tests__/lib/interventionDetail.test.ts` (7): Trigger/Steering/Target composition across drift-only, drift+rev, refine.target_agent_id precedence, plan-rev-only, task-cancel.
- `__tests__/components/TrajectoryView.steering.test.tsx` (5): steering edge + goldfive gutter + user gutter rendering, drift marker → detail panel click path.

## Test plan

- [ ] `pnpm -C frontend test --run` passes (342)
- [ ] `pnpm -C frontend tsc -b` clean
- [ ] `pnpm -C frontend lint` clean (pre-existing GanttView useEffect-deps warning unchanged)
- [ ] Eyeball review: goldfive lane, user lane, steering arrow, intervention panel render on a real session
- [ ] After goldfive PR merges: re-bump submodule, verify extra detail surfaces in the Trigger / Steering / Target sections