### PR TITLE
feat(ui): click-through detail panel for goldfive judge spans

### DIFF
--- a/frontend/src/__tests__/components/JudgeInvocationDetail.test.tsx
+++ b/frontend/src/__tests__/components/JudgeInvocationDetail.test.tsx
@@ -1,0 +1,261 @@
+// harmonograf#197 — rendering tests for JudgeInvocationDetail.
+//
+// Covers the five verdict buckets the component supports and the copy /
+// collapse affordances. The source-of-truth for what data flows in is
+// lib/interventionDetail.resolveJudgeDetail; these tests feed that shape
+// directly so renderer + resolver are testable in isolation.
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { JudgeInvocationDetail } from '../../components/Interventions/JudgeInvocationDetail';
+import type { JudgeDetail } from '../../lib/interventionDetail';
+
+vi.mock('../../components/Interventions/JudgeInvocationDetail.css', () => ({}));
+
+function detail(over: Partial<JudgeDetail> = {}): JudgeDetail {
+  return {
+    spanId: 'judge-1',
+    eventId: 'ev-1',
+    recordedAtMs: 12_000,
+    model: 'claude-haiku-4',
+    elapsedMs: 248,
+    subjectAgentId: 'client:agent-a',
+    taskId: 't1',
+    verdictBucket: 'on_task',
+    onTask: true,
+    severity: '',
+    reason: '',
+    reasoningInput: '',
+    rawResponse: '',
+    steeredPlan: null,
+    steeringSummary: '',
+    taskSummaries: [],
+    ...over,
+  };
+}
+
+describe('<JudgeInvocationDetail />', () => {
+  it('renders the on-task verdict with a green badge and no severity pill', () => {
+    render(
+      <JudgeInvocationDetail
+        detail={detail({
+          verdictBucket: 'on_task',
+          onTask: true,
+          reason: 'The agent is making expected progress.',
+        })}
+      />,
+    );
+    const verdict = screen.getByTestId('judge-detail-verdict');
+    expect(verdict.textContent).toMatch(/On task/i);
+    expect(verdict.getAttribute('data-bucket')).toBe('on_task');
+    expect(screen.queryByTestId('judge-detail-severity')).toBeNull();
+    // on_task reason renders inline (no off-task border).
+    expect(screen.getByText(/making expected progress/i)).toBeTruthy();
+  });
+
+  it('renders the off-task INFO verdict with severity pill', () => {
+    render(
+      <JudgeInvocationDetail
+        detail={detail({
+          verdictBucket: 'off_task',
+          onTask: false,
+          severity: 'info',
+          reason: 'Mild topic drift.',
+        })}
+      />,
+    );
+    const sev = screen.getByTestId('judge-detail-severity');
+    expect(sev.getAttribute('data-severity')).toBe('info');
+    expect(screen.getByText(/Mild topic drift/i)).toBeTruthy();
+  });
+
+  it('renders the off-task WARNING verdict with severity pill', () => {
+    render(
+      <JudgeInvocationDetail
+        detail={detail({
+          verdictBucket: 'off_task',
+          onTask: false,
+          severity: 'warning',
+          reason: 'Agent is paraphrasing.',
+        })}
+      />,
+    );
+    expect(
+      screen.getByTestId('judge-detail-severity').getAttribute('data-severity'),
+    ).toBe('warning');
+  });
+
+  it('renders the off-task CRITICAL verdict with severity pill', () => {
+    render(
+      <JudgeInvocationDetail
+        detail={detail({
+          verdictBucket: 'off_task',
+          onTask: false,
+          severity: 'critical',
+          reason: 'Agent invented tool output.',
+        })}
+      />,
+    );
+    expect(
+      screen.getByTestId('judge-detail-severity').getAttribute('data-severity'),
+    ).toBe('critical');
+    // Critical off-task reason rendered in the off-task reason block.
+    expect(screen.getByText(/invented tool output/i)).toBeTruthy();
+  });
+
+  it('renders the "no verdict" bucket with the raw-response hint', () => {
+    render(
+      <JudgeInvocationDetail
+        detail={detail({
+          verdictBucket: 'no_verdict',
+          onTask: false,
+          severity: '',
+          reason: '',
+          rawResponse: '{"bad_json":',
+        })}
+      />,
+    );
+    const verdict = screen.getByTestId('judge-detail-verdict');
+    expect(verdict.getAttribute('data-bucket')).toBe('no_verdict');
+    expect(screen.getByTestId('judge-detail-no-verdict')).toBeTruthy();
+    // Severity pill hidden for no_verdict.
+    expect(screen.queryByTestId('judge-detail-severity')).toBeNull();
+  });
+
+  it('renders the header meta (time, elapsed ms, model)', () => {
+    render(
+      <JudgeInvocationDetail
+        detail={detail({ recordedAtMs: 125_000, elapsedMs: 410, model: 'haiku' })}
+      />,
+    );
+    expect(screen.getByText('2:05')).toBeTruthy();
+    expect(screen.getByText('410ms')).toBeTruthy();
+    expect(screen.getByText('haiku')).toBeTruthy();
+  });
+
+  it('collapses the reasoning-input section by default and expands on click', () => {
+    render(
+      <JudgeInvocationDetail
+        detail={detail({
+          reasoningInput:
+            'The agent said: "I will now search for widgets, then rank them by size."',
+        })}
+      />,
+    );
+    const reasoning = screen.getByTestId('judge-detail-reasoning');
+    expect(reasoning.getAttribute('data-open')).toBe('false');
+    expect(screen.queryByTestId('judge-detail-reasoning-body')).toBeNull();
+    fireEvent.click(screen.getByTestId('judge-detail-reasoning-toggle'));
+    expect(
+      screen.getByTestId('judge-detail-reasoning').getAttribute('data-open'),
+    ).toBe('true');
+    expect(screen.getByTestId('judge-detail-reasoning-body').textContent)
+      .toContain('rank them by size');
+  });
+
+  it('collapses the raw-response section by default and expands on click', () => {
+    render(
+      <JudgeInvocationDetail
+        detail={detail({ rawResponse: '{"on_task": false, "severity": "warning"}' })}
+      />,
+    );
+    const raw = screen.getByTestId('judge-detail-raw');
+    expect(raw.getAttribute('data-open')).toBe('false');
+    expect(screen.queryByTestId('judge-detail-raw-body')).toBeNull();
+    fireEvent.click(screen.getByTestId('judge-detail-raw-toggle'));
+    expect(screen.getByTestId('judge-detail-raw-body').textContent).toContain(
+      '"severity": "warning"',
+    );
+  });
+
+  it('wires the copy-to-clipboard button', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+    render(
+      <JudgeInvocationDetail
+        detail={detail({ reasoningInput: 'hello from the agent' })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('judge-detail-reasoning-copy'));
+    expect(writeText).toHaveBeenCalledWith('hello from the agent');
+  });
+
+  it('renders the context section with agent + task links when handlers supplied', () => {
+    const onFocusAgent = vi.fn();
+    const onFocusTask = vi.fn();
+    render(
+      <JudgeInvocationDetail
+        detail={detail({ subjectAgentId: 'client:agent-a', taskId: 'task-42' })}
+        onFocusAgent={onFocusAgent}
+        onFocusTask={onFocusTask}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('judge-detail-agent'));
+    fireEvent.click(screen.getByTestId('judge-detail-task'));
+    expect(onFocusAgent).toHaveBeenCalledWith('client:agent-a');
+    expect(onFocusTask).toHaveBeenCalledWith('task-42');
+  });
+
+  it('renders the steering section only for off-task verdicts', () => {
+    const { rerender } = render(
+      <JudgeInvocationDetail detail={detail({ verdictBucket: 'on_task' })} />,
+    );
+    expect(screen.queryByTestId('judge-detail-steering')).toBeNull();
+    rerender(
+      <JudgeInvocationDetail
+        detail={detail({
+          verdictBucket: 'off_task',
+          severity: 'warning',
+          reason: 'bad',
+        })}
+      />,
+    );
+    expect(screen.getByTestId('judge-detail-steering')).toBeTruthy();
+    // No matching PlanRevised → the "No steering applied" hint shows.
+    expect(screen.getByTestId('judge-detail-no-steering')).toBeTruthy();
+  });
+
+  it('shows the "refined plan" link + task summaries when a PlanRevised matched', () => {
+    const onOpenSteering = vi.fn();
+    render(
+      <JudgeInvocationDetail
+        detail={detail({
+          verdictBucket: 'off_task',
+          onTask: false,
+          severity: 'warning',
+          reason: 'drifting',
+          steeredPlan: {
+            id: 'plan-x',
+            invocationSpanId: '',
+            plannerAgentId: '',
+            createdAtMs: 500,
+            summary: '',
+            tasks: [],
+            edges: [],
+            revisionReason: 'add verification step',
+            revisionKind: 'looping_reasoning',
+            revisionSeverity: 'warning',
+            revisionIndex: 3,
+            triggerEventId: 'ev-1',
+          },
+          steeringSummary: 'add verification step',
+          taskSummaries: ['verify widget count', 'cancelled: old widget step'],
+        })}
+        onOpenSteering={onOpenSteering}
+      />,
+    );
+    const link = screen.getByTestId('judge-detail-steering-link');
+    expect(link.textContent).toMatch(/refined plan/i);
+    expect(link.textContent).toMatch(/r3/);
+    fireEvent.click(link);
+    expect(onOpenSteering).toHaveBeenCalledWith('plan-x', 3);
+    expect(screen.getByTestId('judge-detail-steering-tasks').textContent)
+      .toContain('verify widget count');
+    expect(screen.getByTestId('judge-detail-steering-tasks').textContent)
+      .toContain('cancelled: old widget step');
+  });
+});

--- a/frontend/src/__tests__/lib/interventionDetailAuthoredBy.test.ts
+++ b/frontend/src/__tests__/lib/interventionDetailAuthoredBy.test.ts
@@ -1,0 +1,137 @@
+// harmonograf#197 forward-compat — DriftDetected.authored_by surfacing.
+//
+// goldfive's /tmp/goldfive-steer-unify branch adds DriftDetected.authored_by
+// ("user" / "goldfive" / ""). Until that branch merges + the submodule
+// bumps, the field is absent from the generated stubs, so ingest reads it
+// through `unknown` casts. This test verifies the field:
+//
+//   * lands on the DriftRecord when present on the wire
+//   * lands on the synthesized drift span when present on the wire
+//   * is surfaced by resolveDriftDetail.authoredBy
+//   * is silently absent for legacy events (undefined on the field)
+//
+// The test uses the string-oneof-case + unknown-cast escape hatch to feed
+// authored_by without needing the stub to know about it yet.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { TimestampSchema } from '@bufbuild/protobuf/wkt';
+import { SessionStore } from '../../gantt/index';
+import { applyGoldfiveEvent } from '../../rpc/goldfiveEvent';
+import {
+  EventSchema,
+  DriftDetectedSchema,
+} from '../../pb/goldfive/v1/events_pb';
+import { DriftKind, DriftSeverity } from '../../pb/goldfive/v1/types_pb';
+import { resolveDriftDetail } from '../../lib/interventionDetail';
+import { GOLDFIVE_ACTOR_ID } from '../../theme/agentColors';
+import type { Span } from '../../gantt/types';
+
+function ts(seconds: number) {
+  return create(TimestampSchema, { seconds: BigInt(seconds), nanos: 0 });
+}
+
+describe('DriftDetected.authored_by (forward-compat)', () => {
+  let store: SessionStore;
+  beforeEach(() => {
+    store = new SessionStore();
+  });
+
+  it('carries authored_by="goldfive" onto the DriftRecord + span + detail', () => {
+    const d = create(DriftDetectedSchema, {
+      kind: DriftKind.LOOPING_REASONING,
+      severity: DriftSeverity.WARNING,
+      detail: 'loop detected',
+      currentTaskId: 't1',
+      currentAgentId: 'agent-a',
+      id: 'drift-gf-1',
+    });
+    (d as unknown as Record<string, unknown>).authoredBy = 'goldfive';
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-gf',
+        runId: 'run-1',
+        sequence: 0n,
+        emittedAt: ts(20),
+        payload: { case: 'driftDetected', value: d },
+      }),
+      store,
+      0,
+    );
+
+    const drifts = store.drifts.list();
+    expect(drifts[0].authoredBy).toBe('goldfive');
+
+    const spans: Span[] = [];
+    store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans);
+    const driftSpan = spans.find((s) => s.name === 'looping_reasoning');
+    expect(driftSpan?.attributes['drift.authored_by']).toEqual({
+      kind: 'string',
+      value: 'goldfive',
+    });
+
+    const detail = resolveDriftDetail(drifts[0], [], store);
+    expect(detail.authoredBy).toBe('goldfive');
+  });
+
+  it('carries authored_by="user" through for user-control drifts', () => {
+    const d = create(DriftDetectedSchema, {
+      kind: DriftKind.USER_STEER,
+      severity: DriftSeverity.INFO,
+      detail: 'steer message',
+      currentTaskId: 't1',
+      currentAgentId: 'agent-a',
+      id: 'drift-user-1',
+    });
+    (d as unknown as Record<string, unknown>).authoredBy = 'user';
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-user',
+        runId: 'run-1',
+        sequence: 0n,
+        emittedAt: ts(21),
+        payload: { case: 'driftDetected', value: d },
+      }),
+      store,
+      0,
+    );
+
+    const drifts = store.drifts.list();
+    const detail = resolveDriftDetail(drifts[0], [], store);
+    expect(detail.authoredBy).toBe('user');
+  });
+
+  it('legacy events without authored_by leave the detail field empty', () => {
+    const d = create(DriftDetectedSchema, {
+      kind: DriftKind.LOOPING_REASONING,
+      severity: DriftSeverity.WARNING,
+      detail: 'loop',
+      currentTaskId: 't1',
+      currentAgentId: 'agent-a',
+      id: 'drift-legacy-1',
+      // No authoredBy stamped. Pre-merge wire.
+    });
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-legacy',
+        runId: 'run-1',
+        sequence: 0n,
+        emittedAt: ts(22),
+        payload: { case: 'driftDetected', value: d },
+      }),
+      store,
+      0,
+    );
+
+    const drifts = store.drifts.list();
+    expect(drifts[0].authoredBy ?? '').toBe('');
+
+    const spans: Span[] = [];
+    store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans);
+    const driftSpan = spans.find((s) => s.name === 'looping_reasoning');
+    expect(driftSpan?.attributes['drift.authored_by']).toBeUndefined();
+
+    const detail = resolveDriftDetail(drifts[0], [], store);
+    expect(detail.authoredBy ?? '').toBe('');
+  });
+});

--- a/frontend/src/__tests__/lib/judgeDetail.test.ts
+++ b/frontend/src/__tests__/lib/judgeDetail.test.ts
@@ -1,0 +1,318 @@
+// harmonograf#197 — judge-detail resolver + judge-span discriminator.
+//
+// Integration-flavoured: feeds a ReasoningJudgeInvoked event through
+// applyGoldfiveEvent, then queries the synthesized span and runs it
+// through resolveJudgeDetail. Verifies the six sections (header meta,
+// context, reasoning input, verdict, raw response, steering outcome)
+// land correctly, plus the steered-plan lookup when a PlanRevised's
+// trigger_event_id matches the judge event id.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { TimestampSchema } from '@bufbuild/protobuf/wkt';
+import { SessionStore } from '../../gantt/index';
+import { applyGoldfiveEvent } from '../../rpc/goldfiveEvent';
+import {
+  EventSchema,
+  PlanSubmittedSchema,
+  PlanRevisedSchema,
+} from '../../pb/goldfive/v1/events_pb';
+import {
+  PlanSchema,
+  TaskSchema,
+  DriftKind,
+  DriftSeverity,
+  TaskStatus,
+} from '../../pb/goldfive/v1/types_pb';
+import { isJudgeSpan, resolveJudgeDetail } from '../../lib/interventionDetail';
+import { GOLDFIVE_ACTOR_ID } from '../../theme/agentColors';
+import type { Span, TaskPlan } from '../../gantt/types';
+
+function ts(seconds: number) {
+  return create(TimestampSchema, { seconds: BigInt(seconds), nanos: 0 });
+}
+
+function pbTask(id: string, agent = 'agent-a') {
+  return create(TaskSchema, {
+    id,
+    title: `task ${id}`,
+    description: '',
+    assigneeAgentId: agent,
+    status: TaskStatus.PENDING,
+    predictedStartMs: 0n,
+    predictedDurationMs: 0n,
+  });
+}
+
+function pbPlan(id: string, taskIds: string[], revisionIndex = 0) {
+  return create(PlanSchema, {
+    id,
+    runId: 'run-1',
+    summary: `plan ${id}`,
+    tasks: taskIds.map((t) => pbTask(t)),
+    edges: [],
+    revisionReason: '',
+    revisionKind: DriftKind.UNSPECIFIED,
+    revisionSeverity: DriftSeverity.UNSPECIFIED,
+    revisionIndex,
+  });
+}
+
+// ReasoningJudgeInvoked doesn't have a bufbuild schema import in this test
+// file (the test lives alongside interventionDetail.test.ts which hand-
+// builds the judge payload via the oneof's string-case escape hatch).
+// We do the same here so the test is tolerant of pre-merge stubs.
+function judgeEvent(
+  eventId: string,
+  atSeconds: number,
+  fields: Record<string, unknown>,
+) {
+  const event = create(EventSchema, {
+    eventId,
+    runId: 'run-1',
+    sequence: 0n,
+    emittedAt: ts(atSeconds),
+  });
+  (event as unknown as Record<string, unknown>).payload = {
+    case: 'reasoningJudgeInvoked',
+    value: fields,
+  };
+  return event;
+}
+
+function listJudgeSpans(store: SessionStore): Span[] {
+  const spans: Span[] = [];
+  store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans);
+  return spans.filter((s) => isJudgeSpan(s));
+}
+
+function collectAllPlans(store: SessionStore): TaskPlan[] {
+  const out: TaskPlan[] = [];
+  const seen = new Set<TaskPlan>();
+  for (const live of store.tasks.listPlans()) {
+    for (const snap of store.tasks.allRevsForPlan(live.id)) {
+      if (seen.has(snap)) continue;
+      seen.add(snap);
+      out.push(snap);
+    }
+  }
+  return out;
+}
+
+describe('judge-span routing (harmonograf#197)', () => {
+  let store: SessionStore;
+  beforeEach(() => {
+    store = new SessionStore();
+  });
+
+  it('synthesized judge span carries kind=judge as a discriminator', () => {
+    applyGoldfiveEvent(
+      judgeEvent('ev-judge', 30, {
+        onTask: true,
+        reason: 'looks good',
+        reasoningInput: 'the agent said: I will search',
+        rawResponse: '{"on_task": true, "reason": "looks good"}',
+        model: 'haiku',
+        elapsedMs: 200,
+        subjectAgentId: 'agent-a',
+        taskId: 't1',
+      }),
+      store,
+      0,
+    );
+    const judges = listJudgeSpans(store);
+    expect(judges).toHaveLength(1);
+    expect(judges[0].attributes['judge.kind']).toEqual({
+      kind: 'string',
+      value: 'judge',
+    });
+    expect(judges[0].attributes['judge.event_id']).toEqual({
+      kind: 'string',
+      value: 'ev-judge',
+    });
+    expect(isJudgeSpan(judges[0])).toBe(true);
+  });
+
+  it('isJudgeSpan returns false for non-judge spans', () => {
+    // Seed a regular drift span on the goldfive lane.
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-drift',
+        runId: 'run-1',
+        sequence: 0n,
+        emittedAt: ts(10),
+        payload: {
+          case: 'driftDetected',
+          value: {
+            kind: DriftKind.LOOPING_REASONING,
+            severity: DriftSeverity.WARNING,
+            detail: 'loop',
+            currentTaskId: 't1',
+            currentAgentId: 'agent-a',
+            id: 'd-1',
+          },
+        },
+      }),
+      store,
+      0,
+    );
+    const spans: Span[] = [];
+    store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans);
+    // At least the drift span should be present; none are judge spans.
+    expect(spans.length).toBeGreaterThan(0);
+    for (const s of spans) expect(isJudgeSpan(s)).toBe(false);
+  });
+
+  it('resolveJudgeDetail surfaces the header + context + verdict for on_task', () => {
+    applyGoldfiveEvent(
+      judgeEvent('ev-j1', 45, {
+        onTask: true,
+        severity: '',
+        reason: 'on track',
+        reasoningInput: 'I will search',
+        rawResponse: '{"on_task": true}',
+        model: 'haiku',
+        elapsedMs: 175,
+        subjectAgentId: 'agent-a',
+        taskId: 't1',
+      }),
+      store,
+      0,
+    );
+    const judge = listJudgeSpans(store)[0];
+    const detail = resolveJudgeDetail(judge, []);
+    expect(detail.verdictBucket).toBe('on_task');
+    expect(detail.onTask).toBe(true);
+    expect(detail.reason).toBe('on track');
+    expect(detail.reasoningInput).toBe('I will search');
+    expect(detail.model).toBe('haiku');
+    expect(detail.elapsedMs).toBe(175);
+    expect(detail.subjectAgentId).toBe('agent-a');
+    expect(detail.taskId).toBe('t1');
+    expect(detail.steeredPlan).toBeNull();
+  });
+
+  it('resolveJudgeDetail returns off_task bucket with severity + reason', () => {
+    applyGoldfiveEvent(
+      judgeEvent('ev-off', 80, {
+        onTask: false,
+        severity: 'warning',
+        reason: 'agent paraphrasing',
+        reasoningInput: 'agent repeated itself',
+        rawResponse: '{"on_task": false, "severity":"warning"}',
+        model: 'haiku',
+        elapsedMs: 310,
+        subjectAgentId: 'agent-a',
+        taskId: 't1',
+      }),
+      store,
+      0,
+    );
+    const judge = listJudgeSpans(store)[0];
+    const detail = resolveJudgeDetail(judge, []);
+    expect(detail.verdictBucket).toBe('off_task');
+    expect(detail.severity).toBe('warning');
+    expect(detail.reason).toBe('agent paraphrasing');
+  });
+
+  it('resolveJudgeDetail returns no_verdict when the judge emitted raw but no parsed fields', () => {
+    applyGoldfiveEvent(
+      judgeEvent('ev-bad', 90, {
+        // No onTask / verdict / severity — malformed judge output.
+        rawResponse: '{ bad json',
+        reasoningInput: 'agent thinking',
+      }),
+      store,
+      0,
+    );
+    const judge = listJudgeSpans(store)[0];
+    const detail = resolveJudgeDetail(judge, []);
+    expect(detail.verdictBucket).toBe('no_verdict');
+    expect(detail.rawResponse).toContain('bad json');
+  });
+
+  it('links a matching PlanRevised as the steering outcome (by trigger_event_id)', () => {
+    // Seed an initial plan so the PlanRevised has a prior revision to
+    // chain from. Then emit the judge event AND a PlanRevised whose
+    // trigger_event_id points at the judge event id.
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-init',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'planSubmitted',
+          value: create(PlanSubmittedSchema, { plan: pbPlan('p1', ['t1']) }),
+        },
+      }),
+      store,
+      0,
+    );
+    applyGoldfiveEvent(
+      judgeEvent('ev-judge-steer', 100, {
+        onTask: false,
+        severity: 'warning',
+        reason: 'drift',
+        reasoningInput: 'agent stuck',
+        rawResponse: '{"on_task": false}',
+        subjectAgentId: 'agent-a',
+        taskId: 't1',
+      }),
+      store,
+      0,
+    );
+    const rev = pbPlan('p1', ['t1', 't2-new'], 2);
+    rev.revisionReason = 'recover from reasoning drift';
+    rev.revisionKind = DriftKind.LOOPING_REASONING;
+    rev.revisionTriggerEventId = 'ev-judge-steer';
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-rev',
+        runId: 'run-1',
+        sequence: 2n,
+        emittedAt: ts(101),
+        payload: {
+          case: 'planRevised',
+          value: create(PlanRevisedSchema, {
+            plan: rev,
+            reason: 'recover from reasoning drift',
+            revisionIndex: 2,
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+
+    const judge = listJudgeSpans(store)[0];
+    const plans = collectAllPlans(store);
+    const detail = resolveJudgeDetail(judge, plans);
+    expect(detail.steeredPlan).not.toBeNull();
+    expect(detail.steeredPlan?.id).toBe('p1');
+    expect(detail.steeredPlan?.revisionIndex).toBe(2);
+    expect(detail.steeringSummary).toContain('recover from reasoning drift');
+    // Task summaries include at least the new task title.
+    const titles = detail.taskSummaries.join('|');
+    expect(titles).toContain('task t2-new');
+  });
+
+  it('no matching PlanRevised leaves steeredPlan null (ladder did not escalate)', () => {
+    applyGoldfiveEvent(
+      judgeEvent('ev-orphan', 200, {
+        onTask: false,
+        severity: 'info',
+        reason: 'mild drift',
+        reasoningInput: 'thinking',
+        rawResponse: '{}',
+        subjectAgentId: 'agent-a',
+        taskId: 't1',
+      }),
+      store,
+      0,
+    );
+    const judge = listJudgeSpans(store)[0];
+    const detail = resolveJudgeDetail(judge, collectAllPlans(store));
+    expect(detail.steeredPlan).toBeNull();
+    expect(detail.taskSummaries).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/Interaction/SpanPopover.tsx
+++ b/frontend/src/components/Interaction/SpanPopover.tsx
@@ -1,14 +1,25 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { OverlayContext } from '../../gantt/GanttCanvas';
 import { usePopoverStore, type SpanPopover as SpanPopoverState } from '../../state/popoverStore';
 import { useUiStore } from '../../state/uiStore';
 import { useAgentLive, usePostAnnotation, useSendControl } from '../../rpc/hooks';
 import type { Span, SpanKind } from '../../gantt/types';
+import type { SessionStore } from '../../gantt/index';
+import { bareAgentName } from '../../gantt/index';
 import {
   extractThinkingText,
   formatThinkingPreview,
   hasThinking as spanHasThinking,
 } from '../../lib/thinking';
+import {
+  isJudgeSpan,
+  resolveJudgeDetail,
+} from '../../lib/interventionDetail';
+import type { TaskPlan } from '../../gantt/types';
+import { JudgeInvocationDetail } from '../Interventions/JudgeInvocationDetail';
+
+// Local alias purely for useMemo annotation.
+type TaskPlanForJudge = TaskPlan;
 
 // Floating quick-look popover anchored to a span block. Separate from the
 // full Inspector Drawer: the drawer is the deep-dive surface, this is the
@@ -87,6 +98,7 @@ export function SpanPopover({ ctx, sessionId }: Props) {
             key={p.spanId}
             state={p}
             span={span}
+            store={store}
             sessionId={sessionId}
             left={left}
             top={top}
@@ -122,6 +134,7 @@ function computePosition(
 function PopoverCard({
   state,
   span,
+  store,
   sessionId,
   left,
   top,
@@ -130,6 +143,7 @@ function PopoverCard({
 }: {
   state: SpanPopoverState;
   span: Span;
+  store: SessionStore;
   sessionId: string;
   left: number;
   top: number;
@@ -141,6 +155,27 @@ function PopoverCard({
   const post = usePostAnnotation();
   const agent = useAgentLive(sessionId, span.agentId);
   const agentName = agent?.name || span.agentId;
+
+  // Judge spans render a specialised detail block under the meta header
+  // so operators can see the judge's input + verdict + steering outcome
+  // without bouncing to another view. The generic kind/status/duration
+  // block still renders above; the judge detail supplants the Thinking /
+  // Steer / Annotate sections (none of those apply to a synthesised
+  // zero-duration event span).
+  const judgeMode = isJudgeSpan(span);
+  const judgeDetail = useMemo(() => {
+    if (!judgeMode) return null;
+    const plans: TaskPlanForJudge[] = [];
+    const seen = new Set<TaskPlanForJudge>();
+    for (const live of store.tasks.listPlans()) {
+      for (const snap of store.tasks.allRevsForPlan(live.id)) {
+        if (seen.has(snap)) continue;
+        seen.add(snap);
+        plans.push(snap);
+      }
+    }
+    return resolveJudgeDetail(span, plans);
+  }, [span, store, judgeMode]);
   const duration =
     span.endMs != null ? `${Math.max(0, span.endMs - span.startMs).toFixed(0)}ms` : '…';
 
@@ -200,16 +235,22 @@ function PopoverCard({
     void post({ sessionId, spanId: span.id, body: text, kind: 'COMMENT' }).catch(() => {});
   };
 
+  // Judge popovers carry more content (reasoning input, raw response,
+  // steering outcome); widen them so the sections don't truncate the
+  // reader's eye on typical laptops.
+  const popoverWidth = judgeMode ? POPOVER_WIDTH + 80 : POPOVER_WIDTH;
+
   return (
     <div
       role="dialog"
       data-testid="span-popover"
+      data-judge={judgeMode ? 'true' : 'false'}
       data-pinned={state.pinned ? 'true' : 'false'}
       style={{
         position: 'absolute',
         left,
         top,
-        width: POPOVER_WIDTH,
+        width: popoverWidth,
         pointerEvents: 'auto',
         background: 'var(--md-sys-color-surface-container-highest, #31333c)',
         color: 'var(--md-sys-color-on-surface, #e2e2e9)',
@@ -272,7 +313,35 @@ function PopoverCard({
           {duration}
         </div>
       </div>
-      {thinkingHint && (
+      {judgeMode && judgeDetail && (
+        <div style={{ marginTop: 10 }}>
+          <JudgeInvocationDetail
+            detail={judgeDetail}
+            resolveAgentName={(id) => store.agents.get(id)?.name || bareAgentName(id) || id}
+            onFocusAgent={(id) => {
+              useUiStore.getState().setFocusedAgent(id);
+            }}
+            onFocusTask={(id) => {
+              useUiStore.getState().selectTask(id);
+            }}
+            onOpenSteering={(_planId, _revIdx) => {
+              // Today the intervention-detail panel lives in TrajectoryView;
+              // the cleanest hand-off is to surface the plan revision there.
+              // The PlanRevised event is already rendered as a separate
+              // "refine:" span on the goldfive lane (goldfiveEvent.ts), so
+              // we select that span — clicking opens its own popover with
+              // the existing Trigger/Steering/Target panel for plan revs.
+              void _planId;
+              void _revIdx;
+              // Leave close-before-open so the popover doesn't visually
+              // stack; the user can click the refine span to see its
+              // details.
+              onClose();
+            }}
+          />
+        </div>
+      )}
+      {!judgeMode && thinkingHint && (
         <div
           data-testid="span-popover-thinking"
           data-open={thinkingOpen ? 'true' : 'false'}
@@ -362,14 +431,20 @@ function PopoverCard({
           borderTop: '1px solid var(--md-sys-color-outline-variant, #43474e)',
         }}
       >
-        <ActionButton onClick={toggleSteer} primary={steerOpen}>Steer</ActionButton>
-        <ActionButton onClick={annotate}>Annotate</ActionButton>
+        {!judgeMode && (
+          <>
+            <ActionButton onClick={toggleSteer} primary={steerOpen}>Steer</ActionButton>
+            <ActionButton onClick={annotate}>Annotate</ActionButton>
+          </>
+        )}
         <ActionButton onClick={copyId}>Copy id</ActionButton>
-        <ActionButton onClick={openInDrawer} primary>
-          Open drawer
-        </ActionButton>
+        {!judgeMode && (
+          <ActionButton onClick={openInDrawer} primary>
+            Open drawer
+          </ActionButton>
+        )}
       </div>
-      {steerOpen && (
+      {!judgeMode && steerOpen && (
         <div
           style={{
             marginTop: 8,

--- a/frontend/src/components/Interventions/JudgeInvocationDetail.css
+++ b/frontend/src/components/Interventions/JudgeInvocationDetail.css
@@ -1,0 +1,274 @@
+/* Judge invocation detail panel. Shares the visual language of
+   InterventionsList.css (uppercase tiny labels, severity swatches) so
+   it slots into the goldfive panel without its own theme. */
+
+.hg-judge-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--md-sys-color-on-surface, #e2e2e9);
+  font: 12px/1.4 var(--md-sys-typescale-body-small-font, system-ui, sans-serif);
+}
+
+.hg-judge-detail__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant, #43474e);
+}
+
+.hg-judge-detail__title {
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.2px;
+}
+
+.hg-judge-detail__meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  color: var(--md-sys-color-on-surface-variant, #9da3b4);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.hg-judge-detail__at,
+.hg-judge-detail__elapsed,
+.hg-judge-detail__model {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 140px;
+}
+
+.hg-judge-detail__badges {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.hg-judge-detail__verdict {
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: #0b0d12;
+}
+
+.hg-judge-detail__verdict[data-bucket='on_task'] {
+  background: #3bb273;
+}
+.hg-judge-detail__verdict[data-bucket='off_task'] {
+  background: #e06070;
+}
+.hg-judge-detail__verdict[data-bucket='no_verdict'] {
+  background: #8d9199;
+}
+
+.hg-judge-detail__severity {
+  padding: 0 6px;
+  border-radius: 8px;
+  font-size: 9px;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #0b0d12;
+  background: #f59e0b;
+}
+
+.hg-judge-detail__severity[data-severity='critical'] {
+  background: #e06070;
+}
+.hg-judge-detail__severity[data-severity='info'] {
+  background: #5b8def;
+  color: #e8f0ff;
+}
+
+.hg-judge-detail__section-label {
+  display: block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  opacity: 0.7;
+  margin-bottom: 2px;
+}
+
+.hg-judge-detail__context {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  align-items: baseline;
+}
+
+.hg-judge-detail__ctx-link,
+.hg-judge-detail__ctx-plain {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  cursor: pointer;
+}
+
+.hg-judge-detail__ctx-plain {
+  cursor: default;
+}
+
+.hg-judge-detail__ctx-link:hover {
+  text-decoration: underline;
+}
+
+.hg-judge-detail__ctx-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  opacity: 0.65;
+  letter-spacing: 0.3px;
+}
+
+.hg-judge-detail__collapsible {
+  border: 1px solid var(--md-sys-color-outline-variant, #43474e);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.hg-judge-detail__collapsible-header {
+  display: flex;
+  align-items: center;
+  padding: 4px 6px;
+}
+
+.hg-judge-detail__collapsible-toggle {
+  flex: 1;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  opacity: 0.8;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.hg-judge-detail__collapsible-toggle:hover {
+  opacity: 1;
+}
+
+.hg-judge-detail__copy {
+  background: transparent;
+  border: 1px solid var(--md-sys-color-outline-variant, #43474e);
+  color: inherit;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0.75;
+}
+
+.hg-judge-detail__copy:hover {
+  opacity: 1;
+}
+
+.hg-judge-detail__collapsible-body {
+  padding: 4px 8px 6px;
+}
+
+.hg-judge-detail__pre {
+  margin: 0;
+  max-height: 180px;
+  overflow: auto;
+  font: 11px/1.45 var(--hg-mono, ui-monospace, Menlo, monospace);
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--md-sys-color-on-surface, #e2e2e9);
+}
+
+.hg-judge-detail__verdict-section {
+  padding: 4px 0;
+}
+
+.hg-judge-detail__reason {
+  padding: 6px 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.hg-judge-detail__reason--off {
+  border-left: 3px solid #e06070;
+  background: rgba(224, 96, 112, 0.08);
+}
+
+.hg-judge-detail__reason--none {
+  font-style: italic;
+  opacity: 0.75;
+}
+
+.hg-judge-detail__empty {
+  padding: 4px 8px;
+  font-style: italic;
+  opacity: 0.65;
+  font-size: 11px;
+}
+
+.hg-judge-detail__steering {
+  padding: 6px 8px;
+  background: rgba(168, 200, 255, 0.06);
+  border: 1px solid rgba(168, 200, 255, 0.15);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.hg-judge-detail__steering-link {
+  background: transparent;
+  border: 0;
+  color: var(--md-sys-color-primary, #a8c8ff);
+  font: inherit;
+  font-weight: 600;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.hg-judge-detail__steering-link:disabled {
+  cursor: default;
+  color: var(--md-sys-color-on-surface, #e2e2e9);
+  font-weight: 600;
+}
+
+.hg-judge-detail__steering-link:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.hg-judge-detail__steering-summary {
+  font-size: 11px;
+  opacity: 0.85;
+  white-space: pre-wrap;
+}
+
+.hg-judge-detail__tasks {
+  list-style: disc;
+  margin: 4px 0 0;
+  padding-left: 18px;
+  font-size: 11px;
+  opacity: 0.85;
+}
+
+.hg-judge-detail__tasks li {
+  margin-bottom: 1px;
+}

--- a/frontend/src/components/Interventions/JudgeInvocationDetail.tsx
+++ b/frontend/src/components/Interventions/JudgeInvocationDetail.tsx
@@ -1,0 +1,380 @@
+// Click-through detail panel for goldfive judge spans (harmonograf#197).
+//
+// Rendered when the user clicks a synthesized judge span on the
+// __goldfive__ lane. Surfaces the six questions an operator asks about
+// an LLM-as-judge invocation:
+//
+//   1. when did it fire, which model, how long did it take
+//   2. which agent + task was being judged
+//   3. what reasoning did the judge see (reasoning_input, collapsible)
+//   4. what did it decide (on_task / off_task + severity + reason)
+//   5. raw LLM response, for debugging malformed verdicts (collapsible)
+//   6. did the verdict actually trigger steering (PlanRevised lookup)
+//
+// The component is deliberately layout-light — it reuses the existing
+// CSS language from InterventionsList (data-severity / swatches / tiny
+// uppercase labels) so it slots into the goldfive panel without its own
+// theme. The parent container (currently SpanPopover) supplies the box
+// chrome; this component contributes the inner sections.
+
+import { useState } from 'react';
+import type { JudgeDetail } from '../../lib/interventionDetail';
+import { bareAgentName } from '../../gantt/index';
+import './JudgeInvocationDetail.css';
+
+interface Props {
+  detail: JudgeDetail;
+  // Optional: agent-id → display-name resolver (SessionStore agents).
+  // When omitted the component falls back to `bareAgentName(id)`.
+  resolveAgentName?: (agentId: string) => string;
+  // Optional: scroll-to / highlight callbacks — the Gantt can pass
+  // handlers here so the header's context links (agent / task) pan the
+  // canvas. When omitted the links render as plain text.
+  onFocusAgent?: (agentId: string) => void;
+  onFocusTask?: (taskId: string) => void;
+  // Optional: click handler for the steered-plan link. Lets the parent
+  // route the click into the existing intervention-detail pane (the one
+  // that renders Trigger / Steering / Target for PlanRevised rows).
+  onOpenSteering?: (planId: string, revisionIndex: number) => void;
+}
+
+function fmtTime(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n: number): string => n.toString().padStart(2, '0');
+  if (h > 0) return `${h}:${pad(m)}:${pad(s)}`;
+  return `${m}:${pad(s)}`;
+}
+
+function copyToClipboard(text: string): void {
+  if (!text) return;
+  void navigator.clipboard?.writeText(text).catch(() => {});
+}
+
+export function JudgeInvocationDetail({
+  detail,
+  resolveAgentName,
+  onFocusAgent,
+  onFocusTask,
+  onOpenSteering,
+}: Props) {
+  const [inputOpen, setInputOpen] = useState(false);
+  const [rawOpen, setRawOpen] = useState(false);
+
+  const displayAgent = (id: string): string => {
+    if (!id) return '';
+    if (resolveAgentName) return resolveAgentName(id) || bareAgentName(id) || id;
+    return bareAgentName(id) || id;
+  };
+
+  const verdictLabel =
+    detail.verdictBucket === 'on_task'
+      ? 'On task'
+      : detail.verdictBucket === 'off_task'
+        ? 'Off task'
+        : 'No verdict';
+
+  return (
+    <div
+      className="hg-judge-detail"
+      data-testid="judge-invocation-detail"
+      data-verdict={detail.verdictBucket}
+    >
+      <header className="hg-judge-detail__header">
+        <div className="hg-judge-detail__title">Judge invocation</div>
+        <div className="hg-judge-detail__meta">
+          {detail.recordedAtMs >= 0 && (
+            <span className="hg-judge-detail__at" title="Session-relative time">
+              {fmtTime(detail.recordedAtMs)}
+            </span>
+          )}
+          {detail.elapsedMs > 0 && (
+            <span
+              className="hg-judge-detail__elapsed"
+              title="Wall-clock duration of the judge call"
+            >
+              {detail.elapsedMs}ms
+            </span>
+          )}
+          {detail.model && (
+            <span className="hg-judge-detail__model" title="Judge model">
+              {detail.model}
+            </span>
+          )}
+        </div>
+        <div className="hg-judge-detail__badges">
+          <span
+            className="hg-judge-detail__verdict"
+            data-testid="judge-detail-verdict"
+            data-bucket={detail.verdictBucket}
+          >
+            {verdictLabel}
+          </span>
+          {detail.verdictBucket === 'off_task' && detail.severity && (
+            <span
+              className="hg-judge-detail__severity"
+              data-testid="judge-detail-severity"
+              data-severity={detail.severity}
+            >
+              {detail.severity}
+            </span>
+          )}
+        </div>
+      </header>
+
+      {(detail.subjectAgentId || detail.taskId) && (
+        <section
+          className="hg-judge-detail__context"
+          data-testid="judge-detail-context"
+        >
+          <span className="hg-judge-detail__section-label">Context</span>
+          {detail.subjectAgentId && (
+            <ContextLink
+              label="agent"
+              value={displayAgent(detail.subjectAgentId)}
+              title={detail.subjectAgentId}
+              testId="judge-detail-agent"
+              onClick={
+                onFocusAgent
+                  ? () => onFocusAgent(detail.subjectAgentId)
+                  : undefined
+              }
+            />
+          )}
+          {detail.taskId && (
+            <ContextLink
+              label="task"
+              value={detail.taskId}
+              title={detail.taskId}
+              testId="judge-detail-task"
+              onClick={onFocusTask ? () => onFocusTask(detail.taskId) : undefined}
+              mono
+            />
+          )}
+        </section>
+      )}
+
+      {(detail.reasoningInput || detail.verdictBucket === 'no_verdict') && (
+        <Collapsible
+          label="Reasoning input"
+          open={inputOpen}
+          onToggle={() => setInputOpen((v) => !v)}
+          testId="judge-detail-reasoning"
+          onCopy={
+            detail.reasoningInput
+              ? () => copyToClipboard(detail.reasoningInput)
+              : undefined
+          }
+        >
+          {detail.reasoningInput ? (
+            <pre
+              className="hg-judge-detail__pre"
+              data-testid="judge-detail-reasoning-body"
+            >
+              {detail.reasoningInput}
+            </pre>
+          ) : (
+            <div className="hg-judge-detail__empty">No reasoning captured.</div>
+          )}
+        </Collapsible>
+      )}
+
+      <section
+        className="hg-judge-detail__verdict-section"
+        data-testid="judge-detail-response"
+      >
+        <span className="hg-judge-detail__section-label">Judge response</span>
+        {detail.verdictBucket === 'on_task' && (
+          <>
+            {detail.reason ? (
+              <div className="hg-judge-detail__reason">{detail.reason}</div>
+            ) : (
+              <div className="hg-judge-detail__empty">
+                No explanation provided.
+              </div>
+            )}
+          </>
+        )}
+        {detail.verdictBucket === 'off_task' && (
+          <div className="hg-judge-detail__reason hg-judge-detail__reason--off">
+            {detail.reason || '(no explanation from judge)'}
+          </div>
+        )}
+        {detail.verdictBucket === 'no_verdict' && (
+          <div
+            className="hg-judge-detail__reason hg-judge-detail__reason--none"
+            data-testid="judge-detail-no-verdict"
+          >
+            The judge returned no parseable verdict. Raw response below.
+          </div>
+        )}
+      </section>
+
+      {detail.rawResponse && (
+        <Collapsible
+          label="Raw LLM response"
+          open={rawOpen}
+          onToggle={() => setRawOpen((v) => !v)}
+          testId="judge-detail-raw"
+          onCopy={() => copyToClipboard(detail.rawResponse)}
+        >
+          <pre
+            className="hg-judge-detail__pre"
+            data-testid="judge-detail-raw-body"
+          >
+            {detail.rawResponse}
+          </pre>
+        </Collapsible>
+      )}
+
+      {detail.verdictBucket === 'off_task' && (
+        <section
+          className="hg-judge-detail__steering"
+          data-testid="judge-detail-steering"
+        >
+          <span className="hg-judge-detail__section-label">Steering outcome</span>
+          {detail.steeredPlan ? (
+            <>
+              <button
+                type="button"
+                className="hg-judge-detail__steering-link"
+                data-testid="judge-detail-steering-link"
+                onClick={
+                  onOpenSteering && detail.steeredPlan
+                    ? () =>
+                        onOpenSteering(
+                          detail.steeredPlan!.id,
+                          detail.steeredPlan!.revisionIndex ?? 0,
+                        )
+                    : undefined
+                }
+                disabled={!onOpenSteering}
+                title="Open the plan-revision detail"
+              >
+                Goldfive steering: refined plan → r
+                {detail.steeredPlan.revisionIndex ?? 0}
+              </button>
+              {detail.steeringSummary && (
+                <div className="hg-judge-detail__steering-summary">
+                  {detail.steeringSummary}
+                </div>
+              )}
+              {detail.taskSummaries.length > 0 && (
+                <ul
+                  className="hg-judge-detail__tasks"
+                  data-testid="judge-detail-steering-tasks"
+                >
+                  {detail.taskSummaries.map((t, i) => (
+                    <li key={`${i}:${t}`}>{t}</li>
+                  ))}
+                </ul>
+              )}
+            </>
+          ) : (
+            <div
+              className="hg-judge-detail__empty"
+              data-testid="judge-detail-no-steering"
+            >
+              No steering applied (ladder did not escalate or suppression
+              fired).
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+function ContextLink({
+  label,
+  value,
+  title,
+  testId,
+  onClick,
+  mono,
+}: {
+  label: string;
+  value: string;
+  title?: string;
+  testId?: string;
+  onClick?: () => void;
+  mono?: boolean;
+}) {
+  const body = mono ? <code>{value}</code> : value;
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        className="hg-judge-detail__ctx-link"
+        data-testid={testId}
+        onClick={onClick}
+        title={title}
+      >
+        <span className="hg-judge-detail__ctx-label">{label}</span>
+        {body}
+      </button>
+    );
+  }
+  return (
+    <span
+      className="hg-judge-detail__ctx-plain"
+      data-testid={testId}
+      title={title}
+    >
+      <span className="hg-judge-detail__ctx-label">{label}</span>
+      {body}
+    </span>
+  );
+}
+
+function Collapsible({
+  label,
+  open,
+  onToggle,
+  onCopy,
+  testId,
+  children,
+}: {
+  label: string;
+  open: boolean;
+  onToggle: () => void;
+  onCopy?: () => void;
+  testId?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      className="hg-judge-detail__collapsible"
+      data-testid={testId}
+      data-open={open ? 'true' : 'false'}
+    >
+      <div className="hg-judge-detail__collapsible-header">
+        <button
+          type="button"
+          className="hg-judge-detail__collapsible-toggle"
+          data-testid={testId ? `${testId}-toggle` : undefined}
+          aria-expanded={open}
+          onClick={onToggle}
+        >
+          <span aria-hidden="true">{open ? '▾' : '▸'}</span>
+          {label}
+        </button>
+        {onCopy && (
+          <button
+            type="button"
+            className="hg-judge-detail__copy"
+            data-testid={testId ? `${testId}-copy` : undefined}
+            onClick={onCopy}
+            title="Copy to clipboard"
+          >
+            copy
+          </button>
+        )}
+      </div>
+      {open && <div className="hg-judge-detail__collapsible-body">{children}</div>}
+    </section>
+  );
+}

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -1444,6 +1444,21 @@ function InterventionDetailSections({
           {detail.targetTaskId && (
             <code style={{ opacity: 0.7, fontSize: 10 }}>{detail.targetTaskId}</code>
           )}
+          {detail.authoredBy && (
+            <span
+              data-testid="detail-drift-authored-by"
+              data-authored-by={detail.authoredBy}
+              title="Who initiated this intervention"
+              style={{
+                fontSize: 10,
+                opacity: 0.65,
+                marginLeft: 'auto',
+                textTransform: 'none',
+              }}
+            >
+              Authored by: {detail.authoredBy}
+            </span>
+          )}
         </div>
       )}
     </section>

--- a/frontend/src/gantt/index.ts
+++ b/frontend/src/gantt/index.ts
@@ -631,6 +631,11 @@ export interface DriftRecord {
   // PlanRevised row triggered by this autonomous drift onto the drift
   // row (the PlanRevised.trigger_event_id will match).
   driftId: string;
+  // Forward-compat (goldfive/tmp/goldfive-steer-unify): drift authorship.
+  // "user" (user_steer / user_cancel / user_pause), "goldfive" (anything
+  // the orchestrator minted itself), or "" when the producing goldfive
+  // build predates the field. Surfaced in the intervention detail pane.
+  authoredBy?: string;
 }
 
 // Drift registry — in-memory list of DriftDetected events received during

--- a/frontend/src/lib/interventionDetail.ts
+++ b/frontend/src/lib/interventionDetail.ts
@@ -45,6 +45,10 @@ export interface InterventionDetail {
   // Target task id, when known. Surfaced alongside the agent in the
   // detail pane so the "Target" section can link to the task lane too.
   targetTaskId: string;
+  // Forward-compat: DriftDetected.authored_by ("user" / "goldfive" / "").
+  // Empty string on legacy events or non-drift selections — the view
+  // hides the label in that case.
+  authoredBy?: string;
 }
 
 // Pull a string attribute off a Span, handling absent / wrong-kind gracefully.
@@ -142,11 +146,18 @@ export function resolveDriftDetail(
   const refineTarget = readStringAttr(refineSpan, 'refine.target_agent_id');
   const targetAgentId = refineTarget || drift.agentId || '';
   const targetTaskId = drift.taskId || '';
+  // authored_by is forward-compat (goldfive /tmp/goldfive-steer-unify).
+  // Prefer the drift record field (populated from the wire) and fall
+  // back to the synthesized drift span's attribute (stamped by the
+  // ingest layer) so either carrying path surfaces the label.
+  const authoredBy =
+    drift.authoredBy || readStringAttr(driftSpan, 'drift.authored_by') || '';
   return {
     trigger: triggerParts.join('\n\n'),
     steering: steeringText,
     targetAgentId,
     targetTaskId,
+    authoredBy,
   };
 }
 
@@ -173,6 +184,151 @@ export function resolvePlanRevisionDetail(
     targetAgentId: readStringAttr(refineSpan, 'refine.target_agent_id'),
     targetTaskId: '',
   };
+}
+
+// Verdict bucket used by the judge detail panel to pick the badge + colour.
+// Kept stable across pre-merge / post-merge wire shapes: callers inspect
+// `onTask` / `verdict` / `rawResponse` in that order to decide the bucket.
+export type JudgeVerdictBucket = 'on_task' | 'off_task' | 'no_verdict';
+
+export interface JudgeDetail {
+  // Span that triggered the detail lookup. Held so the view can key off
+  // its id (copy-to-clipboard, deep-link) without a second query.
+  spanId: string;
+  eventId: string;
+  recordedAtMs: number;
+  model: string;
+  elapsedMs: number;
+  subjectAgentId: string;
+  taskId: string;
+  verdictBucket: JudgeVerdictBucket;
+  // Parsed verdict fields.
+  onTask: boolean;
+  severity: string; // empty when on_task or no_verdict
+  reason: string;   // judge's short explanation
+  reasoningInput: string; // what the judge saw (chain-of-thought)
+  rawResponse: string;    // raw LLM output before JSON parse
+  // Steering outcome: the plan-revision this judge invocation triggered,
+  // if any. Resolved via PlanRevised.trigger_event_id == this event id.
+  steeredPlan: TaskPlan | null;
+  steeringSummary: string; // human-readable summary of the plan rev
+  taskSummaries: string[]; // short bullet points for new / changed tasks
+}
+
+function classifyVerdict(
+  onTask: boolean,
+  verdict: string,
+  rawResponse: string,
+): JudgeVerdictBucket {
+  if (onTask || verdict === 'on_task') return 'on_task';
+  // "no verdict" covers malformed / error / null cases where the judge
+  // didn't produce an on_task boolean but emitted raw response text.
+  // We detect this by the absence of a verdict string + the presence of
+  // raw output (otherwise we'd hide empty panels).
+  if (!verdict && rawResponse) return 'no_verdict';
+  if (!verdict && !rawResponse) return 'no_verdict';
+  return 'off_task';
+}
+
+// Resolve detail for a judge-span click. The caller finds the clicked
+// span by id; this helper reads its attributes + scans the plan list
+// for a PlanRevised whose trigger_event_id matches the judge event id.
+export function resolveJudgeDetail(
+  span: Span,
+  plans: readonly TaskPlan[],
+): JudgeDetail {
+  const eventId = readStringAttr(span, 'judge.event_id');
+  const verdict = readStringAttr(span, 'judge.verdict');
+  const onTaskAttr = span.attributes['judge.on_task'];
+  const onTask =
+    onTaskAttr?.kind === 'bool'
+      ? onTaskAttr.value
+      : verdict === 'on_task';
+  const severity = readStringAttr(span, 'judge.severity');
+  const reason = readStringAttr(span, 'judge.reason')
+    || readStringAttr(span, 'judge.reasoning');
+  const reasoningInput = readStringAttr(span, 'judge.reasoning_input')
+    || readStringAttr(span, 'judge.reasoning');
+  const rawResponse = readStringAttr(span, 'judge.raw_response');
+  const model = readStringAttr(span, 'judge.model');
+  const elapsedStr = readStringAttr(span, 'judge.elapsed_ms');
+  const elapsedMs = elapsedStr ? Number(elapsedStr) || 0 : 0;
+  const subjectAgentId = readStringAttr(span, 'judge.subject_agent_id')
+    || readStringAttr(span, 'judge.target_agent_id');
+  const taskId = readStringAttr(span, 'judge.target_task_id');
+  const verdictBucket = classifyVerdict(onTask, verdict, rawResponse);
+
+  let steeredPlan: TaskPlan | null = null;
+  if (eventId && verdictBucket === 'off_task') {
+    for (const p of plans) {
+      if ((p.revisionIndex ?? 0) <= 0) continue;
+      if (p.triggerEventId === eventId) {
+        // Prefer the latest revision when multiple match (chained refines).
+        if (!steeredPlan || p.createdAtMs > steeredPlan.createdAtMs) {
+          steeredPlan = p;
+        }
+      }
+    }
+  }
+
+  let steeringSummary = '';
+  const taskSummaries: string[] = [];
+  if (steeredPlan) {
+    steeringSummary = steeredPlan.revisionReason
+      || `Plan revised to r${steeredPlan.revisionIndex}`;
+    // Stash new-task titles for the view to list. Keep the list short:
+    // the detail panel is a peek surface, not the full plan diff.
+    const maxTasks = 6;
+    for (const t of steeredPlan.tasks.slice(0, maxTasks)) {
+      const label = t.title || t.id || '';
+      if (!label) continue;
+      const flag =
+        t.status === 'CANCELLED'
+          ? 'cancelled: '
+          : t.status === 'FAILED'
+            ? 'failed: '
+            : '';
+      taskSummaries.push(`${flag}${label}`);
+    }
+    if (steeredPlan.tasks.length > maxTasks) {
+      taskSummaries.push(`… +${steeredPlan.tasks.length - maxTasks} more`);
+    }
+  }
+
+  return {
+    spanId: span.id,
+    eventId,
+    recordedAtMs: span.startMs,
+    model,
+    elapsedMs,
+    subjectAgentId,
+    taskId,
+    verdictBucket,
+    onTask,
+    severity,
+    reason,
+    reasoningInput,
+    rawResponse,
+    steeredPlan,
+    steeringSummary,
+    taskSummaries,
+  };
+}
+
+// Returns true when the given span was synthesized by the judge-event
+// ingest path. Click handlers route to the judge detail card when this
+// is true. The discriminator is an explicit attribute stamped by the
+// synthesizer (see goldfiveEvent.synthesizeJudgeSpan) — do NOT match on
+// the span name, since display-name renames would silently break
+// routing.
+export function isJudgeSpan(span: Span | null | undefined): boolean {
+  if (!span) return false;
+  const attr = span.attributes['judge.kind'];
+  if (attr && attr.kind === 'string' && attr.value === 'judge') return true;
+  // Back-compat for spans produced before the `judge.kind` attribute
+  // existed: the old synthesizer named spans `judge: ...`. Keep matching
+  // so older sessions replayed from the server don't lose the routing.
+  return span.agentId === '__goldfive__' && span.name.startsWith('judge:');
 }
 
 // Resolve detail for a task cancellation (terminal status + cancelReason).

--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -69,6 +69,8 @@ function synthesizeDriftSpan(
   targetAgentId: string,
   recordedAtMs: number,
   triggerInput?: string,
+  authoredBy?: string,
+  driftEventId?: string,
 ): void {
   const spanKind: SpanKind = actorId === USER_ACTOR_ID ? 'USER_MESSAGE' : 'CUSTOM';
   const id = `drift-${actorId}-${recordedAtMs}-${kind}`;
@@ -88,6 +90,18 @@ function synthesizeDriftSpan(
   // (not empty-string) when the field is missing on the pre-merge wire.
   if (triggerInput) {
     attributes['drift.trigger_input'] = { kind: 'string', value: triggerInput };
+  }
+  // harmonograf forward-compat: goldfive's /tmp/goldfive-steer-unify branch
+  // adds DriftDetected.authored_by ("user" / "goldfive" / ""). Pre-merge
+  // the field is absent; surface it on the span so the intervention detail
+  // pane can label rows as "Authored by: goldfive" vs "Authored by: user"
+  // once the submodule bumps. Absent / empty-string ⇒ no attribute so the
+  // UI hides the label.
+  if (authoredBy) {
+    attributes['drift.authored_by'] = { kind: 'string', value: authoredBy };
+  }
+  if (driftEventId) {
+    attributes['drift.event_id'] = { kind: 'string', value: driftEventId };
   }
   const span: Span = {
     id,
@@ -215,23 +229,58 @@ function synthesizeUserGoalSpan(
   store.spans.append(span);
 }
 
+// Parameters for the judge-span synthesizer. Grouped into an options
+// object so new forward-compat fields added on the wire (reason,
+// reasoning_input, raw_response, elapsed_ms, model, subject_agent_id)
+// don't balloon the positional arg list. All fields are optional —
+// callers supply what the event carried; missing fields render as empty
+// attributes so the detail panel can hide sections cleanly.
+interface JudgeSpanInput {
+  sessionId: string | null;
+  eventId: string;
+  recordedAtMs: number;
+  // Parsed-verdict fields (post-merge ReasoningJudgeInvoked).
+  onTask: boolean;
+  verdict: string; // 'on_task' | 'drift' | '' when malformed
+  severity: string;
+  reason: string;
+  // Raw judge payload + metadata.
+  reasoningInput: string;
+  rawResponse: string;
+  elapsedMs: number;
+  model: string;
+  subjectAgentId: string;
+  currentTaskId: string;
+}
+
 // Forward-compat: synthesize a "judge" span on the goldfive actor row
 // when a goldfive.v1.ReasoningJudgeInvoked event arrives. The stub may
 // not exist on the pre-merge submodule — callers guard the call path
 // with a string-case check on the oneof so a missing case does not crash
 // ingest. Once the submodule bumps the generated ``Event.payload.case``
 // union includes 'reasoningJudgeInvoked' and TS narrows automatically.
-function synthesizeJudgeSpan(
-  store: SessionStore,
-  sessionId: string | null,
-  verdict: string,
-  severity: string,
-  reasoning: string,
-  currentAgentId: string,
-  currentTaskId: string,
-  recordedAtMs: number,
-): void {
-  const id = `judge-${recordedAtMs}-${verdict || 'on_task'}`;
+//
+// The span carries ``judge.kind = "judge"`` as an explicit discriminator
+// so click handlers can route to JudgeInvocationDetail without having
+// to match on the span name. All the event's structured fields land as
+// string attributes on the span — the detail panel reads them back.
+function synthesizeJudgeSpan(store: SessionStore, input: JudgeSpanInput): void {
+  const {
+    sessionId,
+    eventId,
+    recordedAtMs,
+    onTask,
+    verdict,
+    severity,
+    reason,
+    reasoningInput,
+    rawResponse,
+    elapsedMs,
+    model,
+    subjectAgentId,
+    currentTaskId,
+  } = input;
+  const id = `judge-${recordedAtMs}-${verdict || (onTask ? 'on_task' : 'unspec')}`;
   const name =
     verdict && verdict !== 'on_task'
       ? `judge: ${verdict}${severity ? ` (${severity})` : ''}`
@@ -248,11 +297,26 @@ function synthesizeJudgeSpan(
     endMs: recordedAtMs,
     links: [],
     attributes: {
+      // Discriminator — read by click handlers to route to the judge
+      // detail card. Backed by an explicit attribute (not the span name)
+      // so renames to the display name don't accidentally break routing.
+      'judge.kind': { kind: 'string', value: 'judge' },
+      'judge.event_id': { kind: 'string', value: eventId },
       'judge.verdict': { kind: 'string', value: verdict },
+      'judge.on_task': { kind: 'bool', value: onTask },
       'judge.severity': { kind: 'string', value: severity },
-      'judge.reasoning': { kind: 'string', value: reasoning },
-      'judge.target_agent_id': { kind: 'string', value: currentAgentId },
+      'judge.reason': { kind: 'string', value: reason },
+      'judge.reasoning_input': { kind: 'string', value: reasoningInput },
+      'judge.raw_response': { kind: 'string', value: rawResponse },
+      'judge.elapsed_ms': { kind: 'string', value: String(elapsedMs) },
+      'judge.model': { kind: 'string', value: model },
+      'judge.subject_agent_id': { kind: 'string', value: subjectAgentId },
+      'judge.target_agent_id': { kind: 'string', value: subjectAgentId },
       'judge.target_task_id': { kind: 'string', value: currentTaskId },
+      // Back-compat alias: pre-rework tests and the existing detail
+      // resolvers still read ``judge.reasoning`` (judge's one-sentence
+      // reason / explanation). Keep both until nothing reads it.
+      'judge.reasoning': { kind: 'string', value: reason || reasoningInput },
       'harmonograf.synthetic_span': { kind: 'bool', value: true },
     },
     payloadRefs: [],
@@ -501,6 +565,11 @@ export function applyGoldfiveEvent(
       const emittedMs = emittedAbsMs ? emittedAbsMs - sessionStartMs : 0;
       const kindStr = driftKindToString(d.kind as unknown as number);
       const sevStr = driftSeverityToString(d.severity as unknown as number);
+      // Forward-compat read for DriftDetected.authored_by
+      // (goldfive /tmp/goldfive-steer-unify). Empty on pre-merge events.
+      const duEarly = d as unknown as Record<string, unknown>;
+      const authoredByForRecord =
+        typeof duEarly.authoredBy === 'string' ? (duEarly.authoredBy as string) : '';
       store.drifts.append({
         kind: kindStr,
         severity: sevStr,
@@ -518,6 +587,7 @@ export function applyGoldfiveEvent(
         // subsequent PlanRevised (whose trigger_event_id == this id)
         // onto the drift row.
         driftId: d.id || '',
+        authoredBy: authoredByForRecord,
       });
       // Attribute the drift to an actor row so it shows up in gantt / graph /
       // trajectory without those views having to special-case drift events.
@@ -533,6 +603,8 @@ export function applyGoldfiveEvent(
       const du = d as unknown as Record<string, unknown>;
       const triggerInput =
         typeof du.triggerInput === 'string' ? (du.triggerInput as string) : '';
+      const authoredBy =
+        typeof du.authoredBy === 'string' ? (du.authoredBy as string) : '';
       synthesizeDriftSpan(
         store,
         sessionId,
@@ -544,6 +616,8 @@ export function applyGoldfiveEvent(
         d.currentAgentId,
         emittedMs,
         triggerInput,
+        authoredBy,
+        event.eventId || '',
       );
       return;
     }
@@ -595,7 +669,13 @@ export function applyGoldfiveEvent(
       const emittedAbsMs = tsToMsAbs(event.emittedAt);
       const emittedMs = emittedAbsMs ? emittedAbsMs - sessionStartMs : 0;
       const ju = payload.value as unknown as Record<string, unknown>;
-      const verdict = typeof ju.verdict === 'string' ? (ju.verdict as string) : '';
+      // `verdict` is a harmonograf-local string synthesized from
+      // `on_task`/`severity` since the wire message doesn't expose a
+      // single-string verdict field. Pre-merge test fixtures that set
+      // ``verdict`` directly still flow through (the explicit string
+      // wins over the on_task derivation).
+      const onTaskRaw = ju.onTask;
+      const onTask = typeof onTaskRaw === 'boolean' ? onTaskRaw : false;
       const severityRaw = ju.severity;
       const severity =
         typeof severityRaw === 'string'
@@ -603,22 +683,57 @@ export function applyGoldfiveEvent(
           : typeof severityRaw === 'number'
             ? driftSeverityToString(severityRaw)
             : '';
+      let verdict = typeof ju.verdict === 'string' ? (ju.verdict as string) : '';
+      if (!verdict) {
+        verdict = onTask ? 'on_task' : severity ? severity : '';
+      }
+      // Pre-merge tests pass `reasoning` as the single reasoning string;
+      // post-merge the wire separates `reasoning_input` (what the judge
+      // saw) from `reason` (the judge's explanation). Accept both and
+      // prefer the richer pair when both are set.
       const reasoning =
         typeof ju.reasoning === 'string' ? (ju.reasoning as string) : '';
-      const currentAgentId =
-        typeof ju.currentAgentId === 'string' ? (ju.currentAgentId as string) : '';
+      const reason = typeof ju.reason === 'string' ? (ju.reason as string) : reasoning;
+      const reasoningInput =
+        typeof ju.reasoningInput === 'string'
+          ? (ju.reasoningInput as string)
+          : reasoning;
+      const rawResponse =
+        typeof ju.rawResponse === 'string' ? (ju.rawResponse as string) : '';
+      const elapsedRaw = ju.elapsedMs;
+      let elapsedMs = 0;
+      if (typeof elapsedRaw === 'number') elapsedMs = elapsedRaw;
+      else if (typeof elapsedRaw === 'bigint') elapsedMs = Number(elapsedRaw);
+      const model = typeof ju.model === 'string' ? (ju.model as string) : '';
+      // Post-merge field is `subject_agent_id`; pre-merge test fixtures
+      // used `currentAgentId`. Read both so neither wire shape breaks.
+      const subjectAgentId =
+        typeof ju.subjectAgentId === 'string'
+          ? (ju.subjectAgentId as string)
+          : typeof ju.currentAgentId === 'string'
+            ? (ju.currentAgentId as string)
+            : '';
       const currentTaskId =
-        typeof ju.currentTaskId === 'string' ? (ju.currentTaskId as string) : '';
-      synthesizeJudgeSpan(
-        store,
+        typeof ju.taskId === 'string'
+          ? (ju.taskId as string)
+          : typeof ju.currentTaskId === 'string'
+            ? (ju.currentTaskId as string)
+            : '';
+      synthesizeJudgeSpan(store, {
         sessionId,
+        eventId: event.eventId || '',
+        recordedAtMs: emittedMs,
+        onTask,
         verdict,
         severity,
-        reasoning,
-        currentAgentId,
+        reason,
+        reasoningInput,
+        rawResponse,
+        elapsedMs,
+        model,
+        subjectAgentId,
         currentTaskId,
-        emittedMs,
-      );
+      });
       return;
     }
     case 'delegationObserved': {


### PR DESCRIPTION
Closes #146.

## Summary

Adds a judge-specific detail card rendered inside the span popover when the user clicks a synthesized `ReasoningJudgeInvoked` span on the `__goldfive__` lane. The generic `SpanPopover` (kind / status / duration) is uninformative for a zero-duration synthesized judge span; the new card surfaces what the judge actually saw, what it decided, and whether a `PlanRevised` was triggered as a result.

### Sections (as specified in #146)

1. **Header** — session-relative time + elapsed ms + model name, verdict badge (On task / Off task / No verdict), severity pill for off-task.
2. **Context** — subject agent id + task id. Clickable when the host passes `onFocusAgent` / `onFocusTask` handlers; the SpanPopover wiring routes these to `uiStore.setFocusedAgent` + `uiStore.selectTask`.
3. **Reasoning input** — collapsible (default collapsed), monospace, copy-to-clipboard button. Backed by `ReasoningJudgeInvoked.reasoning_input` (up to 4 KB, truncated server-side).
4. **Judge response** — structured by verdict bucket:
   - `on_task=true` → green "On task" badge + optional reason.
   - `on_task=false` → red "Off task" badge + severity pill + reason in a left-bordered block.
   - Malformed / null → grey "No verdict" badge + raw-response fallback below.
5. **Raw LLM response** — collapsible (default collapsed), copy-to-clipboard. Always rendered when `raw_response` is non-empty so operators can diagnose malformed verdicts.
6. **Steering outcome** (off-task only) — scans the plan revision list for a `PlanRevised` whose `revision_trigger_event_id` matches this judge event id. If found: summary + new/cancelled task titles + a button that closes the judge popover (the goldfive lane's own "refine:" span carries the plan-revision detail via the existing #142 intervention-detail panel). If not found: "No steering applied" hint.

## Discriminator — how judge spans are detected at click time

`goldfiveEvent.synthesizeJudgeSpan` now stamps `judge.kind = "judge"` as an **explicit attribute** on the synthesized span alongside all the event's fields (`judge.event_id`, `judge.reasoning_input`, `judge.raw_response`, `judge.model`, `judge.elapsed_ms`, `judge.on_task`, `judge.severity`, `judge.reason`, `judge.subject_agent_id`, `judge.target_task_id`).

`lib/interventionDetail.isJudgeSpan` reads that attribute. Back-compat: for spans replayed from older sessions (pre-this-PR) where the attribute is absent, `isJudgeSpan` falls back to matching `agentId === __goldfive__` + `name.startsWith("judge:")`, so no replayed session loses routing.

## Integration point

In `components/Interaction/SpanPopover.tsx`: the popover card checks `isJudgeSpan(span)` and, if true, resolves `resolveJudgeDetail(span, plans)` and renders `<JudgeInvocationDetail>` inside the card body. For judge spans the popover also hides the Steer / Annotate / Open-drawer actions (none apply to a synthesized zero-duration event) and widens the card by 80 px to fit the richer content.

## Forward-compat: DriftDetected.authored_by

goldfive's parallel `/tmp/goldfive-steer-unify` branch adds `DriftDetected.authored_by` (values `"user"` / `"goldfive"` / `""`) and a `_LADDER` action that elevates goldfive-detected WARNING+ drifts.

This PR pre-lands the UI half:

- `goldfiveEvent.applyGoldfiveEvent` reads `authored_by` through the pre-merge `unknown` cast and forwards it onto `DriftRecord.authoredBy` + the synthesized drift span's `drift.authored_by` attribute + `InterventionDetail.authoredBy`.
- `TrajectoryView.InterventionDetailSections` renders "Authored by: goldfive" / "Authored by: user" next to Target when the field is present.
- Absent field ⇒ no label (legacy events stay identical). See `interventionDetailAuthoredBy.test.ts` for the three-case matrix.

## Test plan

- [x] `pnpm -C frontend test --run` — 342 → 364 (+22 tests, 3 new files).
- [x] `pnpm -C frontend tsc -b` — clean.
- [x] `pnpm -C frontend lint` — clean (one pre-existing warning in `GanttView.tsx` unrelated to this PR).
- [x] Rendering test for `JudgeInvocationDetail` in all five buckets: on-task, off-task INFO / WARNING / CRITICAL, malformed / no_verdict.
- [x] Integration: synthesized judge span → resolver → expected shape (header meta + context + reasoning input + verdict + steering outcome).
- [x] Forward-compat: events with `authored_by` surface the label; events without don't; both "user" and "goldfive" values work.
- [x] Steering-outcome: judge event + matching PlanRevised (trigger_event_id) → `steeredPlan` populated; orphan judge event → `steeredPlan === null`.

## Substance budget

Target was ~400 substance + ~250 tests. Shipped is higher (≈680 substance + 716 CSS+tests). The overshoot is mostly in `JudgeInvocationDetail.tsx` (380 lines, with small Collapsible / ContextLink / Copy sub-components) and the CSS file (274 lines matching the existing InterventionsList.css language). Happy to split the sub-components into a shared `components/Interventions/` helpers module if reviewers prefer — flagging rather than trimming features.