### PR TITLE
fix(ui): judge spans get real width from elapsed_ms, not zero-duration

### DIFF
--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -285,6 +285,16 @@ function synthesizeJudgeSpan(store: SessionStore, input: JudgeSpanInput): void {
     verdict && verdict !== 'on_task'
       ? `judge: ${verdict}${severity ? ` (${severity})` : ''}`
       : 'judge: on_task';
+  // ``recordedAtMs`` is when goldfive stamped the event — right after
+  // the judge's LLM call completed. The judge's actual wall-clock
+  // duration is ``elapsedMs``; the span covers
+  // ``[recordedAtMs - elapsedMs, recordedAtMs]`` so it has visible
+  // width on the Gantt. Zero-width spans are invisible at normal
+  // zoom levels; the whole point of surfacing goldfive's judge
+  // as a lane is to make its actual cost visible on the timeline.
+  // Clamp at 0 to defend against negative/zero elapsed values.
+  const safeElapsed = Number.isFinite(elapsedMs) && elapsedMs > 0 ? elapsedMs : 0;
+  const startMs = Math.max(0, recordedAtMs - safeElapsed);
   const span: Span = {
     id,
     sessionId: sessionId ?? '',
@@ -293,7 +303,7 @@ function synthesizeJudgeSpan(store: SessionStore, input: JudgeSpanInput): void {
     kind: 'CUSTOM',
     status: 'COMPLETED',
     name,
-    startMs: recordedAtMs,
+    startMs,
     endMs: recordedAtMs,
     links: [],
     attributes: {


### PR DESCRIPTION
## Summary

One-line fix. The \`synthesizeJudgeSpan\` helper in \`frontend/src/rpc/goldfiveEvent.ts\` was setting \`startMs === endMs === recordedAtMs\` — zero-width spans are invisible at normal Gantt zoom. So even though goldfive emits \`reasoning_judge_invoked\` events with real \`elapsed_ms\` (observed: 13s, 63s, 63s, 86s in a live session), none of that shows on the Gantt.

Fix: use \`[recordedAtMs - elapsedMs, recordedAtMs]\` as the span range. Clamped at 0 to defend against malformed events.

Judge calls now appear as visible bands on the goldfive lane, matching their actual wall-clock duration.

## Test plan

- [x] \`pnpm test --run\` — 364 passed.
- [x] \`pnpm tsc -b\` clean.