### PR TITLE
refactor(frontend): retire client-side goldfive judge-span synthesizer (#152)

### DIFF
--- a/frontend/src/__tests__/lib/judgeDetail.test.ts
+++ b/frontend/src/__tests__/lib/judgeDetail.test.ts
@@ -1,11 +1,11 @@
 // harmonograf#197 — judge-detail resolver + judge-span discriminator.
 //
-// Integration-flavoured: feeds a ReasoningJudgeInvoked event through
-// applyGoldfiveEvent, then queries the synthesized span and runs it
-// through resolveJudgeDetail. Verifies the six sections (header meta,
-// context, reasoning input, verdict, raw response, steering outcome)
-// land correctly, plus the steered-plan lookup when a PlanRevised's
-// trigger_event_id matches the judge event id.
+// Option X update (harmonograf#N): ReasoningJudgeInvoked is now
+// translated to SpanStart/SpanEnd at the harmonograf client sink (see
+// harmonograf_client/sink.py). The frontend sees judge invocations as
+// ordinary spans on the goldfive lane carrying the documented
+// `judge.*` attributes — this test seeds such spans directly and
+// exercises the resolver against them.
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { create } from '@bufbuild/protobuf';
@@ -26,7 +26,7 @@ import {
 } from '../../pb/goldfive/v1/types_pb';
 import { isJudgeSpan, resolveJudgeDetail } from '../../lib/interventionDetail';
 import { GOLDFIVE_ACTOR_ID } from '../../theme/agentColors';
-import type { Span, TaskPlan } from '../../gantt/types';
+import type { AttributeValue, Span, TaskPlan } from '../../gantt/types';
 
 function ts(seconds: number) {
   return create(TimestampSchema, { seconds: BigInt(seconds), nanos: 0 });
@@ -58,26 +58,88 @@ function pbPlan(id: string, taskIds: string[], revisionIndex = 0) {
   });
 }
 
-// ReasoningJudgeInvoked doesn't have a bufbuild schema import in this test
-// file (the test lives alongside interventionDetail.test.ts which hand-
-// builds the judge payload via the oneof's string-case escape hatch).
-// We do the same here so the test is tolerant of pre-merge stubs.
-function judgeEvent(
-  eventId: string,
-  atSeconds: number,
-  fields: Record<string, unknown>,
-) {
-  const event = create(EventSchema, {
-    eventId,
-    runId: 'run-1',
-    sequence: 0n,
-    emittedAt: ts(atSeconds),
-  });
-  (event as unknown as Record<string, unknown>).payload = {
-    case: 'reasoningJudgeInvoked',
-    value: fields,
+// Seed a judge span directly onto the goldfive lane — mirroring what the
+// harmonograf client sink emits after translating a ReasoningJudgeInvoked
+// event under Option X. Only the `judge.*` attributes that the resolver
+// reads are populated; callers override via `attrs`.
+interface JudgeSpanSeed {
+  eventId: string;
+  atMs: number;
+  onTask?: boolean;
+  verdict?: string;
+  severity?: string;
+  reason?: string;
+  reasoningInput?: string;
+  rawResponse?: string;
+  model?: string;
+  elapsedMs?: number;
+  subjectAgentId?: string;
+  taskId?: string;
+}
+
+function seedJudgeSpan(store: SessionStore, seed: JudgeSpanSeed): Span {
+  const attrs: Record<string, AttributeValue> = {
+    'judge.kind': { kind: 'string', value: 'judge' },
+    'judge.event_id': { kind: 'string', value: seed.eventId },
   };
-  return event;
+  if (seed.onTask !== undefined) {
+    attrs['judge.on_task'] = { kind: 'bool', value: seed.onTask };
+  }
+  if (seed.verdict !== undefined) {
+    attrs['judge.verdict'] = { kind: 'string', value: seed.verdict };
+  }
+  if (seed.severity !== undefined) {
+    attrs['judge.severity'] = { kind: 'string', value: seed.severity };
+  }
+  if (seed.reason !== undefined) {
+    attrs['judge.reason'] = { kind: 'string', value: seed.reason };
+  }
+  if (seed.reasoningInput !== undefined) {
+    attrs['judge.reasoning_input'] = {
+      kind: 'string',
+      value: seed.reasoningInput,
+    };
+  }
+  if (seed.rawResponse !== undefined) {
+    attrs['judge.raw_response'] = { kind: 'string', value: seed.rawResponse };
+  }
+  if (seed.model !== undefined) {
+    attrs['judge.model'] = { kind: 'string', value: seed.model };
+  }
+  if (seed.elapsedMs !== undefined) {
+    attrs['judge.elapsed_ms'] = {
+      kind: 'string',
+      value: String(seed.elapsedMs),
+    };
+  }
+  if (seed.subjectAgentId !== undefined) {
+    attrs['judge.subject_agent_id'] = {
+      kind: 'string',
+      value: seed.subjectAgentId,
+    };
+  }
+  if (seed.taskId !== undefined) {
+    attrs['judge.target_task_id'] = { kind: 'string', value: seed.taskId };
+  }
+  const span: Span = {
+    id: `judge-${seed.eventId}`,
+    sessionId: 'sess-1',
+    agentId: GOLDFIVE_ACTOR_ID,
+    parentSpanId: null,
+    kind: 'CUSTOM',
+    status: 'COMPLETED',
+    name: `judge: ${seed.verdict || (seed.onTask ? 'on_task' : 'unspec')}`,
+    startMs: seed.atMs,
+    endMs: seed.atMs,
+    links: [],
+    attributes: attrs,
+    payloadRefs: [],
+    error: null,
+    lane: -1,
+    replaced: false,
+  };
+  store.spans.append(span);
+  return span;
 }
 
 function listJudgeSpans(store: SessionStore): Span[] {
@@ -99,27 +161,25 @@ function collectAllPlans(store: SessionStore): TaskPlan[] {
   return out;
 }
 
-describe('judge-span routing (harmonograf#197)', () => {
+describe('judge-span routing (harmonograf#197, Option X)', () => {
   let store: SessionStore;
   beforeEach(() => {
     store = new SessionStore();
   });
 
-  it('synthesized judge span carries kind=judge as a discriminator', () => {
-    applyGoldfiveEvent(
-      judgeEvent('ev-judge', 30, {
-        onTask: true,
-        reason: 'looks good',
-        reasoningInput: 'the agent said: I will search',
-        rawResponse: '{"on_task": true, "reason": "looks good"}',
-        model: 'haiku',
-        elapsedMs: 200,
-        subjectAgentId: 'agent-a',
-        taskId: 't1',
-      }),
-      store,
-      0,
-    );
+  it('judge span (as emitted by the sink translator) is discoverable via isJudgeSpan', () => {
+    seedJudgeSpan(store, {
+      eventId: 'ev-judge',
+      atMs: 30,
+      onTask: true,
+      reason: 'looks good',
+      reasoningInput: 'the agent said: I will search',
+      rawResponse: '{"on_task": true, "reason": "looks good"}',
+      model: 'haiku',
+      elapsedMs: 200,
+      subjectAgentId: 'agent-a',
+      taskId: 't1',
+    });
     const judges = listJudgeSpans(store);
     expect(judges).toHaveLength(1);
     expect(judges[0].attributes['judge.kind']).toEqual({
@@ -133,8 +193,9 @@ describe('judge-span routing (harmonograf#197)', () => {
     expect(isJudgeSpan(judges[0])).toBe(true);
   });
 
-  it('isJudgeSpan returns false for non-judge spans', () => {
-    // Seed a regular drift span on the goldfive lane.
+  it('isJudgeSpan returns false for non-judge spans on the goldfive lane', () => {
+    // Seed a regular drift span on the goldfive lane (drift synthesis
+    // stays under Option X — only LLM-call synthesis was retired).
     applyGoldfiveEvent(
       create(EventSchema, {
         eventId: 'ev-drift',
@@ -158,29 +219,25 @@ describe('judge-span routing (harmonograf#197)', () => {
     );
     const spans: Span[] = [];
     store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans);
-    // At least the drift span should be present; none are judge spans.
     expect(spans.length).toBeGreaterThan(0);
     for (const s of spans) expect(isJudgeSpan(s)).toBe(false);
   });
 
   it('resolveJudgeDetail surfaces the header + context + verdict for on_task', () => {
-    applyGoldfiveEvent(
-      judgeEvent('ev-j1', 45, {
-        onTask: true,
-        severity: '',
-        reason: 'on track',
-        reasoningInput: 'I will search',
-        rawResponse: '{"on_task": true}',
-        model: 'haiku',
-        elapsedMs: 175,
-        subjectAgentId: 'agent-a',
-        taskId: 't1',
-      }),
-      store,
-      0,
-    );
-    const judge = listJudgeSpans(store)[0];
-    const detail = resolveJudgeDetail(judge, []);
+    const span = seedJudgeSpan(store, {
+      eventId: 'ev-j1',
+      atMs: 45,
+      onTask: true,
+      severity: '',
+      reason: 'on track',
+      reasoningInput: 'I will search',
+      rawResponse: '{"on_task": true}',
+      model: 'haiku',
+      elapsedMs: 175,
+      subjectAgentId: 'agent-a',
+      taskId: 't1',
+    });
+    const detail = resolveJudgeDetail(span, []);
     expect(detail.verdictBucket).toBe('on_task');
     expect(detail.onTask).toBe(true);
     expect(detail.reason).toBe('on track');
@@ -193,47 +250,42 @@ describe('judge-span routing (harmonograf#197)', () => {
   });
 
   it('resolveJudgeDetail returns off_task bucket with severity + reason', () => {
-    applyGoldfiveEvent(
-      judgeEvent('ev-off', 80, {
-        onTask: false,
-        severity: 'warning',
-        reason: 'agent paraphrasing',
-        reasoningInput: 'agent repeated itself',
-        rawResponse: '{"on_task": false, "severity":"warning"}',
-        model: 'haiku',
-        elapsedMs: 310,
-        subjectAgentId: 'agent-a',
-        taskId: 't1',
-      }),
-      store,
-      0,
-    );
-    const judge = listJudgeSpans(store)[0];
-    const detail = resolveJudgeDetail(judge, []);
+    const span = seedJudgeSpan(store, {
+      eventId: 'ev-off',
+      atMs: 80,
+      onTask: false,
+      verdict: 'warning',
+      severity: 'warning',
+      reason: 'agent paraphrasing',
+      reasoningInput: 'agent repeated itself',
+      rawResponse: '{"on_task": false, "severity":"warning"}',
+      model: 'haiku',
+      elapsedMs: 310,
+      subjectAgentId: 'agent-a',
+      taskId: 't1',
+    });
+    const detail = resolveJudgeDetail(span, []);
     expect(detail.verdictBucket).toBe('off_task');
     expect(detail.severity).toBe('warning');
     expect(detail.reason).toBe('agent paraphrasing');
   });
 
   it('resolveJudgeDetail returns no_verdict when the judge emitted raw but no parsed fields', () => {
-    applyGoldfiveEvent(
-      judgeEvent('ev-bad', 90, {
-        // No onTask / verdict / severity — malformed judge output.
-        rawResponse: '{ bad json',
-        reasoningInput: 'agent thinking',
-      }),
-      store,
-      0,
-    );
-    const judge = listJudgeSpans(store)[0];
-    const detail = resolveJudgeDetail(judge, []);
+    const span = seedJudgeSpan(store, {
+      eventId: 'ev-bad',
+      atMs: 90,
+      // No onTask / verdict / severity — malformed judge output.
+      rawResponse: '{ bad json',
+      reasoningInput: 'agent thinking',
+    });
+    const detail = resolveJudgeDetail(span, []);
     expect(detail.verdictBucket).toBe('no_verdict');
     expect(detail.rawResponse).toContain('bad json');
   });
 
   it('links a matching PlanRevised as the steering outcome (by trigger_event_id)', () => {
     // Seed an initial plan so the PlanRevised has a prior revision to
-    // chain from. Then emit the judge event AND a PlanRevised whose
+    // chain from. Then seed a judge span AND a PlanRevised whose
     // trigger_event_id points at the judge event id.
     applyGoldfiveEvent(
       create(EventSchema, {
@@ -248,19 +300,18 @@ describe('judge-span routing (harmonograf#197)', () => {
       store,
       0,
     );
-    applyGoldfiveEvent(
-      judgeEvent('ev-judge-steer', 100, {
-        onTask: false,
-        severity: 'warning',
-        reason: 'drift',
-        reasoningInput: 'agent stuck',
-        rawResponse: '{"on_task": false}',
-        subjectAgentId: 'agent-a',
-        taskId: 't1',
-      }),
-      store,
-      0,
-    );
+    const judgeSpan = seedJudgeSpan(store, {
+      eventId: 'ev-judge-steer',
+      atMs: 100,
+      onTask: false,
+      verdict: 'warning',
+      severity: 'warning',
+      reason: 'drift',
+      reasoningInput: 'agent stuck',
+      rawResponse: '{"on_task": false}',
+      subjectAgentId: 'agent-a',
+      taskId: 't1',
+    });
     const rev = pbPlan('p1', ['t1', 't2-new'], 2);
     rev.revisionReason = 'recover from reasoning drift';
     rev.revisionKind = DriftKind.LOOPING_REASONING;
@@ -284,9 +335,8 @@ describe('judge-span routing (harmonograf#197)', () => {
       0,
     );
 
-    const judge = listJudgeSpans(store)[0];
     const plans = collectAllPlans(store);
-    const detail = resolveJudgeDetail(judge, plans);
+    const detail = resolveJudgeDetail(judgeSpan, plans);
     expect(detail.steeredPlan).not.toBeNull();
     expect(detail.steeredPlan?.id).toBe('p1');
     expect(detail.steeredPlan?.revisionIndex).toBe(2);
@@ -297,21 +347,19 @@ describe('judge-span routing (harmonograf#197)', () => {
   });
 
   it('no matching PlanRevised leaves steeredPlan null (ladder did not escalate)', () => {
-    applyGoldfiveEvent(
-      judgeEvent('ev-orphan', 200, {
-        onTask: false,
-        severity: 'info',
-        reason: 'mild drift',
-        reasoningInput: 'thinking',
-        rawResponse: '{}',
-        subjectAgentId: 'agent-a',
-        taskId: 't1',
-      }),
-      store,
-      0,
-    );
-    const judge = listJudgeSpans(store)[0];
-    const detail = resolveJudgeDetail(judge, collectAllPlans(store));
+    const span = seedJudgeSpan(store, {
+      eventId: 'ev-orphan',
+      atMs: 200,
+      onTask: false,
+      verdict: 'info',
+      severity: 'info',
+      reason: 'mild drift',
+      reasoningInput: 'thinking',
+      rawResponse: '{}',
+      subjectAgentId: 'agent-a',
+      taskId: 't1',
+    });
+    const detail = resolveJudgeDetail(span, collectAllPlans(store));
     expect(detail.steeredPlan).toBeNull();
     expect(detail.taskSummaries).toHaveLength(0);
   });

--- a/frontend/src/__tests__/rpc/goldfiveEventLanes.test.ts
+++ b/frontend/src/__tests__/rpc/goldfiveEventLanes.test.ts
@@ -344,11 +344,13 @@ describe('goldfive lane synthesis (harmonograf#196)', () => {
     });
   });
 
-  it('forward-compat: reasoningJudgeInvoked (unknown oneof case pre-merge) is tolerated', () => {
-    // Pre-merge stubs don't know this case. Build the event manually so
-    // the oneof `case` string is 'reasoningJudgeInvoked' and verify that
-    // applyGoldfiveEvent either handles it (post-merge) or simply no-ops
-    // (pre-merge) without crashing.
+  it('Option X: reasoningJudgeInvoked is dropped client-side (sink translates to a span)', () => {
+    // Under Option X the harmonograf client sink translates
+    // goldfive_llm_call_{start,end} and reasoning_judge_invoked events
+    // into SpanStart/SpanEnd frames on the span transport. If a stale
+    // ReasoningJudgeInvoked reaches the frontend via the goldfive-event
+    // channel (e.g. an old-format replay), the handler no-ops — no
+    // synthetic span, no actor row mutation.
     const event = create(EventSchema, {
       eventId: 'ev',
       runId: 'run-1',
@@ -368,22 +370,8 @@ describe('goldfive lane synthesis (harmonograf#196)', () => {
 
     expect(() => applyGoldfiveEvent(event, store, 0)).not.toThrow();
 
-    // Post-merge path: if the switch case ran, a judge span landed.
-    // Pre-merge path: nothing happens (no assertion on span count, but
-    // the synthetic goldfive actor row is created on the judge branch).
     const spans: Array<ReturnType<typeof store.spans.get>> = [];
     store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans as never);
-    // If the branch ran (which it does — the switch uses the string
-    // compare directly), exactly one judge span lands.
-    const judge = spans.find((s) => s && s.name.startsWith('judge:'));
-    expect(judge).toBeTruthy();
-    expect(judge?.attributes['judge.verdict']).toEqual({
-      kind: 'string',
-      value: 'drift',
-    });
-    expect(judge?.attributes['judge.target_agent_id']).toEqual({
-      kind: 'string',
-      value: 'agent-a',
-    });
+    expect(spans).toHaveLength(0);
   });
 });

--- a/frontend/src/components/Interventions/JudgeInvocationDetail.tsx
+++ b/frontend/src/components/Interventions/JudgeInvocationDetail.tsx
@@ -1,8 +1,14 @@
 // Click-through detail panel for goldfive judge spans (harmonograf#197).
 //
-// Rendered when the user clicks a synthesized judge span on the
-// __goldfive__ lane. Surfaces the six questions an operator asks about
-// an LLM-as-judge invocation:
+// Rendered when the user clicks a judge span on the goldfive lane. The
+// span arrives via the normal span transport — the harmonograf client
+// sink translates ReasoningJudgeInvoked goldfive events into
+// SpanStart/SpanEnd frames under Option X (harmonograf#N). The panel
+// reads `judge.*` attributes directly off the span; nothing here
+// depends on the event-side synthesizer that Option X retired.
+//
+// Surfaces the six questions an operator asks about an LLM-as-judge
+// invocation:
 //
 //   1. when did it fire, which model, how long did it take
 //   2. which agent + task was being judged

--- a/frontend/src/lib/interventionDetail.ts
+++ b/frontend/src/lib/interventionDetail.ts
@@ -315,19 +315,21 @@ export function resolveJudgeDetail(
   };
 }
 
-// Returns true when the given span was synthesized by the judge-event
-// ingest path. Click handlers route to the judge detail card when this
-// is true. The discriminator is an explicit attribute stamped by the
-// synthesizer (see goldfiveEvent.synthesizeJudgeSpan) — do NOT match on
-// the span name, since display-name renames would silently break
-// routing.
+// Returns true when the given span represents a goldfive LLM-as-judge
+// invocation. Click handlers route to the judge detail card when this
+// is true. The discriminator is an explicit `judge.kind = "judge"`
+// attribute stamped by the harmonograf client sink when it translates
+// a ReasoningJudgeInvoked event to a span (Option X, harmonograf#N).
+// Do NOT match on the span name — display-name renames would silently
+// break routing.
 export function isJudgeSpan(span: Span | null | undefined): boolean {
   if (!span) return false;
   const attr = span.attributes['judge.kind'];
   if (attr && attr.kind === 'string' && attr.value === 'judge') return true;
   // Back-compat for spans produced before the `judge.kind` attribute
-  // existed: the old synthesizer named spans `judge: ...`. Keep matching
-  // so older sessions replayed from the server don't lose the routing.
+  // existed (pre-Option-X synthesizer named spans `judge: ...`). Keep
+  // matching so older sessions replayed from the server don't lose the
+  // routing.
   return span.agentId === '__goldfive__' && span.name.startsWith('judge:');
 }
 

--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -8,6 +8,16 @@
 // from persisted state) and on the live tail (fanned out from the Phase
 // B bus). This module maps the envelope's payload oneof onto the
 // existing gantt stores without introducing any new store concepts.
+//
+// Note (Option X, harmonograf#N): goldfive LLM-call events
+// (goldfive_llm_call_start, goldfive_llm_call_end, reasoning_judge_invoked)
+// are now translated to SpanStart/SpanEnd at the harmonograf client
+// sink (see harmonograf_client/sink.py). They arrive as ordinary spans
+// via the span transport and are rendered by the normal span-ingest
+// path; no frontend-side synthesis needed. If you see a synthesize*Span
+// helper in this file, it's probably for user-lane synthesis (user
+// goal message from RunStarted) or the drift/refine visual-marker
+// synthesis — NOT part of Option X, those stay.
 
 import type { SessionStore } from '../gantt/index';
 import { bareAgentName } from '../gantt/index';
@@ -219,114 +229,6 @@ function synthesizeUserGoalSpan(
     attributes: {
       'user.goal_summary': { kind: 'string', value: goalSummary },
       'user.run_id': { kind: 'string', value: runId },
-      'harmonograf.synthetic_span': { kind: 'bool', value: true },
-    },
-    payloadRefs: [],
-    error: null,
-    lane: -1,
-    replaced: false,
-  };
-  store.spans.append(span);
-}
-
-// Parameters for the judge-span synthesizer. Grouped into an options
-// object so new forward-compat fields added on the wire (reason,
-// reasoning_input, raw_response, elapsed_ms, model, subject_agent_id)
-// don't balloon the positional arg list. All fields are optional —
-// callers supply what the event carried; missing fields render as empty
-// attributes so the detail panel can hide sections cleanly.
-interface JudgeSpanInput {
-  sessionId: string | null;
-  eventId: string;
-  recordedAtMs: number;
-  // Parsed-verdict fields (post-merge ReasoningJudgeInvoked).
-  onTask: boolean;
-  verdict: string; // 'on_task' | 'drift' | '' when malformed
-  severity: string;
-  reason: string;
-  // Raw judge payload + metadata.
-  reasoningInput: string;
-  rawResponse: string;
-  elapsedMs: number;
-  model: string;
-  subjectAgentId: string;
-  currentTaskId: string;
-}
-
-// Forward-compat: synthesize a "judge" span on the goldfive actor row
-// when a goldfive.v1.ReasoningJudgeInvoked event arrives. The stub may
-// not exist on the pre-merge submodule — callers guard the call path
-// with a string-case check on the oneof so a missing case does not crash
-// ingest. Once the submodule bumps the generated ``Event.payload.case``
-// union includes 'reasoningJudgeInvoked' and TS narrows automatically.
-//
-// The span carries ``judge.kind = "judge"`` as an explicit discriminator
-// so click handlers can route to JudgeInvocationDetail without having
-// to match on the span name. All the event's structured fields land as
-// string attributes on the span — the detail panel reads them back.
-function synthesizeJudgeSpan(store: SessionStore, input: JudgeSpanInput): void {
-  const {
-    sessionId,
-    eventId,
-    recordedAtMs,
-    onTask,
-    verdict,
-    severity,
-    reason,
-    reasoningInput,
-    rawResponse,
-    elapsedMs,
-    model,
-    subjectAgentId,
-    currentTaskId,
-  } = input;
-  const id = `judge-${recordedAtMs}-${verdict || (onTask ? 'on_task' : 'unspec')}`;
-  const name =
-    verdict && verdict !== 'on_task'
-      ? `judge: ${verdict}${severity ? ` (${severity})` : ''}`
-      : 'judge: on_task';
-  // ``recordedAtMs`` is when goldfive stamped the event — right after
-  // the judge's LLM call completed. The judge's actual wall-clock
-  // duration is ``elapsedMs``; the span covers
-  // ``[recordedAtMs - elapsedMs, recordedAtMs]`` so it has visible
-  // width on the Gantt. Zero-width spans are invisible at normal
-  // zoom levels; the whole point of surfacing goldfive's judge
-  // as a lane is to make its actual cost visible on the timeline.
-  // Clamp at 0 to defend against negative/zero elapsed values.
-  const safeElapsed = Number.isFinite(elapsedMs) && elapsedMs > 0 ? elapsedMs : 0;
-  const startMs = Math.max(0, recordedAtMs - safeElapsed);
-  const span: Span = {
-    id,
-    sessionId: sessionId ?? '',
-    agentId: GOLDFIVE_ACTOR_ID,
-    parentSpanId: null,
-    kind: 'CUSTOM',
-    status: 'COMPLETED',
-    name,
-    startMs,
-    endMs: recordedAtMs,
-    links: [],
-    attributes: {
-      // Discriminator — read by click handlers to route to the judge
-      // detail card. Backed by an explicit attribute (not the span name)
-      // so renames to the display name don't accidentally break routing.
-      'judge.kind': { kind: 'string', value: 'judge' },
-      'judge.event_id': { kind: 'string', value: eventId },
-      'judge.verdict': { kind: 'string', value: verdict },
-      'judge.on_task': { kind: 'bool', value: onTask },
-      'judge.severity': { kind: 'string', value: severity },
-      'judge.reason': { kind: 'string', value: reason },
-      'judge.reasoning_input': { kind: 'string', value: reasoningInput },
-      'judge.raw_response': { kind: 'string', value: rawResponse },
-      'judge.elapsed_ms': { kind: 'string', value: String(elapsedMs) },
-      'judge.model': { kind: 'string', value: model },
-      'judge.subject_agent_id': { kind: 'string', value: subjectAgentId },
-      'judge.target_agent_id': { kind: 'string', value: subjectAgentId },
-      'judge.target_task_id': { kind: 'string', value: currentTaskId },
-      // Back-compat alias: pre-rework tests and the existing detail
-      // resolvers still read ``judge.reasoning`` (judge's one-sentence
-      // reason / explanation). Keep both until nothing reads it.
-      'judge.reasoning': { kind: 'string', value: reason || reasoningInput },
       'harmonograf.synthetic_span': { kind: 'bool', value: true },
     },
     payloadRefs: [],
@@ -666,86 +568,14 @@ export function applyGoldfiveEvent(
     case 'agentInvocationStarted':
     case 'agentInvocationCompleted':
       return;
-    // harmonograf#196 forward-compat: goldfive#feat/judge-observability-events
-    // adds a `reasoningJudgeInvoked` oneof case (the orchestrator's LLM-as-
-    // judge fires on each reasoning step and classifies it on-task / drift).
-    // The case string is matched as a wide string because the generated
-    // union on the current submodule pin doesn't include it yet — once the
-    // submodule bumps the `payload.case` type narrows automatically and this
-    // branch becomes reachable through the normal switch.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    case 'reasoningJudgeInvoked' as any: {
-      ensureSyntheticActor(store, GOLDFIVE_ACTOR_ID);
-      const emittedAbsMs = tsToMsAbs(event.emittedAt);
-      const emittedMs = emittedAbsMs ? emittedAbsMs - sessionStartMs : 0;
-      const ju = payload.value as unknown as Record<string, unknown>;
-      // `verdict` is a harmonograf-local string synthesized from
-      // `on_task`/`severity` since the wire message doesn't expose a
-      // single-string verdict field. Pre-merge test fixtures that set
-      // ``verdict`` directly still flow through (the explicit string
-      // wins over the on_task derivation).
-      const onTaskRaw = ju.onTask;
-      const onTask = typeof onTaskRaw === 'boolean' ? onTaskRaw : false;
-      const severityRaw = ju.severity;
-      const severity =
-        typeof severityRaw === 'string'
-          ? severityRaw
-          : typeof severityRaw === 'number'
-            ? driftSeverityToString(severityRaw)
-            : '';
-      let verdict = typeof ju.verdict === 'string' ? (ju.verdict as string) : '';
-      if (!verdict) {
-        verdict = onTask ? 'on_task' : severity ? severity : '';
-      }
-      // Pre-merge tests pass `reasoning` as the single reasoning string;
-      // post-merge the wire separates `reasoning_input` (what the judge
-      // saw) from `reason` (the judge's explanation). Accept both and
-      // prefer the richer pair when both are set.
-      const reasoning =
-        typeof ju.reasoning === 'string' ? (ju.reasoning as string) : '';
-      const reason = typeof ju.reason === 'string' ? (ju.reason as string) : reasoning;
-      const reasoningInput =
-        typeof ju.reasoningInput === 'string'
-          ? (ju.reasoningInput as string)
-          : reasoning;
-      const rawResponse =
-        typeof ju.rawResponse === 'string' ? (ju.rawResponse as string) : '';
-      const elapsedRaw = ju.elapsedMs;
-      let elapsedMs = 0;
-      if (typeof elapsedRaw === 'number') elapsedMs = elapsedRaw;
-      else if (typeof elapsedRaw === 'bigint') elapsedMs = Number(elapsedRaw);
-      const model = typeof ju.model === 'string' ? (ju.model as string) : '';
-      // Post-merge field is `subject_agent_id`; pre-merge test fixtures
-      // used `currentAgentId`. Read both so neither wire shape breaks.
-      const subjectAgentId =
-        typeof ju.subjectAgentId === 'string'
-          ? (ju.subjectAgentId as string)
-          : typeof ju.currentAgentId === 'string'
-            ? (ju.currentAgentId as string)
-            : '';
-      const currentTaskId =
-        typeof ju.taskId === 'string'
-          ? (ju.taskId as string)
-          : typeof ju.currentTaskId === 'string'
-            ? (ju.currentTaskId as string)
-            : '';
-      synthesizeJudgeSpan(store, {
-        sessionId,
-        eventId: event.eventId || '',
-        recordedAtMs: emittedMs,
-        onTask,
-        verdict,
-        severity,
-        reason,
-        reasoningInput,
-        rawResponse,
-        elapsedMs,
-        model,
-        subjectAgentId,
-        currentTaskId,
-      });
+    // Option X (harmonograf#N): reasoningJudgeInvoked is now translated
+    // to SpanStart/SpanEnd at the harmonograf client sink (see
+    // harmonograf_client/sink.py). Judge spans arrive via the normal
+    // span transport; no frontend-side synthesis needed. Treat as a
+    // no-op if one reaches here (e.g. replay from an old-format
+    // recording that still used the goldfive-event channel).
+    case 'reasoningJudgeInvoked':
       return;
-    }
     case 'delegationObserved': {
       // DelegationObserved carries the coordinator→sub_agent edge that the
       // telemetry plugin only records as a generic TOOL_CALL span on the


### PR DESCRIPTION
## DO NOT MERGE BEFORE the client-sink translator PR

**Prerequisite:** `feat/client-sink-translate-goldfive-llm-events` (parallel work — the harmonograf client sink translating `reasoning_judge_invoked` + `goldfive_llm_call_{start,end}` into SpanStart/SpanEnd frames).

If this PR lands first, goldfive LLM-as-judge calls temporarily vanish from the Gantt because the synthesizer removed here was their only renderer.

Tracking: #152.

## Summary

- Delete `synthesizeJudgeSpan` + the `reasoningJudgeInvoked` case in `rpc/goldfiveEvent.ts`. Stale events arriving via the goldfive-event channel (old-format replays) are dropped silently.
- Update header comments (`goldfiveEvent.ts`, `interventionDetail.ts`, `JudgeInvocationDetail.tsx`) to document Option X and the new attribute contract.
- Rewrite the two tests that exercised the judge synthesizer:
  - `goldfiveEventLanes.test.ts::reasoningJudgeInvoked ...` → asserts the event is dropped (no synthetic span, no actor row).
  - `judgeDetail.test.ts` → seeds judge spans directly on the goldfive lane (mirroring sink output) and runs them through `isJudgeSpan` + `resolveJudgeDetail`.

## What stays

- `synthesizeDriftSpan` / `synthesizeRefineSpan` — visual markers for drift / plan-revision events. NOT translated by the sink; they stay.
- `synthesizeUserGoalSpan` — user-lane synthesis from `RunStarted`. Outside Option X scope.
- `ensureSyntheticActor` — used by the drift + refine paths to create the `__goldfive__` / `__user__` actor rows. The sink-translated spans bring their own compound-id actor rows via the normal span-ingest path.
- `isJudgeSpan` + `resolveJudgeDetail` + `JudgeInvocationDetail` — unchanged attribute-read path. The sink translator is under contract to preserve `judge.kind`, `judge.event_id`, `judge.on_task`, `judge.verdict`, `judge.severity`, `judge.reason`, `judge.reasoning_input`, `judge.raw_response`, `judge.elapsed_ms`, `judge.model`, `judge.subject_agent_id`, `judge.target_task_id`.

## Diff size

- Substance: 36 insertions / 198 deletions across `goldfiveEvent.ts`, `interventionDetail.ts`, `JudgeInvocationDetail.tsx`.
- Tests: ~315 lines across `judgeDetail.test.ts` + `goldfiveEventLanes.test.ts`.

## Test plan

- [x] `pnpm -C frontend tsc -b` clean
- [x] `pnpm -C frontend test --run` — 364 passed (364). Same count as baseline (42 files / 364 tests); the `reasoningJudgeInvoked` test is rewritten, not deleted.
- [x] `pnpm -C frontend lint` — only the pre-existing `GanttView.tsx` warning (untouched by this PR).
- [ ] Post-merge smoke: load a goldfive session with judge activity after both PRs merge and a submodule bump; judge spans should render on the goldfive lane and click-through to `JudgeInvocationDetail` with verdict + reasoning input + raw response + steering outcome.