### PR TITLE
Option X: translate goldfive LLM events to span frames at client sink

### DIFF
--- a/client/harmonograf_client/sink.py
+++ b/client/harmonograf_client/sink.py
@@ -12,6 +12,49 @@ Module identity: harmonograf's generated ``telemetry_pb2`` imports
 so ``TelemetryUp.goldfive_event`` shares its class with whatever goldfive's
 runner produces. No serialize/parse round-trip is required.
 
+LLM-call translation (harmonograf Option X — unify goldfive LLM observability)
+-----------------------------------------------------------------------------
+Goldfive and ADK emit LLM-call telemetry through two different channels. ADK
+agent LLM calls land as proper ``SpanStart`` / ``SpanEnd`` proto frames on
+the span transport; goldfive-internal LLM calls (``refine_steer``,
+``judge_reasoning``, ``goal_derive``, ``plan_generate``, ...) land as
+``GoldfiveLLMCallStart`` / ``GoldfiveLLMCallEnd`` / ``ReasoningJudgeInvoked``
+goldfive-event variants that require per-event-kind synthesizers in the
+frontend. Every new goldfive-internal LLM call therefore needed a new
+frontend handler — and when goldfive#244 shipped the start/end pair, nothing
+rendered until the frontend caught up.
+
+This sink closes the asymmetry at the client seam: when a goldfive Event
+carries one of those three LLM-call oneof variants, it is translated to the
+equivalent ``SpanStart`` / ``SpanEnd`` frame and pushed via the existing
+span transport — so the server stores the result in the ``spans`` table
+like any other span and the frontend renders it uniformly. The original
+``goldfive_event`` envelope is NOT forwarded for these variants; the span
+pair is the authoritative wire surface.
+
+Translation rules (all three event kinds stamp ``agent_id = <client>:goldfive``,
+``kind = LLM_CALL``, ``status = COMPLETED`` on end):
+
+  * ``GoldfiveLLMCallStart`` → ``SpanStart`` with span id + name from the
+    event, ``start_time_ns`` as the span start time, attributes carrying
+    ``goldfive.task_id`` / ``goldfive.model`` / ``goldfive.run_id``.
+  * ``GoldfiveLLMCallEnd`` → ``SpanEnd`` with the matching span id,
+    ``end_time_ns`` as the end time, status ``COMPLETED`` / ``FAILED``
+    derived from the event's ``status`` string, and ``error`` plumbed
+    when ``status == "failed"``.
+  * ``ReasoningJudgeInvoked`` → a ``SpanStart`` + ``SpanEnd`` pair emitted
+    back-to-back (the event is a terminal-only record; the start is
+    synthesized at ``emitted_at - elapsed_ms`` so the span has visible
+    width on the Gantt). Verdict fields land as ``judge.*`` attributes so
+    the existing :class:`JudgeInvocationDetail` click-through panel
+    continues to read them verbatim (harmonograf#147).
+
+Ordering: goldfive's ``_llm_span`` context manager emits Start then End
+via ``EventSink.emit`` — the sink translates each event in isolation and
+pushes in the order it received, so SpanStart always precedes SpanEnd for
+the same span id. For the judge pair the order is fixed internally
+(start then end, stamped on the same wire push).
+
 Agent-id canonicalization (harmonograf#125)
 ------------------------------------------
 Goldfive emits two forms of agent identity:
@@ -49,7 +92,47 @@ from __future__ import annotations
 
 from typing import Any
 
+from google.protobuf import timestamp_pb2
+
 from .client import Client
+
+# Events whose translation-to-span semantics the sink owns. Anything else
+# passes through ``emit_goldfive_event`` as before.
+_LLM_SPAN_EVENT_KINDS = frozenset(
+    {
+        "goldfive_llm_call_start",
+        "goldfive_llm_call_end",
+        "reasoning_judge_invoked",
+    }
+)
+
+# Truncation ceilings match the goldfive proto's own: ``reasoning_input``
+# is truncated by the goldfive emitter to 4096 chars and ``raw_response``
+# to 2048 (see ReasoningJudgeInvoked field comments). The sink echoes the
+# bytes verbatim — no further truncation — so the ``JudgeInvocationDetail``
+# panel sees exactly what the judge returned.
+
+
+def _ts_from_nanos(ns: int) -> timestamp_pb2.Timestamp | None:
+    """Build a Timestamp from a unix-epoch-ns int. Returns ``None`` on
+    zero / negative inputs so the caller can fall back to wall-clock
+    stamping at the client layer (``Client.emit_span_start`` does that
+    when ``start_time`` is ``None``)."""
+    if ns is None or ns <= 0:
+        return None
+    ts = timestamp_pb2.Timestamp()
+    ts.FromNanoseconds(int(ns))
+    return ts
+
+
+def _ts_to_nanos(ts: timestamp_pb2.Timestamp) -> int | None:
+    """Convert a ``Timestamp`` to unix-epoch nanoseconds, or ``None``
+    when the Timestamp is the zero value (unset field on the envelope)."""
+    if ts is None:
+        return None
+    if ts.seconds == 0 and ts.nanos == 0:
+        return None
+    return ts.seconds * 1_000_000_000 + ts.nanos
 
 
 class HarmonografSink:
@@ -87,6 +170,16 @@ class HarmonografSink:
         bare→compound (see module docstring).
         """
         if self._closed:
+            return
+        which = (
+            event_pb.WhichOneof("payload")
+            if hasattr(event_pb, "WhichOneof")
+            else None
+        )
+        if which in _LLM_SPAN_EVENT_KINDS:
+            # Translate to span transport — do NOT also forward the
+            # goldfive_event envelope (the span pair is authoritative).
+            self._translate_and_emit_span(event_pb, which)
             return
         self._canonicalize_agent_ids(event_pb)
         self._client.emit_goldfive_event(event_pb)
@@ -175,3 +268,188 @@ class HarmonografSink:
             return
         for task in plan.tasks:
             self._rewrite_field(task, "assignee_agent_id")
+
+    # ------------------------------------------------------------------
+    # LLM-call translation (Option X)
+    # ------------------------------------------------------------------
+
+    def _goldfive_agent_id(self) -> str:
+        """Compound agent id for goldfive-internal spans.
+
+        Equivalent to ``self._compound("goldfive")`` but stable across
+        future goldfive changes — if goldfive starts stamping the
+        compound form itself on any of these events, ``_compound`` is
+        idempotent so double-emits still land a clean id.
+        """
+        return self._compound("goldfive")
+
+    def _translate_and_emit_span(self, event_pb: Any, which: str) -> None:
+        """Translate one of the three LLM-call oneof variants to a span
+        pair (or half, for the start/end cases) and push via the client's
+        span transport. Never raises: on an unexpected shape (e.g. a
+        future proto bump adds fields) the helper falls back to emitting
+        what it can and swallows the rest — the span is non-critical
+        observability and must not break orchestration."""
+        if which == "goldfive_llm_call_start":
+            self._emit_llm_call_start(event_pb)
+        elif which == "goldfive_llm_call_end":
+            self._emit_llm_call_end(event_pb)
+        elif which == "reasoning_judge_invoked":
+            self._emit_reasoning_judge_span(event_pb)
+
+    def _emit_llm_call_start(self, event_pb: Any) -> None:
+        """``GoldfiveLLMCallStart`` → ``SpanStart``."""
+        start = event_pb.goldfive_llm_call_start
+        span_id = start.span_id or self._derive_span_id(event_pb)
+        self._client.emit_span_start(
+            kind="LLM_CALL",
+            name=start.name or "goldfive_llm_call",
+            span_id=span_id,
+            start_time=_ts_from_nanos(start.start_time_ns),
+            agent_id=self._goldfive_agent_id(),
+            session_id=event_pb.session_id or None,
+            attributes=self._llm_call_attributes(event_pb, start),
+        )
+
+    def _emit_llm_call_end(self, event_pb: Any) -> None:
+        """``GoldfiveLLMCallEnd`` → ``SpanEnd``."""
+        end = event_pb.goldfive_llm_call_end
+        span_id = end.span_id or self._derive_span_id(event_pb)
+        wire_status = (end.status or "").lower()
+        status = "FAILED" if wire_status == "failed" else "COMPLETED"
+        error = (
+            {"type": "goldfive_llm_call", "message": end.error}
+            if wire_status == "failed" and end.error
+            else None
+        )
+        attributes: dict[str, Any] = {}
+        if end.name:
+            # Echo the call name on end so out-of-order End-before-Start
+            # consumers can still label the span (mirrors the proto field
+            # comment).
+            attributes["goldfive.call_name"] = end.name
+        if wire_status:
+            attributes["goldfive.status"] = wire_status
+        self._client.emit_span_end(
+            span_id,
+            status=status,
+            end_time=_ts_from_nanos(end.end_time_ns),
+            error=error,
+            attributes=attributes or None,
+        )
+
+    def _emit_reasoning_judge_span(self, event_pb: Any) -> None:
+        """``ReasoningJudgeInvoked`` → ``SpanStart`` + ``SpanEnd``.
+
+        The judge event is terminal-only (the LLM-as-judge classifier
+        emits a single Event after the call completes, not a start/end
+        pair). Synthesize a start at ``emitted_at - elapsed_ms`` so the
+        span has visible width on the Gantt — matches the pre-Option-X
+        frontend synthesizer (harmonograf#147) byte for byte.
+
+        Attributes are stamped with the ``judge.*`` namespace that
+        :class:`JudgeInvocationDetail` reads back (see
+        ``frontend/src/lib/interventionDetail.ts``). Keys preserved:
+        ``judge.kind``, ``judge.event_id``, ``judge.verdict``,
+        ``judge.on_task``, ``judge.severity``, ``judge.reason``,
+        ``judge.reasoning_input``, ``judge.reasoning`` (back-compat
+        alias), ``judge.raw_response``, ``judge.elapsed_ms``,
+        ``judge.model``, ``judge.subject_agent_id``,
+        ``judge.target_agent_id`` (alias), ``judge.target_task_id``.
+        """
+        ju = event_pb.reasoning_judge_invoked
+        on_task = bool(ju.on_task)
+        severity = ju.severity or ""
+        reason = ju.reason or ""
+        verdict = "on_task" if on_task else (severity or ("off_task" if not on_task else ""))
+        display = (
+            f"judge: {verdict}" + (f" ({severity})" if verdict != "on_task" and severity else "")
+            if verdict
+            else "judge: on_task"
+        )
+        elapsed_ms = int(ju.elapsed_ms or 0)
+        # emitted_at is a google.protobuf.Timestamp — fall back to "now"
+        # when the envelope didn't populate it (shouldn't happen on a
+        # well-formed runner, but the span must still be renderable).
+        emitted_ts: timestamp_pb2.Timestamp = event_pb.emitted_at
+        end_ns = _ts_to_nanos(emitted_ts)
+        if end_ns is None:
+            # No emitted_at; let the client stamp wall-clock on both.
+            start_time: Any = None
+            end_time: Any = None
+        else:
+            start_ns = max(0, end_ns - max(0, elapsed_ms) * 1_000_000)
+            start_time = _ts_from_nanos(start_ns)
+            end_time = _ts_from_nanos(end_ns)
+
+        subject = ju.subject_agent_id or ""
+        task_id = ju.task_id or ""
+        attrs: dict[str, Any] = {
+            # Discriminator — read by click-through routing. Backed by
+            # an explicit attribute (not the span name) so label renames
+            # don't accidentally break routing.
+            "judge.kind": "judge",
+            "judge.event_id": event_pb.event_id or "",
+            "judge.verdict": verdict,
+            "judge.on_task": on_task,
+            "judge.severity": severity,
+            "judge.reason": reason,
+            "judge.reasoning_input": ju.reasoning_input or "",
+            # Back-compat alias: pre-rework detail resolvers and tests
+            # still read ``judge.reasoning``. Carry both until nothing
+            # reads the alias.
+            "judge.reasoning": reason or (ju.reasoning_input or ""),
+            "judge.raw_response": ju.raw_response or "",
+            "judge.elapsed_ms": str(elapsed_ms),
+            "judge.model": ju.model or "",
+            "judge.subject_agent_id": subject,
+            # Alias used by the detail resolver's fallback read order.
+            "judge.target_agent_id": subject,
+            "judge.target_task_id": task_id,
+            # Run id is handy for debugging cross-session judge lookups.
+            "judge.run_id": event_pb.run_id or "",
+        }
+        session_id = event_pb.session_id or None
+        agent_id = self._goldfive_agent_id()
+        span_id = self._derive_span_id(event_pb)
+        self._client.emit_span_start(
+            kind="LLM_CALL",
+            name=display,
+            span_id=span_id,
+            start_time=start_time,
+            agent_id=agent_id,
+            session_id=session_id,
+            attributes=attrs,
+        )
+        self._client.emit_span_end(
+            span_id,
+            status="COMPLETED",
+            end_time=end_time,
+        )
+
+    def _llm_call_attributes(self, event_pb: Any, start: Any) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        if start.model:
+            attrs["goldfive.model"] = start.model
+        if start.task_id:
+            attrs["goldfive.task_id"] = start.task_id
+        if event_pb.run_id:
+            attrs["goldfive.run_id"] = event_pb.run_id
+        if start.name:
+            attrs["goldfive.call_name"] = start.name
+        return attrs
+
+    def _derive_span_id(self, event_pb: Any) -> str:
+        """Fallback span id when the event doesn't carry its own.
+
+        Used only for ``ReasoningJudgeInvoked`` (no ``span_id`` field on
+        the proto) and as a defense for malformed start/end events. The
+        derivation keys on ``event_id + payload case`` so a Start + End
+        pair minted from the same event_id would collide — acceptable
+        because that combination is nonsensical (events with a span_id
+        use it; the derived path is the exception, not the rule).
+        """
+        which = (
+            event_pb.WhichOneof("payload") if hasattr(event_pb, "WhichOneof") else ""
+        )
+        return f"goldfive-{which}-{event_pb.event_id}"

--- a/client/tests/test_sink_llm_span_translation.py
+++ b/client/tests/test_sink_llm_span_translation.py
@@ -1,0 +1,422 @@
+"""Tests for LLM-call Event → SpanStart/SpanEnd translation at the
+:class:`HarmonografSink` boundary (harmonograf Option X).
+
+Background
+----------
+Goldfive emits three LLM-call-flavored Event oneof variants:
+
+* ``GoldfiveLLMCallStart`` / ``GoldfiveLLMCallEnd`` — pairs around every
+  internal ``await call_llm(...)`` (planner refine, goal-derive, ...)
+* ``ReasoningJudgeInvoked`` — terminal-only record of every judge call.
+
+Pre-Option-X these rode as ``goldfive_event`` envelopes and the frontend
+synthesized "spans" locally — requiring a new handler for every new
+event kind and producing spans that weren't stored in the server's
+``spans`` table. Option X translates at the client sink so the server
+stores them as real spans and the frontend renders them uniformly.
+
+These tests pin the contract:
+
+* translated variants never reach ``emit_goldfive_event`` — they become
+  ``SPAN_START`` / ``SPAN_END`` envelopes on the same ring buffer;
+* every other goldfive oneof passes through unchanged;
+* the judge variant preserves the full ``judge.*`` attribute vocabulary
+  so :class:`JudgeInvocationDetail` (harmonograf#147) keeps reading the
+  same keys post-migration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from goldfive.pb.goldfive.v1 import events_pb2 as ge
+
+from harmonograf_client.buffer import EnvelopeKind, SpanEnvelope
+from harmonograf_client.client import Client
+from harmonograf_client.sink import HarmonografSink
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+CLIENT_AGENT_ID = "presentation-orchestrated-abc123"
+GOLDFIVE_AGENT_ID = f"{CLIENT_AGENT_ID}:goldfive"
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="presentation",
+        agent_id=CLIENT_AGENT_ID,
+        session_id="sess-x",
+        framework="ADK",
+        buffer_size=32,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def sink(client: Client) -> HarmonografSink:
+    return HarmonografSink(client)
+
+
+def _drain(client: Client) -> list[SpanEnvelope]:
+    return list(client._events.drain())
+
+
+def _event(which_setter, event_id: str = "e-1", run_id: str = "run-1") -> ge.Event:
+    evt = ge.Event()
+    evt.event_id = event_id
+    evt.run_id = run_id
+    evt.sequence = 0
+    # Stamp a non-zero emitted_at so translators can derive timestamps.
+    evt.emitted_at.seconds = 1_700_000_000
+    evt.emitted_at.nanos = 250_000_000
+    which_setter(evt)
+    return evt
+
+
+def _attr_str(env: SpanEnvelope, key: str) -> str:
+    return env.payload.span.attributes[key].string_value
+
+
+def _attr_bool(env: SpanEnvelope, key: str) -> bool:
+    return env.payload.span.attributes[key].bool_value
+
+
+# ---------------------------------------------------------------------------
+# GoldfiveLLMCallStart → SpanStart
+# ---------------------------------------------------------------------------
+
+
+class TestGoldfiveLLMCallStart:
+    @pytest.mark.asyncio
+    async def test_becomes_span_start(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        def setup(e: ge.Event) -> None:
+            s = e.goldfive_llm_call_start
+            s.span_id = "span-refine-1"
+            s.name = "refine_steer"
+            s.model = "gpt-4o"
+            s.task_id = "task-42"
+            s.start_time_ns = 1_700_000_000_000_000_000
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        # Exactly one SPAN_START, no goldfive_event forwarded.
+        assert len(envs) == 1
+        assert envs[0].kind is EnvelopeKind.SPAN_START
+        span = envs[0].payload.span
+        assert span.id == "span-refine-1"
+        assert span.agent_id == GOLDFIVE_AGENT_ID
+        assert span.name == "refine_steer"
+        # LLM_CALL enum value.
+        types_pb2 = client._types_pb2
+        assert span.kind == types_pb2.SPAN_KIND_LLM_CALL
+        # start_time_ns is preserved on the wire.
+        assert span.start_time.seconds == 1_700_000_000
+        # Attributes round-trip run/model/task.
+        assert _attr_str(envs[0], "goldfive.model") == "gpt-4o"
+        assert _attr_str(envs[0], "goldfive.task_id") == "task-42"
+        assert _attr_str(envs[0], "goldfive.run_id") == "run-1"
+        assert _attr_str(envs[0], "goldfive.call_name") == "refine_steer"
+
+    @pytest.mark.asyncio
+    async def test_missing_span_id_is_derived_from_event(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """A runner that forgets to stamp ``span_id`` still produces a
+        renderable span — deterministic derivation from event_id."""
+
+        def setup(e: ge.Event) -> None:
+            s = e.goldfive_llm_call_start
+            s.name = "goal_derive"
+            s.start_time_ns = 1_700_000_000_000_000_000
+        evt = _event(setup, event_id="e-bare")
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert envs[0].payload.span.id == "goldfive-goldfive_llm_call_start-e-bare"
+
+
+# ---------------------------------------------------------------------------
+# GoldfiveLLMCallEnd → SpanEnd
+# ---------------------------------------------------------------------------
+
+
+class TestGoldfiveLLMCallEnd:
+    @pytest.mark.asyncio
+    async def test_becomes_span_end_completed(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        def setup(e: ge.Event) -> None:
+            end = e.goldfive_llm_call_end
+            end.span_id = "span-refine-1"
+            end.name = "refine_steer"
+            end.end_time_ns = 1_700_000_000_500_000_000
+            end.status = "completed"
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert len(envs) == 1
+        assert envs[0].kind is EnvelopeKind.SPAN_END
+        se = envs[0].payload
+        types_pb2 = client._types_pb2
+        assert se.span_id == "span-refine-1"
+        assert se.status == types_pb2.SPAN_STATUS_COMPLETED
+        assert se.end_time.seconds == 1_700_000_000
+        # Echo of the call name survives for End-before-Start consumers.
+        assert se.attributes["goldfive.call_name"].string_value == "refine_steer"
+        assert se.attributes["goldfive.status"].string_value == "completed"
+        # No error plumbed on success.
+        assert se.error.message == ""
+
+    @pytest.mark.asyncio
+    async def test_failed_status_plumbs_error_message(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        def setup(e: ge.Event) -> None:
+            end = e.goldfive_llm_call_end
+            end.span_id = "span-boom"
+            end.name = "plan_generate"
+            end.end_time_ns = 1_700_000_000_500_000_000
+            end.status = "failed"
+            end.error = "timeout after 30s"
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert len(envs) == 1
+        se = envs[0].payload
+        types_pb2 = client._types_pb2
+        assert se.status == types_pb2.SPAN_STATUS_FAILED
+        assert se.error.type == "goldfive_llm_call"
+        assert se.error.message == "timeout after 30s"
+
+
+# ---------------------------------------------------------------------------
+# ReasoningJudgeInvoked → SpanStart + SpanEnd (pair)
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningJudgeInvoked:
+    @pytest.mark.asyncio
+    async def test_becomes_span_pair_in_order(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        def setup(e: ge.Event) -> None:
+            ju = e.reasoning_judge_invoked
+            ju.run_id = "run-1"
+            ju.task_id = "t-work"
+            ju.subject_agent_id = "research_agent"
+            ju.model = "claude-3-opus"
+            ju.elapsed_ms = 250
+            ju.reasoning_input = "the model is considering options A and B"
+            ju.raw_response = '{"on_task": true}'
+            ju.on_task = True
+            ju.severity = ""
+            ju.reason = "staying within scope"
+        evt = _event(setup, event_id="e-judge-1")
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        # Exactly: SPAN_START then SPAN_END, back-to-back.
+        assert [env.kind for env in envs] == [
+            EnvelopeKind.SPAN_START,
+            EnvelopeKind.SPAN_END,
+        ]
+        # Ids match across the pair.
+        assert envs[0].payload.span.id == envs[1].payload.span_id
+
+    @pytest.mark.asyncio
+    async def test_judge_attributes_preserved(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """All ``judge.*`` attribute reads used by ``JudgeInvocationDetail``
+        must land on the translated SpanStart verbatim. This pins the
+        contract from ``frontend/src/lib/interventionDetail.ts``."""
+
+        def setup(e: ge.Event) -> None:
+            ju = e.reasoning_judge_invoked
+            ju.run_id = "run-1"
+            ju.task_id = "t-work"
+            ju.subject_agent_id = "research_agent"
+            ju.model = "claude-3-opus"
+            ju.elapsed_ms = 1500
+            ju.reasoning_input = "chain of thought text"
+            ju.raw_response = '{"on_task": false, "severity": "warning", "reason": "scope creep"}'
+            ju.on_task = False
+            ju.severity = "warning"
+            ju.reason = "scope creep"
+        evt = _event(setup, event_id="e-judge-2")
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        start = envs[0]
+        assert _attr_str(start, "judge.kind") == "judge"
+        assert _attr_str(start, "judge.event_id") == "e-judge-2"
+        assert _attr_str(start, "judge.verdict") == "warning"
+        assert _attr_bool(start, "judge.on_task") is False
+        assert _attr_str(start, "judge.severity") == "warning"
+        assert _attr_str(start, "judge.reason") == "scope creep"
+        assert _attr_str(start, "judge.reasoning_input") == "chain of thought text"
+        # Back-compat alias (detail resolver reads ``judge.reasoning``).
+        assert _attr_str(start, "judge.reasoning") == "scope creep"
+        assert _attr_str(start, "judge.raw_response").startswith("{")
+        assert _attr_str(start, "judge.elapsed_ms") == "1500"
+        assert _attr_str(start, "judge.model") == "claude-3-opus"
+        assert _attr_str(start, "judge.subject_agent_id") == "research_agent"
+        # Alias checked by detail resolver's fallback read order.
+        assert _attr_str(start, "judge.target_agent_id") == "research_agent"
+        assert _attr_str(start, "judge.target_task_id") == "t-work"
+
+    @pytest.mark.asyncio
+    async def test_span_has_visible_width_from_elapsed_ms(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """The pre-Option-X synthesizer covered ``[emitted_at - elapsed, emitted_at]``
+        so zero-width judge spans weren't invisible on the Gantt. The
+        sink's translation must preserve that invariant — see
+        harmonograf#149."""
+
+        def setup(e: ge.Event) -> None:
+            # emitted_at set by _event() to sec=1_700_000_000 nanos=250_000_000.
+            ju = e.reasoning_judge_invoked
+            ju.elapsed_ms = 1000
+            ju.on_task = True
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        start_span = envs[0].payload.span
+        end_msg = envs[1].payload
+        # end_time is the event's emitted_at (1_700_000_000.25s).
+        assert end_msg.end_time.seconds == 1_700_000_000
+        assert end_msg.end_time.nanos == 250_000_000
+        # start_time is 1s earlier.
+        assert start_span.start_time.seconds == 1_699_999_999
+        assert start_span.start_time.nanos == 250_000_000
+
+    @pytest.mark.asyncio
+    async def test_verdict_derived_from_on_task(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """When ``on_task`` is true, verdict stamps ``"on_task"`` even
+        with no explicit verdict field on the wire."""
+
+        def setup(e: ge.Event) -> None:
+            ju = e.reasoning_judge_invoked
+            ju.on_task = True
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert _attr_str(envs[0], "judge.verdict") == "on_task"
+        assert envs[0].payload.span.name == "judge: on_task"
+
+
+# ---------------------------------------------------------------------------
+# Pass-through: non-LLM events still take the goldfive_event path
+# ---------------------------------------------------------------------------
+
+
+class TestPassThroughUnchanged:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "setup,kind",
+        [
+            (lambda e: e.run_started.SetInParent(), "run_started"),
+            (lambda e: e.drift_detected.SetInParent(), "drift_detected"),
+            (lambda e: e.task_started.SetInParent(), "task_started"),
+            (lambda e: e.plan_revised.SetInParent(), "plan_revised"),
+        ],
+    )
+    async def test_non_llm_events_forwarded_unchanged(
+        self,
+        sink: HarmonografSink,
+        client: Client,
+        setup: Any,
+        kind: str,
+    ) -> None:
+        evt = _event(setup, event_id=f"e-{kind}")
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert len(envs) == 1
+        assert envs[0].kind is EnvelopeKind.GOLDFIVE_EVENT
+        assert envs[0].payload.WhichOneof("payload") == kind
+
+
+# ---------------------------------------------------------------------------
+# Agent-id compound form + idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestGoldfiveAgentId:
+    @pytest.mark.asyncio
+    async def test_agent_id_is_compound_goldfive(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        def setup(e: ge.Event) -> None:
+            e.goldfive_llm_call_start.span_id = "s1"
+            e.goldfive_llm_call_start.name = "goal_derive"
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert envs[0].payload.span.agent_id == f"{CLIENT_AGENT_ID}:goldfive"
+
+    @pytest.mark.asyncio
+    async def test_judge_span_agent_id_is_compound_goldfive(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        def setup(e: ge.Event) -> None:
+            e.reasoning_judge_invoked.on_task = True
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert envs[0].payload.span.agent_id == f"{CLIENT_AGENT_ID}:goldfive"
+
+
+# ---------------------------------------------------------------------------
+# Closed-sink semantics
+# ---------------------------------------------------------------------------
+
+
+class TestClosedSinkDropsTranslated:
+    @pytest.mark.asyncio
+    async def test_closed_sink_drops_llm_start(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        await sink.close()
+
+        def setup(e: ge.Event) -> None:
+            e.goldfive_llm_call_start.span_id = "s1"
+            e.goldfive_llm_call_start.name = "refine"
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        assert _drain(client) == []
+
+    @pytest.mark.asyncio
+    async def test_closed_sink_drops_judge(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        await sink.close()
+
+        def setup(e: ge.Event) -> None:
+            e.reasoning_judge_invoked.on_task = False
+            e.reasoning_judge_invoked.severity = "warning"
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        assert _drain(client) == []


### PR DESCRIPTION
Closes #154.

## Summary

- \`HarmonografSink.emit\` now intercepts three goldfive Event oneof variants (\`goldfive_llm_call_start\`, \`goldfive_llm_call_end\`, \`reasoning_judge_invoked\`) and translates them to \`SpanStart\` / \`SpanEnd\` frames on the span transport instead of forwarding as \`goldfive_event\`.
- All translated spans stamp \`agent_id = <client>:goldfive\` (via the existing idempotent \`_compound\` helper), \`kind = LLM_CALL\`.
- \`ReasoningJudgeInvoked\` becomes a start/end pair covering \`[emitted_at - elapsed_ms, emitted_at]\` so the span has visible Gantt width (preserves harmonograf#149's fix). All \`judge.*\` attribute keys that \`JudgeInvocationDetail\` reads are stamped on the translated SpanStart verbatim — click-through panel keeps working.
- Non-translated goldfive events (run_started, drift_detected, plan_revised, task_*, approvals, ...) still take the existing \`emit_goldfive_event\` path unchanged.

## Why at the client sink

Goldfive stays proto-stable (no changes to the goldfive proto or library). The server stores translated spans in the \`spans\` table like any other span. The frontend no longer needs per-event-kind synthesizers for LLM calls. When the next goldfive-internal LLM site lands, it renders automatically without a frontend follow-up.

## Proto audit

- \`GoldfiveLLMCallStart\` / \`End\` already carry \`span_id\` — deterministic pairing.
- \`ReasoningJudgeInvoked\` carries no \`span_id\` (pre-span-pair model). The translator derives \`goldfive-reasoning_judge_invoked-<event_id>\` — stable under re-emission, unique per judge call. No goldfive issue filed; existing fields are sufficient.

## Merge coordination

A parallel PR on \`refactor/retire-frontend-goldfive-span-synthesis\` removes the frontend synthesizers. Merge THIS PR first so spans don't vanish: post-merge both the frontend-synthesized and the translated spans render briefly (harmless double-render) until the retirement PR lands.

Do NOT merge per user instruction — review only.

## Attribute contract preserved (for JudgeInvocationDetail, harmonograf#147)

Every key read by \`frontend/src/lib/interventionDetail.ts\` lands on the translated SpanStart: \`judge.kind\`, \`judge.event_id\`, \`judge.verdict\`, \`judge.on_task\`, \`judge.severity\`, \`judge.reason\`, \`judge.reasoning_input\`, \`judge.reasoning\` (back-compat alias), \`judge.raw_response\`, \`judge.elapsed_ms\`, \`judge.model\`, \`judge.subject_agent_id\`, \`judge.target_agent_id\` (alias), \`judge.target_task_id\`, \`judge.run_id\`.

## Test plan

- [x] \`uv run --extra e2e pytest client/tests -q\`: 285 → 301 (+16, all passing).
- [x] \`uvx ruff check client/harmonograf_client/sink.py client/tests/test_sink_llm_span_translation.py\`: clean.
- [x] \`uvx mypy client/harmonograf_client/sink.py\`: one new import-untyped on \`google.protobuf\`; same category as the pre-existing errors on \`client.py\` (no protobuf stubs installed project-wide). No new functional type errors.
- [x] Judge translation end-to-end: start precedes end, span ids match, \`judge.*\` attributes round-trip, width equals \`elapsed_ms\`.
- [x] Closed-sink drops translated events (parity with existing semantics).
- [x] Pass-through events (drift, run_started, task_*, plan_revised) still hit \`emit_goldfive_event\`.