### PR TITLE
feat(client): stamp goldfive input/output/target/decision attributes on translated spans

### DIFF
--- a/client/harmonograf_client/sink.py
+++ b/client/harmonograf_client/sink.py
@@ -7,6 +7,46 @@ transport's backpressure, reconnect, and heartbeat semantics — nothing new on
 the wire except the ``goldfive_event`` variant introduced in the Phase A proto
 migration (issue #2).
 
+Goldfive agent-row display-name (harmonograf#156, Issue A)
+----------------------------------------------------------
+The server auto-registers a new agent row on the first span emitted against
+a ``(session_id, agent_id)`` it has not seen. Display name is resolved in
+``ingest.py::_register_agent_if_new`` with precedence
+``hgraf.agent.name → span.name → agent_id``. The very first translated span
+on the ``<client>:goldfive`` row used to be whichever goldfive-internal call
+ran first (``goal_derive`` in practice), so the row was mislabeled and every
+subsequent judge/refine span joined a ``goal_derive``-named row.
+
+The fix stamps ``hgraf.agent.name=goldfive`` and ``hgraf.agent.kind=goldfive``
+on the FIRST translated SpanStart emitted in this sink's lifetime. Subsequent
+translations skip the stamp — the row is already registered server-side and
+re-stamping would burn bytes without changing behaviour (see the equivalent
+first-sight gating in
+:meth:`HarmonografTelemetryPlugin._stamp_agent_attrs`).
+
+There is no dedicated ``AgentRegister`` wire primitive today; the first-span
+harvest is the only registration hook. Adding one (plus a
+``FRAMEWORK_GOLDFIVE`` enum value) is tracked as a follow-up on #156.
+
+Goldfive decision-context attributes (harmonograf#156, Issue B)
+---------------------------------------------------------------
+A parallel goldfive PR extends ``GoldfiveLLMCallStart`` /
+``GoldfiveLLMCallEnd`` / ``ReasoningJudgeInvoked`` with decision-context
+fields (``input_preview``, ``output_preview``, ``target_agent_id``,
+``target_task_id``, ``decision_summary``). The sink stamps each non-empty
+field onto the translated span with a ``goldfive.`` prefix so the frontend
+can render click-through detail panels uniformly.
+
+``target_agent_id`` is canonicalized via :meth:`_compound` so bare goldfive
+agent names become ``<client>:<bare>`` ids — matching the rewrite pattern
+:meth:`_canonicalize_agent_ids` applies to pass-through events.
+
+Forward-compat: ``hasattr(event, 'input_preview')`` guards every read so the
+sink continues to work both before and after the goldfive submodule bump
+that lands the new proto fields. A one-shot debug log fires when the proto
+is missing the fields so operators can correlate "no decision context on
+spans" with "goldfive submodule needs bump".
+
 Module identity: harmonograf's generated ``telemetry_pb2`` imports
 ``goldfive.v1.events_pb2`` via the same module grafted onto ``goldfive.pb``,
 so ``TelemetryUp.goldfive_event`` shares its class with whatever goldfive's
@@ -90,11 +130,19 @@ Rewrite rules:
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from google.protobuf import timestamp_pb2
 
 from .client import Client
+
+logger = logging.getLogger(__name__)
+
+# One-shot flag: True after we've logged the "goldfive proto missing
+# decision-context fields" warning once per process. Keeps the log from
+# firing on every translated event when the submodule is pre-bump.
+_LOGGED_MISSING_PROTO_FIELDS: bool = False
 
 # Events whose translation-to-span semantics the sink owns. Anything else
 # passes through ``emit_goldfive_event`` as before.
@@ -154,6 +202,11 @@ class HarmonografSink:
     def __init__(self, client: Client) -> None:
         self._client = client
         self._closed = False
+        # First-translated-SpanStart stamps ``hgraf.agent.{name,kind}`` so
+        # the server registers the ``<client>:goldfive`` row with a
+        # human-readable name (harmonograf#156 Issue A). Subsequent
+        # translations skip the stamp — the row is already registered.
+        self._goldfive_agent_registered: bool = False
 
     @property
     def client(self) -> Client:
@@ -301,6 +354,9 @@ class HarmonografSink:
         """``GoldfiveLLMCallStart`` → ``SpanStart``."""
         start = event_pb.goldfive_llm_call_start
         span_id = start.span_id or self._derive_span_id(event_pb)
+        attrs = self._llm_call_attributes(event_pb, start)
+        self._stamp_decision_context(attrs, start, is_end=False)
+        self._maybe_stamp_agent_registration(attrs)
         self._client.emit_span_start(
             kind="LLM_CALL",
             name=start.name or "goldfive_llm_call",
@@ -308,7 +364,7 @@ class HarmonografSink:
             start_time=_ts_from_nanos(start.start_time_ns),
             agent_id=self._goldfive_agent_id(),
             session_id=event_pb.session_id or None,
-            attributes=self._llm_call_attributes(event_pb, start),
+            attributes=attrs,
         )
 
     def _emit_llm_call_end(self, event_pb: Any) -> None:
@@ -330,6 +386,7 @@ class HarmonografSink:
             attributes["goldfive.call_name"] = end.name
         if wire_status:
             attributes["goldfive.status"] = wire_status
+        self._stamp_decision_context(attributes, end, is_end=True)
         self._client.emit_span_end(
             span_id,
             status=status,
@@ -409,6 +466,15 @@ class HarmonografSink:
             # Run id is handy for debugging cross-session judge lookups.
             "judge.run_id": event_pb.run_id or "",
         }
+        # Goldfive PR extending the judge event with decision-context
+        # fields (harmonograf#156 Issue B): stamp the same ``goldfive.*``
+        # prefix used on the LLM call pair so frontend reads keys
+        # consistently regardless of the source oneof. ``is_end=True`` is
+        # a lie at the read layer — the judge pair collapses both
+        # preview/summary onto the SpanStart since there is no separate
+        # End record to carry ``output_preview``/``decision_summary``.
+        self._stamp_decision_context(attrs, ju, is_end=True)
+        self._maybe_stamp_agent_registration(attrs)
         session_id = event_pb.session_id or None
         agent_id = self._goldfive_agent_id()
         span_id = self._derive_span_id(event_pb)
@@ -438,6 +504,83 @@ class HarmonografSink:
         if start.name:
             attrs["goldfive.call_name"] = start.name
         return attrs
+
+    def _maybe_stamp_agent_registration(self, attrs: dict[str, Any]) -> None:
+        """Stamp ``hgraf.agent.{name,kind}`` on the first translated span.
+
+        Harmonograf has no dedicated agent-registration wire primitive;
+        the server derives an agent row's display name from the first
+        span's ``hgraf.agent.name`` attribute (with fall-through to
+        ``span.name`` and ``agent_id``). Without this stamp the
+        ``<client>:goldfive`` row would be labeled with whichever
+        goldfive-internal LLM call fired first (typically
+        ``goal_derive``) — see harmonograf#156.
+
+        First-sight gated by :attr:`_goldfive_agent_registered` so the
+        stamp lands exactly once per sink instance. The server's
+        ``seen_routes`` cache short-circuits re-registers anyway, but
+        keeping the client side tight avoids bloating every span frame
+        with redundant attribute entries.
+        """
+        if self._goldfive_agent_registered:
+            return
+        attrs["hgraf.agent.name"] = "goldfive"
+        attrs["hgraf.agent.kind"] = "goldfive"
+        self._goldfive_agent_registered = True
+
+    def _stamp_decision_context(
+        self, attrs: dict[str, Any], payload: Any, *, is_end: bool
+    ) -> None:
+        """Stamp goldfive decision-context fields as ``goldfive.*`` attributes.
+
+        The sibling goldfive PR (goldfive-span-context) extends the three
+        LLM-call-flavored event payloads with:
+
+        * ``input_preview`` — truncated input shown to the LLM (both Start and End)
+        * ``output_preview`` — truncated model output (End only)
+        * ``target_agent_id`` — bare or compound id of the subject agent
+          (canonicalized to compound via :meth:`_compound`)
+        * ``target_task_id`` — task this call is deciding on
+        * ``decision_summary`` — one-line summary of the decision (End only)
+
+        Empty strings are skipped to avoid attribute-map clutter. Fields
+        missing from the proto (pre-submodule-bump) are detected via
+        ``hasattr`` and skipped — a one-shot debug log fires so operators
+        can correlate.
+
+        ``is_end`` scopes which fields are read: Start events don't carry
+        ``output_preview``/``decision_summary`` on the goldfive proto, so
+        we don't probe them there. (The judge-span path passes
+        ``is_end=True`` because its terminal-only event carries both.)
+        """
+        # Probe a single field to detect pre-bump protos. Only one field
+        # is needed; the sibling PR lands all five atomically.
+        if not hasattr(payload, "input_preview"):
+            global _LOGGED_MISSING_PROTO_FIELDS
+            if not _LOGGED_MISSING_PROTO_FIELDS:
+                logger.debug(
+                    "GoldfiveLLMCallStart/End proto missing input_preview field; "
+                    "awaiting goldfive submodule bump"
+                )
+                _LOGGED_MISSING_PROTO_FIELDS = True
+            return
+
+        input_preview = getattr(payload, "input_preview", "") or ""
+        if input_preview:
+            attrs["goldfive.input_preview"] = input_preview
+        target_agent_id = getattr(payload, "target_agent_id", "") or ""
+        if target_agent_id:
+            attrs["goldfive.target_agent_id"] = self._compound(target_agent_id)
+        target_task_id = getattr(payload, "target_task_id", "") or ""
+        if target_task_id:
+            attrs["goldfive.target_task_id"] = target_task_id
+        if is_end:
+            output_preview = getattr(payload, "output_preview", "") or ""
+            if output_preview:
+                attrs["goldfive.output_preview"] = output_preview
+            decision_summary = getattr(payload, "decision_summary", "") or ""
+            if decision_summary:
+                attrs["goldfive.decision_summary"] = decision_summary
 
     def _derive_span_id(self, event_pb: Any) -> str:
         """Fallback span id when the event doesn't carry its own.

--- a/client/tests/test_sink_llm_span_translation.py
+++ b/client/tests/test_sink_llm_span_translation.py
@@ -420,3 +420,479 @@ class TestClosedSinkDropsTranslated:
         await sink.emit(evt)
 
         assert _drain(client) == []
+
+
+# ---------------------------------------------------------------------------
+# Agent-row display-name registration (harmonograf#156 Issue A)
+# ---------------------------------------------------------------------------
+
+
+class TestGoldfiveAgentRegistration:
+    """Pin the first-translated-span registration contract.
+
+    The server's auto-register-on-first-span path (see
+    ``ingest.py::_register_agent_if_new``) reads ``hgraf.agent.name`` and
+    ``hgraf.agent.kind`` off the first span's attributes. Without the
+    stamp, the ``<client>:goldfive`` row ends up labeled with whichever
+    goldfive-internal call fired first (``goal_derive`` in every real
+    session). Once registered, subsequent translations skip the stamp.
+    """
+
+    @pytest.mark.asyncio
+    async def test_first_goldfive_span_registers_display_name(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        def setup(e: ge.Event) -> None:
+            s = e.goldfive_llm_call_start
+            s.span_id = "s-first"
+            s.name = "goal_derive"
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert len(envs) == 1
+        assert _attr_str(envs[0], "hgraf.agent.name") == "goldfive"
+        assert _attr_str(envs[0], "hgraf.agent.kind") == "goldfive"
+        # The span is emitted against the compound agent id — confirms the
+        # server will key the harvest against the goldfive row and not
+        # the client root.
+        assert envs[0].payload.span.agent_id == GOLDFIVE_AGENT_ID
+
+    @pytest.mark.asyncio
+    async def test_subsequent_spans_do_not_re_register(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        def setup_a(e: ge.Event) -> None:
+            s = e.goldfive_llm_call_start
+            s.span_id = "s-1"
+            s.name = "goal_derive"
+
+        def setup_b(e: ge.Event) -> None:
+            s = e.goldfive_llm_call_start
+            s.span_id = "s-2"
+            s.name = "refine_steer"
+
+        await sink.emit(_event(setup_a, event_id="e-1"))
+        await sink.emit(_event(setup_b, event_id="e-2"))
+
+        envs = _drain(client)
+        assert len(envs) == 2
+        # First span carries the registration attrs.
+        assert _attr_str(envs[0], "hgraf.agent.name") == "goldfive"
+        # Second span is free of them — re-stamping burns bytes for no
+        # behavioural gain (the server's ``seen_routes`` cache would
+        # ignore them anyway).
+        assert "hgraf.agent.name" not in envs[1].payload.span.attributes
+        assert "hgraf.agent.kind" not in envs[1].payload.span.attributes
+
+    @pytest.mark.asyncio
+    async def test_first_translated_judge_also_registers(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """The registration flag keys off "first translated span in this
+        sink's lifetime" — not "first ``goldfive_llm_call_start``". A
+        session that opens with a judge event must also register the row.
+        """
+
+        def setup(e: ge.Event) -> None:
+            ju = e.reasoning_judge_invoked
+            ju.on_task = True
+            ju.elapsed_ms = 100
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        # Start carries the stamp; End does not (first-sight gates on the
+        # Start alone).
+        assert _attr_str(envs[0], "hgraf.agent.name") == "goldfive"
+        assert _attr_str(envs[0], "hgraf.agent.kind") == "goldfive"
+
+
+# ---------------------------------------------------------------------------
+# Decision-context attribute stamping (harmonograf#156 Issue B)
+# ---------------------------------------------------------------------------
+#
+# Goldfive's sibling PR extends GoldfiveLLMCallStart/End with
+# ``input_preview`` / ``output_preview`` / ``target_agent_id`` /
+# ``target_task_id`` / ``decision_summary``. At the time this test file
+# was written the goldfive submodule is pre-bump so the proto fields
+# don't exist yet. We exercise both modes:
+#
+# * post-bump: build a stub payload + event that quacks like the future
+#   proto message (``WhichOneof`` plus the payload attribute accessors).
+# * pre-bump: use the real ``ge.Event`` and assert no new attrs leak +
+#   no crash.
+
+
+class _StubEvent:
+    """Quacks like a ``ge.Event`` enough for the sink to route.
+
+    The translator reads ``WhichOneof("payload")`` to dispatch and then
+    pulls the payload via attribute lookup (``event.goldfive_llm_call_start``
+    etc). No other event-level fields are required for the decision-
+    context tests — ``run_id``, ``session_id``, ``event_id``,
+    ``emitted_at`` are consumed by the translator via ``or ""`` / ``or None``
+    fallbacks so defaults are fine.
+    """
+
+    def __init__(self, which: str, payload: Any) -> None:
+        self._which = which
+        # Attach the payload under the oneof-case-name attribute the
+        # translator reads. Other oneof-slot attributes are deliberately
+        # missing so any accidental cross-field read raises AttributeError
+        # rather than silently returning a default proto message.
+        setattr(self, which, payload)
+        self.event_id = "stub-evt"
+        self.run_id = "stub-run"
+        self.session_id = "stub-sess"
+        # emitted_at: a duck-typed Timestamp with seconds + nanos so the
+        # reasoning-judge path can compute start/end.
+        self.emitted_at = _StubTs(1_700_000_000, 0)
+
+    def WhichOneof(self, _oneof: str) -> str:
+        return self._which
+
+
+class _StubTs:
+    def __init__(self, seconds: int, nanos: int) -> None:
+        self.seconds = seconds
+        self.nanos = nanos
+
+
+class _StubLLMPayload:
+    """Duck-typed ``GoldfiveLLMCallStart`` / ``GoldfiveLLMCallEnd``.
+
+    Carries every field the translator reads, including the post-bump
+    decision-context fields. Any attribute absent from ``**kwargs``
+    defaults to the proto-scalar zero value (``""`` / ``0``) so the
+    skip-on-empty logic exercises realistically.
+    """
+
+    _DEFAULTS = {
+        "span_id": "",
+        "name": "",
+        "model": "",
+        "task_id": "",
+        "start_time_ns": 0,
+        "end_time_ns": 0,
+        "status": "",
+        "error": "",
+        "input_preview": "",
+        "output_preview": "",
+        "target_agent_id": "",
+        "target_task_id": "",
+        "decision_summary": "",
+    }
+
+    def __init__(self, **kwargs: Any) -> None:
+        for k, default in self._DEFAULTS.items():
+            setattr(self, k, kwargs.pop(k, default))
+        if kwargs:
+            raise TypeError(f"unknown stub fields: {list(kwargs)}")
+
+
+class _StubJudgePayload:
+    """Duck-typed ``ReasoningJudgeInvoked`` with post-bump context fields."""
+
+    _DEFAULTS = {
+        "run_id": "",
+        "task_id": "",
+        "subject_agent_id": "",
+        "model": "",
+        "elapsed_ms": 0,
+        "reasoning_input": "",
+        "raw_response": "",
+        "on_task": False,
+        "severity": "",
+        "reason": "",
+        "input_preview": "",
+        "output_preview": "",
+        "target_agent_id": "",
+        "target_task_id": "",
+        "decision_summary": "",
+    }
+
+    def __init__(self, **kwargs: Any) -> None:
+        for k, default in self._DEFAULTS.items():
+            setattr(self, k, kwargs.pop(k, default))
+        if kwargs:
+            raise TypeError(f"unknown stub fields: {list(kwargs)}")
+
+
+class TestDecisionContextStamping:
+    @pytest.mark.asyncio
+    async def test_input_preview_stamped_as_span_attribute(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        payload = _StubLLMPayload(
+            span_id="s1",
+            name="refine_steer",
+            input_preview="foo bar baz",
+        )
+        await sink.emit(_StubEvent("goldfive_llm_call_start", payload))
+
+        envs = _drain(client)
+        assert len(envs) == 1
+        assert _attr_str(envs[0], "goldfive.input_preview") == "foo bar baz"
+
+    @pytest.mark.asyncio
+    async def test_output_preview_only_on_end(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """Start doesn't carry ``output_preview`` semantically — even if
+        the stub leaks the attribute with an empty value, the sink's
+        skip-on-empty logic keeps the Start span clean."""
+        start = _StubLLMPayload(
+            span_id="s-pair",
+            name="refine_steer",
+            input_preview="prompt text",
+            output_preview="",  # empty → not stamped on Start
+        )
+        await sink.emit(_StubEvent("goldfive_llm_call_start", start))
+
+        end = _StubLLMPayload(
+            span_id="s-pair",
+            name="refine_steer",
+            status="completed",
+            end_time_ns=1_700_000_000_500_000_000,
+            output_preview="bar",  # non-empty → stamped on End
+        )
+        await sink.emit(_StubEvent("goldfive_llm_call_end", end))
+
+        envs = _drain(client)
+        assert [env.kind for env in envs] == [
+            EnvelopeKind.SPAN_START,
+            EnvelopeKind.SPAN_END,
+        ]
+        assert (
+            "goldfive.output_preview"
+            not in envs[0].payload.span.attributes
+        )
+        assert envs[1].payload.attributes["goldfive.output_preview"].string_value == "bar"
+
+    @pytest.mark.asyncio
+    async def test_target_agent_id_compound_canonicalization(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        payload = _StubLLMPayload(
+            span_id="s-canon",
+            name="judge_reasoning",
+            target_agent_id="research_agent",  # bare
+            target_task_id="t-99",
+        )
+        await sink.emit(_StubEvent("goldfive_llm_call_start", payload))
+
+        envs = _drain(client)
+        assert (
+            _attr_str(envs[0], "goldfive.target_agent_id")
+            == f"{CLIENT_AGENT_ID}:research_agent"
+        )
+        assert _attr_str(envs[0], "goldfive.target_task_id") == "t-99"
+
+    @pytest.mark.asyncio
+    async def test_target_agent_id_already_compound_passthrough(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """Already-compound ids pass through untouched — the ``:``
+        presence check in :meth:`_compound` is idempotent."""
+        compound = f"{CLIENT_AGENT_ID}:research_agent"
+        payload = _StubLLMPayload(
+            span_id="s-id",
+            name="judge_reasoning",
+            target_agent_id=compound,
+        )
+        await sink.emit(_StubEvent("goldfive_llm_call_start", payload))
+
+        envs = _drain(client)
+        assert _attr_str(envs[0], "goldfive.target_agent_id") == compound
+
+    @pytest.mark.asyncio
+    async def test_decision_summary_stamped_on_end(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        end = _StubLLMPayload(
+            span_id="s-end",
+            name="plan_generate",
+            status="completed",
+            decision_summary="picked plan A",
+        )
+        await sink.emit(_StubEvent("goldfive_llm_call_end", end))
+
+        envs = _drain(client)
+        assert envs[0].kind is EnvelopeKind.SPAN_END
+        assert (
+            envs[0].payload.attributes["goldfive.decision_summary"].string_value
+            == "picked plan A"
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_fields_not_stamped(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """All decision-context fields empty → no ``goldfive.{input_preview,
+        output_preview,target_*,decision_summary}`` keys on the span."""
+        end = _StubLLMPayload(
+            span_id="s-empty",
+            name="refine_steer",
+            status="completed",
+        )
+        await sink.emit(_StubEvent("goldfive_llm_call_end", end))
+
+        envs = _drain(client)
+        attr_keys = set(envs[0].payload.attributes.keys())
+        # None of the post-bump keys leaked.
+        for k in (
+            "goldfive.input_preview",
+            "goldfive.output_preview",
+            "goldfive.target_agent_id",
+            "goldfive.target_task_id",
+            "goldfive.decision_summary",
+        ):
+            assert k not in attr_keys
+
+    @pytest.mark.asyncio
+    async def test_judge_event_also_stamps_decision_context(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """``ReasoningJudgeInvoked`` gains the same decision-context
+        fields as the LLM-call pair in the sibling goldfive PR. The
+        judge span collapses both preview + summary onto its SpanStart
+        (there is no separate End record to carry them)."""
+        payload = _StubJudgePayload(
+            run_id="run-j",
+            task_id="t-j",
+            subject_agent_id="research_agent",
+            model="claude-3-opus",
+            elapsed_ms=250,
+            on_task=True,
+            input_preview="the reasoning input preview",
+            output_preview="the judge output preview",
+            target_agent_id="research_agent",
+            target_task_id="t-j",
+            decision_summary="on_task: yes",
+        )
+        await sink.emit(_StubEvent("reasoning_judge_invoked", payload))
+
+        envs = _drain(client)
+        assert [env.kind for env in envs] == [
+            EnvelopeKind.SPAN_START,
+            EnvelopeKind.SPAN_END,
+        ]
+        start = envs[0]
+        assert _attr_str(start, "goldfive.input_preview") == "the reasoning input preview"
+        assert _attr_str(start, "goldfive.output_preview") == "the judge output preview"
+        assert _attr_str(start, "goldfive.decision_summary") == "on_task: yes"
+        # target_agent_id canonicalized to compound.
+        assert (
+            _attr_str(start, "goldfive.target_agent_id")
+            == f"{CLIENT_AGENT_ID}:research_agent"
+        )
+        assert _attr_str(start, "goldfive.target_task_id") == "t-j"
+
+
+# ---------------------------------------------------------------------------
+# Forward-compat: pre-goldfive-submodule-bump protos work without crashes
+# ---------------------------------------------------------------------------
+
+
+class TestMissingProtoFieldsGraceful:
+    """The goldfive submodule bump may land before or after this PR. If
+    the sibling PR hasn't merged yet, ``hasattr(event, 'input_preview')``
+    is False and the sink must continue translating without stamping
+    the new attrs — no crash, no spammy logs.
+
+    These tests use the real ``ge.Event`` (pre-bump proto at the time of
+    writing this suite) so they exercise the ``hasattr`` guard exactly
+    as production would.
+    """
+
+    @pytest.mark.asyncio
+    async def test_real_proto_translates_without_crash(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        def setup(e: ge.Event) -> None:
+            s = e.goldfive_llm_call_start
+            s.span_id = "s-compat"
+            s.name = "refine_steer"
+            s.model = "gpt-4o"
+            s.start_time_ns = 1_700_000_000_000_000_000
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert len(envs) == 1
+        assert envs[0].kind is EnvelopeKind.SPAN_START
+
+    @pytest.mark.asyncio
+    async def test_real_proto_skips_new_attributes(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """Without the new proto fields, none of the new
+        ``goldfive.{input_preview,output_preview,target_*,decision_summary}``
+        keys land on the span."""
+
+        def setup(e: ge.Event) -> None:
+            s = e.goldfive_llm_call_start
+            s.span_id = "s-no-extras"
+            s.name = "refine_steer"
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        attrs = envs[0].payload.span.attributes
+        for k in (
+            "goldfive.input_preview",
+            "goldfive.output_preview",
+            "goldfive.target_agent_id",
+            "goldfive.target_task_id",
+            "goldfive.decision_summary",
+        ):
+            assert k not in attrs
+
+    @pytest.mark.asyncio
+    async def test_real_proto_end_translates_without_crash(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        def setup(e: ge.Event) -> None:
+            end = e.goldfive_llm_call_end
+            end.span_id = "s-e"
+            end.name = "plan_generate"
+            end.end_time_ns = 1_700_000_000_500_000_000
+            end.status = "completed"
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert len(envs) == 1
+        assert envs[0].kind is EnvelopeKind.SPAN_END
+
+    @pytest.mark.asyncio
+    async def test_missing_field_logs_once(
+        self,
+        sink: HarmonografSink,
+        client: Client,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """One-shot debug log fires when the proto is pre-bump so
+        operators can correlate 'no decision context on spans' with
+        'submodule needs bump'."""
+        import harmonograf_client.sink as sink_mod
+
+        # Reset the module-level one-shot flag so the test sees the log
+        # regardless of test-collection order.
+        sink_mod._LOGGED_MISSING_PROTO_FIELDS = False
+        caplog.set_level("DEBUG", logger=sink_mod.logger.name)
+
+        def setup(e: ge.Event) -> None:
+            e.goldfive_llm_call_start.span_id = "s-log"
+            e.goldfive_llm_call_start.name = "refine_steer"
+        # Two emissions back-to-back — the log should fire exactly once.
+        await sink.emit(_event(setup, event_id="e-1"))
+        await sink.emit(_event(setup, event_id="e-2"))
+
+        matches = [
+            r
+            for r in caplog.records
+            if "awaiting goldfive submodule bump" in r.getMessage()
+        ]
+        assert len(matches) == 1


### PR DESCRIPTION
Closes #156.

## Summary

Two fixes on the client-side goldfive-LLM sink translator:

- **Display name**: the ``<client>:goldfive`` agent row was mislabeled as ``goal_derive`` because the server derives display names from the first span's ``name`` and ``LLMGoalDeriver.derive()`` runs first. Stamp ``hgraf.agent.name=goldfive`` + ``hgraf.agent.kind=goldfive`` on the FIRST translated SpanStart in this sink's lifetime. Gated by an instance flag; subsequent spans don't re-stamp.
- **Decision context**: stamp the sibling goldfive PR's new fields (``input_preview``, ``output_preview``, ``target_agent_id``, ``target_task_id``, ``decision_summary``) as ``goldfive.*`` span attributes so the frontend can render click-through detail panels. ``target_agent_id`` is canonicalized to compound via ``_compound()``. Empty fields are skipped.
- **Forward-compat**: ``hasattr(event, 'input_preview')`` guards every read so the sink works both before and after the goldfive submodule bump. One-shot debug log fires when the proto is missing the fields.

## Design notes

**No agent-registration wire primitive exists** on harmonograf today — the server's auto-register-on-first-span path is the only registration hook. Per the task spec, I fell back to stamping ``hgraf.agent.{name,kind}`` attributes on the first translated span. Adding a proper ``AgentRegister`` oneof + ``FRAMEWORK_GOLDFIVE`` enum is tracked as a follow-up on #156.

The judge-span path (``ReasoningJudgeInvoked``) also stamps the new decision-context fields — the sibling goldfive PR extends that event too. Since the judge has no separate End record, ``output_preview`` + ``decision_summary`` collapse onto the synthesized SpanStart.

## Coordination

- goldfive (``/tmp/goldfive-span-context``) — the proto field names here (``input_preview``, ``output_preview``, ``target_agent_id``, ``target_task_id``, ``decision_summary``) match the sibling PR. If those names change, coordinate.
- harmonograf frontend (``/tmp/harmonograf-goldfive-render``) — consumes the ``goldfive.*`` attribute keys stamped here.

## Test plan

- [x] ``pytest client/tests/test_sink_llm_span_translation.py -q`` passes (30 tests: 16 originals + 14 new).
- [x] ``ruff check client/harmonograf_client/sink.py client/tests/test_sink_llm_span_translation.py`` clean.
- [x] Full ``pytest client/tests -q`` green except for 4 pre-existing telemetry_plugin_dedup failures (unrelated; present at baseline before this branch).
- [ ] Manual verification after the goldfive submodule bump that the new attributes arrive on spans in a real session.
- [ ] Frontend renders click-through panels from the new ``goldfive.*`` keys.

## New tests

- ``TestGoldfiveAgentRegistration`` (3): first span registers, subsequent spans don't, first-translated judge also registers.
- ``TestDecisionContextStamping`` (7): input_preview stamped, output_preview only on End, target_agent_id canonicalization + passthrough, decision_summary on End, empty fields skipped, judge event stamps context too.
- ``TestMissingProtoFieldsGraceful`` (4): real pre-bump proto translates without crash, new attrs absent, End path still works, one-shot log fires exactly once.