### PR TITLE
feat(state): plan-history registry + cumulative-plan / revision / supersedes selector hooks

### DIFF
--- a/frontend/src/__tests__/state/planHistory.test.ts
+++ b/frontend/src/__tests__/state/planHistory.test.ts
@@ -1,0 +1,506 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { SessionStore } from '../../gantt/index';
+import {
+  PlanHistoryRegistry,
+  type PlanRevisionRecord,
+} from '../../state/planHistoryStore';
+import { applyGoldfiveEvent } from '../../rpc/goldfiveEvent';
+import { loadPlanHistory, revisionFromWire } from '../../state/planHistoryLoader';
+import type { Task, TaskPlan } from '../../gantt/types';
+import {
+  EventSchema,
+  PlanSubmittedSchema,
+  PlanRevisedSchema,
+} from '../../pb/goldfive/v1/events_pb';
+import {
+  PlanSchema,
+  TaskSchema,
+  TaskEdgeSchema,
+  TaskStatus,
+  DriftKind,
+  DriftSeverity,
+} from '../../pb/goldfive/v1/types_pb';
+
+function mkTask(
+  id: string,
+  overrides: Partial<Task> = {},
+): Task {
+  return {
+    id,
+    title: `Task ${id}`,
+    description: '',
+    assigneeAgentId: 'agent-a',
+    status: 'PENDING',
+    predictedStartMs: 0,
+    predictedDurationMs: 0,
+    boundSpanId: '',
+    ...overrides,
+  };
+}
+
+function mkPlan(id: string, tasks: Task[], rev = 0): TaskPlan {
+  return {
+    id,
+    invocationSpanId: '',
+    plannerAgentId: '',
+    createdAtMs: 0,
+    summary: '',
+    tasks,
+    edges: [],
+    revisionReason: '',
+    revisionKind: '',
+    revisionSeverity: '',
+    revisionIndex: rev,
+    triggerEventId: '',
+  };
+}
+
+function mkRecord(
+  planId: string,
+  revision: number,
+  tasks: Task[],
+  overrides: Partial<PlanRevisionRecord> = {},
+): PlanRevisionRecord {
+  return {
+    revision,
+    plan: mkPlan(planId, tasks, revision),
+    reason: '',
+    kind: '',
+    triggerEventId: '',
+    emittedAtMs: revision * 1000,
+    ...overrides,
+  };
+}
+
+// ── Registry unit tests ───────────────────────────────────────────────
+
+describe('PlanHistoryRegistry', () => {
+  let reg: PlanHistoryRegistry;
+  beforeEach(() => {
+    reg = new PlanHistoryRegistry();
+  });
+
+  it('append is idempotent on (plan_id, revision)', () => {
+    reg.append(mkRecord('p1', 0, [mkTask('t1'), mkTask('t2')]));
+    reg.append(mkRecord('p1', 0, [mkTask('t1'), mkTask('t2')]));
+    reg.append(mkRecord('p1', 0, [mkTask('t1')])); // different payload, same rev — still deduped
+    expect(reg.historyFor('p1')).toHaveLength(1);
+    // Dedup keeps the FIRST-seen payload (explicit contract — subsequent
+    // duplicates are dropped, not overwritten).
+    expect(reg.historyFor('p1')[0].plan.tasks.map((t) => t.id)).toEqual([
+      't1',
+      't2',
+    ]);
+  });
+
+  it('historyFor returns records sorted by revision number', () => {
+    // Intentionally append out of order.
+    reg.append(mkRecord('p1', 2, [mkTask('t1'), mkTask('t3')]));
+    reg.append(mkRecord('p1', 0, [mkTask('t1')]));
+    reg.append(mkRecord('p1', 1, [mkTask('t1'), mkTask('t2')]));
+    const revs = reg.historyFor('p1').map((r) => r.revision);
+    expect(revs).toEqual([0, 1, 2]);
+  });
+
+  it('historyFor returns an empty array for unknown plan ids', () => {
+    expect(reg.historyFor('nope')).toEqual([]);
+  });
+
+  it('planAtRevision(0) returns the initial plan', () => {
+    reg.append(mkRecord('p1', 0, [mkTask('t1')]));
+    reg.append(mkRecord('p1', 1, [mkTask('t1'), mkTask('t2')]));
+    const initial = reg.planAtRevision('p1', 0);
+    expect(initial).not.toBeNull();
+    expect(initial!.tasks.map((t) => t.id)).toEqual(['t1']);
+    expect(reg.planAtRevision('p1', 5)).toBeNull();
+    expect(reg.planAtRevision('no-plan', 0)).toBeNull();
+  });
+
+  it('append deep-clones the plan so later mutations do not leak', () => {
+    const task = mkTask('t1', { status: 'PENDING' });
+    const plan = mkPlan('p1', [task], 0);
+    reg.append({
+      revision: 0,
+      plan,
+      reason: '',
+      kind: '',
+      triggerEventId: '',
+      emittedAtMs: 0,
+    });
+    // Mutate the source after append.
+    task.status = 'RUNNING';
+    plan.tasks[0].status = 'COMPLETED';
+    const snapshot = reg.planAtRevision('p1', 0);
+    expect(snapshot!.tasks[0].status).toBe('PENDING');
+  });
+
+  it('cumulativePlan unions tasks across revisions and flags superseded', () => {
+    // rev 0: t1, t2
+    reg.append(mkRecord('p1', 0, [mkTask('t1'), mkTask('t2')]));
+    // rev 1: t1 edits (title change), t3 added, t2 dropped
+    reg.append(
+      mkRecord(
+        'p1',
+        1,
+        [
+          mkTask('t1', { title: 'Task t1 (edited)' }),
+          mkTask('t3'),
+        ],
+        { reason: 'user wanted faster', kind: 'user_steer' },
+      ),
+    );
+    // rev 2: t1 untouched, t3 edited
+    reg.append(
+      mkRecord('p1', 2, [
+        mkTask('t1', { title: 'Task t1 (edited)' }),
+        mkTask('t3', { description: 'now with detail' }),
+      ]),
+    );
+
+    const cum = reg.cumulativePlan('p1');
+    expect(cum).not.toBeNull();
+    // All three tasks present (superseded t2 retained).
+    const ids = cum!.tasks.map((t) => t.id);
+    expect(ids.sort()).toEqual(['t1', 't2', 't3']);
+
+    const t1Meta = cum!.taskRevisionMeta.get('t1')!;
+    expect(t1Meta.introducedInRevision).toBe(0);
+    expect(t1Meta.lastModifiedInRevision).toBe(1);
+    expect(t1Meta.isSuperseded).toBe(false);
+
+    const t2Meta = cum!.taskRevisionMeta.get('t2')!;
+    expect(t2Meta.introducedInRevision).toBe(0);
+    expect(t2Meta.isSuperseded).toBe(true);
+
+    const t3Meta = cum!.taskRevisionMeta.get('t3')!;
+    expect(t3Meta.introducedInRevision).toBe(1);
+    expect(t3Meta.lastModifiedInRevision).toBe(2);
+    expect(t3Meta.isSuperseded).toBe(false);
+  });
+
+  it('cumulativePlan returns null for an unknown plan id', () => {
+    expect(reg.cumulativePlan('nope')).toBeNull();
+  });
+
+  it('supersedesMap extracts links annotated with kind/reason/trigger', () => {
+    reg.append(mkRecord('p1', 0, [mkTask('t1'), mkTask('t2')]));
+    // rev 1: t2 → t2b because of an off-topic drift
+    reg.append(
+      mkRecord('p1', 1, [mkTask('t1'), mkTask('t2b')], {
+        reason: 'off topic — reorient on goal',
+        kind: 'off_topic',
+        triggerEventId: 'drift-abc',
+      }),
+    );
+    // rev 2: t1 retired outright (no replacement) via user steer
+    reg.append(
+      mkRecord('p1', 2, [mkTask('t2b')], {
+        reason: 'user cancelled t1',
+        kind: 'user_steer',
+        triggerEventId: 'ann-xyz',
+      }),
+    );
+
+    const map = reg.supersedesMap('p1');
+    expect(map.size).toBe(2);
+    const t2Link = map.get('t2')!;
+    expect(t2Link).toEqual({
+      oldTaskId: 't2',
+      newTaskId: 't2b',
+      revision: 1,
+      kind: 'off_topic',
+      reason: 'off topic — reorient on goal',
+      triggerEventId: 'drift-abc',
+    });
+    const t1Link = map.get('t1')!;
+    expect(t1Link.oldTaskId).toBe('t1');
+    // No truly-new task in rev 2, so the link is a dangling retire.
+    expect(t1Link.newTaskId).toBe('');
+    expect(t1Link.revision).toBe(2);
+    expect(t1Link.kind).toBe('user_steer');
+    expect(t1Link.triggerEventId).toBe('ann-xyz');
+  });
+
+  it('supersedesMap is empty for a plan with only its initial rev', () => {
+    reg.append(mkRecord('p1', 0, [mkTask('t1'), mkTask('t2')]));
+    expect(reg.supersedesMap('p1').size).toBe(0);
+  });
+
+  it('subscribe + clear emits once and wipes', () => {
+    reg.append(mkRecord('p1', 0, [mkTask('t1')]));
+    let hits = 0;
+    const unsub = reg.subscribe(() => hits++);
+    reg.clear();
+    expect(hits).toBe(1);
+    expect(reg.historyFor('p1')).toEqual([]);
+    // A second clear on an already-empty registry is a no-op.
+    reg.clear();
+    expect(hits).toBe(1);
+    unsub();
+  });
+});
+
+// ── Integration with the goldfive event stream ────────────────────────
+
+function pbTask(id: string, status: TaskStatus = TaskStatus.PENDING) {
+  return create(TaskSchema, {
+    id,
+    title: `Task ${id}`,
+    description: '',
+    assigneeAgentId: 'agent-a',
+    status,
+    predictedStartMs: 0n,
+    predictedDurationMs: 0n,
+  });
+}
+
+function pbPlan(
+  id: string,
+  taskIds: string[],
+  opts: {
+    revisionIndex?: number;
+    revisionReason?: string;
+    revisionKind?: DriftKind;
+    triggerEventId?: string;
+  } = {},
+) {
+  return create(PlanSchema, {
+    id,
+    runId: 'run-1',
+    summary: '',
+    tasks: taskIds.map((t) => pbTask(t)),
+    edges:
+      taskIds.length >= 2
+        ? [
+            create(TaskEdgeSchema, {
+              fromTaskId: taskIds[0],
+              toTaskId: taskIds[1],
+            }),
+          ]
+        : [],
+    revisionReason: opts.revisionReason ?? '',
+    revisionKind: opts.revisionKind ?? DriftKind.UNSPECIFIED,
+    revisionSeverity: DriftSeverity.UNSPECIFIED,
+    revisionIndex: opts.revisionIndex ?? 0,
+    revisionTriggerEventId: opts.triggerEventId ?? '',
+  });
+}
+
+describe('planHistory ingestion via applyGoldfiveEvent', () => {
+  it('accumulates plan_submitted + plan_revised onto store.planHistory', () => {
+    const store = new SessionStore();
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-0',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'planSubmitted',
+          value: create(PlanSubmittedSchema, {
+            plan: pbPlan('p1', ['t1', 't2'], { revisionIndex: 0 }),
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-1',
+        runId: 'run-1',
+        sequence: 1n,
+        payload: {
+          case: 'planRevised',
+          value: create(PlanRevisedSchema, {
+            plan: pbPlan('p1', ['t1', 't3'], {
+              revisionIndex: 1,
+              revisionReason: 'off topic',
+              revisionKind: DriftKind.OFF_TOPIC,
+              triggerEventId: 'drift-1',
+            }),
+            reason: 'off topic',
+            driftKind: DriftKind.OFF_TOPIC,
+            revisionIndex: 1,
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-2',
+        runId: 'run-1',
+        sequence: 2n,
+        payload: {
+          case: 'planRevised',
+          value: create(PlanRevisedSchema, {
+            plan: pbPlan('p1', ['t1', 't3', 't4'], {
+              revisionIndex: 2,
+              revisionReason: 'user wants scope expanded',
+              revisionKind: DriftKind.USER_STEER,
+              triggerEventId: 'ann-2',
+            }),
+            reason: 'user wants scope expanded',
+            driftKind: DriftKind.USER_STEER,
+            revisionIndex: 2,
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+
+    const history = store.planHistory.historyFor('p1');
+    expect(history.map((r) => r.revision)).toEqual([0, 1, 2]);
+    expect(history[1].kind).toBe('off_topic');
+    expect(history[1].triggerEventId).toBe('drift-1');
+    expect(history[2].kind).toBe('user_steer');
+
+    const cum = store.planHistory.cumulativePlan('p1')!;
+    const cumIds = cum.tasks.map((t) => t.id).sort();
+    expect(cumIds).toEqual(['t1', 't2', 't3', 't4']);
+    expect(cum.taskRevisionMeta.get('t2')!.isSuperseded).toBe(true);
+    expect(cum.taskRevisionMeta.get('t4')!.introducedInRevision).toBe(2);
+
+    const sup = store.planHistory.supersedesMap('p1');
+    expect(sup.get('t2')!.kind).toBe('off_topic');
+    expect(sup.get('t2')!.newTaskId).toBe('t3');
+  });
+
+  it('replay of the same event is idempotent (no duplicate revision)', () => {
+    const store = new SessionStore();
+    const mkEvent = () =>
+      create(EventSchema, {
+        eventId: 'ev-0',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'planSubmitted',
+          value: create(PlanSubmittedSchema, {
+            plan: pbPlan('p1', ['t1']),
+          }),
+        },
+      });
+    applyGoldfiveEvent(mkEvent(), store, 0);
+    applyGoldfiveEvent(mkEvent(), store, 0);
+    applyGoldfiveEvent(mkEvent(), store, 0);
+    expect(store.planHistory.historyFor('p1')).toHaveLength(1);
+  });
+});
+
+// ── RPC loader (graceful degradation) ─────────────────────────────────
+
+describe('loadPlanHistory', () => {
+  it('degrades gracefully when the client lacks getSessionPlanHistory', async () => {
+    const store = new SessionStore();
+    // Stub client with NO getSessionPlanHistory method — this mirrors
+    // the current generated client (RPC hasn't landed yet).
+    const stub = {};
+    const result = await loadPlanHistory('sess-1', store, 0, stub);
+    expect(result.skipped).toBe(true);
+    expect(result.fetched).toBe(false);
+    expect(result.appended).toBe(0);
+    expect(result.error).toBeNull();
+    expect(store.planHistory.historyFor('p1')).toEqual([]);
+  });
+
+  it('seeds the registry when the RPC returns revisions', async () => {
+    const store = new SessionStore();
+    const stub = {
+      getSessionPlanHistory: async (req: { sessionId: string }) => {
+        expect(req.sessionId).toBe('sess-1');
+        return {
+          revisions: [
+            {
+              plan: pbPlan('p1', ['t1', 't2'], { revisionIndex: 0 }),
+              revisionNumber: 0,
+              revisionReason: '',
+              revisionKind: 'UNSPECIFIED',
+              revisionTriggerEventId: '',
+              emittedAt: { seconds: 1000n, nanos: 0 },
+            },
+            {
+              plan: pbPlan('p1', ['t1', 't3'], {
+                revisionIndex: 1,
+                revisionReason: 'off topic',
+                revisionKind: DriftKind.OFF_TOPIC,
+                triggerEventId: 'drift-1',
+              }),
+              revisionNumber: 1,
+              revisionReason: 'off topic',
+              revisionKind: 'OFF_TOPIC',
+              revisionTriggerEventId: 'drift-1',
+              emittedAt: { seconds: 1010n, nanos: 0 },
+            },
+          ],
+        };
+      },
+    };
+    const result = await loadPlanHistory('sess-1', store, 0, stub);
+    expect(result.skipped).toBe(false);
+    expect(result.fetched).toBe(true);
+    expect(result.appended).toBe(2);
+    const revs = store.planHistory.historyFor('p1');
+    expect(revs).toHaveLength(2);
+    expect(revs[1].kind).toBe('off_topic');
+    expect(revs[1].triggerEventId).toBe('drift-1');
+  });
+
+  it('records RPC error and leaves the registry untouched', async () => {
+    const store = new SessionStore();
+    const stub = {
+      getSessionPlanHistory: async () => {
+        throw new Error('unavailable');
+      },
+    };
+    const result = await loadPlanHistory('sess-1', store, 0, stub);
+    expect(result.skipped).toBe(false);
+    expect(result.fetched).toBe(false);
+    expect(result.error?.message).toBe('unavailable');
+    expect(store.planHistory.historyFor('p1')).toEqual([]);
+  });
+
+  it('RPC-then-stream dedups on (plan_id, revision_number)', async () => {
+    const store = new SessionStore();
+    const stub = {
+      getSessionPlanHistory: async () => ({
+        revisions: [
+          {
+            plan: pbPlan('p1', ['t1']),
+            revisionNumber: 0,
+            revisionReason: '',
+            revisionKind: '',
+            revisionTriggerEventId: '',
+            emittedAt: { seconds: 0n, nanos: 0 },
+          },
+        ],
+      }),
+    };
+    await loadPlanHistory('sess-1', store, 0, stub);
+    // Now simulate the live stream replaying the same plan_submitted.
+    applyGoldfiveEvent(
+      create(EventSchema, {
+        eventId: 'ev-0',
+        runId: 'run-1',
+        sequence: 0n,
+        payload: {
+          case: 'planSubmitted',
+          value: create(PlanSubmittedSchema, {
+            plan: pbPlan('p1', ['t1']),
+          }),
+        },
+      }),
+      store,
+      0,
+    );
+    expect(store.planHistory.historyFor('p1')).toHaveLength(1);
+  });
+
+  it('revisionFromWire returns null when plan payload is missing', () => {
+    expect(
+      revisionFromWire({ revisionNumber: 0 }, 0),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/gantt/index.ts
+++ b/frontend/src/gantt/index.ts
@@ -5,6 +5,7 @@
 import type { Agent, ContextWindowSample, Task, TaskPlan, TaskStatus } from './types';
 import { SpanIndex, type DirtyRect } from './spatialIndex';
 import { hasThinking } from '../lib/thinking';
+import { PlanHistoryRegistry } from '../state/planHistoryStore';
 
 export type { DirtyRect } from './spatialIndex';
 export { SpanIndex } from './spatialIndex';
@@ -836,6 +837,13 @@ export class SessionStore {
   readonly drifts = new DriftRegistry();
   readonly delegations = new DelegationRegistry();
   readonly contextSeries = new ContextSeriesRegistry();
+  // Accumulator for every revision of every plan observed in this
+  // session. Fed by the `planSubmitted` / `planRevised` event handlers
+  // and by the optional `GetSessionPlanHistory` RPC loader so the Task
+  // / Plan panel and Trajectory view can render plans as evolving
+  // artifacts (generation badges, annotated supersedes edges, historic
+  // nodes) without mining the rolling snapshot buffer on `tasks`.
+  readonly planHistory = new PlanHistoryRegistry();
 
   // Scan the span index for TOOL_CALL spans whose name is one of the
   // harmonograf reporting tools and project them as OrchestrationEvents.
@@ -988,6 +996,7 @@ export class SessionStore {
     this.drifts.clear();
     this.delegations.clear();
     this.contextSeries.clear();
+    this.planHistory.clear();
     this.nowMs = 0;
   }
 }

--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -342,6 +342,20 @@ export function applyGoldfiveEvent(
       if (plan) {
         const converted = convertGoldfivePlan(plan, sessionStartMs);
         store.tasks.upsertPlan(converted);
+        // Plan-history accumulator: append this revision to the
+        // per-plan registry so the Task/Plan panel + Trajectory view
+        // can render cumulative / per-rev / supersedes views. The
+        // registry dedups on (plan_id, revision_number), so this is
+        // safe to call on stream reconnect replays too.
+        const emittedAbsMsHist = tsToMsAbs(event.emittedAt);
+        store.planHistory.append({
+          revision: Number(plan.revisionIndex ?? 0),
+          plan: converted,
+          reason: plan.revisionReason || '',
+          kind: driftKindToString(plan.revisionKind as unknown as number),
+          triggerEventId: plan.revisionTriggerEventId || '',
+          emittedAtMs: emittedAbsMsHist,
+        });
         // harmonograf#133: seed the agent registry from plan content so
         // tasks whose assignee hasn't emitted a span yet still resolve
         // to a bare display name (e.g. `reviewer_agent`) instead of the

--- a/frontend/src/state/planHistoryHooks.ts
+++ b/frontend/src/state/planHistoryHooks.ts
@@ -1,0 +1,111 @@
+// React selector hooks over PlanHistoryRegistry.
+//
+// These are the stable API the Task/Plan panel (harmonograf-plan-panel)
+// and the Trajectory view (harmonograf-trajectory) build against. The
+// signatures are frozen by the planning doc; any change here must be
+// coordinated with both renderer agents.
+//
+// All hooks:
+//   - Resolve the SessionStore via `getSessionStore(sessionId)`.
+//   - Subscribe to `store.planHistory` for re-render on every append /
+//     clear.
+//   - Return `null` / empty when data isn't loaded yet. Renderers
+//     branch on null to show a skeleton / placeholder.
+//
+// The hooks are pure projections over the registry — no caching, no
+// memoized data structures on their own. Renderers that need
+// referential stability over expensive derived data should wrap the
+// return values in their own `useMemo`.
+
+import { useEffect, useState } from 'react';
+import type { TaskPlan } from '../gantt/types';
+import { getSessionStore } from '../rpc/hooks';
+import type {
+  CumulativePlan,
+  PlanRevisionRecord,
+  SupersessionLink,
+} from './planHistoryStore';
+
+// Shared tick/subscribe shim. Mirrors the pattern used elsewhere in
+// the app (useAgentLive, CurrentTaskStrip): force a re-render whenever
+// the registry emits, and re-read from the live store on every render.
+function usePlanHistoryTick(sessionId: string | null): void {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!sessionId) return;
+    const store = getSessionStore(sessionId);
+    if (!store) return;
+    return store.planHistory.subscribe(() => setTick((t) => t + 1));
+  }, [sessionId]);
+}
+
+/**
+ * All revisions for a plan, sorted by revision number ascending.
+ * Returns `[]` when the session isn't loaded or the plan id is unknown.
+ */
+export function usePlanHistory(
+  sessionId: string | null,
+  planId: string | null,
+): PlanRevisionRecord[] {
+  usePlanHistoryTick(sessionId);
+  if (!sessionId || !planId) return EMPTY_RECORDS;
+  const store = getSessionStore(sessionId);
+  if (!store) return EMPTY_RECORDS;
+  return store.planHistory.historyFor(planId);
+}
+
+/**
+ * The Plan snapshot at an exact revision. Returns `null` if the
+ * session isn't loaded, the plan id is unknown, or the revision
+ * hasn't been recorded.
+ */
+export function usePlanAtRevision(
+  sessionId: string | null,
+  planId: string | null,
+  revision: number,
+): TaskPlan | null {
+  usePlanHistoryTick(sessionId);
+  if (!sessionId || !planId) return null;
+  const store = getSessionStore(sessionId);
+  if (!store) return null;
+  return store.planHistory.planAtRevision(planId, revision);
+}
+
+/**
+ * Cumulative plan (union of tasks across all revisions) with per-task
+ * revision metadata. Returns `null` when no revisions have been seen
+ * yet. The returned object is a fresh reference on every render (the
+ * registry rebuilds it on demand) — memoize at the call site if
+ * reference stability matters.
+ */
+export function useCumulativePlan(
+  sessionId: string | null,
+  planId: string | null,
+): CumulativePlan | null {
+  usePlanHistoryTick(sessionId);
+  if (!sessionId || !planId) return null;
+  const store = getSessionStore(sessionId);
+  if (!store) return null;
+  return store.planHistory.cumulativePlan(planId);
+}
+
+/**
+ * Map of oldTaskId → SupersessionLink. Empty map when no revisions
+ * have replaced tasks yet (initial plan, or revisions that only edit
+ * existing tasks in place).
+ */
+export function useSupersedesMap(
+  sessionId: string | null,
+  planId: string | null,
+): Map<string, SupersessionLink> {
+  usePlanHistoryTick(sessionId);
+  if (!sessionId || !planId) return EMPTY_LINKS;
+  const store = getSessionStore(sessionId);
+  if (!store) return EMPTY_LINKS;
+  return store.planHistory.supersedesMap(planId);
+}
+
+const EMPTY_RECORDS: PlanRevisionRecord[] = Object.freeze(
+  [],
+) as unknown as PlanRevisionRecord[];
+const EMPTY_LINKS: Map<string, SupersessionLink> = new Map();

--- a/frontend/src/state/planHistoryLoader.ts
+++ b/frontend/src/state/planHistoryLoader.ts
@@ -1,0 +1,184 @@
+// RPC-snapshot loader for PlanHistoryRegistry.
+//
+// Sibling server agent (harmonograf-plan-rpc) is adding
+// `GetSessionPlanHistory` — returns every persisted PlanRevision for a
+// session. The frontend prefers this unary fetch over walking the
+// event stream because (a) it gives an atomic snapshot, (b) it works
+// before WatchSession finishes its initial burst, and (c) it exposes
+// revisions from sessions that have long since completed and whose
+// events are no longer being replayed.
+//
+// The loader is entirely best-effort: if the generated client doesn't
+// yet have `getSessionPlanHistory` (i.e. the RPC hasn't landed in the
+// submodule / codegen hasn't regenerated yet), we silently bail. The
+// live event stream always populates `planHistory` via
+// `applyGoldfiveEvent`, so a missing RPC degrades to "incremental only,
+// no atomic seed" without breaking the renderers.
+//
+// Both paths are idempotent on (plan_id, revision_number) so a
+// successful RPC followed by a live-stream replay of the same events
+// produces the same final state.
+
+import type { SessionStore } from '../gantt/index';
+import { getHarmonografClient } from '../rpc/client';
+import type { PlanRevisionRecord } from './planHistoryStore';
+import { convertGoldfivePlan } from '../rpc/goldfiveEvent';
+import {
+  DriftKind as GoldfiveDriftKindEnum,
+} from '../pb/goldfive/v1/types_pb.js';
+
+// Structural type for the expected wire shape. We read through a shallow
+// structural cast rather than importing a generated type so this file
+// compiles cleanly against the current pb (where the RPC doesn't yet
+// exist). Once the spec lands and codegen regenerates, the real
+// generated type naturally satisfies this interface.
+//
+// Mirrors:
+//   message PlanRevision {
+//     Plan plan = 1;
+//     int32 revision_number = 2;
+//     string revision_reason = 3;
+//     string revision_kind = 4;            // DriftKind name
+//     string revision_trigger_event_id = 5;
+//     google.protobuf.Timestamp emitted_at = 6;
+//   }
+interface WirePlanRevision {
+  plan?: unknown;
+  revisionNumber?: number;
+  revisionReason?: string;
+  revisionKind?: string;
+  revisionTriggerEventId?: string;
+  emittedAt?: { seconds: bigint; nanos: number };
+}
+
+interface WirePlanHistoryResponse {
+  revisions?: WirePlanRevision[];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ClientLike = Record<string, any>;
+
+/**
+ * Return value of `loadPlanHistory`. Tests assert on these to confirm
+ * graceful degradation: `skipped` is true when the client lacks the
+ * RPC method, regardless of whether a live event stream is feeding
+ * the registry in parallel.
+ */
+export interface PlanHistoryLoadResult {
+  /** True if the RPC method was missing at call time (graceful bail). */
+  skipped: boolean;
+  /** True if the RPC call was made and returned without throwing. */
+  fetched: boolean;
+  /** Count of revisions appended to the registry (post-dedup). */
+  appended: number;
+  /** Any error observed — exposed for logging/metrics, never thrown. */
+  error: Error | null;
+}
+
+function tsToMsAbs(
+  t: { seconds: bigint; nanos: number } | undefined,
+): number {
+  if (!t) return 0;
+  return Number(t.seconds) * 1000 + Math.floor(t.nanos / 1_000_000);
+}
+
+// The on-wire DriftKind for a PlanRevision is the enum name as a string
+// (per the spec comment). Normalize it to the lowercase form used
+// throughout the harmonograf UI to match the event-stream path.
+function normalizeRevisionKind(raw: string | undefined): string {
+  if (!raw) return '';
+  // Tolerate both "OFF_TOPIC" (enum name) and "off_topic" (already
+  // normalized). UNSPECIFIED collapses to the empty string.
+  const upper = raw.toUpperCase();
+  if (upper === 'UNSPECIFIED' || upper === '') return '';
+  // If the string is one of the known enum names, lowercase it. If
+  // not, echo back lowercase — better to pass through an unknown
+  // token than to drop a signal the server thought worth sending.
+  const known = Object.keys(GoldfiveDriftKindEnum).some(
+    (k) => k === upper,
+  );
+  return known ? upper.toLowerCase() : raw.toLowerCase();
+}
+
+/**
+ * Fetch a session's persisted plan-revision history and seed
+ * `store.planHistory`. Safe to call unconditionally from session-load
+ * flows — it degrades to a no-op when the RPC method is absent.
+ *
+ * `clientOverride` exists for tests (inject a stub client instead of
+ * the singleton). Production callers pass no args.
+ */
+export async function loadPlanHistory(
+  sessionId: string,
+  store: SessionStore,
+  sessionStartMs: number,
+  clientOverride?: ClientLike,
+): Promise<PlanHistoryLoadResult> {
+  const result: PlanHistoryLoadResult = {
+    skipped: false,
+    fetched: false,
+    appended: 0,
+    error: null,
+  };
+  if (!sessionId) {
+    result.skipped = true;
+    return result;
+  }
+  const client: ClientLike =
+    clientOverride ?? (getHarmonografClient() as unknown as ClientLike);
+  // Graceful bail when the generated client predates the RPC.
+  if (typeof client.getSessionPlanHistory !== 'function') {
+    result.skipped = true;
+    return result;
+  }
+  let resp: WirePlanHistoryResponse;
+  try {
+    resp = (await client.getSessionPlanHistory({
+      sessionId,
+    })) as WirePlanHistoryResponse;
+    result.fetched = true;
+  } catch (err) {
+    result.error = err instanceof Error ? err : new Error(String(err));
+    return result;
+  }
+  const wireRevisions = resp?.revisions ?? [];
+  for (const wire of wireRevisions) {
+    const record = revisionFromWire(wire, sessionStartMs);
+    if (!record) continue;
+    const before = store.planHistory.historyFor(record.plan.id).length;
+    store.planHistory.append(record);
+    const after = store.planHistory.historyFor(record.plan.id).length;
+    if (after > before) result.appended++;
+  }
+  return result;
+}
+
+/**
+ * Convert a wire PlanRevision into a PlanRevisionRecord. Returns null
+ * when the row is missing its Plan payload (defensive: the server
+ * should never emit one, but the wire shape allows it). Exported so
+ * tests can drive the converter without standing up a full client.
+ */
+export function revisionFromWire(
+  wire: WirePlanRevision,
+  sessionStartMs: number,
+): PlanRevisionRecord | null {
+  const rawPlan = wire.plan;
+  if (!rawPlan || typeof rawPlan !== 'object') return null;
+  // convertGoldfivePlan is structurally compatible with the goldfive
+  // Plan type used by both the event stream and this RPC — it reads
+  // the same fields off the same proto message. Cast through unknown
+  // to satisfy the compiler without dragging the full generated type.
+  const converted = convertGoldfivePlan(
+    rawPlan as unknown as Parameters<typeof convertGoldfivePlan>[0],
+    sessionStartMs,
+  );
+  return {
+    revision: Number(wire.revisionNumber ?? 0),
+    plan: converted,
+    reason: wire.revisionReason || '',
+    kind: normalizeRevisionKind(wire.revisionKind),
+    triggerEventId: wire.revisionTriggerEventId || '',
+    emittedAtMs: tsToMsAbs(wire.emittedAt),
+  };
+}

--- a/frontend/src/state/planHistoryStore.ts
+++ b/frontend/src/state/planHistoryStore.ts
@@ -1,0 +1,314 @@
+// Plan-evolution registry: accumulates every revision of every plan in a
+// session so the Task/Plan panel and the Trajectory view can render plans
+// as evolving artifacts (generation badges, historical-dim styling,
+// annotated supersedes edges) rather than a single live snapshot.
+//
+// `SessionStore.tasks` (TaskRegistry) keeps the *current* plan per id plus
+// a rolling list of the last N past snapshots; that's sufficient for the
+// existing PlanRevisionBanner + Trajectory walk, but it discards once-seen
+// tasks as soon as a new revision lands, so the downstream renderers can't
+// show "superseded" nodes without digging through the snapshot array.
+//
+// PlanHistoryRegistry keeps every revision keyed by (plan_id,
+// revision_number) and derives three views on demand:
+//
+//   - `cumulativePlan(planId)` — the union of tasks across all revisions
+//     with per-task `introducedInRevision` / `lastModifiedInRevision` /
+//     `isSuperseded` metadata for generation badges.
+//   - `supersedesMap(planId)` — per-task supersession links carrying the
+//     drift kind / reason / trigger event id from the revision that
+//     replaced each task. Used to draw annotated supersedes edges.
+//   - `planAtRevision(planId, n)` — the Plan snapshot at an exact rev.
+//
+// All append paths are idempotent on (plan_id, revision_number), so the
+// RPC snapshot loader and the live event stream can both populate the
+// registry without worrying about double-insert.
+
+import type { Task, TaskEdge, TaskPlan } from '../gantt/types';
+
+export interface PlanRevisionRecord {
+  /** 0 for the initial plan_submitted, 1..N for each plan_revised. */
+  revision: number;
+  /** Full Plan snapshot at this revision (deep-cloned on append). */
+  plan: TaskPlan;
+  /** Drift detail or user steer body ('' on the initial rev). */
+  reason: string;
+  /** DriftKind name ("off_topic" | "user_steer" | …); '' on initial. */
+  kind: string;
+  /** Goldfive drift/annotation id that triggered this rev ('' on initial). */
+  triggerEventId: string;
+  /** Wall-clock ms when the revision was recorded. */
+  emittedAtMs: number;
+}
+
+export interface SupersessionLink {
+  /** Task id that was replaced. */
+  oldTaskId: string;
+  /** Task id that replaced it. Empty string if the old task was dropped
+   *  outright (renderers typically render this as a dangling "retired"
+   *  edge anchored at the old task). */
+  newTaskId: string;
+  /** Revision number of the plan that introduced the replacement. */
+  revision: number;
+  /** DriftKind name of the triggering drift (e.g. "off_topic",
+   *  "user_steer"). Empty when the surrounding revision had no kind. */
+  kind: string;
+  /** drift.detail or user steer body. */
+  reason: string;
+  /** Goldfive drift/annotation id tied to the triggering event. */
+  triggerEventId: string;
+}
+
+export interface CumulativeTaskMeta {
+  introducedInRevision: number;
+  lastModifiedInRevision: number;
+  /** True when the task id does NOT appear in the latest revision's
+   *  task list — i.e. it was dropped or replaced somewhere along the
+   *  revision chain. */
+  isSuperseded: boolean;
+}
+
+export interface CumulativePlan extends TaskPlan {
+  /** Per-task revision metadata. Keyed by Task.id. */
+  taskRevisionMeta: Map<string, CumulativeTaskMeta>;
+}
+
+function clonePlan(p: TaskPlan): TaskPlan {
+  return {
+    ...p,
+    tasks: p.tasks.map((t) => ({ ...t })),
+    edges: p.edges.map((e) => ({ ...e })),
+  };
+}
+
+function taskFingerprint(t: Task): string {
+  // Fields that, when changed, mean a task was meaningfully edited by a
+  // revision (vs. merely carried through unchanged). Mirrors the change
+  // axes already tracked by computePlanDiff in gantt/index.ts so the two
+  // diff notions stay consistent.
+  return [
+    t.title,
+    t.description,
+    t.assigneeAgentId,
+    t.status,
+    t.predictedStartMs,
+    t.predictedDurationMs,
+  ].join('');
+}
+
+/**
+ * Accumulates every revision of every plan observed in a session.
+ *
+ * Lives on `SessionStore.planHistory` alongside the existing TaskRegistry.
+ * Fed by two idempotent paths:
+ *   A) `GetSessionPlanHistory` RPC snapshot at session load.
+ *   B) Live `planSubmitted` / `planRevised` events from the goldfive
+ *      event stream.
+ * Both paths dedup on (plan_id, revision_number).
+ */
+export class PlanHistoryRegistry {
+  private revisions = new Map<string, PlanRevisionRecord[]>();
+  private listeners = new Set<() => void>();
+
+  /**
+   * Append a revision. Idempotent: a second append of the same
+   * (plan.id, revision) is a no-op and does NOT emit. If the revision
+   * arrives out of order (e.g. RPC replay + live tail race), it is
+   * inserted in the correct sorted position.
+   */
+  append(record: PlanRevisionRecord): void {
+    const planId = record.plan.id;
+    if (!planId) return;
+    let arr = this.revisions.get(planId);
+    if (!arr) {
+      arr = [];
+      this.revisions.set(planId, arr);
+    }
+    // Idempotency on (plan_id, revision): skip exact-rev duplicates.
+    if (arr.some((r) => r.revision === record.revision)) return;
+    // Deep-clone the Plan so later mutations on the live TaskRegistry
+    // don't leak into the historical snapshot. All other fields on
+    // PlanRevisionRecord are primitives.
+    const cloned: PlanRevisionRecord = { ...record, plan: clonePlan(record.plan) };
+    // Linear insert keeping the array sorted by revision number.
+    let i = arr.length;
+    while (i > 0 && arr[i - 1].revision > cloned.revision) i--;
+    if (i === arr.length) arr.push(cloned);
+    else arr.splice(i, 0, cloned);
+    this.emit();
+  }
+
+  /**
+   * All revisions for a plan, sorted by revision number ascending.
+   * Returns an empty array for unknown plan ids. The returned array is
+   * a stable internal reference — callers must not mutate it.
+   */
+  historyFor(planId: string): PlanRevisionRecord[] {
+    return this.revisions.get(planId) ?? EMPTY_REVISIONS;
+  }
+
+  /**
+   * The Plan snapshot at an exact revision. Returns null when either
+   * the plan id is unknown or no record exists for that revision.
+   */
+  planAtRevision(planId: string, revision: number): TaskPlan | null {
+    const arr = this.revisions.get(planId);
+    if (!arr) return null;
+    const hit = arr.find((r) => r.revision === revision);
+    return hit ? hit.plan : null;
+  }
+
+  /**
+   * The cumulative plan: union of tasks across all revisions, most-recent
+   * definition wins per id. Retains tasks that have been superseded
+   * (marked `isSuperseded=true`) so the renderer can show them as
+   * historical nodes. Edges are taken from the latest revision.
+   *
+   * Returns null when no revisions have been recorded for the plan id.
+   */
+  cumulativePlan(planId: string): CumulativePlan | null {
+    const arr = this.revisions.get(planId);
+    if (!arr || arr.length === 0) return null;
+    const latest = arr[arr.length - 1].plan;
+    const meta = new Map<string, CumulativeTaskMeta>();
+    const unionById = new Map<string, Task>();
+    const lastFingerprint = new Map<string, string>();
+    for (const rev of arr) {
+      for (const task of rev.plan.tasks) {
+        const fp = taskFingerprint(task);
+        const existingMeta = meta.get(task.id);
+        if (!existingMeta) {
+          meta.set(task.id, {
+            introducedInRevision: rev.revision,
+            lastModifiedInRevision: rev.revision,
+            isSuperseded: false,
+          });
+        } else if (lastFingerprint.get(task.id) !== fp) {
+          existingMeta.lastModifiedInRevision = rev.revision;
+        }
+        lastFingerprint.set(task.id, fp);
+        // Most-recent definition wins (tasks mutate status across revs).
+        unionById.set(task.id, { ...task });
+      }
+    }
+    // Mark tasks that no longer appear in the latest revision.
+    const latestIds = new Set(latest.tasks.map((t) => t.id));
+    for (const [id, m] of meta) {
+      if (!latestIds.has(id)) m.isSuperseded = true;
+    }
+    // Stable output ordering: latest revision's tasks first (preserving
+    // planner-supplied order), then any superseded tasks in the order
+    // they were first seen. This keeps the renderer's primary DAG stable
+    // frame-to-frame and appends historical nodes at the tail.
+    const tasks: Task[] = [];
+    const emitted = new Set<string>();
+    for (const t of latest.tasks) {
+      const unioned = unionById.get(t.id);
+      if (unioned) {
+        tasks.push(unioned);
+        emitted.add(t.id);
+      }
+    }
+    for (const [id, t] of unionById) {
+      if (!emitted.has(id)) tasks.push(t);
+    }
+    // Edge union: a task-level cumulative view should preserve edges
+    // that were ever present so the renderer can draw historical
+    // dependencies. Dedup by "from->to" and attach the latest occurrence.
+    const edgeKeys = new Set<string>();
+    const edges: TaskEdge[] = [];
+    for (const rev of arr) {
+      for (const e of rev.plan.edges) {
+        const k = `${e.fromTaskId}->${e.toTaskId}`;
+        if (edgeKeys.has(k)) continue;
+        edgeKeys.add(k);
+        edges.push({ fromTaskId: e.fromTaskId, toTaskId: e.toTaskId });
+      }
+    }
+    return {
+      ...latest,
+      tasks,
+      edges,
+      taskRevisionMeta: meta,
+    };
+  }
+
+  /**
+   * Map of oldTaskId → SupersessionLink for every task that was
+   * superseded or dropped across the revision chain.
+   *
+   * Interpretation: walking rev N → rev N+1, every task id that was in
+   * N but not in N+1 is considered superseded by rev N+1. When rev N+1
+   * introduces exactly one new task id (not present in any earlier
+   * rev), that task id is paired as the `newTaskId`. Otherwise the old
+   * task is considered dropped and `newTaskId` stays empty so the
+   * renderer can draw a dangling "retired" marker.
+   */
+  supersedesMap(planId: string): Map<string, SupersessionLink> {
+    const out = new Map<string, SupersessionLink>();
+    const arr = this.revisions.get(planId);
+    if (!arr || arr.length < 2) return out;
+    // Track every task id ever seen, so we can distinguish genuinely new
+    // tasks (candidates for "newTaskId" pairing) from re-surfaced ids.
+    const everSeen = new Set<string>();
+    for (const t of arr[0].plan.tasks) everSeen.add(t.id);
+    for (let i = 1; i < arr.length; i++) {
+      const prev = arr[i - 1].plan;
+      const next = arr[i].plan;
+      const nextIds = new Set(next.tasks.map((t) => t.id));
+      const dropped: string[] = [];
+      for (const t of prev.tasks) {
+        if (!nextIds.has(t.id)) dropped.push(t.id);
+      }
+      const trulyNew: string[] = [];
+      for (const t of next.tasks) {
+        if (!everSeen.has(t.id)) trulyNew.push(t.id);
+      }
+      // Pair one-for-one when possible; if counts mismatch, pair prefix
+      // and leave the remainder as dropped-without-successor.
+      const pairs = Math.min(dropped.length, trulyNew.length);
+      const rec = arr[i];
+      for (let k = 0; k < dropped.length; k++) {
+        out.set(dropped[k], {
+          oldTaskId: dropped[k],
+          newTaskId: k < pairs ? trulyNew[k] : '',
+          revision: rec.revision,
+          kind: rec.kind,
+          reason: rec.reason,
+          triggerEventId: rec.triggerEventId,
+        });
+      }
+      for (const id of nextIds) everSeen.add(id);
+    }
+    return out;
+  }
+
+  /**
+   * List every plan id known to the registry. Order is insertion (first
+   * append wins); callers sort by `createdAtMs` if needed.
+   */
+  planIds(): string[] {
+    return Array.from(this.revisions.keys());
+  }
+
+  /** Wipe everything. Called from SessionStore.clear(). */
+  clear(): void {
+    if (this.revisions.size === 0) return;
+    this.revisions.clear();
+    this.emit();
+  }
+
+  /** Subscribe to any change. Returns an unsubscribe fn. */
+  subscribe(fn: () => void): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+
+  private emit(): void {
+    for (const fn of this.listeners) fn();
+  }
+}
+
+const EMPTY_REVISIONS: PlanRevisionRecord[] = Object.freeze(
+  [],
+) as unknown as PlanRevisionRecord[];


### PR DESCRIPTION
Closes #161.

## Summary

- `SessionStore.planHistory: PlanHistoryRegistry` accumulates every revision of every plan observed in a session (initial `plan_submitted` = rev 0, each `plan_revised` = rev 1..N), keyed by plan id and deduped on `(plan_id, revision_number)`.
- Registry methods: `append`, `historyFor`, `planAtRevision`, `cumulativePlan`, `supersedesMap`, `planIds`, `subscribe`, `clear`.
- `cumulativePlan(planId)` returns a union of tasks across revisions with per-task `introducedInRevision` / `lastModifiedInRevision` / `isSuperseded` metadata so the Task/Plan panel can draw generation badges and historical-dim nodes.
- `supersedesMap(planId)` walks rev N -> rev N+1 pairs to extract oldTaskId -> { newTaskId, kind, reason, triggerEventId } links for annotated supersedes edges in the Trajectory view.
- Two idempotent ingest paths:
  - **RPC snapshot** via `GetSessionPlanHistory` at session-load time (`state/planHistoryLoader.ts`). Degrades gracefully when the generated client lacks the method (sibling agent `harmonograf-plan-rpc` is landing the spec) — returns `{ skipped: true }` and the renderer still renders via path B.
  - **Live event stream** via `applyGoldfiveEvent`'s existing `planSubmitted` / `planRevised` handlers — appends to `planHistory` alongside the existing `tasks.upsertPlan()` call.
- React selector hooks in `state/planHistoryHooks.ts` — **signatures frozen** for the sibling renderer agents (harmonograf-plan-panel, harmonograf-trajectory):
  - `usePlanHistory(sessionId, planId) -> PlanRevisionRecord[]`
  - `usePlanAtRevision(sessionId, planId, n) -> TaskPlan | null`
  - `useCumulativePlan(sessionId, planId) -> CumulativePlan | null`
  - `useSupersedesMap(sessionId, planId) -> Map<string, SupersessionLink>`

## Coordination

- Depends on: sibling `harmonograf-plan-rpc` for the `GetSessionPlanHistory` RPC spec (frozen: `PlanRevision { plan, revision_number, revision_reason, revision_kind, revision_trigger_event_id, emitted_at }`). Loader works without the RPC via the live-stream fallback.
- Consumed by: `harmonograf-plan-panel` (Task/Plan panel) and `harmonograf-trajectory` (Trajectory view) — hooks are the stable API surface.
- No interaction with the three in-flight goldfive span-context-attributes agents.

## Data-shape notes

- `PlanHistoryRegistry.append` deep-clones the plan so later status mutations on the live `TaskRegistry` don't leak into history.
- Registry does not replace or modify the existing `TaskRegistry` rolling-snapshot buffer — `PlanRevisionBanner` keeps working unchanged.
- Dedup is first-write-wins: a duplicate `(plan_id, revision)` append is a no-op (not an overwrite). Live-stream replays on reconnect are therefore safe.

## Test plan

- [x] `pnpm tsc -b` clean
- [x] `pnpm lint` clean (no new warnings/errors attributable to this change)
- [x] `pnpm test --run` green: 381 tests (17 new under `src/__tests__/state/planHistory.test.ts`)
- [x] Registry unit tests: idempotency, sort order, `planAtRevision(0)`, deep-clone isolation, cumulative union, per-task rev metadata, supersedes extraction (pair + dangling retire), empty-registry cases
- [x] Integration test: `plan_submitted` + 2x `plan_revised` via `applyGoldfiveEvent` accumulates correctly; cumulative + supersedes land as expected
- [x] RPC-loader tests: missing-method skip, successful fetch + seed, throw -> recorded in result, RPC-then-stream dedup