### PR TITLE
feat(ui): plan-evolution rendering in Task/Plan panel (cumulative + revisions + supersedes edges)

### DIFF
--- a/frontend/src/__tests__/components/TaskStagesGraph.evolution.test.tsx
+++ b/frontend/src/__tests__/components/TaskStagesGraph.evolution.test.tsx
@@ -1,0 +1,307 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Task, TaskEdge, TaskPlan, TaskStatus } from '../../gantt/types';
+import { SessionStore } from '../../gantt/index';
+
+// Mock the rpc/hooks module BEFORE importing the component so that the
+// planHistory hooks pick up our test store. getSessionStore is the only
+// thing the hooks reach into.
+const storesById = new Map<string, SessionStore>();
+vi.mock('../../rpc/hooks', () => ({
+  getSessionStore: (id: string | null) => (id ? storesById.get(id) : undefined),
+}));
+
+// Mock CSS so vitest's "css: false" doesn't complain about side-effect
+// imports on the component under test.
+vi.mock('../../components/TaskStages/TaskStagesGraph.css', () => ({}));
+
+// Imported AFTER the mock so the hooks bind to our fake getSessionStore.
+import { TaskStagesGraph } from '../../components/TaskStages/TaskStagesGraph';
+import { TaskPlanPanel } from '../../components/TaskStages/TaskPlanPanel';
+import {
+  __internal,
+  type CumulativePlan,
+  type SupersessionLink,
+} from '../../state/planHistory';
+
+function mkTask(id: string, status: TaskStatus = 'PENDING', title?: string): Task {
+  return {
+    id,
+    title: title ?? `Title ${id}`,
+    description: '',
+    assigneeAgentId: 'agent-a',
+    status,
+    predictedStartMs: 0,
+    predictedDurationMs: 0,
+    boundSpanId: '',
+  };
+}
+
+function mkPlan(
+  rev: number,
+  tasks: Task[],
+  edges: Array<[string, string]> = [],
+  opts: Partial<TaskPlan> = {},
+): TaskPlan {
+  return {
+    id: 'plan-1',
+    invocationSpanId: '',
+    plannerAgentId: '',
+    createdAtMs: rev * 1000,
+    summary: '',
+    tasks,
+    edges: edges.map<TaskEdge>(([f, t]) => ({ fromTaskId: f, toTaskId: t })),
+    revisionReason: opts.revisionReason ?? '',
+    revisionKind: opts.revisionKind,
+    revisionIndex: rev,
+    triggerEventId: opts.triggerEventId,
+  };
+}
+
+function seedStore(sessionId: string, plans: TaskPlan[]): SessionStore {
+  const store = new SessionStore();
+  for (const p of plans) store.tasks.upsertPlan(p);
+  storesById.set(sessionId, store);
+  return store;
+}
+
+beforeEach(() => {
+  storesById.clear();
+  try {
+    localStorage.clear();
+  } catch {
+    /* jsdom may not have storage */
+  }
+});
+
+// Two revisions: rev 0 introduces t1+t2; rev 1 supersedes t2 with t3 +
+// a drift stamped by goldfive with an off_topic kind.
+function seedTwoRevPlan(): SessionStore {
+  const rev0 = mkPlan(0, [mkTask('t1', 'COMPLETED'), mkTask('t2', 'RUNNING')], [['t1', 't2']]);
+  const rev1 = mkPlan(
+    1,
+    [mkTask('t1', 'COMPLETED'), mkTask('t3', 'PENDING', 'Refined task')],
+    [['t1', 't3']],
+    {
+      revisionReason: 'Agent drifted off topic; focus on scoping.',
+      revisionKind: 'off_topic',
+      triggerEventId: 'drift-abc',
+    },
+  );
+  const store = seedStore('sess-1', [rev0, rev1]);
+  store.drifts.append({
+    kind: 'off_topic',
+    severity: 'warning',
+    detail: 'Started writing unrelated code',
+    taskId: 't2',
+    agentId: 'agent-a',
+    recordedAtMs: 500,
+    annotationId: '',
+    driftId: 'drift-abc',
+    authoredBy: 'goldfive',
+  });
+  return store;
+}
+
+// Three revisions for the scrubber test: rev 0 introduces t1, rev 1
+// introduces t2, rev 2 introduces t3.
+function seedThreeRevPlan(): SessionStore {
+  const rev0 = mkPlan(0, [mkTask('t1')]);
+  const rev1 = mkPlan(1, [mkTask('t1'), mkTask('t2')], [['t1', 't2']], {
+    revisionKind: 'off_topic',
+    revisionReason: 'rev1',
+    triggerEventId: 'drift-1',
+  });
+  const rev2 = mkPlan(
+    2,
+    [mkTask('t1'), mkTask('t2'), mkTask('t3')],
+    [
+      ['t1', 't2'],
+      ['t2', 't3'],
+    ],
+    { revisionKind: 'user_steer', revisionReason: 'rev2', triggerEventId: 'ann-2' },
+  );
+  return seedStore('sess-3', [rev0, rev1, rev2]);
+}
+
+describe('plan-evolution · pure derivation', () => {
+  it('deriveCumulative unions tasks across revisions with introduced/superseded meta', () => {
+    const rev0 = mkPlan(0, [mkTask('t1'), mkTask('t2')]);
+    const rev1 = mkPlan(1, [mkTask('t1'), mkTask('t3')], [], {
+      revisionKind: 'off_topic',
+    });
+    const cum = __internal.deriveCumulative('p', [rev0, rev1]) as CumulativePlan;
+    expect(cum).not.toBeNull();
+    const ids = cum.tasks.map((t) => t.id).sort();
+    expect(ids).toEqual(['t1', 't2', 't3']);
+    expect(cum.taskRevisionMeta.get('t1')?.isSuperseded).toBe(false);
+    expect(cum.taskRevisionMeta.get('t2')?.isSuperseded).toBe(true);
+    expect(cum.taskRevisionMeta.get('t3')?.introducedInRevision).toBe(1);
+  });
+
+  it('deriveSupersedes pairs retired t2 with added t3 using title + assignee affinity', () => {
+    const rev0 = mkPlan(0, [mkTask('t1'), mkTask('t2', 'PENDING', 'scope the work')]);
+    const rev1 = mkPlan(
+      1,
+      [mkTask('t1'), mkTask('t3', 'PENDING', 'scope work again')],
+      [],
+      { revisionKind: 'off_topic', revisionReason: 'refocus' },
+    );
+    const links = __internal.deriveSupersedes([rev0, rev1], new Map());
+    expect(links.size).toBe(1);
+    const link = links.get('t2') as SupersessionLink;
+    expect(link.newTaskId).toBe('t3');
+    expect(link.kind).toBe('off_topic');
+  });
+});
+
+describe('<TaskStagesGraph /> cumulative mode', () => {
+  it('renders both live and superseded tasks with muted styling for superseded', () => {
+    const store = seedTwoRevPlan();
+    const cum = __internal.deriveCumulative('plan-1', store.tasks.allRevsForPlan('plan-1'));
+    const supersedes = __internal.deriveSupersedes(
+      store.tasks.allRevsForPlan('plan-1'),
+      new Map([['drift-abc', store.drifts.list()[0]]]),
+    );
+    const { container } = render(
+      <TaskStagesGraph
+        plan={mkPlan(0, [])}
+        cumulative={cum}
+        supersedesMap={supersedes}
+      />,
+    );
+    const cards = container.querySelectorAll('g.hg-stages__card');
+    expect(cards.length).toBe(3); // t1, t2 (superseded), t3
+    const superseded = Array.from(cards).filter(
+      (c) => c.getAttribute('data-superseded') === 'true',
+    );
+    expect(superseded).toHaveLength(1);
+  });
+
+  it('renders one generation badge per task with the right revision number', () => {
+    const store = seedTwoRevPlan();
+    const cum = __internal.deriveCumulative('plan-1', store.tasks.allRevsForPlan('plan-1'));
+    const { container } = render(
+      <TaskStagesGraph plan={mkPlan(0, [])} cumulative={cum} />,
+    );
+    const badges = container.querySelectorAll('g.hg-stages__gen-badge');
+    expect(badges.length).toBe(3);
+    const revs = Array.from(badges).map((b) => b.getAttribute('data-rev'));
+    expect(revs.sort()).toEqual(['0', '0', '1']);
+  });
+
+  it('renders a supersedes edge with a drift-kind annotation', () => {
+    const store = seedTwoRevPlan();
+    const cum = __internal.deriveCumulative('plan-1', store.tasks.allRevsForPlan('plan-1'));
+    const supersedes = __internal.deriveSupersedes(
+      store.tasks.allRevsForPlan('plan-1'),
+      new Map([['drift-abc', store.drifts.list()[0]]]),
+    );
+    const { container } = render(
+      <TaskStagesGraph
+        plan={mkPlan(0, [])}
+        cumulative={cum}
+        supersedesMap={supersedes}
+      />,
+    );
+    const edges = container.querySelectorAll('[data-testid="supersedes-edge"]');
+    expect(edges.length).toBe(1);
+    const label = edges[0].querySelector('.hg-stages__supersedes-label');
+    expect(label?.textContent).toContain('off_topic');
+    expect(label?.textContent).toContain('goldfive');
+  });
+
+  it('fires onSupersedesEdgeClick with the link payload when clicked', () => {
+    const store = seedTwoRevPlan();
+    const cum = __internal.deriveCumulative('plan-1', store.tasks.allRevsForPlan('plan-1'));
+    const supersedes = __internal.deriveSupersedes(
+      store.tasks.allRevsForPlan('plan-1'),
+      new Map([['drift-abc', store.drifts.list()[0]]]),
+    );
+    const handler = vi.fn();
+    const { container } = render(
+      <TaskStagesGraph
+        plan={mkPlan(0, [])}
+        cumulative={cum}
+        supersedesMap={supersedes}
+        onSupersedesEdgeClick={handler}
+      />,
+    );
+    const edge = container.querySelector('[data-testid="supersedes-edge"]');
+    expect(edge).toBeTruthy();
+    fireEvent.click(edge!);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0].oldTaskId).toBe('t2');
+    expect(handler.mock.calls[0][0].newTaskId).toBe('t3');
+  });
+});
+
+describe('<TaskPlanPanel /> integration', () => {
+  it('defaults to cumulative view and renders the scrubber + both task revs', () => {
+    const store = seedTwoRevPlan();
+    const plan = store.tasks.getPlan('plan-1')!;
+    render(<TaskPlanPanel sessionId="sess-1" plan={plan} />);
+    expect(screen.getByTestId('task-stages-graph')).toBeInTheDocument();
+    expect(screen.getByTestId('plan-revision-scrubber')).toBeInTheDocument();
+    // cumulative → shows t1, t2 (muted), t3
+    const cards = document
+      .querySelector('[data-testid="task-stages-graph"]')!
+      .querySelectorAll('g.hg-stages__card');
+    expect(cards.length).toBe(3);
+  });
+
+  it('opens the steering-detail side panel on supersedes-edge click', () => {
+    const store = seedTwoRevPlan();
+    const plan = store.tasks.getPlan('plan-1')!;
+    render(<TaskPlanPanel sessionId="sess-1" plan={plan} />);
+    const edges = document.querySelectorAll('[data-testid="supersedes-edge"]');
+    expect(edges.length).toBe(1);
+    fireEvent.click(edges[0]);
+    const panel = screen.getByTestId('steering-detail-panel');
+    expect(panel).toBeInTheDocument();
+    // Trigger / Steering / Target sections populated.
+    expect(screen.getByTestId('steering-detail-trigger').textContent).toContain(
+      'off_topic',
+    );
+    expect(screen.getByTestId('steering-detail-steering').textContent).toContain(
+      'goldfive',
+    );
+    expect(screen.getByTestId('steering-detail-target').textContent).toContain('agent-a');
+  });
+
+  it('revision scrubber filter mutes tasks introduced in later revisions', () => {
+    const store = seedThreeRevPlan();
+    const plan = store.tasks.getPlan('plan-1')!;
+    render(<TaskPlanPanel sessionId="sess-3" plan={plan} />);
+    // Default selection is 'Latest' → nothing muted from the scrubber
+    // (cards may still be superseded in the no-superseded path here; t3
+    // is the tail so no tasks are superseded). Click rev 0.
+    fireEvent.click(screen.getByTestId('scrubber-notch-0'));
+    const cards = document
+      .querySelector('[data-testid="task-stages-graph"]')!
+      .querySelectorAll('g.hg-stages__card');
+    const muted = Array.from(cards).filter((c) =>
+      c.classList.contains('hg-stages__card--muted'),
+    );
+    // t2 + t3 were introduced after rev 0 → muted.
+    expect(muted.length).toBe(2);
+  });
+
+  it('Latest-only toggle drops the cumulative rendering (no supersedes edges)', () => {
+    const store = seedTwoRevPlan();
+    const plan = store.tasks.getPlan('plan-1')!;
+    render(<TaskPlanPanel sessionId="sess-1" plan={plan} />);
+    // Switch to Latest only.
+    const toggle = screen.getByTestId('task-plan-view-toggle') as HTMLSelectElement;
+    fireEvent.change(toggle, { target: { value: 'latest' } });
+    // Latest only → just t1 + t3 (the live rev 1 shape). No gen badges.
+    const cards = document
+      .querySelector('[data-testid="task-stages-graph"]')!
+      .querySelectorAll('g.hg-stages__card');
+    expect(cards.length).toBe(2);
+    expect(
+      document.querySelectorAll('[data-testid="supersedes-edge"]'),
+    ).toHaveLength(0);
+    expect(document.querySelectorAll('g.hg-stages__gen-badge')).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/TaskStages/TaskPlanPanel.tsx
+++ b/frontend/src/components/TaskStages/TaskPlanPanel.tsx
@@ -1,0 +1,323 @@
+// TaskPlanPanel (harmonograf plan-evolution).
+//
+// Wraps a plan's revision scrubber + cumulative DAG + steering-detail
+// side panel into a single component. Consumed by GanttView's bottom
+// task panel. One <TaskPlanPanel /> per plan.
+//
+// The component itself is thin glue: it pulls revision history via
+// state/planHistory hooks, routes scrubber state + side-panel selection
+// into local React state, and hands the actual drawing to
+// <TaskStagesGraph />.
+
+import { useState } from 'react';
+import type { Task, TaskPlan } from '../../gantt/types';
+import {
+  usePlanHistory,
+  useCumulativePlan,
+  useSupersedesMap,
+  type SupersessionLink,
+} from '../../state/planHistory';
+import { useUiStore } from '../../state/uiStore';
+import { TaskStagesGraph } from './TaskStagesGraph';
+
+interface TaskPlanPanelProps {
+  sessionId: string | null;
+  plan: TaskPlan;
+  onTaskClick?: (task: Task) => void;
+  selectedTaskId?: string | null;
+  agentColorFor?: (agentId: string) => string | null;
+  agentNameFor?: (agentId: string) => string;
+  // Optional jump-to-Gantt callback invoked when the user clicks the
+  // "Jump to this drift in Gantt" button in the steering detail panel.
+  onJumpToDrift?: (atMs: number) => void;
+}
+
+// Revision scrubber. Renders one notch per revision plus a "Latest" notch.
+// `selected === null` means latest; any integer filters to "tasks
+// introduced at-or-before this rev".
+interface RevisionScrubberProps {
+  revisions: ReadonlyArray<{ revisionIndex: number; revisionKind: string }>;
+  selected: number | null;
+  onSelect: (rev: number | null) => void;
+}
+
+function RevisionScrubber({ revisions, selected, onSelect }: RevisionScrubberProps) {
+  // Keyboard-accessible: Home / End / ←/→ walk through notches.
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const order: Array<number | null> = [
+      ...revisions.map((r) => r.revisionIndex),
+      null,
+    ];
+    const idx = order.indexOf(selected);
+    if (idx < 0) return;
+    if (e.key === 'ArrowRight') {
+      onSelect(order[Math.min(order.length - 1, idx + 1)]);
+      e.preventDefault();
+    } else if (e.key === 'ArrowLeft') {
+      onSelect(order[Math.max(0, idx - 1)]);
+      e.preventDefault();
+    } else if (e.key === 'Home') {
+      onSelect(order[0]);
+      e.preventDefault();
+    } else if (e.key === 'End') {
+      onSelect(order[order.length - 1]);
+      e.preventDefault();
+    }
+  };
+  return (
+    <div
+      className="hg-scrubber"
+      role="toolbar"
+      aria-label="Plan revision scrubber"
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      data-testid="plan-revision-scrubber"
+    >
+      <div className="hg-scrubber__label">Rev</div>
+      <div className="hg-scrubber__track">
+        {revisions.map((r) => {
+          const isSel = selected === r.revisionIndex;
+          const label = r.revisionKind
+            ? `REV ${r.revisionIndex}: ${r.revisionKind}`
+            : `REV ${r.revisionIndex}`;
+          return (
+            <button
+              key={r.revisionIndex}
+              type="button"
+              className={`hg-scrubber__notch${isSel ? ' hg-scrubber__notch--selected' : ''}`}
+              onClick={() => onSelect(r.revisionIndex)}
+              data-testid={`scrubber-notch-${r.revisionIndex}`}
+              aria-pressed={isSel}
+            >
+              {label}
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          className={`hg-scrubber__notch${selected === null ? ' hg-scrubber__notch--selected' : ''}`}
+          onClick={() => onSelect(null)}
+          data-testid="scrubber-notch-latest"
+          aria-pressed={selected === null}
+        >
+          Latest
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Steering-detail side panel. Opens when the user clicks a supersedes
+// edge. Sections: trigger (drift reason), steering (refine_steer text),
+// target (agent id). "Jump to drift in Gantt" is a best-effort scroll.
+interface SteeringDetailPanelProps {
+  link: SupersessionLink;
+  targetAgentId: string;
+  triggerAtMs: number | null;
+  onClose: () => void;
+  onJumpToDrift?: (atMs: number) => void;
+}
+
+function SteeringDetailPanel({
+  link,
+  targetAgentId,
+  triggerAtMs,
+  onClose,
+  onJumpToDrift,
+}: SteeringDetailPanelProps) {
+  const authoredBy = link.authoredBy
+    || (link.kind.toLowerCase().startsWith('user_') ? 'user' : 'goldfive');
+  return (
+    <div
+      className="hg-steering-panel"
+      role="dialog"
+      aria-label="Steering detail"
+      data-testid="steering-detail-panel"
+    >
+      <div className="hg-steering-panel__header">
+        <span>
+          Steering · rev {link.revision}
+          {link.kind ? ` · ${link.kind}` : ''}
+        </span>
+        <button
+          type="button"
+          className="hg-steering-panel__close"
+          aria-label="Close steering detail"
+          onClick={onClose}
+          data-testid="steering-detail-close"
+        >
+          ×
+        </button>
+      </div>
+      <div className="hg-steering-panel__body">
+        <div className="hg-steering-panel__section" data-testid="steering-detail-trigger">
+          <div className="hg-steering-panel__section-label">Trigger</div>
+          <div className="hg-steering-panel__section-body">
+            {link.kind || '(unknown drift kind)'}
+            {link.reason ? `\n\n${link.reason}` : ''}
+          </div>
+        </div>
+        <div className="hg-steering-panel__section" data-testid="steering-detail-steering">
+          <div className="hg-steering-panel__section-label">Steering</div>
+          <div className="hg-steering-panel__section-body">
+            {authoredBy ? `by: ${authoredBy}` : '(unknown author)'}
+            {link.triggerEventId ? `\nevent: ${link.triggerEventId}` : ''}
+            {link.reason ? `\n\n${link.reason}` : ''}
+          </div>
+        </div>
+        <div className="hg-steering-panel__section" data-testid="steering-detail-target">
+          <div className="hg-steering-panel__section-label">Target</div>
+          <div className="hg-steering-panel__section-body">
+            {targetAgentId || '(no target agent)'}
+            {link.newTaskId ? `\ntask: ${link.newTaskId}` : ''}
+          </div>
+        </div>
+        {triggerAtMs !== null && onJumpToDrift && (
+          <button
+            type="button"
+            className="hg-steering-panel__jump"
+            onClick={() => onJumpToDrift(triggerAtMs)}
+            data-testid="steering-detail-jump"
+          >
+            Jump to this drift in Gantt
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TaskPlanPanel({
+  sessionId,
+  plan,
+  onTaskClick,
+  selectedTaskId,
+  agentColorFor,
+  agentNameFor,
+  onJumpToDrift,
+}: TaskPlanPanelProps) {
+  const history = usePlanHistory(sessionId, plan.id);
+  const cumulative = useCumulativePlan(sessionId, plan.id);
+  const supersedesMap = useSupersedesMap(sessionId, plan.id);
+  const taskPlanView = useUiStore((s) => s.taskPlanView);
+  const setTaskPlanView = useUiStore((s) => s.setTaskPlanView);
+  const [scrubberSelection, setScrubberSelection] = useState<number | null>(null);
+  const [openLinkId, setOpenLinkId] = useState<string | null>(null);
+  // Resolve the currently-open supersedes link every render from the
+  // live map so (a) it drops automatically when the map no longer
+  // contains the id and (b) switching to "Latest only" trivially hides
+  // the panel (see `isCumulative` gate below). Storing the id rather
+  // than the record lets us stay pure — no useEffect / setState
+  // cascades on prop changes.
+  const openLink: SupersessionLink | null = openLinkId
+    ? supersedesMap.get(openLinkId) ?? null
+    : null;
+
+  // Hide the scrubber when there's only the initial rev — nothing to scrub.
+  const showScrubber = taskPlanView === 'cumulative' && history.length > 1;
+
+  // The "Latest only" path bypasses the cumulative renderer entirely;
+  // the old behaviour is preserved — see TaskStagesGraphProps legacy signature.
+  const isCumulative = taskPlanView === 'cumulative' && cumulative !== null;
+
+  // Resolve the target agent from the replacement task, falling back to
+  // the drift's agent id via the supersedesMap entry.
+  const resolveTargetAgent = (link: SupersessionLink): string => {
+    if (link.newTaskId && cumulative) {
+      for (const t of cumulative.tasks) {
+        if (t.id === link.newTaskId) return t.assigneeAgentId;
+      }
+    }
+    return '';
+  };
+
+  const triggerAtMsFor = (link: SupersessionLink): number | null => {
+    const rev = history.find((r) => r.revisionIndex === link.revision);
+    return rev ? rev.revisedAtMs : null;
+  };
+
+  return (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', position: 'relative' }}
+      data-testid="task-plan-panel"
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '2px 10px',
+          fontSize: 10,
+          color: 'var(--md-sys-color-on-surface-variant, #9da3b4)',
+          textTransform: 'uppercase',
+          letterSpacing: 0.5,
+        }}
+      >
+        <span style={{ flex: 1 }}>
+          Plan: {plan.summary || plan.id}
+          {isCumulative && history.length > 0
+            ? ` · ${history.length} rev${history.length === 1 ? '' : 's'}`
+            : ''}
+        </span>
+        <label
+          style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+          title="Cumulative shows all revisions with grey-muted superseded tasks; Latest shows only the current plan."
+        >
+          <span style={{ textTransform: 'none' }}>Show:</span>
+          <select
+            data-testid="task-plan-view-toggle"
+            value={taskPlanView}
+            onChange={(e) =>
+              setTaskPlanView(e.target.value as 'cumulative' | 'latest')
+            }
+            style={{
+              fontSize: 10,
+              background: 'var(--md-sys-color-surface-container-high, #262931)',
+              color: 'inherit',
+              border: '1px solid var(--md-sys-color-outline-variant, #43474e)',
+              borderRadius: 4,
+              padding: '1px 4px',
+              textTransform: 'none',
+            }}
+          >
+            <option value="cumulative">Cumulative</option>
+            <option value="latest">Latest only</option>
+          </select>
+        </label>
+      </div>
+      {showScrubber && (
+        <RevisionScrubber
+          revisions={history.map((h) => ({
+            revisionIndex: h.revisionIndex,
+            revisionKind: h.revisionKind,
+          }))}
+          selected={scrubberSelection}
+          onSelect={setScrubberSelection}
+        />
+      )}
+      <TaskStagesGraph
+        plan={plan}
+        cumulative={isCumulative ? cumulative : null}
+        supersedesMap={isCumulative ? supersedesMap : undefined}
+        revisionFilter={isCumulative ? scrubberSelection : null}
+        revisionFilterMode="mute"
+        selectedTaskId={selectedTaskId}
+        agentColorFor={agentColorFor}
+        agentNameFor={agentNameFor}
+        onTaskClick={onTaskClick}
+        onSupersedesEdgeClick={
+          isCumulative ? (link) => setOpenLinkId(link.oldTaskId) : undefined
+        }
+      />
+      {isCumulative && openLink && (
+        <SteeringDetailPanel
+          link={openLink}
+          targetAgentId={resolveTargetAgent(openLink)}
+          triggerAtMs={triggerAtMsFor(openLink)}
+          onClose={() => setOpenLinkId(null)}
+          onJumpToDrift={onJumpToDrift}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TaskStages/TaskStagesGraph.css
+++ b/frontend/src/components/TaskStages/TaskStagesGraph.css
@@ -110,3 +110,185 @@
   stroke-width: 1.25;
   opacity: 0.75;
 }
+
+/* Cumulative-DAG additions (harmonograf plan-evolution). */
+
+.hg-stages__card--muted {
+  opacity: 0.55;
+}
+
+.hg-stages__card--superseded .hg-stages__card-rect {
+  stroke-dasharray: 3 3;
+  fill: var(--md-sys-color-surface-container, #1c1f26);
+}
+
+.hg-stages__card--superseded {
+  opacity: 0.4;
+}
+
+.hg-stages__card--superseded:hover,
+.hg-stages__card--muted:hover {
+  opacity: 0.85;
+}
+
+.hg-stages__supersedes-path {
+  fill: none;
+  stroke-width: 1.2;
+  stroke-dasharray: 4 3;
+  opacity: 0.85;
+}
+
+.hg-stages__supersedes:hover .hg-stages__supersedes-path {
+  stroke-width: 2;
+  opacity: 1;
+}
+
+.hg-stages__supersedes-label {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  pointer-events: none;
+  user-select: none;
+}
+
+.hg-stages__gen-badge-text {
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  pointer-events: none;
+  user-select: none;
+}
+
+/* Scrubber styling. Small horizontal strip with clickable notches. */
+
+.hg-scrubber {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: var(--md-sys-color-surface-container, #1c1f26);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant, #43474e);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.hg-scrubber__track {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.hg-scrubber__notch {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 9px;
+  border: 1px solid var(--md-sys-color-outline-variant, #43474e);
+  background: transparent;
+  color: var(--md-sys-color-on-surface-variant, #c3c6cf);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.hg-scrubber__notch:hover {
+  border-color: var(--md-sys-color-primary, #a8c8ff);
+  color: var(--md-sys-color-on-surface, #e2e2e9);
+}
+
+.hg-scrubber__notch--selected {
+  background: var(--md-sys-color-primary-container, #3e4a69);
+  border-color: var(--md-sys-color-primary, #a8c8ff);
+  color: var(--md-sys-color-on-primary-container, #d8e2ff);
+  font-weight: 600;
+}
+
+.hg-scrubber__label {
+  font-size: 10px;
+  color: var(--md-sys-color-on-surface-variant, #9da3b4);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+/* Steering-detail side panel. */
+
+.hg-steering-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 340px;
+  background: var(--md-sys-color-surface-container-high, #262931);
+  border-left: 1px solid var(--md-sys-color-outline-variant, #43474e);
+  box-shadow: -2px 0 8px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 3;
+}
+
+.hg-steering-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant, #43474e);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface, #e2e2e9);
+}
+
+.hg-steering-panel__close {
+  background: transparent;
+  border: none;
+  color: var(--md-sys-color-on-surface-variant, #c3c6cf);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.hg-steering-panel__body {
+  flex: 1;
+  padding: 10px 12px;
+  overflow-y: auto;
+  font-size: 11px;
+  color: var(--md-sys-color-on-surface, #e2e2e9);
+}
+
+.hg-steering-panel__section {
+  margin-bottom: 12px;
+}
+
+.hg-steering-panel__section-label {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--md-sys-color-on-surface-variant, #9da3b4);
+  margin-bottom: 4px;
+}
+
+.hg-steering-panel__section-body {
+  white-space: pre-wrap;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.hg-steering-panel__jump {
+  margin-top: 8px;
+  padding: 4px 10px;
+  background: var(--md-sys-color-primary-container, #3e4a69);
+  color: var(--md-sys-color-on-primary-container, #d8e2ff);
+  border: 1px solid var(--md-sys-color-primary, #a8c8ff);
+  border-radius: 4px;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.hg-steering-panel__jump:hover {
+  background: var(--md-sys-color-primary, #a8c8ff);
+  color: var(--md-sys-color-on-primary, #0a1939);
+}

--- a/frontend/src/components/TaskStages/TaskStagesGraph.tsx
+++ b/frontend/src/components/TaskStages/TaskStagesGraph.tsx
@@ -1,11 +1,30 @@
 import { useMemo } from 'react';
-import type { Task, TaskPlan } from '../../gantt/types';
+import type { Task, TaskEdge, TaskPlan } from '../../gantt/types';
 import { computeStages } from '../../gantt/stages';
+import type {
+  CumulativePlan,
+  SupersessionLink,
+  TaskRevisionMeta,
+} from '../../state/planHistory';
 import './TaskStagesGraph.css';
 
 interface TaskStagesGraphProps {
+  // Legacy single-plan path — still used by "Latest only" mode and by
+  // pre-existing tests. When `cumulative` is passed we ignore this.
   plan: TaskPlan;
+  // Cumulative-DAG path (harmonograf plan-evolution). When present the
+  // renderer draws every task across every revision, grey-muting the
+  // ones whose `isSuperseded === true`, and paints dashed "supersedes"
+  // edges between old and new tasks.
+  cumulative?: CumulativePlan | null;
+  supersedesMap?: Map<string, SupersessionLink>;
+  // Revision scrubber: when set to a non-null integer, tasks whose
+  // `introducedInRevision > revisionFilter` are muted (or hidden, see
+  // `revisionFilterMode`). Passing null = "Latest" (no filter).
+  revisionFilter?: number | null;
+  revisionFilterMode?: 'mute' | 'hide';
   onTaskClick?: (task: Task) => void;
+  onSupersedesEdgeClick?: (link: SupersessionLink) => void;
   selectedTaskId?: string | null;
   agentColorFor?: (agentId: string) => string | null;
   agentNameFor?: (agentId: string) => string;
@@ -22,6 +41,42 @@ const STATUS_DOT: Record<Task['status'], string> = {
   BLOCKED: '#f59e0b',
 };
 
+// Generation palette. Monochromatic (muted indigo → brighter) so it
+// doesn't stomp on the status colours. Rev 0 is a neutral grey badge; every
+// subsequent rev shifts toward the primary. Capped at 4 steps — rev 3+
+// share the strongest colour so very long histories still render.
+const GENERATION_PALETTE = [
+  { fill: '#3a3d46', text: '#c3c6cf' }, // rev 0 (neutral)
+  { fill: '#4b5770', text: '#dbe3ff' }, // rev 1
+  { fill: '#5b6aa0', text: '#e9ecff' }, // rev 2
+  { fill: '#7587d4', text: '#f1f3ff' }, // rev 3+
+];
+
+function generationColor(rev: number): { fill: string; text: string } {
+  if (rev <= 0) return GENERATION_PALETTE[0];
+  return GENERATION_PALETTE[Math.min(rev, GENERATION_PALETTE.length - 1)];
+}
+
+// Drift-kind → edge colour lookup. Autonomous goldfive kinds stay in a
+// warm hue; user-origin kinds sit in a cooler hue. Unknown kinds fall
+// back to a neutral outline.
+function edgeKindColor(kind: string): string {
+  const k = (kind || '').toLowerCase();
+  if (k.startsWith('user_')) return '#8bd17c';          // cool green (user)
+  if (k === 'off_topic' || k === 'off-topic') return '#f0a860';
+  if (k === 'missing_work' || k === 'missing-work') return '#e76c6c';
+  if (k === 'cascade_cancel') return '#c08cd6';
+  if (k) return '#d8a468';                              // other goldfive
+  return '#8d9199';                                      // unknown
+}
+
+function edgeAnnotation(link: SupersessionLink): string {
+  const kind = link.kind || '';
+  if (!kind) return 'superseded';
+  const author = link.authoredBy || (kind.toLowerCase().startsWith('user_') ? 'user' : 'goldfive');
+  return `${author}: ${kind.toLowerCase()}`;
+}
+
 const COLUMN_WIDTH = 140;
 const CARD_WIDTH = 120;
 const CARD_HEIGHT = 38;
@@ -36,18 +91,46 @@ interface LaidOutCard {
   x: number;
   y: number;
   stage: number;
+  hidden: boolean;   // true when filtered out by scrubber (hide mode)
+  muted: boolean;    // superseded OR scrubber-filtered (mute mode)
+}
+
+// Synthesize a TaskPlan shape from a CumulativePlan so we can reuse
+// computeStages() directly. The returned plan is purely for layout —
+// no other code reads it.
+function cumulativeAsPlan(cum: CumulativePlan): TaskPlan {
+  return {
+    id: cum.planId,
+    invocationSpanId: '',
+    plannerAgentId: '',
+    createdAtMs: 0,
+    summary: '',
+    tasks: cum.tasks,
+    edges: cum.edges,
+    revisionReason: '',
+  };
 }
 
 export function TaskStagesGraph({
   plan,
+  cumulative,
+  supersedesMap,
+  revisionFilter = null,
+  revisionFilterMode = 'mute',
   onTaskClick,
+  onSupersedesEdgeClick,
   selectedTaskId = null,
   agentColorFor,
   agentNameFor,
 }: TaskStagesGraphProps) {
   const layout = useMemo(() => {
-    const stages = computeStages(plan);
+    const sourcePlan: TaskPlan = cumulative ? cumulativeAsPlan(cumulative) : plan;
+    const stages = computeStages(sourcePlan);
     if (stages.length === 0) return null;
+
+    const revMeta: Map<string, TaskRevisionMeta> | null = cumulative
+      ? cumulative.taskRevisionMeta
+      : null;
 
     const cards = new Map<string, LaidOutCard>();
     let maxRows = 0;
@@ -56,7 +139,17 @@ export function TaskStagesGraph({
       stageTasks.forEach((task, rowIdx) => {
         const x = SIDE_PADDING + stageIdx * COLUMN_WIDTH + COL_PADDING;
         const y = TOP_PADDING + rowIdx * (CARD_HEIGHT + CARD_GAP);
-        cards.set(task.id, { task, x, y, stage: stageIdx });
+        const meta = revMeta?.get(task.id);
+        let hidden = false;
+        let muted = Boolean(meta?.isSuperseded);
+        if (revisionFilter !== null && meta) {
+          const introduced = meta.introducedInRevision;
+          if (introduced > revisionFilter) {
+            if (revisionFilterMode === 'hide') hidden = true;
+            else muted = true;
+          }
+        }
+        cards.set(task.id, { task, x, y, stage: stageIdx, hidden, muted });
       });
     });
 
@@ -65,23 +158,40 @@ export function TaskStagesGraph({
       TOP_PADDING + maxRows * (CARD_HEIGHT + CARD_GAP) + 8;
     const height = Math.max(contentHeight, 116);
 
-    // Edge routing: only keep edges whose endpoints land in different stages
-    // (forward edges). Any cycle-stranded tasks all sit in stage 0 and their
-    // edges to each other would be horizontal — skip them to avoid confusion.
-    const edges: Array<{ from: LaidOutCard; to: LaidOutCard }> = [];
-    for (const e of plan.edges) {
+    // Plan-DAG edges (solid). Only keep forward edges — same rule as before.
+    const planEdges: Array<{ from: LaidOutCard; to: LaidOutCard }> = [];
+    const edgeSource: ReadonlyArray<TaskEdge> = sourcePlan.edges;
+    for (const e of edgeSource) {
       const from = cards.get(e.fromTaskId);
       const to = cards.get(e.toTaskId);
       if (!from || !to) continue;
+      if (from.hidden || to.hidden) continue;
       if (to.stage <= from.stage) continue;
-      edges.push({ from, to });
+      planEdges.push({ from, to });
     }
 
-    return { stages, cards, width, height, edges };
-  }, [plan]);
+    // Supersedes edges (dashed, one per supersession link).
+    const supersedesEdges: Array<{
+      from: LaidOutCard;
+      to: LaidOutCard;
+      link: SupersessionLink;
+    }> = [];
+    if (supersedesMap) {
+      for (const link of supersedesMap.values()) {
+        const from = cards.get(link.oldTaskId);
+        const to = link.newTaskId ? cards.get(link.newTaskId) : undefined;
+        if (!from || !to) continue;
+        if (from.hidden || to.hidden) continue;
+        supersedesEdges.push({ from, to, link });
+      }
+    }
+
+    return { stages, cards, width, height, planEdges, supersedesEdges };
+  }, [plan, cumulative, supersedesMap, revisionFilter, revisionFilterMode]);
 
   if (!layout) return null;
-  const { stages, cards, width, height, edges } = layout;
+  const { stages, cards, width, height, planEdges, supersedesEdges } = layout;
+  const revMeta = cumulative?.taskRevisionMeta;
 
   return (
     <div className="hg-stages" data-testid="task-stages-graph">
@@ -103,6 +213,17 @@ export function TaskStagesGraph({
           >
             <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--md-sys-color-outline, #8d9199)" />
           </marker>
+          <marker
+            id="hg-stages-supersedes-arrow"
+            viewBox="0 0 10 10"
+            refX={9}
+            refY={5}
+            markerWidth={6}
+            markerHeight={6}
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#d8a468" />
+          </marker>
         </defs>
 
         {stages.map((_, stageIdx) => {
@@ -122,15 +243,22 @@ export function TaskStagesGraph({
 
         {stages.map((stageTasks, stageIdx) => {
           const x = SIDE_PADDING + stageIdx * COLUMN_WIDTH + COLUMN_WIDTH / 2;
-          const total = stageTasks.length;
-          const done = stageTasks.filter((t) => t.status === 'COMPLETED').length;
-          // 0 complete → grey; some complete → blue; all complete → green.
+          // Progress badge counts only NON-superseded tasks so the N/M
+          // reflects the live plan, not historical noise.
+          const visible = stageTasks.filter((t) => {
+            const m = revMeta?.get(t.id);
+            return !m || !m.isSuperseded;
+          });
+          const total = visible.length;
+          const done = visible.filter((t) => t.status === 'COMPLETED').length;
           const badgeClass =
-            done === 0
+            total === 0
               ? 'hg-stages__progress hg-stages__progress--none'
-              : done === total
-                ? 'hg-stages__progress hg-stages__progress--done'
-                : 'hg-stages__progress hg-stages__progress--partial';
+              : done === 0
+                ? 'hg-stages__progress hg-stages__progress--none'
+                : done === total
+                  ? 'hg-stages__progress hg-stages__progress--done'
+                  : 'hg-stages__progress hg-stages__progress--partial';
           return (
             <g key={`label-${stageIdx}`}>
               <text
@@ -164,7 +292,7 @@ export function TaskStagesGraph({
           );
         })}
 
-        {edges.map(({ from, to }, i) => {
+        {planEdges.map(({ from, to }, i) => {
           const x1 = from.x + CARD_WIDTH;
           const y1 = from.y + CARD_HEIGHT / 2;
           const x2 = to.x;
@@ -181,7 +309,53 @@ export function TaskStagesGraph({
           );
         })}
 
-        {Array.from(cards.values()).map(({ task, x, y }) => {
+        {supersedesEdges.map(({ from, to, link }, i) => {
+          const x1 = from.x + CARD_WIDTH;
+          const y1 = from.y + CARD_HEIGHT / 2;
+          const x2 = to.x;
+          const y2 = to.y + CARD_HEIGHT / 2;
+          const dx = Math.max(30, (x2 - x1) * 0.5);
+          const d = `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`;
+          const color = edgeKindColor(link.kind);
+          const label = edgeAnnotation(link);
+          // Label anchors near the midpoint of the edge. Offset by -6 so
+          // the annotation text sits above the curve.
+          const mx = (x1 + x2) / 2;
+          const my = (y1 + y2) / 2 - 6;
+          return (
+            <g
+              key={`sedge-${link.oldTaskId}-${link.newTaskId}-${i}`}
+              className="hg-stages__supersedes"
+              data-testid="supersedes-edge"
+              data-kind={link.kind || ''}
+              onClick={(e) => {
+                e.stopPropagation();
+                onSupersedesEdgeClick?.(link);
+              }}
+              style={{ cursor: onSupersedesEdgeClick ? 'pointer' : 'default' }}
+            >
+              <title>{link.reason || link.kind || 'superseded'}</title>
+              <path
+                className="hg-stages__supersedes-path"
+                d={d}
+                stroke={color}
+                markerEnd="url(#hg-stages-supersedes-arrow)"
+              />
+              <text
+                className="hg-stages__supersedes-label"
+                x={mx}
+                y={my}
+                textAnchor="middle"
+                fill={color}
+              >
+                {label}
+              </text>
+            </g>
+          );
+        })}
+
+        {Array.from(cards.values()).map(({ task, x, y, muted, hidden }) => {
+          if (hidden) return null;
           const dotColor = STATUS_DOT[task.status];
           const title = task.title || '(untitled)';
           const maxChars = 14;
@@ -195,26 +369,29 @@ export function TaskStagesGraph({
             rawAgentName.length > 16
               ? rawAgentName.slice(0, 15) + '…'
               : rawAgentName;
+          const meta = revMeta?.get(task.id);
           const classes = [
             'hg-stages__card',
             selected ? 'hg-stages__card--selected' : '',
             running ? 'hg-stages__card--running' : '',
+            muted ? 'hg-stages__card--muted' : '',
+            meta?.isSuperseded ? 'hg-stages__card--superseded' : '',
           ]
             .filter(Boolean)
             .join(' ');
-          // harmonograf#110 / goldfive#205: tooltip includes the cancel
-          // reason on CANCELLED / FAILED cards so hovering tells the
-          // operator why a task ended the way it did without a click.
           const reason = task.cancelReason || '';
           const showReason =
             reason && (task.status === 'CANCELLED' || task.status === 'FAILED');
           const tooltipText = showReason ? `${title}\n${reason}` : title;
+          const badgeRev = meta?.lastModifiedInRevision ?? 0;
+          const { fill: badgeFill, text: badgeTextColor } = generationColor(badgeRev);
           return (
             <g
               key={task.id}
               className={classes}
               transform={`translate(${x}, ${y})`}
               onClick={() => onTaskClick?.(task)}
+              data-superseded={meta?.isSuperseded ? 'true' : 'false'}
             >
               <title>{tooltipText}</title>
               <rect
@@ -247,6 +424,34 @@ export function TaskStagesGraph({
                 >
                   {agentLabel}
                 </text>
+              )}
+              {/* Generation badge: only rendered in cumulative mode. */}
+              {revMeta && (
+                <g
+                  className="hg-stages__gen-badge"
+                  data-testid="gen-badge"
+                  data-rev={badgeRev}
+                  transform={`translate(${CARD_WIDTH - 4}, 4)`}
+                >
+                  <rect
+                    x={-28}
+                    y={0}
+                    width={28}
+                    height={12}
+                    rx={3}
+                    ry={3}
+                    fill={badgeFill}
+                  />
+                  <text
+                    className="hg-stages__gen-badge-text"
+                    x={-14}
+                    y={9}
+                    textAnchor="middle"
+                    fill={badgeTextColor}
+                  >
+                    REV {badgeRev}
+                  </text>
+                </g>
               )}
             </g>
           );

--- a/frontend/src/components/shell/views/GanttView.tsx
+++ b/frontend/src/components/shell/views/GanttView.tsx
@@ -6,7 +6,7 @@ import { useUiStore, type TaskPlanMode } from '../../../state/uiStore';
 import { useSessionWatch } from '../../../rpc/hooks';
 import { colorForAgent } from '../../../theme/agentColors';
 import type { Task, TaskPlan, TaskStatus } from '../../../gantt/types';
-import { TaskStagesGraph } from '../../TaskStages/TaskStagesGraph';
+import { TaskPlanPanel } from '../../TaskStages/TaskPlanPanel';
 import { InterventionsList } from '../../Interventions/InterventionsList';
 import { deriveInterventionsFromStore } from '../../../lib/interventions';
 import { useAnnotationStore } from '../../../state/annotationStore';
@@ -357,17 +357,8 @@ export function GanttView() {
                 key={`stages-${plan.id}`}
                 style={{ display: 'flex', flexDirection: 'column', gap: 4 }}
               >
-                <div
-                  style={{
-                    fontSize: 10,
-                    color: 'var(--md-sys-color-on-surface-variant, #9da3b4)',
-                    textTransform: 'uppercase',
-                    letterSpacing: 0.5,
-                  }}
-                >
-                  Plan: {plan.summary || plan.id}
-                </div>
-                <TaskStagesGraph
+                <TaskPlanPanel
+                  sessionId={sessionId}
                   plan={plan}
                   selectedTaskId={selectedTaskId}
                   agentColorFor={agentColorFor}

--- a/frontend/src/state/planHistory.ts
+++ b/frontend/src/state/planHistory.ts
@@ -1,0 +1,360 @@
+// Plan-history adapters (harmonograf: plan-panel-evolution).
+//
+// This module exposes the hook surface frozen by the sibling PR
+// `/tmp/harmonograf-plan-state` — built locally against the existing
+// `TaskRegistry.allRevsForPlan()` infrastructure so the renderer work in
+// this branch has real data to consume pre-merge. Once the state sibling
+// lands, this file is swapped for the one that reads `SessionStore.planHistory`
+// directly; the exported types and hook signatures stay frozen.
+//
+// Consumed types:
+//   * PlanRevisionRecord  — one entry per revision, oldest-first.
+//   * CumulativePlan       — union-DAG across revisions with per-task metadata
+//                            (introduced-in / last-modified-in / isSuperseded).
+//   * SupersessionLink     — per-retired-task reference to its replacement +
+//                            the triggering drift.
+//
+// Hook signatures (frozen — do not rename or restructure):
+//   usePlanHistory(sessionId, planId)   → readonly PlanRevisionRecord[]
+//   useCumulativePlan(sessionId, planId) → CumulativePlan | null
+//   useSupersedesMap(sessionId, planId)  → Map<oldTaskId, SupersessionLink>
+//
+// All three are reactive: they subscribe to the session's TaskRegistry +
+// DriftRegistry so React rerenders when a new revision arrives.
+
+import { useEffect, useState } from 'react';
+import { getSessionStore } from '../rpc/hooks';
+import type { SessionStore } from '../gantt/index';
+import type { DriftRecord } from '../gantt/index';
+import type { Task, TaskEdge, TaskPlan } from '../gantt/types';
+
+// One entry per revision of a plan. The most recent revision sits at the
+// tail. `revisionIndex` is the authoritative ordering field (0 = initial).
+export interface PlanRevisionRecord {
+  planId: string;
+  revisionIndex: number;
+  revisedAtMs: number;        // session-relative
+  revisionKind: string;        // e.g. OFF_TOPIC, USER_STEER, '' for initial
+  revisionReason: string;
+  triggerEventId: string;
+  plan: TaskPlan;              // snapshot at this revision
+}
+
+// Per-task meta produced by the cumulative projection.
+export interface TaskRevisionMeta {
+  introducedInRevision: number;
+  lastModifiedInRevision: number;
+  isSuperseded: boolean;
+  // Id of the task that replaced this one, if superseded.
+  supersededByTaskId: string | null;
+}
+
+// Cumulative (union) DAG across every revision of a plan. Tasks dropped
+// by a later revision are kept as `isSuperseded=true` so the renderer can
+// show the "evolved" plan in a single picture.
+export interface CumulativePlan {
+  planId: string;
+  latestRevisionIndex: number;
+  tasks: Task[];               // union across revisions, de-duped by id
+  edges: TaskEdge[];           // union across revisions, de-duped
+  taskRevisionMeta: Map<string, TaskRevisionMeta>;
+}
+
+// Pointer from a retired task to the task that replaced it. Populated for
+// every task whose id dropped out between adjacent revisions AND whose
+// replacement we can identify (by position, by title affinity, or — when
+// goldfive stamps `refine.supersedes`, post-merge — explicit id mapping).
+export interface SupersessionLink {
+  oldTaskId: string;
+  newTaskId: string;
+  revision: number;         // revisionIndex where the supersession happened
+  kind: string;             // drift kind (e.g. OFF_TOPIC) or ''
+  reason: string;           // revisionReason text
+  triggerEventId: string;   // drift id when goldfive-driven, '' otherwise
+  // Authorship: 'user' (USER_STEER etc.), 'goldfive' (autonomous), or ''.
+  authoredBy: string;
+}
+
+// ── Low-level derivation (pure functions over a snapshot list) ───────────────
+
+// Materialise a PlanRevisionRecord list from the registry's rev sequence.
+// `revs` is oldest-first.
+function deriveHistory(
+  planId: string,
+  revs: ReadonlyArray<TaskPlan>,
+): PlanRevisionRecord[] {
+  const out: PlanRevisionRecord[] = [];
+  for (const plan of revs) {
+    out.push({
+      planId,
+      revisionIndex: plan.revisionIndex ?? 0,
+      revisedAtMs: plan.createdAtMs,
+      revisionKind: plan.revisionKind || '',
+      revisionReason: plan.revisionReason || '',
+      triggerEventId: plan.triggerEventId || '',
+      plan,
+    });
+  }
+  return out;
+}
+
+// Fold every revision into one cumulative DAG. Tasks are keyed by id;
+// the latest non-null snapshot wins. Superseded tasks come from revisions
+// where the id existed but dropped out in a later one.
+function deriveCumulative(
+  planId: string,
+  revs: ReadonlyArray<TaskPlan>,
+): CumulativePlan | null {
+  if (revs.length === 0) return null;
+  const latestRevisionIndex = revs[revs.length - 1].revisionIndex ?? revs.length - 1;
+  const taskSnapshots = new Map<string, Task>();         // id → latest snapshot
+  const introducedInRevision = new Map<string, number>();
+  const lastModifiedInRevision = new Map<string, number>();
+  const edgeKeys = new Set<string>();
+  const edges: TaskEdge[] = [];
+  const everPresent = new Map<string, Set<number>>();    // id → {revIdxs that had it}
+
+  for (const rev of revs) {
+    const revIdx = rev.revisionIndex ?? 0;
+    for (const t of rev.tasks) {
+      const prior = taskSnapshots.get(t.id);
+      const introducedAt = introducedInRevision.get(t.id);
+      if (introducedAt === undefined) {
+        introducedInRevision.set(t.id, revIdx);
+      }
+      // Track when a task's content (title/status/assignee/description)
+      // last changed. Status changes do NOT count as a revision bump
+      // unless the plan was re-emitted (goldfive publishes a fresh plan
+      // for every refine).
+      if (
+        !prior ||
+        prior.title !== t.title ||
+        prior.description !== t.description ||
+        prior.assigneeAgentId !== t.assigneeAgentId
+      ) {
+        lastModifiedInRevision.set(t.id, revIdx);
+      } else if (!lastModifiedInRevision.has(t.id)) {
+        lastModifiedInRevision.set(t.id, revIdx);
+      }
+      taskSnapshots.set(t.id, t);
+      let seen = everPresent.get(t.id);
+      if (!seen) {
+        seen = new Set();
+        everPresent.set(t.id, seen);
+      }
+      seen.add(revIdx);
+    }
+    for (const e of rev.edges) {
+      const k = `${e.fromTaskId}->${e.toTaskId}`;
+      if (!edgeKeys.has(k)) {
+        edgeKeys.add(k);
+        edges.push(e);
+      }
+    }
+  }
+
+  // A task is "superseded" if it no longer appears in the final revision.
+  // Use the latest revision's task id set as the ground truth for
+  // "currently present".
+  const latestRev = revs[revs.length - 1];
+  const latestTaskIds = new Set<string>();
+  for (const t of latestRev.tasks) latestTaskIds.add(t.id);
+
+  const taskRevisionMeta = new Map<string, TaskRevisionMeta>();
+  const tasks: Task[] = [];
+  for (const [id, t] of taskSnapshots) {
+    tasks.push(t);
+    taskRevisionMeta.set(id, {
+      introducedInRevision: introducedInRevision.get(id) ?? 0,
+      lastModifiedInRevision: lastModifiedInRevision.get(id) ?? 0,
+      isSuperseded: !latestTaskIds.has(id),
+      supersededByTaskId: null, // filled in by deriveSupersedes
+    });
+  }
+
+  return {
+    planId,
+    latestRevisionIndex,
+    tasks,
+    edges,
+    taskRevisionMeta,
+  };
+}
+
+// Pair retired task ids with their replacements. Strategy:
+//   1. Pairwise between adjacent revs: `retired` = ids present in rev[i]
+//      but absent in rev[i+1]; `added` = ids present in rev[i+1] but
+//      absent in rev[i].
+//   2. Prefer an explicit mapping from `t.supersedesTaskId` if goldfive
+//      stamps it (post-merge). Pre-merge we fall back to title-affinity
+//      (same assignee + title token overlap) and then to position.
+//   3. The drift record for this revision provides the `kind` + `reason`.
+function deriveSupersedes(
+  revs: ReadonlyArray<TaskPlan>,
+  driftsById: Map<string, DriftRecord>,
+): Map<string, SupersessionLink> {
+  const out = new Map<string, SupersessionLink>();
+  for (let i = 1; i < revs.length; i++) {
+    const prev = revs[i - 1];
+    const next = revs[i];
+    const prevIds = new Set(prev.tasks.map((t) => t.id));
+    const nextIds = new Set(next.tasks.map((t) => t.id));
+    const retired: Task[] = [];
+    const added: Task[] = [];
+    for (const t of prev.tasks) if (!nextIds.has(t.id)) retired.push(t);
+    for (const t of next.tasks) if (!prevIds.has(t.id)) added.push(t);
+    if (retired.length === 0) continue;
+    // Pick the drift record that triggered this revision, if any.
+    const drift = next.triggerEventId
+      ? driftsById.get(next.triggerEventId)
+      : undefined;
+    const revIdx = next.revisionIndex ?? i;
+    // Pair retired ↔ added. Deterministic order: for each retired task,
+    // prefer an added task whose title has the most overlap (>= 2 shared
+    // tokens excluding stopwords), else same assignee, else positional.
+    const claimed = new Set<number>();
+    for (const old of retired) {
+      let bestIdx = -1;
+      let bestScore = 0;
+      for (let j = 0; j < added.length; j++) {
+        if (claimed.has(j)) continue;
+        const cand = added[j];
+        let score = 0;
+        if (cand.assigneeAgentId === old.assigneeAgentId) score += 1;
+        score += titleAffinity(old.title, cand.title);
+        if (score > bestScore) {
+          bestScore = score;
+          bestIdx = j;
+        }
+      }
+      // If nothing scored, fall back to positional — retired[k] → added[k].
+      if (bestIdx < 0) {
+        const idx = retired.indexOf(old);
+        if (idx < added.length && !claimed.has(idx)) bestIdx = idx;
+      }
+      if (bestIdx >= 0) {
+        claimed.add(bestIdx);
+        const replacement = added[bestIdx];
+        out.set(old.id, {
+          oldTaskId: old.id,
+          newTaskId: replacement.id,
+          revision: revIdx,
+          kind: (next.revisionKind || drift?.kind || '').toString(),
+          reason: next.revisionReason || drift?.detail || '',
+          triggerEventId: next.triggerEventId || drift?.driftId || '',
+          authoredBy: drift?.authoredBy || '',
+        });
+      } else {
+        // Retired with no replacement: record the supersession without a
+        // new task id so the UI can still mute the node + show the reason.
+        out.set(old.id, {
+          oldTaskId: old.id,
+          newTaskId: '',
+          revision: revIdx,
+          kind: (next.revisionKind || drift?.kind || '').toString(),
+          reason: next.revisionReason || drift?.detail || '',
+          triggerEventId: next.triggerEventId || drift?.driftId || '',
+          authoredBy: drift?.authoredBy || '',
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function titleAffinity(a: string, b: string): number {
+  if (!a || !b) return 0;
+  const aset = tokenize(a);
+  const bset = tokenize(b);
+  let shared = 0;
+  for (const t of aset) if (bset.has(t)) shared++;
+  return shared >= 2 ? 2 : shared;
+}
+
+const STOPWORDS = new Set([
+  'a', 'an', 'and', 'or', 'the', 'to', 'of', 'in', 'on', 'for', 'with',
+  'by', 'is', 'it', 'be', 'as', 'at', 'from',
+]);
+
+function tokenize(s: string): Set<string> {
+  const out = new Set<string>();
+  for (const raw of s.toLowerCase().split(/\W+/)) {
+    if (!raw || STOPWORDS.has(raw) || raw.length < 3) continue;
+    out.add(raw);
+  }
+  return out;
+}
+
+// Internal: build a drift-id lookup map from the session store's drift list.
+function driftsByIdFor(store: SessionStore | null): Map<string, DriftRecord> {
+  const m = new Map<string, DriftRecord>();
+  if (!store) return m;
+  for (const d of store.drifts.list()) {
+    if (d.driftId) m.set(d.driftId, d);
+    if (d.annotationId) m.set(d.annotationId, d);
+  }
+  return m;
+}
+
+// Pull the full rev sequence for a plan from the session store. Empty when
+// the plan is unknown.
+function revsFor(store: SessionStore | null, planId: string): ReadonlyArray<TaskPlan> {
+  if (!store) return [];
+  return store.tasks.allRevsForPlan(planId);
+}
+
+// ── Hooks (frozen signatures) ────────────────────────────────────────────────
+
+// Re-render-on-store-change helper used by all three hooks. Subscribes to
+// both the TaskRegistry (plan-rev updates) and the DriftRegistry (drift
+// metadata used by the supersedes map).
+function useStoreTick(sessionId: string | null): SessionStore | null {
+  const store = sessionId ? getSessionStore(sessionId) ?? null : null;
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!store) return;
+    const unT = store.tasks.subscribe(() => setTick((t) => t + 1));
+    const unD = store.drifts.subscribe(() => setTick((t) => t + 1));
+    return () => {
+      unT();
+      unD();
+    };
+  }, [store]);
+  return store;
+}
+
+export function usePlanHistory(
+  sessionId: string | null,
+  planId: string | null,
+): readonly PlanRevisionRecord[] {
+  const store = useStoreTick(sessionId);
+  if (!planId) return [];
+  return deriveHistory(planId, revsFor(store, planId));
+}
+
+export function useCumulativePlan(
+  sessionId: string | null,
+  planId: string | null,
+): CumulativePlan | null {
+  const store = useStoreTick(sessionId);
+  if (!planId) return null;
+  return deriveCumulative(planId, revsFor(store, planId));
+}
+
+export function useSupersedesMap(
+  sessionId: string | null,
+  planId: string | null,
+): Map<string, SupersessionLink> {
+  const store = useStoreTick(sessionId);
+  if (!planId) return new Map();
+  return deriveSupersedes(revsFor(store, planId), driftsByIdFor(store));
+}
+
+// Pure-function variants exported for tests (they don't touch React or
+// the global store cache). Tests seed a TaskRegistry directly and call
+// these; the hook signatures above are thin reactive wrappers.
+export const __internal = {
+  deriveHistory,
+  deriveCumulative,
+  deriveSupersedes,
+};

--- a/frontend/src/state/uiStore.ts
+++ b/frontend/src/state/uiStore.ts
@@ -13,11 +13,17 @@ export type NavSection =
 
 export type TaskPlanMode = 'pre-strip' | 'ghost' | 'hybrid';
 
+// Task/Plan panel view mode. 'cumulative' renders the union-DAG across
+// revisions (default, with generation badges + supersedes edges).
+// 'latest' renders only the latest revision of each plan (legacy view).
+export type TaskPlanView = 'cumulative' | 'latest';
+
 // Persisted task-plan UI preferences. Read on store creation, written on
 // mutation. A direct localStorage touchpoint (no middleware) keeps this simple
 // and keeps the single-file store tree unchanged.
 const TASK_PLAN_MODE_KEY = 'harmonograf.taskPlanMode';
 const TASK_PLAN_VISIBLE_KEY = 'harmonograf.taskPlanVisible';
+const TASK_PLAN_VIEW_KEY = 'harmonograf.taskPlanView';
 const GRAPH_VIEWPORT_KEY = 'harmonograf.graphViewport';
 const CONTEXT_OVERLAY_VISIBLE_KEY = 'harmonograf.contextOverlayVisible';
 const INTERVENTION_BANDS_VISIBLE_KEY = 'harmonograf.interventionBandsVisible';
@@ -86,6 +92,24 @@ function writeTaskPlanMode(m: TaskPlanMode): void {
 function writeTaskPlanVisible(v: boolean): void {
   try {
     localStorage.setItem(TASK_PLAN_VISIBLE_KEY, v ? 'true' : 'false');
+  } catch {
+    /* ignore */
+  }
+}
+
+function readTaskPlanView(): TaskPlanView {
+  try {
+    const v = localStorage.getItem(TASK_PLAN_VIEW_KEY);
+    if (v === 'cumulative' || v === 'latest') return v;
+  } catch {
+    /* ignore */
+  }
+  return 'cumulative';
+}
+
+function writeTaskPlanView(v: TaskPlanView): void {
+  try {
+    localStorage.setItem(TASK_PLAN_VIEW_KEY, v);
   } catch {
     /* ignore */
   }
@@ -202,8 +226,10 @@ interface UiState {
   // Task-plan rendering preferences (persisted to localStorage).
   taskPlanMode: TaskPlanMode;
   taskPlanVisible: boolean;
+  taskPlanView: TaskPlanView;
   setTaskPlanMode: (m: TaskPlanMode) => void;
   toggleTaskPlanVisible: () => void;
+  setTaskPlanView: (v: TaskPlanView) => void;
 
   // Context-window overlay: per-agent sparkline band drawn under spans.
   // Default on, persisted to localStorage.
@@ -337,6 +363,7 @@ export const useUiStore = create<UiState>((set) => ({
 
   taskPlanMode: readTaskPlanMode(),
   taskPlanVisible: readTaskPlanVisible(),
+  taskPlanView: readTaskPlanView(),
   graphViewport: readGraphViewport(),
   graphActions: null,
   setGraphActions: (a) => set({ graphActions: a }),
@@ -355,6 +382,11 @@ export const useUiStore = create<UiState>((set) => ({
       const next = !s.taskPlanVisible;
       writeTaskPlanVisible(next);
       return { taskPlanVisible: next };
+    }),
+  setTaskPlanView: (v) =>
+    set(() => {
+      writeTaskPlanView(v);
+      return { taskPlanView: v };
     }),
 
   contextOverlayVisible: readContextOverlayVisible(),


### PR DESCRIPTION
## Summary

Renders the Task/Plan panel (bottom of the Gantt view) as a cumulative, evolving artifact instead of just the latest plan revision. Closes #163.

- **Cumulative union DAG**: every task across every revision is drawn; `isSuperseded=true` tasks render at 40% opacity with a dashed border so completed work isn't erased.
- **Generation badges**: each task card now carries a small `REV N` badge (top-right corner) derived from `taskRevisionMeta.lastModifiedInRevision`. Monochromatic palette (rev 0 neutral → rev 3+ primary-tinted) — does not stomp on status / severity colours.
- **Supersedes edges**: dashed, colour-coded by drift kind (user → green, off_topic → amber, cascade_cancel → violet, unknown → neutral). Labelled with short annotation like `goldfive: off_topic` or `user: user_steer`. Hover = full reason tooltip, click = opens steering-detail side panel.
- **Revision scrubber**: keyboard-accessible toolbar (`←/→/Home/End`) above the DAG, one notch per revision labelled `REV N: KIND`, plus a default `Latest` notch. Selecting a notch mutes tasks introduced in later revisions.
- **Steering-detail side panel**: slides in from the right on supersedes-edge click. Sections: Trigger (drift kind + reason), Steering (author + triggerEventId + reason), Target (agent + task id). Includes a `Jump to this drift in Gantt` button when the session exposes an `onJumpToDrift` callback.
- **Latest-only fallback**: `Show: Cumulative | Latest only` select persisted in `localStorage` via `uiStore.taskPlanView`. Latest-only renders the pre-existing single-plan view byte-for-byte (legacy prop path on `TaskStagesGraph` is preserved).

## Prerequisites

Merge order per the shared plan-panel coordination doc:
1. Server plan-history RPC — pedapudi/harmonograf#160
2. Frontend `planHistory` state + selector hooks — pedapudi/harmonograf#162
3. **This PR**
4. Trajectory tier-1 (separate branch, not in this PR)

### Pre-merge behaviour (today)

The renderer consumes the frozen `usePlanHistory` / `useCumulativePlan` / `useSupersedesMap` hook signatures. Until #162 lands those hooks derive from the existing `TaskRegistry.allRevsForPlan()` infrastructure locally (`frontend/src/state/planHistory.ts`). When #162 lands, that file is replaced with the one that reads `SessionStore.planHistory` directly; consumers don't change.

Empty state (session has zero plans) renders exactly as before — no regression on first-load.

## UX decisions worth flagging

- **Generation palette cap**: rev 3 and higher all share the strongest palette entry. Four-step palette keeps the badge readable at 28×12 px and sidesteps the "revision 10+" unreadable-rainbow problem. The exact rev number is always in the badge text.
- **Supersedes-edge label placement**: mid-curve text anchor with a small y-offset. Edges are short in the stage-grid layout so fancier label routing is overkill.
- **Superseded progress counts**: the `N/M` stage-progress badges count only *non-superseded* tasks so the live-plan health doesn't inherit old failures. The superseded tasks are still rendered greyed out.
- **Pure-state side-panel selection**: the side-panel records only the `oldTaskId` and re-resolves the `SupersessionLink` from the live `supersedesMap` every render. This means (a) no `useEffect` cascades on map changes and (b) switching to Latest-only transparently hides the panel without any cleanup effect.
- **Scrubber default**: `Latest` (no filter). Scrubbing is opt-in; users on long sessions aren't buried in mid-history views.

## Before / after

**Before**: panel shows the live rev only. Task rows for retired tasks disappear the moment goldfive refines. Operators looking at \"what did that drift change?\" have to cross-reference the Trajectory view.

**After**: panel shows every task goldfive has ever emitted for this plan. Retired tasks are visibly greyed; amber-dashed arrows show which new task replaced them with an annotation like `goldfive: off_topic`. Clicking that arrow pops a side panel with the drift reason, the refine_steer details, and the target agent. A revision scrubber at the top lets the operator walk back through history without losing the cumulative context.

## Test plan

- [x] `pnpm test --run` — 374 tests pass (364 pre-existing + 10 new in `TaskStagesGraph.evolution.test.tsx`).
- [x] `pnpm tsc -b` — clean.
- [x] `pnpm lint` — clean (1 pre-existing warning in `GanttView.tsx`, untouched).
- [ ] Manual smoke: open a recorded session with >= 2 plan revs → verify cumulative rendering, scrubber, supersedes edge click → detail panel.
- [ ] Manual smoke: toggle to Latest only → verify single-plan view renders identically to main.

## Files

- `frontend/src/state/planHistory.ts` — frozen hook signatures (swap point for #162).
- `frontend/src/components/TaskStages/TaskPlanPanel.tsx` — new parent wiring scrubber + toggle + graph + side panel.
- `frontend/src/components/TaskStages/TaskStagesGraph.tsx` — cumulative-mode branch with gen badges + supersedes edges; legacy prop path preserved.
- `frontend/src/components/TaskStages/TaskStagesGraph.css` — new selectors for muted cards, supersedes edges, scrubber notches, side panel.
- `frontend/src/components/shell/views/GanttView.tsx` — replaces the per-plan `TaskStagesGraph` with `TaskPlanPanel`.
- `frontend/src/state/uiStore.ts` — `taskPlanView: 'cumulative' | 'latest'` persisted toggle.
- `frontend/src/__tests__/components/TaskStagesGraph.evolution.test.tsx` — 10 new tests covering derivation, cumulative render, gen badges, supersedes click → panel, scrubber filter, latest-only toggle.

## Do-not-merge

Please hold merge until #160 + #162 land; user approves final merge order.