### PR TITLE
feat(ui): goldfive span visual + popover + drawer detail

### DIFF
--- a/frontend/src/__tests__/components/Drawer.goldfive.test.tsx
+++ b/frontend/src/__tests__/components/Drawer.goldfive.test.tsx
@@ -1,0 +1,230 @@
+// Drawer integration tests for goldfive-aware span detail (harmonograf#157).
+//
+// Covers three routing questions:
+//
+//   1. Generic goldfive spans render GoldfiveSpanDetail inside SummaryTab
+//      with all their sections (header, input/output previews, context).
+//   2. Judge spans (judge.kind=judge) keep using JudgeInvocationDetail so
+//      the verdict badge + reasoning sections still show up.
+//   3. Spans that are not goldfive at all keep the vanilla SummaryTab.
+//
+// Uses the same usePayload mock style as Drawer.reasoning.test.tsx so
+// the Reasoning section never fetches.
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const usePayloadSpy = vi.fn<(digest: string | null) => {
+  bytes: Uint8Array | null;
+  mimeType: string;
+  loading: boolean;
+  error: string | null;
+}>();
+
+let mockStore: unknown = undefined;
+
+vi.mock('../../rpc/hooks', async () => {
+  const actual = await vi.importActual<object>('../../rpc/hooks');
+  return {
+    ...actual,
+    usePayload: (digest: string | null) => usePayloadSpy(digest),
+    getSessionStore: () => mockStore,
+  };
+});
+
+import { SummaryTab } from '../../components/shell/Drawer';
+import { SessionStore } from '../../gantt/index';
+import type { AttributeValue, Span } from '../../gantt/types';
+
+function attr(value: string): AttributeValue {
+  return { kind: 'string', value };
+}
+function boolAttr(value: boolean): AttributeValue {
+  return { kind: 'bool', value };
+}
+
+function mkSpan(overrides: Partial<Span> = {}): Span {
+  return {
+    id: 'sp-gf',
+    sessionId: 'sess',
+    agentId: 'client-1:goldfive',
+    parentSpanId: null,
+    kind: 'LLM_CALL',
+    name: 'refine_steer',
+    status: 'COMPLETED',
+    startMs: 100,
+    endMs: 300,
+    lane: 0,
+    attributes: {},
+    payloadRefs: [],
+    links: [],
+    replaced: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  usePayloadSpy.mockReset();
+  usePayloadSpy.mockReturnValue({
+    bytes: null,
+    mimeType: '',
+    loading: false,
+    error: null,
+  });
+  const store = new SessionStore();
+  store.agents.upsert({
+    id: 'client-1:goldfive',
+    name: 'goldfive',
+    framework: 'CUSTOM',
+    status: 'CONNECTED',
+    capabilities: [],
+    connectedAtMs: 0,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+  });
+  mockStore = store;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mockStore = undefined;
+  cleanup();
+});
+
+describe('Drawer SummaryTab — goldfive routing', () => {
+  it('renders GoldfiveSpanDetail for a refine_* goldfive span', () => {
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('refine_steer'),
+        'goldfive.decision_summary': attr(
+          'refined plan in response to OFF_TOPIC drift',
+        ),
+        'goldfive.target_agent_id': attr('client-1:research_agent'),
+        'goldfive.input_preview': attr('input text'),
+        'goldfive.output_preview': attr('output text'),
+      },
+    });
+    render(<SummaryTab span={span} />);
+    const section = screen.getByTestId('drawer-goldfive-section');
+    expect(section.getAttribute('data-mode')).toBe('generic');
+    expect(screen.getByTestId('goldfive-span-detail')).toBeTruthy();
+    expect(
+      screen.getByTestId('goldfive-span-detail-header').textContent,
+    ).toMatch(/OFF_TOPIC drift/);
+    expect(
+      screen.getByTestId('goldfive-span-detail-input-body').textContent,
+    ).toBe('input text');
+  });
+
+  it('renders JudgeInvocationDetail for a judge span (judge.kind=judge)', () => {
+    const span = mkSpan({
+      id: 'sp-judge',
+      name: 'judge_reasoning',
+      attributes: {
+        'goldfive.call_name': attr('judge_reasoning'),
+        'judge.kind': attr('judge'),
+        'judge.on_task': boolAttr(true),
+        'judge.reason': attr('agent is on task'),
+      },
+    });
+    render(<SummaryTab span={span} />);
+    const section = screen.getByTestId('drawer-goldfive-section');
+    expect(section.getAttribute('data-mode')).toBe('judge');
+    expect(screen.getByTestId('judge-invocation-detail')).toBeTruthy();
+    // And the generic panel does NOT render (routing is exclusive).
+    expect(screen.queryByTestId('goldfive-span-detail')).toBeNull();
+  });
+
+  it('does not render a goldfive section for non-goldfive spans', () => {
+    const span: Span = mkSpan({
+      id: 'sp-plain',
+      agentId: 'client-1:research_agent',
+      kind: 'LLM_CALL',
+      name: 'gemini-2.0',
+      attributes: {},
+    });
+    render(<SummaryTab span={span} />);
+    expect(screen.queryByTestId('drawer-goldfive-section')).toBeNull();
+    expect(screen.queryByTestId('goldfive-span-detail')).toBeNull();
+    expect(screen.queryByTestId('judge-invocation-detail')).toBeNull();
+  });
+
+  it('graceful-degrades when a goldfive span carries no new attributes', () => {
+    // Legacy __goldfive__ span — isGoldfiveSpan still returns true so the
+    // GoldfiveSpanDetail renders, but the sections show the empty-state
+    // placeholders instead of crashing.
+    const span = mkSpan({
+      id: 'sp-legacy',
+      agentId: '__goldfive__',
+      name: 'refine: drift',
+      attributes: {},
+    });
+    render(<SummaryTab span={span} />);
+    expect(screen.getByTestId('drawer-goldfive-section')).toBeTruthy();
+    expect(
+      screen.getByTestId('goldfive-span-detail-input').textContent,
+    ).toMatch(/No input preview captured/);
+    expect(
+      screen.getByTestId('goldfive-span-detail-output').textContent,
+    ).toMatch(/No output preview captured/);
+  });
+
+  it('links a refine_* span to its PlanRevised by target_task_id + time proximity', () => {
+    // Seed a plan revision (rev 2) whose task list includes the span's
+    // target_task_id and whose createdAtMs is slightly after the span's
+    // startMs — the expected pairing.
+    const store = mockStore as SessionStore;
+    store.tasks.upsertPlan({
+      id: 'p1',
+      invocationSpanId: '',
+      plannerAgentId: '',
+      createdAtMs: 180,
+      summary: '',
+      tasks: [
+        {
+          id: 't-research-corrected',
+          title: 'Research corrected topic',
+          description: '',
+          assigneeAgentId: 'client-1:research_agent',
+          status: 'PENDING',
+          predictedStartMs: 0,
+          predictedDurationMs: 0,
+          boundSpanId: '',
+        },
+      ],
+      edges: [],
+      revisionReason: 'OFF_TOPIC drift',
+      revisionIndex: 2,
+    });
+
+    const span = mkSpan({
+      startMs: 150,
+      endMs: 170,
+      attributes: {
+        'goldfive.call_name': attr('refine_steer'),
+        'goldfive.target_task_id': attr('t-research-corrected'),
+      },
+    });
+    render(<SummaryTab span={span} />);
+    const linked = screen.getByTestId('goldfive-span-detail-linked-plan-link');
+    expect(linked.textContent).toMatch(/Plan refined → r2/);
+    expect(linked.textContent).toMatch(/OFF_TOPIC drift/);
+  });
+
+  it('does not link a refine_* span when no plan revisions exist', () => {
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('refine_steer'),
+        'goldfive.target_task_id': attr('t-missing'),
+      },
+    });
+    render(<SummaryTab span={span} />);
+    expect(
+      screen.queryByTestId('goldfive-span-detail-linked-plan'),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/components/Drawer.reasoning.test.tsx
+++ b/frontend/src/__tests__/components/Drawer.reasoning.test.tsx
@@ -14,6 +14,11 @@ const usePayloadSpy = vi.fn<(digest: string | null) => {
 
 vi.mock('../../rpc/hooks', () => ({
   usePayload: (digest: string | null) => usePayloadSpy(digest),
+  // SummaryTab now reads the session store to look up plan revisions for
+  // goldfive detail injection. The reasoning tests feed plain SummaryTab
+  // spans (not goldfive); returning undefined short-circuits the goldfive
+  // branch without exercising any store code.
+  getSessionStore: () => undefined,
 }));
 
 import { ReasoningSection, SummaryTab } from '../../components/shell/Drawer';

--- a/frontend/src/__tests__/components/GoldfiveSpanDetail.test.tsx
+++ b/frontend/src/__tests__/components/GoldfiveSpanDetail.test.tsx
@@ -1,0 +1,273 @@
+// Rendering tests for the GoldfiveSpanDetail drawer panel (harmonograf#157).
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GoldfiveSpanDetail } from '../../components/Interventions/GoldfiveSpanDetail';
+import {
+  resolveGoldfiveSpanInfo,
+  type GoldfiveSpanInfo,
+} from '../../lib/goldfiveSpan';
+import type { AttributeValue, Span, TaskPlan } from '../../gantt/types';
+
+function attr(value: string): AttributeValue {
+  return { kind: 'string', value };
+}
+function intAttr(value: bigint | number): AttributeValue {
+  return { kind: 'int', value: typeof value === 'bigint' ? value : BigInt(value) };
+}
+
+function mkSpan(overrides: Partial<Span> = {}): Span {
+  return {
+    id: 'sp-gf',
+    sessionId: 'sess-1',
+    agentId: 'client-1:goldfive',
+    parentSpanId: null,
+    kind: 'LLM_CALL',
+    name: 'refine_steer',
+    status: 'COMPLETED',
+    startMs: 0,
+    endMs: 248,
+    lane: 0,
+    attributes: {},
+    payloadRefs: [],
+    links: [],
+    replaced: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('<GoldfiveSpanDetail />', () => {
+  it('renders the decision summary as the header title', () => {
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('refine_steer'),
+        'goldfive.decision_summary': attr(
+          'refined plan in response to OFF_TOPIC drift on research_solar',
+        ),
+      },
+    });
+    const info = resolveGoldfiveSpanInfo(span);
+    render(<GoldfiveSpanDetail span={span} info={info} />);
+    expect(
+      screen.getByTestId('goldfive-span-detail-header').textContent,
+    ).toMatch(/OFF_TOPIC drift on research_solar/);
+  });
+
+  it('renders call_name, target_agent, and target_task badges', () => {
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('judge_reasoning'),
+        'goldfive.decision_summary': attr('reviewed plan'),
+        'goldfive.target_agent_id': attr('client-1:research_agent'),
+        'goldfive.target_task_id': attr('t-research'),
+      },
+    });
+    const info = resolveGoldfiveSpanInfo(span);
+    render(<GoldfiveSpanDetail span={span} info={info} />);
+    expect(screen.getByTestId('goldfive-span-detail-call-name').textContent).toBe(
+      'judge_reasoning',
+    );
+    expect(
+      screen.getByTestId('goldfive-span-detail-target-agent').textContent,
+    ).toMatch(/research_agent/);
+    expect(
+      screen.getByTestId('goldfive-span-detail-target-task').textContent,
+    ).toMatch(/t-research/);
+  });
+
+  it('renders the input + output preview blocks verbatim', () => {
+    const input = 'drift=OFF_TOPIC\nprevious plan summary';
+    const output = 'new plan: research_solar_corrected';
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('refine_steer'),
+        'goldfive.input_preview': attr(input),
+        'goldfive.output_preview': attr(output),
+      },
+    });
+    const info = resolveGoldfiveSpanInfo(span);
+    render(<GoldfiveSpanDetail span={span} info={info} />);
+    expect(
+      screen.getByTestId('goldfive-span-detail-input-body').textContent,
+    ).toBe(input);
+    expect(
+      screen.getByTestId('goldfive-span-detail-output-body').textContent,
+    ).toBe(output);
+  });
+
+  it('renders "No preview captured" when input/output are absent', () => {
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('refine_steer'),
+      },
+    });
+    const info = resolveGoldfiveSpanInfo(span);
+    render(<GoldfiveSpanDetail span={span} info={info} />);
+    expect(
+      screen.getByTestId('goldfive-span-detail-input').textContent,
+    ).toMatch(/No input preview captured/);
+    expect(
+      screen.getByTestId('goldfive-span-detail-output').textContent,
+    ).toMatch(/No output preview captured/);
+  });
+
+  it('fires the copy button for input + output', () => {
+    const onCopy = vi.fn();
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('refine_steer'),
+        'goldfive.input_preview': attr('IN'),
+        'goldfive.output_preview': attr('OUT'),
+      },
+    });
+    const info = resolveGoldfiveSpanInfo(span);
+    render(
+      <GoldfiveSpanDetail span={span} info={info} onCopy={onCopy} />,
+    );
+    fireEvent.click(screen.getByTestId('goldfive-span-detail-input-copy'));
+    fireEvent.click(screen.getByTestId('goldfive-span-detail-output-copy'));
+    expect(onCopy).toHaveBeenCalledTimes(2);
+    expect(onCopy).toHaveBeenCalledWith('IN');
+    expect(onCopy).toHaveBeenCalledWith('OUT');
+  });
+
+  it('renders the context definition list with model, elapsed, run, session, task, target', () => {
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('judge_reasoning'),
+        'goldfive.target_agent_id': attr('client-1:research_agent'),
+        'goldfive.target_task_id': attr('t-research'),
+        'goldfive.model': attr('claude-haiku-4'),
+        'goldfive.elapsed_ms': intAttr(248),
+        'goldfive.run_id': attr('run-alpha'),
+      },
+    });
+    const info = resolveGoldfiveSpanInfo(span);
+    render(<GoldfiveSpanDetail span={span} info={info} />);
+    expect(screen.getByTestId('goldfive-span-detail-ctx-model').textContent).toBe(
+      'claude-haiku-4',
+    );
+    expect(
+      screen.getByTestId('goldfive-span-detail-ctx-elapsed').textContent,
+    ).toBe('248ms');
+    expect(screen.getByTestId('goldfive-span-detail-ctx-run').textContent).toBe(
+      'run-alpha',
+    );
+    expect(
+      screen.getByTestId('goldfive-span-detail-ctx-session').textContent,
+    ).toBe('sess-1');
+    expect(screen.getByTestId('goldfive-span-detail-ctx-task').textContent).toBe(
+      't-research',
+    );
+    expect(
+      screen.getByTestId('goldfive-span-detail-ctx-target').textContent,
+    ).toBe('client-1:research_agent');
+  });
+
+  it('falls back to span duration for elapsed when no attribute is set', () => {
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('refine_steer'),
+      },
+      startMs: 1_000,
+      endMs: 1_500,
+    });
+    const info = resolveGoldfiveSpanInfo(span);
+    render(<GoldfiveSpanDetail span={span} info={info} />);
+    expect(
+      screen.getByTestId('goldfive-span-detail-ctx-elapsed').textContent,
+    ).toBe('500ms');
+  });
+
+  it('renders the linked-plan section for refine_* calls when a plan is provided', () => {
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('refine_steer'),
+        'goldfive.target_task_id': attr('t-research'),
+      },
+    });
+    const info = resolveGoldfiveSpanInfo(span);
+    const plan: TaskPlan = {
+      id: 'p1',
+      invocationSpanId: '',
+      plannerAgentId: '',
+      createdAtMs: 300,
+      summary: '',
+      tasks: [
+        {
+          id: 't-research-corrected',
+          title: 'Research corrected topic',
+          description: '',
+          assigneeAgentId: 'client-1:research_agent',
+          status: 'PENDING',
+          predictedStartMs: 0,
+          predictedDurationMs: 0,
+          boundSpanId: '',
+        },
+      ],
+      edges: [],
+      revisionReason: 'OFF_TOPIC drift',
+      revisionIndex: 2,
+    };
+    const onOpen = vi.fn();
+    render(
+      <GoldfiveSpanDetail
+        span={span}
+        info={info}
+        linkedPlanRevision={{ plan, onOpen }}
+      />,
+    );
+    const link = screen.getByTestId('goldfive-span-detail-linked-plan-link');
+    expect(link.textContent).toMatch(/Plan refined → r2/);
+    expect(link.textContent).toMatch(/OFF_TOPIC drift/);
+    fireEvent.click(link);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    const tasksList = screen.getByTestId(
+      'goldfive-span-detail-linked-plan-tasks',
+    );
+    expect(tasksList.textContent).toMatch(/Research corrected topic/);
+  });
+
+  it('does not render the linked-plan section for non-refine categories', () => {
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('judge_reasoning'),
+      },
+    });
+    const info = resolveGoldfiveSpanInfo(span);
+    const plan: TaskPlan = {
+      id: 'p1',
+      invocationSpanId: '',
+      plannerAgentId: '',
+      createdAtMs: 300,
+      summary: '',
+      tasks: [],
+      edges: [],
+      revisionReason: 'x',
+      revisionIndex: 1,
+    };
+    render(
+      <GoldfiveSpanDetail
+        span={span}
+        info={info}
+        linkedPlanRevision={{ plan }}
+      />,
+    );
+    expect(screen.queryByTestId('goldfive-span-detail-linked-plan')).toBeNull();
+  });
+
+  it('renders the decision summary fallback when only the call_name is stamped', () => {
+    const span = mkSpan({
+      attributes: {
+        'goldfive.call_name': attr('goal_derive'),
+      },
+    });
+    const info: GoldfiveSpanInfo = resolveGoldfiveSpanInfo(span);
+    render(<GoldfiveSpanDetail span={span} info={info} />);
+    expect(screen.getByTestId('goldfive-span-detail-header').textContent).toMatch(
+      /goldfive: goal_derive/,
+    );
+  });
+});

--- a/frontend/src/__tests__/components/SpanPopover.goldfive.test.tsx
+++ b/frontend/src/__tests__/components/SpanPopover.goldfive.test.tsx
@@ -1,0 +1,257 @@
+// Component tests for the goldfive-aware SpanPopover (harmonograf#157).
+//
+// Drives the popover with a seeded SessionStore + a minimal renderer
+// stub (implements only ``rectFor``) + the popover Zustand store so we
+// can assert the goldfive section renders its headline, context row,
+// input/output disclosures, and hides the Steer/Annotate action row.
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The popover imports RPC hooks for live-agent lookups and control
+// sends. In the test environment we stub them so the render doesn't
+// attach to a streaming transport.
+vi.mock('../../rpc/hooks', async () => {
+  const actual = await vi.importActual<object>('../../rpc/hooks');
+  return {
+    ...actual,
+    useAgentLive: () => ({ name: 'goldfive', taskReport: '', currentActivity: '' }),
+    usePostAnnotation: () => () => Promise.resolve(),
+    useSendControl: () => () => Promise.resolve(),
+  };
+});
+
+import { SpanPopover } from '../../components/Interaction/SpanPopover';
+import { SessionStore } from '../../gantt/index';
+import type { AttributeValue, Span } from '../../gantt/types';
+import { usePopoverStore } from '../../state/popoverStore';
+import type { GanttRenderer } from '../../gantt/renderer';
+
+function mkCtx(store: SessionStore): {
+  renderer: GanttRenderer;
+  store: SessionStore;
+  widthCss: number;
+  heightCss: number;
+  tick: number;
+} {
+  // Minimal renderer stub — the popover only calls ``rectFor`` to anchor
+  // the card. A canned rectangle is enough for the render assertions.
+  const renderer = {
+    rectFor: () => ({ x: 100, y: 80, w: 120, h: 20 }),
+  } as unknown as GanttRenderer;
+  return { renderer, store, widthCss: 1024, heightCss: 600, tick: 0 };
+}
+
+function attr(value: string): AttributeValue {
+  return { kind: 'string', value };
+}
+
+function mkGoldfiveSpan(overrides: Partial<Span> = {}): Span {
+  return {
+    id: 'gf-refine-1',
+    sessionId: 'sess',
+    agentId: 'client-42:goldfive',
+    parentSpanId: null,
+    kind: 'LLM_CALL',
+    name: 'refine_steer',
+    status: 'COMPLETED',
+    startMs: 1_000,
+    endMs: 2_300,
+    lane: 0,
+    attributes: {
+      'goldfive.call_name': attr('refine_steer'),
+      'goldfive.decision_summary': attr(
+        'refined plan in response to OFF_TOPIC drift on research_solar',
+      ),
+      'goldfive.target_agent_id': attr('client-42:research_agent'),
+      'goldfive.target_task_id': attr('t-research-solar'),
+      'goldfive.input_preview': attr('drift=OFF_TOPIC\nprevious plan summary'),
+      'goldfive.output_preview': attr('new plan: research_solar_corrected'),
+    },
+    payloadRefs: [],
+    links: [],
+    replaced: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function seedGoldfiveAgent(store: SessionStore): void {
+  store.agents.upsert({
+    id: 'client-42:goldfive',
+    name: 'goldfive',
+    framework: 'CUSTOM',
+    status: 'CONNECTED',
+    capabilities: [],
+    connectedAtMs: 1,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+  });
+}
+
+beforeEach(() => {
+  usePopoverStore.getState().closeAll();
+});
+
+afterEach(() => {
+  usePopoverStore.getState().closeAll();
+  cleanup();
+});
+
+describe('<SpanPopover /> — goldfive spans', () => {
+  it('shows the decision summary as the popover summary line', () => {
+    const store = new SessionStore();
+    seedGoldfiveAgent(store);
+    const span = mkGoldfiveSpan();
+    store.spans.append(span);
+
+    usePopoverStore.getState().openForSpan(span.id, 100, 80);
+
+    render(<SpanPopover ctx={mkCtx(store)} sessionId="sess" />);
+
+    expect(screen.getByTestId('span-popover-title').textContent).toBe('refine_steer');
+    expect(screen.getByTestId('span-popover-summary').textContent).toMatch(
+      /refined plan in response to OFF_TOPIC drift/,
+    );
+  });
+
+  it('shows the target agent (bare) and target task in the context row', () => {
+    const store = new SessionStore();
+    seedGoldfiveAgent(store);
+    const span = mkGoldfiveSpan();
+    store.spans.append(span);
+
+    usePopoverStore.getState().openForSpan(span.id, 100, 80);
+    render(<SpanPopover ctx={mkCtx(store)} sessionId="sess" />);
+
+    const targetAgent = screen.getByTestId('span-popover-goldfive-target-agent');
+    expect(targetAgent.textContent).toMatch(/research_agent/);
+    expect(targetAgent.textContent).not.toMatch(/^client-42:/);
+
+    const targetTask = screen.getByTestId('span-popover-goldfive-target-task');
+    expect(targetTask.textContent).toMatch(/t-research-solar/);
+  });
+
+  it('renders collapsed Input and Output preview disclosures and expands on click', () => {
+    const store = new SessionStore();
+    seedGoldfiveAgent(store);
+    const span = mkGoldfiveSpan();
+    store.spans.append(span);
+
+    usePopoverStore.getState().openForSpan(span.id, 100, 80);
+    render(<SpanPopover ctx={mkCtx(store)} sessionId="sess" />);
+
+    const input = screen.getByTestId('span-popover-goldfive-input');
+    expect(input.getAttribute('data-open')).toBe('false');
+    expect(screen.queryByTestId('span-popover-goldfive-input-body')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('span-popover-goldfive-input-toggle'));
+    expect(screen.getByTestId('span-popover-goldfive-input-body').textContent).toMatch(
+      /drift=OFF_TOPIC/,
+    );
+
+    fireEvent.click(screen.getByTestId('span-popover-goldfive-output-toggle'));
+    expect(screen.getByTestId('span-popover-goldfive-output-body').textContent).toMatch(
+      /research_solar_corrected/,
+    );
+  });
+
+  it('hides the Steer and Annotate buttons but keeps Copy id + Open drawer', () => {
+    const store = new SessionStore();
+    seedGoldfiveAgent(store);
+    const span = mkGoldfiveSpan();
+    store.spans.append(span);
+
+    usePopoverStore.getState().openForSpan(span.id, 100, 80);
+    render(<SpanPopover ctx={mkCtx(store)} sessionId="sess" />);
+
+    expect(screen.queryByText('Steer')).toBeNull();
+    expect(screen.queryByText('Annotate')).toBeNull();
+    expect(screen.getByText('Copy id')).toBeTruthy();
+    expect(screen.getByText('Open drawer')).toBeTruthy();
+  });
+
+  it('degrades gracefully on a goldfive span with no new attributes (pre-merge session)', () => {
+    // Minimal legacy shape — on __goldfive__ row, no goldfive.* attrs.
+    const store = new SessionStore();
+    store.agents.upsert({
+      id: '__goldfive__',
+      name: 'goldfive',
+      framework: 'CUSTOM',
+      status: 'CONNECTED',
+      capabilities: [],
+      connectedAtMs: 1,
+      currentActivity: '',
+      stuck: false,
+      taskReport: '',
+      taskReportAt: 0,
+      metadata: {},
+    });
+    const span = mkGoldfiveSpan({
+      id: 'gf-legacy',
+      agentId: '__goldfive__',
+      name: 'refine: looping',
+      attributes: {},
+    });
+    store.spans.append(span);
+
+    usePopoverStore.getState().openForSpan(span.id, 100, 80);
+    render(<SpanPopover ctx={mkCtx(store)} sessionId="sess" />);
+
+    // No crash; summary falls back to the synthesized decision summary.
+    expect(screen.getByTestId('span-popover-summary').textContent).toMatch(
+      /goldfive: refine: looping/,
+    );
+    // No previews rendered when no attributes present.
+    expect(screen.queryByTestId('span-popover-goldfive-input')).toBeNull();
+    expect(screen.queryByTestId('span-popover-goldfive-output')).toBeNull();
+    // Still hides Steer/Annotate because the span is still a goldfive span.
+    expect(screen.queryByText('Steer')).toBeNull();
+  });
+
+  it('non-goldfive spans keep the legacy popover shape', () => {
+    const store = new SessionStore();
+    store.agents.upsert({
+      id: 'agent-a',
+      name: 'agent-a',
+      framework: 'ADK',
+      status: 'CONNECTED',
+      capabilities: [],
+      connectedAtMs: 0,
+      currentActivity: '',
+      stuck: false,
+      taskReport: '',
+      taskReportAt: 0,
+      metadata: {},
+    });
+    const span: Span = {
+      id: 'sp-llm',
+      sessionId: 'sess',
+      agentId: 'agent-a',
+      parentSpanId: null,
+      kind: 'LLM_CALL',
+      name: 'gemini-2.0',
+      status: 'COMPLETED',
+      startMs: 1_000,
+      endMs: 2_000,
+      lane: 0,
+      attributes: {},
+      payloadRefs: [],
+      links: [],
+      replaced: false,
+      error: null,
+    };
+    store.spans.append(span);
+
+    usePopoverStore.getState().openForSpan(span.id, 100, 80);
+    render(<SpanPopover ctx={mkCtx(store)} sessionId="sess" />);
+
+    expect(screen.getByText('Steer')).toBeTruthy();
+    expect(screen.getByText('Annotate')).toBeTruthy();
+    expect(screen.queryByTestId('span-popover-goldfive-input')).toBeNull();
+    expect(screen.queryByTestId('span-popover-goldfive-context')).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/gantt/goldfiveBarColors.test.ts
+++ b/frontend/src/__tests__/gantt/goldfiveBarColors.test.ts
@@ -1,0 +1,245 @@
+// Renderer tests for goldfive-translated span bar colors (harmonograf#157).
+//
+// Confirms that spans carrying the new goldfive.* attributes land in the
+// category-specific color bucket — judge on-task / off-task / refine /
+// plan / reflective. Exact hex values aren't important (themes can
+// override), but the bucket must be distinct from the default CUSTOM
+// fill AND distinct per category so operators can tell them apart.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { GanttRenderer } from '../../gantt/renderer';
+import { refreshThemeCache } from '../../gantt/colors';
+import { SessionStore } from '../../gantt/index';
+import { applyTheme } from '../../theme/themes';
+import type { AttributeValue, Span } from '../../gantt/types';
+
+beforeEach(() => {
+  // Apply the dark theme so the renderer's cssVar reads resolve to the
+  // actual goldfive-* values (each category gets a distinct hex). Without
+  // this the :root CSS variables are all unset → cssVar's fallback kicks
+  // in and every category collapses onto the same sentinel color.
+  applyTheme('dark', 'none');
+  refreshThemeCache();
+});
+
+function stubCtx(): CanvasRenderingContext2D {
+  const handler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'canvas') return { width: 1200, height: 400 };
+      if (prop === 'globalAlpha') return 1;
+      if (prop === 'measureText') return () => ({ width: 10 });
+      return () => undefined;
+    },
+    set() {
+      return true;
+    },
+  };
+  return new Proxy({}, handler) as CanvasRenderingContext2D;
+}
+
+function stubCanvas(): HTMLCanvasElement {
+  const el = document.createElement('canvas');
+  el.width = 1200;
+  el.height = 400;
+  (el as unknown as { getContext: () => CanvasRenderingContext2D }).getContext =
+    () => stubCtx();
+  return el;
+}
+
+function attr(value: string): AttributeValue {
+  return { kind: 'string', value };
+}
+function boolAttr(value: boolean): AttributeValue {
+  return { kind: 'bool', value };
+}
+
+function seedGoldfiveAgent(store: SessionStore): void {
+  store.agents.upsert({
+    id: 'client-1:goldfive',
+    name: 'goldfive',
+    framework: 'CUSTOM',
+    status: 'CONNECTED',
+    capabilities: [],
+    connectedAtMs: 1,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+  });
+}
+
+function mkGfSpan(id: string, attrs: Record<string, AttributeValue>): Span {
+  return {
+    id,
+    sessionId: 'sess',
+    agentId: 'client-1:goldfive',
+    parentSpanId: null,
+    kind: 'LLM_CALL',
+    name: (attrs['goldfive.call_name'] as { kind: 'string'; value: string } | undefined)?.value ?? 'goldfive',
+    status: 'COMPLETED',
+    startMs: 1_000,
+    endMs: 5_000,
+    lane: 0,
+    attributes: attrs,
+    payloadRefs: [],
+    links: [],
+    replaced: false,
+    error: null,
+  };
+}
+
+function runPass(store: SessionStore): GanttRenderer {
+  const renderer = new GanttRenderer(store);
+  renderer.attach(stubCanvas(), stubCanvas(), stubCanvas());
+  renderer.resize(1200, 400, 1);
+  renderer.setViewport({
+    endMs: 10_000,
+    windowMs: 10_000,
+    liveFollow: false,
+    replay: false,
+  });
+  (renderer as unknown as { drawBlocks: () => void }).drawBlocks();
+  return renderer;
+}
+
+describe('GanttRenderer — goldfive call-category bar colors', () => {
+  it('records distinct fills for judge / refine / plan / reflective categories', () => {
+    const store = new SessionStore();
+    seedGoldfiveAgent(store);
+    store.spans.append(
+      mkGfSpan('gf-judge-on', {
+        'goldfive.call_name': attr('judge_reasoning'),
+        'judge.on_task': boolAttr(true),
+      }),
+    );
+    store.spans.append(
+      mkGfSpan('gf-judge-crit', {
+        'goldfive.call_name': attr('judge_reasoning'),
+        'judge.on_task': boolAttr(false),
+        'judge.severity': attr('critical'),
+      }),
+    );
+    store.spans.append(
+      mkGfSpan('gf-judge-warn', {
+        'goldfive.call_name': attr('judge_reasoning'),
+        'judge.on_task': boolAttr(false),
+        'judge.severity': attr('warning'),
+      }),
+    );
+    store.spans.append(
+      mkGfSpan('gf-refine', {
+        'goldfive.call_name': attr('refine_steer'),
+      }),
+    );
+    store.spans.append(
+      mkGfSpan('gf-plan', {
+        'goldfive.call_name': attr('plan_generate'),
+      }),
+    );
+    store.spans.append(
+      mkGfSpan('gf-reflective', {
+        'goldfive.call_name': attr('reflective_check'),
+      }),
+    );
+
+    const renderer = runPass(store);
+    const fills = renderer.lastGoldfiveFills;
+
+    // Every category span was recorded.
+    expect(fills.size).toBe(6);
+
+    const onTask = fills.get('gf-judge-on');
+    const crit = fills.get('gf-judge-crit');
+    const warn = fills.get('gf-judge-warn');
+    const refine = fills.get('gf-refine');
+    const plan = fills.get('gf-plan');
+    const reflective = fills.get('gf-reflective');
+
+    // On-task / critical / warning are three distinct judge fills.
+    expect(onTask).toBeTruthy();
+    expect(crit).toBeTruthy();
+    expect(warn).toBeTruthy();
+    expect(onTask).not.toBe(crit);
+    expect(onTask).not.toBe(warn);
+    expect(crit).not.toBe(warn);
+
+    // Refine / plan / reflective each differ from the judge colors and
+    // from each other.
+    expect(refine).toBeTruthy();
+    expect(plan).toBeTruthy();
+    expect(reflective).toBeTruthy();
+    expect(refine).not.toBe(plan);
+    expect(refine).not.toBe(onTask);
+    expect(plan).not.toBe(reflective);
+
+    renderer.detach();
+  });
+
+  it('does not record a fill override for non-goldfive spans (graceful degradation)', () => {
+    const store = new SessionStore();
+    store.agents.upsert({
+      id: 'agent-a',
+      name: 'agent-a',
+      framework: 'ADK',
+      status: 'CONNECTED',
+      capabilities: [],
+      connectedAtMs: 0,
+      currentActivity: '',
+      stuck: false,
+      taskReport: '',
+      taskReportAt: 0,
+      metadata: {},
+    });
+    const s: Span = {
+      id: 'sp-plain',
+      sessionId: 'sess',
+      agentId: 'agent-a',
+      parentSpanId: null,
+      kind: 'LLM_CALL',
+      name: 'gemini-2',
+      status: 'COMPLETED',
+      startMs: 1_000,
+      endMs: 5_000,
+      lane: 0,
+      attributes: {},
+      payloadRefs: [],
+      links: [],
+      replaced: false,
+      error: null,
+    };
+    store.spans.append(s);
+    const renderer = runPass(store);
+    expect(renderer.lastGoldfiveFills.size).toBe(0);
+    renderer.detach();
+  });
+
+  it('leaves FAILED goldfive spans with the error fill (status wins over category)', () => {
+    const store = new SessionStore();
+    seedGoldfiveAgent(store);
+    const s = mkGfSpan('gf-refine-failed', {
+      'goldfive.call_name': attr('refine_steer'),
+    });
+    s.status = 'FAILED';
+    store.spans.append(s);
+    const renderer = runPass(store);
+    // Fill override skipped on FAILED so tests of error rendering
+    // continue to work and the red "broken" fill isn't masked by the
+    // refine purple.
+    expect(renderer.lastGoldfiveFills.has('gf-refine-failed')).toBe(false);
+    renderer.detach();
+  });
+
+  it('does not override an unknown call_name (falls through to default CUSTOM fill)', () => {
+    const store = new SessionStore();
+    seedGoldfiveAgent(store);
+    store.spans.append(
+      mkGfSpan('gf-unknown', {
+        'goldfive.call_name': attr('some_future_call_name'),
+      }),
+    );
+    const renderer = runPass(store);
+    expect(renderer.lastGoldfiveFills.has('gf-unknown')).toBe(false);
+    renderer.detach();
+  });
+});

--- a/frontend/src/__tests__/lib/goldfiveSpan.test.ts
+++ b/frontend/src/__tests__/lib/goldfiveSpan.test.ts
@@ -1,0 +1,390 @@
+// Unit tests for the goldfive span helper library (harmonograf#157).
+//
+// Covers the detection + classification + color-resolution path that the
+// renderer + popover + drawer all depend on. Kept separate from the
+// component tests so the pure-function behaviour (category buckets,
+// verdict classification, preview truncation, fallback strings) is
+// testable without a DOM.
+
+import { describe, expect, it } from 'vitest';
+import type { AttributeValue, Span } from '../../gantt/types';
+import {
+  bareGoldfiveAgentName,
+  goldfiveCallFill,
+  isGoldfiveSpan,
+  resolveGoldfiveSpanInfo,
+  truncatePreview,
+} from '../../lib/goldfiveSpan';
+
+function attr(value: string): AttributeValue {
+  return { kind: 'string', value };
+}
+
+function boolAttr(value: boolean): AttributeValue {
+  return { kind: 'bool', value };
+}
+
+function mkSpan(overrides: Partial<Span> = {}): Span {
+  return {
+    id: 'sp-1',
+    sessionId: 'sess',
+    agentId: 'client-1:goldfive',
+    parentSpanId: null,
+    kind: 'CUSTOM',
+    status: 'COMPLETED',
+    name: 'refine_steer',
+    startMs: 0,
+    endMs: 100,
+    lane: 0,
+    attributes: {},
+    payloadRefs: [],
+    links: [],
+    replaced: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function stubCssVar(custom: Record<string, string> = {}): (name: string) => string {
+  return (name: string) => custom[name] ?? '';
+}
+
+describe('isGoldfiveSpan', () => {
+  it('accepts a compound :goldfive agent id', () => {
+    expect(isGoldfiveSpan(mkSpan({ agentId: 'client-x:goldfive' }))).toBe(true);
+  });
+
+  it('accepts the legacy __goldfive__ synthetic actor', () => {
+    expect(isGoldfiveSpan(mkSpan({ agentId: '__goldfive__' }))).toBe(true);
+  });
+
+  it('accepts a span on any agent as long as goldfive.call_name is set', () => {
+    expect(
+      isGoldfiveSpan(
+        mkSpan({
+          agentId: 'agent-a',
+          attributes: { 'goldfive.call_name': attr('judge_reasoning') },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects a normal worker-agent span', () => {
+    expect(isGoldfiveSpan(mkSpan({ agentId: 'client:agent-a' }))).toBe(false);
+  });
+
+  it('rejects null / undefined', () => {
+    expect(isGoldfiveSpan(null)).toBe(false);
+    expect(isGoldfiveSpan(undefined)).toBe(false);
+  });
+});
+
+describe('resolveGoldfiveSpanInfo — category classification', () => {
+  it('classifies judge_* as judge', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({ attributes: { 'goldfive.call_name': attr('judge_reasoning') } }),
+    );
+    expect(info.category).toBe('judge');
+    expect(info.callName).toBe('judge_reasoning');
+  });
+
+  it('classifies refine_* as refine', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({ attributes: { 'goldfive.call_name': attr('refine_steer') } }),
+    );
+    expect(info.category).toBe('refine');
+  });
+
+  it('classifies goal_derive + plan_generate as plan', () => {
+    expect(
+      resolveGoldfiveSpanInfo(
+        mkSpan({ attributes: { 'goldfive.call_name': attr('goal_derive') } }),
+      ).category,
+    ).toBe('plan');
+    expect(
+      resolveGoldfiveSpanInfo(
+        mkSpan({ attributes: { 'goldfive.call_name': attr('plan_generate') } }),
+      ).category,
+    ).toBe('plan');
+  });
+
+  it('classifies reflective_check as reflective', () => {
+    expect(
+      resolveGoldfiveSpanInfo(
+        mkSpan({ attributes: { 'goldfive.call_name': attr('reflective_check') } }),
+      ).category,
+    ).toBe('reflective');
+  });
+
+  it('falls back to unknown for unrecognised call names', () => {
+    expect(
+      resolveGoldfiveSpanInfo(
+        mkSpan({
+          name: 'something_else',
+          attributes: { 'goldfive.call_name': attr('novel_call_name') },
+        }),
+      ).category,
+    ).toBe('unknown');
+  });
+
+  it('treats legacy refine: / judge: span names as refine / judge', () => {
+    expect(resolveGoldfiveSpanInfo(mkSpan({ name: 'refine: looping' })).category).toBe(
+      'refine',
+    );
+    expect(resolveGoldfiveSpanInfo(mkSpan({ name: 'judge: reasoning' })).category).toBe(
+      'judge',
+    );
+  });
+
+  it('returns callName = span.name when goldfive.call_name is absent', () => {
+    const info = resolveGoldfiveSpanInfo(mkSpan({ name: 'refine: drift' }));
+    expect(info.callName).toBe('refine: drift');
+  });
+});
+
+describe('resolveGoldfiveSpanInfo — judge verdict classification', () => {
+  it('verdict on_task when judge.on_task=true', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('judge_reasoning'),
+          'judge.on_task': boolAttr(true),
+        },
+      }),
+    );
+    expect(info.verdict).toBe('on_task');
+    expect(info.onTask).toBe(true);
+  });
+
+  it('verdict off_task_critical when severity=critical', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('judge_reasoning'),
+          'judge.on_task': boolAttr(false),
+          'judge.severity': attr('CRITICAL'),
+        },
+      }),
+    );
+    expect(info.verdict).toBe('off_task_critical');
+    expect(info.severity).toBe('critical');
+  });
+
+  it('verdict off_task_warning when severity=warning', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('judge_reasoning'),
+          'judge.on_task': boolAttr(false),
+          'judge.severity': attr('warning'),
+        },
+      }),
+    );
+    expect(info.verdict).toBe('off_task_warning');
+  });
+
+  it('verdict no_verdict when there is no severity and no verdict string', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('judge_reasoning'),
+        },
+      }),
+    );
+    expect(info.verdict).toBe('no_verdict');
+  });
+
+  it('non-judge spans always report no_verdict', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('refine_steer'),
+          // Even with a stray judge.severity the verdict stays no_verdict.
+          'judge.severity': attr('critical'),
+        },
+      }),
+    );
+    expect(info.verdict).toBe('no_verdict');
+  });
+});
+
+describe('resolveGoldfiveSpanInfo — target + preview reads', () => {
+  it('strips the <client>: prefix from target_agent_id and keeps the raw form', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('refine_steer'),
+          'goldfive.target_agent_id': attr('client-42:research_agent'),
+        },
+      }),
+    );
+    expect(info.targetAgentId).toBe('research_agent');
+    expect(info.targetAgentIdRaw).toBe('client-42:research_agent');
+  });
+
+  it('leaves a non-compound target_agent_id untouched', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('refine_steer'),
+          'goldfive.target_agent_id': attr('research_agent'),
+        },
+      }),
+    );
+    expect(info.targetAgentId).toBe('research_agent');
+  });
+
+  it('reads input + output previews as strings', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('refine_steer'),
+          'goldfive.input_preview': attr('drift=OFF_TOPIC\ncurrent plan: ...'),
+          'goldfive.output_preview': attr('new plan: research_solar_corrected'),
+        },
+      }),
+    );
+    expect(info.inputPreview).toContain('drift=OFF_TOPIC');
+    expect(info.outputPreview).toContain('research_solar_corrected');
+  });
+
+  it('uses decision_summary when present and falls back otherwise', () => {
+    const withSummary = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('refine_steer'),
+          'goldfive.decision_summary': attr(
+            'refined plan after OFF_TOPIC drift on research_solar',
+          ),
+        },
+      }),
+    );
+    expect(withSummary.decisionSummary).toMatch(/refined plan/);
+
+    const noSummary = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('refine_steer'),
+        },
+      }),
+    );
+    expect(noSummary.decisionSummary).toBe('goldfive: refine_steer');
+  });
+});
+
+describe('goldfiveCallFill', () => {
+  const cssVar = stubCssVar({
+    '--hg-goldfive-judge-on-task': '#0af',
+    '--hg-goldfive-judge-warning': '#fa0',
+    '--hg-goldfive-judge-critical': '#f00',
+    '--hg-goldfive-judge-neutral': '#888',
+    '--hg-goldfive-refine': '#a0f',
+    '--hg-goldfive-plan': '#0fa',
+    '--hg-goldfive-reflective': '#ccc',
+  });
+
+  it('maps judge on_task → green (on-task var)', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('judge_reasoning'),
+          'judge.on_task': boolAttr(true),
+        },
+      }),
+    );
+    expect(goldfiveCallFill(info, cssVar, '#default')).toBe('#0af');
+  });
+
+  it('maps judge critical → red (critical var)', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('judge_reasoning'),
+          'judge.on_task': boolAttr(false),
+          'judge.severity': attr('critical'),
+        },
+      }),
+    );
+    expect(goldfiveCallFill(info, cssVar, '#default')).toBe('#f00');
+  });
+
+  it('maps judge warning → amber (warning var)', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({
+        attributes: {
+          'goldfive.call_name': attr('judge_reasoning'),
+          'judge.on_task': boolAttr(false),
+          'judge.severity': attr('warning'),
+        },
+      }),
+    );
+    expect(goldfiveCallFill(info, cssVar, '#default')).toBe('#fa0');
+  });
+
+  it('maps refine → purple (refine var)', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({ attributes: { 'goldfive.call_name': attr('refine_steer') } }),
+    );
+    expect(goldfiveCallFill(info, cssVar, '#default')).toBe('#a0f');
+  });
+
+  it('maps plan (goal_derive / plan_generate) → teal', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({ attributes: { 'goldfive.call_name': attr('goal_derive') } }),
+    );
+    expect(goldfiveCallFill(info, cssVar, '#default')).toBe('#0fa');
+  });
+
+  it('maps reflective → grey', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({ attributes: { 'goldfive.call_name': attr('reflective_check') } }),
+    );
+    expect(goldfiveCallFill(info, cssVar, '#default')).toBe('#ccc');
+  });
+
+  it('returns fallback for unknown category', () => {
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({ name: 'novel_call', attributes: { 'goldfive.call_name': attr('novel_call') } }),
+    );
+    expect(goldfiveCallFill(info, cssVar, '#fallback')).toBe('#fallback');
+  });
+
+  it('returns the hard-coded hex when the CSS var is absent', () => {
+    const emptyCssVar = stubCssVar();
+    const info = resolveGoldfiveSpanInfo(
+      mkSpan({ attributes: { 'goldfive.call_name': attr('refine_steer') } }),
+    );
+    // `goldfiveCallFill` returns the hex fallback hard-coded in the helper
+    // (not the `fallback` arg) when the CSS var is empty — that's the
+    // contract for themed colors: hex is the last-resort default.
+    expect(goldfiveCallFill(info, emptyCssVar, '#default')).toBe('#a78bfa');
+  });
+});
+
+describe('bareGoldfiveAgentName', () => {
+  it('strips the <client>: prefix', () => {
+    expect(bareGoldfiveAgentName('client-1:research_agent')).toBe('research_agent');
+  });
+
+  it('returns the input unchanged when no colon is present', () => {
+    expect(bareGoldfiveAgentName('research_agent')).toBe('research_agent');
+  });
+
+  it('returns an empty string for an empty input', () => {
+    expect(bareGoldfiveAgentName('')).toBe('');
+  });
+});
+
+describe('truncatePreview', () => {
+  it('passes through short strings unchanged', () => {
+    expect(truncatePreview('hello', 10)).toBe('hello');
+  });
+
+  it('truncates with an ellipsis suffix', () => {
+    expect(truncatePreview('1234567890abc', 5)).toBe('12345…');
+  });
+
+  it('returns empty string for empty / undefined input', () => {
+    expect(truncatePreview('', 10)).toBe('');
+  });
+});

--- a/frontend/src/components/Interaction/SpanPopover.tsx
+++ b/frontend/src/components/Interaction/SpanPopover.tsx
@@ -15,6 +15,12 @@ import {
   isJudgeSpan,
   resolveJudgeDetail,
 } from '../../lib/interventionDetail';
+import {
+  isGoldfiveSpan,
+  resolveGoldfiveSpanInfo,
+  truncatePreview,
+  type GoldfiveSpanInfo,
+} from '../../lib/goldfiveSpan';
 import type { TaskPlan } from '../../gantt/types';
 import { JudgeInvocationDetail } from '../Interventions/JudgeInvocationDetail';
 
@@ -176,6 +182,17 @@ function PopoverCard({
     }
     return resolveJudgeDetail(span, plans);
   }, [span, store, judgeMode]);
+  // Non-judge goldfive spans (refine_*, goal_derive, plan_generate,
+  // reflective_check, unknown) get their own compact detail block —
+  // decision summary headline, target row, input/output disclosures.
+  // Judge spans also resolve info here so the popover header can swap
+  // the bare span name for the call_name when the sink has stamped one,
+  // but the judge detail component is still authoritative for verdict.
+  const goldfiveMode = isGoldfiveSpan(span);
+  const goldfiveInfo: GoldfiveSpanInfo | null = useMemo(
+    () => (goldfiveMode ? resolveGoldfiveSpanInfo(span) : null),
+    [goldfiveMode, span],
+  );
   const duration =
     span.endMs != null ? `${Math.max(0, span.endMs - span.startMs).toFixed(0)}ms` : '…';
 
@@ -235,10 +252,11 @@ function PopoverCard({
     void post({ sessionId, spanId: span.id, body: text, kind: 'COMMENT' }).catch(() => {});
   };
 
-  // Judge popovers carry more content (reasoning input, raw response,
-  // steering outcome); widen them so the sections don't truncate the
-  // reader's eye on typical laptops.
-  const popoverWidth = judgeMode ? POPOVER_WIDTH + 80 : POPOVER_WIDTH;
+  // Judge popovers + generic goldfive popovers carry more content
+  // (reasoning input, raw response, steering outcome, input/output
+  // previews); widen them so the sections don't truncate the reader's
+  // eye on typical laptops.
+  const popoverWidth = judgeMode || goldfiveMode ? POPOVER_WIDTH + 80 : POPOVER_WIDTH;
 
   return (
     <div
@@ -277,8 +295,11 @@ function PopoverCard({
           marginBottom: 4,
         }}
       >
-        <div style={{ fontWeight: 600, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {span.name}
+        <div
+          data-testid="span-popover-title"
+          style={{ fontWeight: 600, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        >
+          {goldfiveInfo ? goldfiveInfo.callName : span.name}
         </div>
         <div style={{ display: 'flex', gap: 4 }}>
           <IconButton
@@ -294,9 +315,38 @@ function PopoverCard({
           </IconButton>
         </div>
       </div>
-      <div style={{ opacity: 0.85, lineHeight: 1.5, marginBottom: 6 }}>
-        {summary}
+      <div
+        data-testid="span-popover-summary"
+        style={{ opacity: 0.85, lineHeight: 1.5, marginBottom: 6 }}
+      >
+        {goldfiveInfo ? goldfiveInfo.decisionSummary : summary}
       </div>
+      {goldfiveInfo && (goldfiveInfo.targetAgentId || goldfiveInfo.targetTaskId) && (
+        <div
+          data-testid="span-popover-goldfive-context"
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '2px 10px',
+            marginBottom: 6,
+            fontSize: 11,
+            opacity: 0.85,
+          }}
+        >
+          {goldfiveInfo.targetAgentId && (
+            <span data-testid="span-popover-goldfive-target-agent">
+              <span style={{ opacity: 0.6 }}>target </span>
+              {goldfiveInfo.targetAgentId}
+            </span>
+          )}
+          {goldfiveInfo.targetTaskId && (
+            <span data-testid="span-popover-goldfive-target-task">
+              <span style={{ opacity: 0.6 }}>task </span>
+              <code style={{ fontSize: 10 }}>{goldfiveInfo.targetTaskId}</code>
+            </span>
+          )}
+        </div>
+      )}
       <div style={{ opacity: 0.85, lineHeight: 1.5 }}>
         <div>
           <span style={{ opacity: 0.7 }}>kind </span>
@@ -341,7 +391,10 @@ function PopoverCard({
           />
         </div>
       )}
-      {!judgeMode && thinkingHint && (
+      {goldfiveMode && !judgeMode && goldfiveInfo && (
+        <GoldfivePreviewDisclosures info={goldfiveInfo} />
+      )}
+      {!judgeMode && !goldfiveMode && thinkingHint && (
         <div
           data-testid="span-popover-thinking"
           data-open={thinkingOpen ? 'true' : 'false'}
@@ -431,20 +484,20 @@ function PopoverCard({
           borderTop: '1px solid var(--md-sys-color-outline-variant, #43474e)',
         }}
       >
-        {!judgeMode && (
+        {!judgeMode && !goldfiveMode && (
           <>
             <ActionButton onClick={toggleSteer} primary={steerOpen}>Steer</ActionButton>
             <ActionButton onClick={annotate}>Annotate</ActionButton>
           </>
         )}
         <ActionButton onClick={copyId}>Copy id</ActionButton>
-        {!judgeMode && (
+        {(!judgeMode || goldfiveMode) && (
           <ActionButton onClick={openInDrawer} primary>
             Open drawer
           </ActionButton>
         )}
       </div>
-      {!judgeMode && steerOpen && (
+      {!judgeMode && !goldfiveMode && steerOpen && (
         <div
           style={{
             marginTop: 8,
@@ -521,6 +574,116 @@ function PopoverCard({
             </ActionButton>
           </div>
         </div>
+      )}
+    </div>
+  );
+}
+
+function GoldfivePreviewDisclosures({ info }: { info: GoldfiveSpanInfo }) {
+  // Both disclosures closed by default — operators usually only want one of
+  // them at a time. Popover variant is ~400 chars; the drawer shows the full
+  // 4 KiB preview.
+  const [inputOpen, setInputOpen] = useState(false);
+  const [outputOpen, setOutputOpen] = useState(false);
+  const hasInput = !!info.inputPreview;
+  const hasOutput = !!info.outputPreview;
+  if (!hasInput && !hasOutput) return null;
+  return (
+    <div
+      data-testid="span-popover-goldfive-previews"
+      style={{
+        marginTop: 10,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
+      {hasInput && (
+        <GoldfiveDisclosure
+          label="Input preview"
+          open={inputOpen}
+          onToggle={() => setInputOpen((v) => !v)}
+          text={info.inputPreview}
+          testId="span-popover-goldfive-input"
+        />
+      )}
+      {hasOutput && (
+        <GoldfiveDisclosure
+          label="Output preview"
+          open={outputOpen}
+          onToggle={() => setOutputOpen((v) => !v)}
+          text={info.outputPreview}
+          testId="span-popover-goldfive-output"
+        />
+      )}
+    </div>
+  );
+}
+
+function GoldfiveDisclosure({
+  label,
+  open,
+  onToggle,
+  text,
+  testId,
+}: {
+  label: string;
+  open: boolean;
+  onToggle: () => void;
+  text: string;
+  testId: string;
+}) {
+  const preview = truncatePreview(text, 400);
+  return (
+    <div
+      data-testid={testId}
+      data-open={open ? 'true' : 'false'}
+      style={{
+        border: '1px solid var(--md-sys-color-outline-variant, #43474e)',
+        borderRadius: 6,
+        background: 'rgba(255,255,255,0.03)',
+      }}
+    >
+      <button
+        type="button"
+        data-testid={`${testId}-toggle`}
+        onClick={onToggle}
+        aria-expanded={open}
+        style={{
+          all: 'unset',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          width: '100%',
+          padding: '4px 8px',
+          fontSize: 10,
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+          opacity: 0.75,
+        }}
+      >
+        <span>{open ? '▾' : '▸'}</span>
+        <span>{label}</span>
+      </button>
+      {open && (
+        <pre
+          data-testid={`${testId}-body`}
+          style={{
+            margin: 0,
+            padding: '4px 8px 6px',
+            fontFamily: "ui-monospace, 'SF Mono', Consolas, monospace",
+            fontSize: 11,
+            lineHeight: 1.4,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            maxHeight: 180,
+            overflow: 'auto',
+            color: 'rgba(226,226,233,0.88)',
+          }}
+        >
+          {preview}
+        </pre>
       )}
     </div>
   );

--- a/frontend/src/components/Interventions/GoldfiveSpanDetail.css
+++ b/frontend/src/components/Interventions/GoldfiveSpanDetail.css
@@ -1,0 +1,206 @@
+/* Drawer detail panel for goldfive-translated spans (harmonograf#157).
+   Shares the visual language of JudgeInvocationDetail.css so the two
+   panels slot into the drawer with consistent chrome — the only new
+   elements are the call-name / target badges and the monospace pre-blocks
+   used for input / output previews. */
+
+.hg-gf-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 16px;
+  color: var(--md-sys-color-on-surface, #e2e2e9);
+  font: 12px/1.45 var(--md-sys-typescale-body-small-font, system-ui, sans-serif);
+}
+
+.hg-gf-detail__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant, #43474e);
+}
+
+.hg-gf-detail__title {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.hg-gf-detail__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 6px;
+  align-items: center;
+}
+
+.hg-gf-detail__badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-transform: lowercase;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--md-sys-color-outline-variant, #43474e);
+  color: var(--md-sys-color-on-surface, #e2e2e9);
+}
+
+/* Category tinting: match the goldfive bar colors. Kept as low-alpha
+   tints so badges read as chips rather than full-saturation swatches. */
+.hg-gf-detail__badge--call[data-category='judge'] {
+  background: rgba(59, 178, 115, 0.18);
+  border-color: rgba(59, 178, 115, 0.4);
+}
+.hg-gf-detail__badge--call[data-category='refine'] {
+  background: rgba(167, 139, 250, 0.18);
+  border-color: rgba(167, 139, 250, 0.4);
+}
+.hg-gf-detail__badge--call[data-category='plan'] {
+  background: rgba(79, 209, 197, 0.18);
+  border-color: rgba(79, 209, 197, 0.4);
+}
+.hg-gf-detail__badge--call[data-category='reflective'] {
+  background: rgba(141, 145, 153, 0.22);
+  border-color: rgba(141, 145, 153, 0.45);
+}
+
+.hg-gf-detail__badge--target {
+  background: rgba(168, 200, 255, 0.15);
+  border-color: rgba(168, 200, 255, 0.4);
+  font-family: var(--hg-mono, ui-monospace, Menlo, monospace);
+  text-transform: none;
+}
+
+.hg-gf-detail__badge--task {
+  background: rgba(255, 255, 255, 0.03);
+  font-family: var(--hg-mono, ui-monospace, Menlo, monospace);
+  text-transform: none;
+}
+
+.hg-gf-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.hg-gf-detail__section--linked {
+  background: rgba(167, 139, 250, 0.07);
+  border: 1px solid rgba(167, 139, 250, 0.25);
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+
+.hg-gf-detail__section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.hg-gf-detail__section-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  opacity: 0.65;
+}
+
+.hg-gf-detail__copy {
+  background: transparent;
+  border: 1px solid var(--md-sys-color-outline-variant, #43474e);
+  color: inherit;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0.75;
+}
+
+.hg-gf-detail__copy:hover {
+  opacity: 1;
+}
+
+.hg-gf-detail__pre {
+  margin: 0;
+  max-height: 260px;
+  overflow: auto;
+  padding: 8px 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 6px;
+  font: 11px/1.5 var(--hg-mono, ui-monospace, Menlo, monospace);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.hg-gf-detail__empty {
+  font-style: italic;
+  opacity: 0.6;
+  padding: 4px 0;
+}
+
+.hg-gf-detail__context-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 2px 12px;
+  margin: 0;
+  padding: 0;
+}
+
+.hg-gf-detail__context-grid dt {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  opacity: 0.6;
+  align-self: baseline;
+}
+
+.hg-gf-detail__context-grid dd {
+  margin: 0;
+  font-size: 11px;
+  word-break: break-all;
+}
+
+.hg-gf-detail__context-grid code {
+  font-size: 10px;
+  opacity: 0.9;
+}
+
+.hg-gf-detail__linked-plan-link {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  font-weight: 600;
+  color: var(--md-sys-color-primary, #a8c8ff);
+  cursor: pointer;
+  text-align: left;
+}
+
+.hg-gf-detail__linked-plan-link:disabled {
+  color: var(--md-sys-color-on-surface, #e2e2e9);
+  cursor: default;
+}
+
+.hg-gf-detail__linked-plan-link:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.hg-gf-detail__linked-plan-reason {
+  font-weight: 400;
+  opacity: 0.85;
+}
+
+.hg-gf-detail__linked-plan-tasks {
+  list-style: disc;
+  margin: 4px 0 0;
+  padding-left: 18px;
+  font-size: 11px;
+  opacity: 0.85;
+}
+
+.hg-gf-detail__linked-plan-task-agent {
+  font-family: var(--hg-mono, ui-monospace, Menlo, monospace);
+  font-size: 10px;
+  opacity: 0.8;
+}

--- a/frontend/src/components/Interventions/GoldfiveSpanDetail.tsx
+++ b/frontend/src/components/Interventions/GoldfiveSpanDetail.tsx
@@ -1,0 +1,288 @@
+// Drawer detail panel for goldfive-translated spans (harmonograf#157).
+//
+// Complements JudgeInvocationDetail: judge spans keep their richer
+// verdict/steering panel (on_task / severity / raw response / steered
+// plan). Everything else — refine_steer, goal_derive, plan_generate,
+// reflective_check, future call names — lands here with a generic but
+// high-signal layout:
+//
+//   Header   — decision summary + call-name / target-agent / target-task
+//              badges so the reader sees "what goldfive did" at a glance.
+//   Input    — full ``goldfive.input_preview`` (up to 4 KiB) in a
+//              monospace pre-block with copy-to-clipboard.
+//   Output   — full ``goldfive.output_preview`` in the same shape.
+//   Context  — definition list: model, elapsed, run/session/task ids,
+//              compound target agent id.
+//   Linked plan revision — for refine_* calls, a link to the resulting
+//              PlanRevised (resolved via target_task_id + time) so the
+//              reader can hop from the steer to the plan diff.
+//
+// All sections collapse gracefully when their attribute is absent — a
+// pre-Option-X session or a goldfive span from before the sibling
+// sink-stamp PR lands still renders the header + context list.
+
+import type { Span, TaskPlan } from '../../gantt/types';
+import { bareAgentName } from '../../gantt/index';
+import type { GoldfiveSpanInfo } from '../../lib/goldfiveSpan';
+import './GoldfiveSpanDetail.css';
+
+interface Props {
+  span: Span;
+  info: GoldfiveSpanInfo;
+  /** When set, rendered as the "linked plan revision" block for refine_* calls. */
+  linkedPlanRevision?: {
+    plan: TaskPlan;
+    onOpen?: () => void;
+  } | null;
+  /** Optional overrides for the two copy-to-clipboard buttons (tests). */
+  onCopy?: (text: string) => void;
+}
+
+function copyText(text: string, override?: (text: string) => void): void {
+  if (!text) return;
+  if (override) {
+    override(text);
+    return;
+  }
+  void navigator.clipboard?.writeText(text).catch(() => {});
+}
+
+function readString(span: Span, key: string): string {
+  const v = span.attributes?.[key];
+  if (!v) return '';
+  if (v.kind !== 'string') return '';
+  return v.value;
+}
+
+function readInt(span: Span, key: string): number | null {
+  const v = span.attributes?.[key];
+  if (!v) return null;
+  if (v.kind === 'int') return Number(v.value);
+  if (v.kind === 'double') return v.value;
+  return null;
+}
+
+export function GoldfiveSpanDetail({
+  span,
+  info,
+  linkedPlanRevision,
+  onCopy,
+}: Props) {
+  const model =
+    readString(span, 'goldfive.model') ||
+    readString(span, 'judge.model') ||
+    readString(span, 'llm.model');
+  const elapsedMs =
+    readInt(span, 'goldfive.elapsed_ms') ??
+    readInt(span, 'judge.elapsed_ms') ??
+    (span.endMs != null ? Math.max(0, Math.round(span.endMs - span.startMs)) : null);
+  const runId =
+    readString(span, 'goldfive.run_id') || readString(span, 'run_id');
+  const taskId =
+    info.targetTaskId || readString(span, 'hgraf.task_id');
+  const sessionIdAttr = readString(span, 'goldfive.session_id') || span.sessionId;
+
+  return (
+    <div
+      className="hg-gf-detail"
+      data-testid="goldfive-span-detail"
+      data-call-name={info.callName}
+      data-category={info.category}
+    >
+      <header
+        className="hg-gf-detail__header"
+        data-testid="goldfive-span-detail-header"
+      >
+        <div className="hg-gf-detail__title">{info.decisionSummary}</div>
+        <div className="hg-gf-detail__badges">
+          <span
+            className="hg-gf-detail__badge hg-gf-detail__badge--call"
+            data-testid="goldfive-span-detail-call-name"
+            data-category={info.category}
+          >
+            {info.callName}
+          </span>
+          {info.targetAgentId && (
+            <span
+              className="hg-gf-detail__badge hg-gf-detail__badge--target"
+              data-testid="goldfive-span-detail-target-agent"
+              title={info.targetAgentIdRaw}
+            >
+              → {info.targetAgentId}
+            </span>
+          )}
+          {info.targetTaskId && (
+            <span
+              className="hg-gf-detail__badge hg-gf-detail__badge--task"
+              data-testid="goldfive-span-detail-target-task"
+            >
+              task {info.targetTaskId}
+            </span>
+          )}
+        </div>
+      </header>
+
+      <section
+        className="hg-gf-detail__section"
+        data-testid="goldfive-span-detail-input"
+      >
+        <div className="hg-gf-detail__section-head">
+          <span className="hg-gf-detail__section-label">Input</span>
+          {info.inputPreview && (
+            <button
+              type="button"
+              className="hg-gf-detail__copy"
+              data-testid="goldfive-span-detail-input-copy"
+              onClick={() => copyText(info.inputPreview, onCopy)}
+              title="Copy input to clipboard"
+            >
+              copy
+            </button>
+          )}
+        </div>
+        {info.inputPreview ? (
+          <pre
+            className="hg-gf-detail__pre"
+            data-testid="goldfive-span-detail-input-body"
+          >
+            {info.inputPreview}
+          </pre>
+        ) : (
+          <div className="hg-gf-detail__empty">
+            No input preview captured.
+          </div>
+        )}
+      </section>
+
+      <section
+        className="hg-gf-detail__section"
+        data-testid="goldfive-span-detail-output"
+      >
+        <div className="hg-gf-detail__section-head">
+          <span className="hg-gf-detail__section-label">Output</span>
+          {info.outputPreview && (
+            <button
+              type="button"
+              className="hg-gf-detail__copy"
+              data-testid="goldfive-span-detail-output-copy"
+              onClick={() => copyText(info.outputPreview, onCopy)}
+              title="Copy output to clipboard"
+            >
+              copy
+            </button>
+          )}
+        </div>
+        {info.outputPreview ? (
+          <pre
+            className="hg-gf-detail__pre"
+            data-testid="goldfive-span-detail-output-body"
+          >
+            {info.outputPreview}
+          </pre>
+        ) : (
+          <div className="hg-gf-detail__empty">
+            No output preview captured.
+          </div>
+        )}
+      </section>
+
+      <section
+        className="hg-gf-detail__section"
+        data-testid="goldfive-span-detail-context"
+      >
+        <span className="hg-gf-detail__section-label">Context</span>
+        <dl className="hg-gf-detail__context-grid">
+          {model && (
+            <>
+              <dt>model</dt>
+              <dd data-testid="goldfive-span-detail-ctx-model">{model}</dd>
+            </>
+          )}
+          {elapsedMs !== null && (
+            <>
+              <dt>elapsed</dt>
+              <dd data-testid="goldfive-span-detail-ctx-elapsed">
+                {elapsedMs}ms
+              </dd>
+            </>
+          )}
+          {runId && (
+            <>
+              <dt>run</dt>
+              <dd data-testid="goldfive-span-detail-ctx-run">
+                <code>{runId}</code>
+              </dd>
+            </>
+          )}
+          {sessionIdAttr && (
+            <>
+              <dt>session</dt>
+              <dd data-testid="goldfive-span-detail-ctx-session">
+                <code>{sessionIdAttr}</code>
+              </dd>
+            </>
+          )}
+          {taskId && (
+            <>
+              <dt>task</dt>
+              <dd data-testid="goldfive-span-detail-ctx-task">
+                <code>{taskId}</code>
+              </dd>
+            </>
+          )}
+          {info.targetAgentIdRaw && (
+            <>
+              <dt>target agent</dt>
+              <dd data-testid="goldfive-span-detail-ctx-target">
+                <code>{info.targetAgentIdRaw}</code>
+              </dd>
+            </>
+          )}
+        </dl>
+      </section>
+
+      {info.category === 'refine' && linkedPlanRevision && (
+        <section
+          className="hg-gf-detail__section hg-gf-detail__section--linked"
+          data-testid="goldfive-span-detail-linked-plan"
+        >
+          <span className="hg-gf-detail__section-label">Steered</span>
+          <button
+            type="button"
+            className="hg-gf-detail__linked-plan-link"
+            data-testid="goldfive-span-detail-linked-plan-link"
+            onClick={linkedPlanRevision.onOpen}
+            disabled={!linkedPlanRevision.onOpen}
+            title="Open the plan revision this steer produced"
+          >
+            Plan refined → r{linkedPlanRevision.plan.revisionIndex ?? 0}
+            {linkedPlanRevision.plan.revisionReason && (
+              <span className="hg-gf-detail__linked-plan-reason">
+                {' · '}
+                {linkedPlanRevision.plan.revisionReason}
+              </span>
+            )}
+          </button>
+          {linkedPlanRevision.plan.tasks.length > 0 && (
+            <ul
+              className="hg-gf-detail__linked-plan-tasks"
+              data-testid="goldfive-span-detail-linked-plan-tasks"
+            >
+              {linkedPlanRevision.plan.tasks.slice(0, 6).map((t) => (
+                <li key={t.id}>
+                  {t.title || t.id}
+                  {t.assigneeAgentId && (
+                    <span className="hg-gf-detail__linked-plan-task-agent">
+                      {' · '}
+                      {bareAgentName(t.assigneeAgentId) || t.assigneeAgentId}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/shell/Drawer.tsx
+++ b/frontend/src/components/shell/Drawer.tsx
@@ -20,11 +20,22 @@ import type {
   PayloadRef,
   SpanLink,
   LinkRelation,
+  TaskPlan,
 } from '../../gantt/types';
-import type { PlanDiff, PlanRevision } from '../../gantt';
+import type { PlanDiff, PlanRevision, SessionStore } from '../../gantt';
 import { bareAgentName } from '../../gantt';
 import { parseRevisionReason } from '../../gantt/driftKinds';
 import { formatDuration } from '../../lib/format';
+import {
+  isGoldfiveSpan,
+  resolveGoldfiveSpanInfo,
+} from '../../lib/goldfiveSpan';
+import {
+  isJudgeSpan,
+  resolveJudgeDetail,
+} from '../../lib/interventionDetail';
+import { GoldfiveSpanDetail } from '../Interventions/GoldfiveSpanDetail';
+import { JudgeInvocationDetail } from '../Interventions/JudgeInvocationDetail';
 import { OrchestrationTimeline } from '../OrchestrationTimeline/OrchestrationTimeline';
 
 type TabId =
@@ -1069,6 +1080,116 @@ function formatRevisionTime(ms: number): string {
   }
 }
 
+// --- Goldfive detail helper -------------------------------------------------
+
+// Produces the JSX injected at the top of SummaryTab when the selected span
+// is a goldfive translated span. Lives outside SummaryTab so tests can
+// cover it in isolation via the component and so we can memoize the
+// expensive plan scan for judge / refine linkage separately from the
+// reasoning-section state the rest of the tab owns.
+function useGoldfiveDetailSection(
+  span: Span,
+  store: SessionStore | null,
+): React.ReactNode {
+  // Narrow to goldfive spans first — this is the common-case short-circuit.
+  const isGf = isGoldfiveSpan(span);
+
+  // Run the plan-scan memo unconditionally so the hook ordering is stable
+  // across calls where `isGf` flips between renders (shouldn't happen in
+  // practice, but React's hook rules demand it).
+  const plans = useMemo<TaskPlan[]>(() => {
+    if (!store) return [];
+    const list: TaskPlan[] = [];
+    const seen = new Set<TaskPlan>();
+    for (const live of store.tasks.listPlans()) {
+      for (const snap of store.tasks.allRevsForPlan(live.id)) {
+        if (seen.has(snap)) continue;
+        seen.add(snap);
+        list.push(snap);
+      }
+    }
+    return list;
+  }, [store]);
+
+  const judgeDetail = useMemo(() => {
+    if (!isGf) return null;
+    if (!isJudgeSpan(span)) return null;
+    return resolveJudgeDetail(span, plans);
+  }, [isGf, span, plans]);
+
+  const gfInfo = useMemo(() => {
+    if (!isGf) return null;
+    return resolveGoldfiveSpanInfo(span);
+  }, [isGf, span]);
+
+  // Linked PlanRevised lookup for refine_* spans. Resolve via
+  // target_task_id + temporal proximity: the plan revision whose plan
+  // contains a task with id == info.targetTaskId AND whose createdAtMs
+  // is closest to (and not before) the span's startMs. Falls back to the
+  // most recent revision of any plan if no task match is found.
+  const linkedPlan = useMemo<TaskPlan | null>(() => {
+    if (!isGf || !gfInfo) return null;
+    if (gfInfo.category !== 'refine') return null;
+    if (plans.length === 0) return null;
+    const targetTask = gfInfo.targetTaskId;
+    // Only consider real revisions (rev index > 0).
+    const candidates = plans.filter((p) => (p.revisionIndex ?? 0) > 0);
+    if (candidates.length === 0) return null;
+    const spanAt = span.startMs;
+    let best: TaskPlan | null = null;
+    let bestScore = Number.POSITIVE_INFINITY;
+    for (const p of candidates) {
+      // Skip revisions that ended before the span even started — those
+      // can't be the effect of this steer.
+      if (p.createdAtMs + 1 < spanAt) continue;
+      const taskMatch = targetTask && p.tasks.some((t) => t.id === targetTask);
+      // Prefer task matches; among task matches pick earliest-after-span.
+      const score = (taskMatch ? 0 : 100_000) + Math.abs(p.createdAtMs - spanAt);
+      if (score < bestScore) {
+        best = p;
+        bestScore = score;
+      }
+    }
+    return best;
+  }, [isGf, gfInfo, plans, span.startMs]);
+
+  if (!isGf || !gfInfo) return null;
+
+  // Judge spans keep their richer detail component — it covers verdict,
+  // severity, raw response, and steered-plan linkage in one panel.
+  if (judgeDetail) {
+    return (
+      <div
+        className="hg-drawer__goldfive"
+        data-testid="drawer-goldfive-section"
+        data-mode="judge"
+      >
+        <JudgeInvocationDetail
+          detail={judgeDetail}
+          resolveAgentName={(id) => store?.agents.get(id)?.name || bareAgentName(id) || id}
+        />
+      </div>
+    );
+  }
+
+  const linked = linkedPlan
+    ? {
+        plan: linkedPlan,
+        onOpen: undefined,
+      }
+    : null;
+
+  return (
+    <div
+      className="hg-drawer__goldfive"
+      data-testid="drawer-goldfive-section"
+      data-mode="generic"
+    >
+      <GoldfiveSpanDetail span={span} info={gfInfo} linkedPlanRevision={linked} />
+    </div>
+  );
+}
+
 // --- Summary tab ------------------------------------------------------------
 
 export function SummaryTab({ span }: { span: Span }) {
@@ -1087,8 +1208,19 @@ export function SummaryTab({ span }: { span: Span }) {
     show: showReasoning,
   } = readReasoning(span);
 
+  // Goldfive detail section: for translated goldfive spans (judge / refine /
+  // plan / reflective / unknown) surface the decision at the top of the
+  // summary tab so the drawer answers "what did goldfive decide?" before
+  // any raw attribute table. Judge spans route to the existing
+  // JudgeInvocationDetail; everything else renders the generic
+  // GoldfiveSpanDetail with input/output previews + context list.
+  const sessionId = useUiStore((s) => s.currentSessionId);
+  const store = getSessionStore(sessionId) ?? null;
+  const goldfiveSection = useGoldfiveDetailSection(span, store);
+
   return (
     <div className="hg-drawer__section">
+      {goldfiveSection}
       {showReasoning && (
         <ReasoningSection
           inline={reasoningInlineText}

--- a/frontend/src/gantt/GanttCanvas.tsx
+++ b/frontend/src/gantt/GanttCanvas.tsx
@@ -9,6 +9,7 @@ import { SpanContextMenu, type ContextMenuState } from '../components/Interactio
 import { usePopoverStore } from '../state/popoverStore';
 import { DelegationTooltip } from '../components/DelegationTooltip/DelegationTooltip';
 import { actorDisplayLabel } from '../theme/agentColors';
+import { isGoldfiveSpan, resolveGoldfiveSpanInfo } from '../lib/goldfiveSpan';
 
 interface ContextHover {
   agentId: string;
@@ -345,34 +346,47 @@ export function GanttCanvas({ store, height, renderOverlay }: Props) {
           </div>
         </div>
       )}
-      {hover && span && (
-        <div
-          role="tooltip"
-          style={{
-            position: 'absolute',
-            left: Math.min(hover.x + 12, 9999),
-            top: Math.max(0, hover.y - 48),
-            background: 'var(--md-sys-color-surface-container-highest, #31333c)',
-            color: 'var(--md-sys-color-on-surface, #e2e2e9)',
-            padding: '6px 10px',
-            borderRadius: 6,
-            pointerEvents: 'none',
-            fontSize: 12,
-            fontFamily: 'system-ui, sans-serif',
-            boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
-            zIndex: 10,
-            maxWidth: 360,
-          }}
-        >
-          <div style={{ fontWeight: 600 }}>{span.name}</div>
-          <div style={{ opacity: 0.8 }}>
-            {span.kind} · {span.status}
-            {span.endMs !== null && (
-              <> · {(span.endMs - span.startMs).toFixed(0)}ms</>
+      {hover && span && (() => {
+        // Goldfive spans swap the bare name for the decision summary so the
+        // pre-click hover already answers "what did goldfive decide?".
+        const gf = isGoldfiveSpan(span) ? resolveGoldfiveSpanInfo(span) : null;
+        const title = gf ? gf.callName : span.name;
+        const summary = gf ? gf.decisionSummary : '';
+        return (
+          <div
+            role="tooltip"
+            data-testid="gantt-hover-tooltip"
+            data-goldfive={gf ? 'true' : 'false'}
+            style={{
+              position: 'absolute',
+              left: Math.min(hover.x + 12, 9999),
+              top: Math.max(0, hover.y - 48),
+              background: 'var(--md-sys-color-surface-container-highest, #31333c)',
+              color: 'var(--md-sys-color-on-surface, #e2e2e9)',
+              padding: '6px 10px',
+              borderRadius: 6,
+              pointerEvents: 'none',
+              fontSize: 12,
+              fontFamily: 'system-ui, sans-serif',
+              boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+              zIndex: 10,
+              maxWidth: 360,
+            }}
+          >
+            <div style={{ fontWeight: 600 }}>{title}</div>
+            {summary && (
+              <div style={{ opacity: 0.85, marginTop: 2 }}>{summary}</div>
             )}
+            <div style={{ opacity: 0.7, marginTop: summary ? 2 : 0 }}>
+              {span.kind} · {span.status}
+              {span.endMs !== null && (
+                <> · {(span.endMs - span.startMs).toFixed(0)}ms</>
+              )}
+              {gf && gf.targetAgentId && <> · → {gf.targetAgentId}</>}
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
       {delegHover && !hover && (
         <DelegationTooltip
           hover={delegHover}

--- a/frontend/src/gantt/renderer.ts
+++ b/frontend/src/gantt/renderer.ts
@@ -25,6 +25,12 @@ import type { DelegationRecord, SessionStore } from './index';
 import type { SpanIndex, DirtyRect } from './spatialIndex';
 import type { Agent, ContextWindowSample, Span, SpanKind, Task, TaskStatus } from './types';
 import { hasThinking } from '../lib/thinking';
+import {
+  goldfiveCallFill,
+  isGoldfiveSpan,
+  resolveGoldfiveSpanInfo,
+  type GoldfiveSpanInfo,
+} from '../lib/goldfiveSpan';
 import { SOURCE_COLOR, type InterventionRow } from '../lib/interventions';
 import {
   GUTTER_WIDTH_PX,
@@ -873,7 +879,14 @@ export class GanttRenderer {
       hatched: boolean;
       dashed: boolean;
       rects: number[]; // flat [x,y,wr,hr,...]
-      labels: Array<{ s: Span; x: number; y: number; w: number; h: number }>;
+      labels: Array<{
+        s: Span;
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+        gf: GoldfiveSpanInfo | null;
+      }>;
     };
     const buckets = new Map<string, Bucket>();
     // Liveness ticks drawn on top of running LLM spans. Each entry is the
@@ -890,6 +903,11 @@ export class GanttRenderer {
     // whose spans carry reasoning content. The badge is a hint that the
     // span has a Trajectory worth opening in the drawer.
     const brainBadges: Array<{ x: number; y: number; w: number; h: number }> = [];
+    // harmonograf#157: track per-span goldfive fills for test assertions.
+    // Populated only when the call-category override fires (judge /
+    // refine / plan / reflective). Copied to lastGoldfiveFills at end of
+    // pass so the exposed field is stable between rebuilds.
+    const goldfiveFillRecord = new Map<string, string>();
 
     let y = TOP_MARGIN_PX;
     let visibleCount = 0;
@@ -933,6 +951,18 @@ export class GanttRenderer {
           continue;
         }
         const style = resolveStyle(s.kind, s.status, s.replaced);
+        // Goldfive-translated spans override the fill with a category-
+        // specific hue so judge/refine/plan/reflective calls read at a
+        // glance on the goldfive lane. Status styling (PENDING opacity,
+        // CANCELLED hatch, FAILED error-icon) still applies on top via
+        // the existing resolveStyle result.
+        const gfInfo: GoldfiveSpanInfo | null = isGoldfiveSpan(s)
+          ? resolveGoldfiveSpanInfo(s)
+          : null;
+        if (gfInfo && gfInfo.category !== 'unknown' && s.status !== 'FAILED') {
+          style.fill = goldfiveCallFill(gfInfo, cssVar, style.fill);
+          goldfiveFillRecord.set(s.id, style.fill);
+        }
         const key = bucketKey(style);
         let b = buckets.get(key);
         if (!b) {
@@ -948,7 +978,7 @@ export class GanttRenderer {
         }
         b.rects.push(x1, laneTop, width, rectH);
         if (width > 12) {
-          b.labels.push({ s, x: x1, y: laneTop, w: width, h: rectH });
+          b.labels.push({ s, x: x1, y: laneTop, w: width, h: rectH, gf: gfInfo });
         }
         if (
           s.status === 'RUNNING' &&
@@ -1017,20 +1047,41 @@ export class GanttRenderer {
     }
 
     // Labels pass — full label for bars > 40px, icon-only for 12–40px.
+    // Goldfive-translated bars (gf set) substitute the call_name for the
+    // span name and append "→ <bare_agent>" on the right when the bar
+    // is wide enough and a target is known.
     ctx.font = '11px system-ui, sans-serif';
     ctx.textBaseline = 'middle';
     ctx.fillStyle = cssVar('--md-sys-color-on-surface') || '#e2e2e9';
     for (const b of buckets.values()) {
       for (const l of b.labels) {
-        const { s, x, y: ly, w: lw, h: lh } = l;
+        const { s, x, y: ly, w: lw, h: lh, gf } = l;
         const icon = KIND_ICON[s.kind];
         if (lw > 40) {
-          const label = icon ? `${icon} ${s.name}` : s.name;
+          const primary = gf ? gf.callName : s.name;
+          const label = icon ? `${icon} ${primary}` : primary;
           ctx.save();
           ctx.beginPath();
           ctx.rect(x, ly, lw, lh);
           ctx.clip();
           ctx.fillText(label, x + 4, ly + lh / 2);
+          // Target-agent right-side suffix for goldfive spans. We only
+          // draw it when the bar is at least ~80px wide and the target
+          // doesn't overlap the left label — a rough two-lane budget.
+          if (gf && gf.targetAgentId && lw > 80) {
+            const arrow = `→ ${gf.targetAgentId}`;
+            const metrics = ctx.measureText(arrow);
+            const arrowW = metrics.width;
+            // Leave 24px gutter between the two texts.
+            const leftW = ctx.measureText(label).width;
+            if (arrowW + leftW + 24 < lw) {
+              ctx.textAlign = 'right';
+              ctx.globalAlpha = 0.85;
+              ctx.fillText(arrow, x + lw - 6, ly + lh / 2);
+              ctx.textAlign = 'left';
+              ctx.globalAlpha = 1;
+            }
+          }
           ctx.restore();
         } else if (icon) {
           // Narrow bar: just the kind icon centered
@@ -1094,6 +1145,7 @@ export class GanttRenderer {
     // Expose last-draw count for stress tooling.
     this.lastDrawnCount = visibleCount;
     this.lastBrainBadgeCount = brainBadges.length;
+    this.lastGoldfiveFills = goldfiveFillRecord;
   }
 
   // --- Links -------------------------------------------------------------
@@ -1974,6 +2026,12 @@ export class GanttRenderer {
   // rows are visible.
   lastInterventionBandCount = 0;
   lastInterventionBandXs: number[] = [];
+  // Exposed for goldfive-bar tests (harmonograf#157): span-id → fill color
+  // used on the most recent drawBlocks pass. Populated only for spans
+  // whose fill came from the goldfive call-category override (judge /
+  // refine / plan / reflective); other spans are omitted so tests can
+  // assert the override fired without walking every bucket.
+  lastGoldfiveFills = new Map<string, string>();
 
   // --- Overlay -----------------------------------------------------------
 

--- a/frontend/src/lib/goldfiveSpan.ts
+++ b/frontend/src/lib/goldfiveSpan.ts
@@ -1,0 +1,201 @@
+// Goldfive span helpers — identify a goldfive-translated span, read its
+// new-wire attributes, and classify it into a "call type" the three
+// rendering surfaces (Gantt bar, popover, drawer) share.
+//
+// Incoming attributes (stamped by the harmonograf client sink when it
+// translates goldfive_llm_call_{start,end} / reasoning_judge_invoked
+// events into span frames):
+//
+//   * goldfive.call_name       — e.g. "refine_steer", "judge_reasoning",
+//                                "goal_derive", "judge_goal_drift",
+//                                "reflective_check", "plan_generate"
+//   * goldfive.input_preview   — up to 4 KiB of the call's input
+//   * goldfive.output_preview  — up to 4 KiB of the call's output / verdict
+//   * goldfive.target_agent_id — compound "<client>:agent_name" or empty
+//   * goldfive.target_task_id  — task context or empty
+//   * goldfive.decision_summary — one-line active-voice summary (≤512 chars)
+//
+// Plus the older `judge.*` attributes the JudgeInvocationDetail already
+// consumes when the call is a judge invocation.
+//
+// All attributes are optional. Pre-merge sessions carry none of them and
+// the helpers degrade: a "goldfive" span is still detected via the
+// legacy `agentId.endsWith(":goldfive")` or `__goldfive__` heuristic, and
+// consumers render the basic popover / drawer.
+
+import type { Span } from '../gantt/types';
+
+export type GoldfiveCallCategory =
+  | 'judge'       // judge_reasoning, judge_goal_drift, etc.
+  | 'refine'      // refine_steer, refine_retry, etc.
+  | 'plan'        // goal_derive, plan_generate
+  | 'reflective'  // reflective_check
+  | 'unknown';
+
+export type GoldfiveVerdict = 'on_task' | 'off_task_warning' | 'off_task_critical' | 'no_verdict';
+
+export interface GoldfiveSpanInfo {
+  /** call_name attribute value (e.g. "refine_steer"). Falls back to the span name. */
+  callName: string;
+  /** coarse category used by the color bucket + drawer branching. */
+  category: GoldfiveCallCategory;
+  /** human-readable one-liner; falls back to `goldfive: <callName>` then the span name. */
+  decisionSummary: string;
+  /** bare agent name (after the ``<client>:`` prefix) when ``target_agent_id`` is set. */
+  targetAgentId: string;
+  /** as-stamped compound target id. */
+  targetAgentIdRaw: string;
+  /** ``target_task_id`` when set. */
+  targetTaskId: string;
+  /** up to ~4 KiB of the input preview. */
+  inputPreview: string;
+  /** up to ~4 KiB of the output preview. */
+  outputPreview: string;
+  /** verdict classification for judge calls; ``no_verdict`` for non-judge / unknown. */
+  verdict: GoldfiveVerdict;
+  /** true when the `judge.on_task` attribute resolved to true. */
+  onTask: boolean;
+  /** lowercased `judge.severity` (info / warning / critical / ""). */
+  severity: string;
+}
+
+/** Read a string attribute gracefully — empty string when absent or wrong kind. */
+function readStr(span: Span, key: string): string {
+  const v = span.attributes?.[key];
+  if (!v) return '';
+  if (v.kind !== 'string') return '';
+  return v.value;
+}
+
+function readBool(span: Span, key: string): boolean | undefined {
+  const v = span.attributes?.[key];
+  if (!v) return undefined;
+  if (v.kind !== 'bool') return undefined;
+  return v.value;
+}
+
+const JUDGE_PREFIXES = ['judge_'];
+const REFINE_PREFIXES = ['refine_'];
+const PLAN_NAMES = new Set(['goal_derive', 'plan_generate']);
+const REFLECTIVE_NAMES = new Set(['reflective_check']);
+
+function classifyCallName(name: string): GoldfiveCallCategory {
+  if (!name) return 'unknown';
+  for (const p of JUDGE_PREFIXES) if (name.startsWith(p)) return 'judge';
+  for (const p of REFINE_PREFIXES) if (name.startsWith(p)) return 'refine';
+  if (PLAN_NAMES.has(name)) return 'plan';
+  if (REFLECTIVE_NAMES.has(name)) return 'reflective';
+  // Back-compat: legacy frontend-synthesized refine spans were named
+  // `refine: <kind>` on the __goldfive__ row. Classify those as refine too
+  // so color + drawer routing match post-Option-X.
+  if (name.startsWith('refine:')) return 'refine';
+  // Legacy frontend-synthesized judge spans were `judge: <...>` — tests
+  // still exercise that shape against isJudgeSpan.
+  if (name.startsWith('judge:')) return 'judge';
+  return 'unknown';
+}
+
+/** Strip ``<client>:`` prefix from a compound agent id; pass-through otherwise. */
+export function bareGoldfiveAgentName(compound: string): string {
+  if (!compound) return '';
+  const colon = compound.indexOf(':');
+  if (colon < 0) return compound;
+  return compound.slice(colon + 1);
+}
+
+/**
+ * True when the span represents a goldfive call — either translated via the
+ * sink (agentId ends with `:goldfive` OR a `goldfive.call_name` is set) or
+ * legacy-synthesized on the `__goldfive__` actor row.
+ */
+export function isGoldfiveSpan(span: Span | null | undefined): boolean {
+  if (!span) return false;
+  if (readStr(span, 'goldfive.call_name')) return true;
+  if (span.agentId === '__goldfive__') return true;
+  // Compound id form stamped by the sink (any `:goldfive` suffix).
+  if (span.agentId.endsWith(':goldfive')) return true;
+  return false;
+}
+
+export function resolveGoldfiveSpanInfo(span: Span): GoldfiveSpanInfo {
+  const callName = readStr(span, 'goldfive.call_name') || span.name;
+  const category = classifyCallName(callName);
+  const targetAgentIdRaw = readStr(span, 'goldfive.target_agent_id');
+  const targetAgentId = bareGoldfiveAgentName(targetAgentIdRaw);
+  const targetTaskId = readStr(span, 'goldfive.target_task_id');
+  const inputPreview = readStr(span, 'goldfive.input_preview');
+  const outputPreview = readStr(span, 'goldfive.output_preview');
+
+  const verdictStr = readStr(span, 'judge.verdict');
+  const onTaskAttr = readBool(span, 'judge.on_task');
+  const onTask = onTaskAttr === true || (onTaskAttr === undefined && verdictStr === 'on_task');
+  const severity = readStr(span, 'judge.severity').toLowerCase();
+  let verdict: GoldfiveVerdict = 'no_verdict';
+  if (category === 'judge') {
+    if (onTask) verdict = 'on_task';
+    else if (severity === 'critical') verdict = 'off_task_critical';
+    else if (severity) verdict = 'off_task_warning';
+    else if (verdictStr) verdict = verdictStr === 'on_task' ? 'on_task' : 'off_task_warning';
+    else verdict = 'no_verdict';
+  }
+
+  let decisionSummary = readStr(span, 'goldfive.decision_summary');
+  if (!decisionSummary) decisionSummary = `goldfive: ${callName}`;
+
+  return {
+    callName,
+    category,
+    decisionSummary,
+    targetAgentId,
+    targetAgentIdRaw,
+    targetTaskId,
+    inputPreview,
+    outputPreview,
+    verdict,
+    onTask,
+    severity,
+  };
+}
+
+/**
+ * Resolve the per-category base color used by the Gantt bar + popover
+ * accents. Reads CSS custom properties so theme switches recolor on the
+ * next frame. Callers provide the ``cssVar`` reader (the renderer's
+ * theme-cache-aware one) so we don't re-read ``getComputedStyle`` per
+ * span.
+ */
+export function goldfiveCallFill(
+  info: GoldfiveSpanInfo,
+  cssVar: (name: string) => string,
+  fallback: string,
+): string {
+  switch (info.category) {
+    case 'judge':
+      if (info.verdict === 'on_task') {
+        return cssVar('--hg-goldfive-judge-on-task') || '#3bb273';
+      }
+      if (info.verdict === 'off_task_critical') {
+        return cssVar('--hg-goldfive-judge-critical') || '#e06070';
+      }
+      if (info.verdict === 'off_task_warning') {
+        return cssVar('--hg-goldfive-judge-warning') || '#f59e0b';
+      }
+      return cssVar('--hg-goldfive-judge-neutral') || '#8d9199';
+    case 'refine':
+      return cssVar('--hg-goldfive-refine') || '#a78bfa';
+    case 'plan':
+      return cssVar('--hg-goldfive-plan') || '#4fd1c5';
+    case 'reflective':
+      return cssVar('--hg-goldfive-reflective') || '#8d9199';
+    case 'unknown':
+    default:
+      return fallback;
+  }
+}
+
+/** Clip a preview to the popover's shorter budget. */
+export function truncatePreview(text: string, limit: number): string {
+  if (!text) return '';
+  if (text.length <= limit) return text;
+  return text.slice(0, limit) + '…';
+}

--- a/frontend/src/theme/themes.ts
+++ b/frontend/src/theme/themes.ts
@@ -44,6 +44,16 @@ export interface ThemeTokens {
   kindTransfer: string;
   kindWaitForHuman: string;
   kindCustom: string;
+  // Goldfive call-category colors. The renderer reads these as
+  // `--hg-goldfive-*` so goldfive-translated spans (judge / refine / plan /
+  // reflective) render with a category-specific hue on the goldfive lane.
+  goldfiveJudgeOnTask: string;
+  goldfiveJudgeWarning: string;
+  goldfiveJudgeCritical: string;
+  goldfiveJudgeNeutral: string;
+  goldfiveRefine: string;
+  goldfivePlan: string;
+  goldfiveReflective: string;
 }
 
 const dark: ThemeTokens = {
@@ -83,6 +93,13 @@ const dark: ThemeTokens = {
   kindTransfer: '#ffd479',
   kindWaitForHuman: '#ffb4ab',
   kindCustom: '#8d9199',
+  goldfiveJudgeOnTask: '#3bb273',
+  goldfiveJudgeWarning: '#f59e0b',
+  goldfiveJudgeCritical: '#e06070',
+  goldfiveJudgeNeutral: '#8d9199',
+  goldfiveRefine: '#a78bfa',
+  goldfivePlan: '#4fd1c5',
+  goldfiveReflective: '#8d9199',
 };
 
 const light: ThemeTokens = {
@@ -122,6 +139,13 @@ const light: ThemeTokens = {
   kindTransfer: '#a8740c',
   kindWaitForHuman: '#ba1a1a',
   kindCustom: '#73777f',
+  goldfiveJudgeOnTask: '#1f8a4b',
+  goldfiveJudgeWarning: '#b86500',
+  goldfiveJudgeCritical: '#b4261a',
+  goldfiveJudgeNeutral: '#73777f',
+  goldfiveRefine: '#7c3aed',
+  goldfivePlan: '#0f8f83',
+  goldfiveReflective: '#73777f',
 };
 
 const amoled: ThemeTokens = {
@@ -156,6 +180,13 @@ const highContrast: ThemeTokens = {
   kindTransfer: '#ffe28f',
   kindWaitForHuman: '#ffd2cc',
   kindCustom: '#cfd1d8',
+  goldfiveJudgeOnTask: '#8affb8',
+  goldfiveJudgeWarning: '#ffd28f',
+  goldfiveJudgeCritical: '#ffbdb6',
+  goldfiveJudgeNeutral: '#cfd1d8',
+  goldfiveRefine: '#d3c3ff',
+  goldfivePlan: '#9ff0e8',
+  goldfiveReflective: '#cfd1d8',
 };
 
 export const themes: Record<ThemeBase, ThemeTokens> = {
@@ -223,7 +254,7 @@ export function applyTheme(base: ThemeBase, colorBlind: ColorBlindMode): void {
   }
   const root = document.documentElement;
   for (const [key, value] of Object.entries(tokens)) {
-    if (key.startsWith('kind')) {
+    if (key.startsWith('kind') || key.startsWith('goldfive')) {
       root.style.setProperty(`--hg-${camelToKebab(key)}`, value);
     } else {
       root.style.setProperty(`--md-sys-color-${camelToKebab(key)}`, value);


### PR DESCRIPTION
Closes #157.

## Summary

Renders goldfive-translated spans (judge / refine / plan / reflective) as first-class citizens on three surfaces — Gantt bar, span popover, and drawer — so operators see what goldfive decided and which agent it targeted without opening the raw attribute dump.

- **Gantt bar** — per-call-category color (judge on-task=green, WARNING=amber, CRITICAL=red, refine=purple, plan=teal, reflective=grey) with label swapped to `call_name` and a `→ <target_agent>` suffix on wide bars. Hover tooltip shows `decision_summary`.
- **Popover** — headline swaps span name for `call_name`; subtitle shows `decision_summary`; target / task context row; collapsed Input/Output preview disclosures (~400 char); Steer/Annotate hidden, Copy id + Open drawer preserved for all goldfive spans including judges.
- **Drawer** — new `GoldfiveSpanDetail` (+ CSS) renders at the top of the Summary tab: header + badges, full Input/Output previews with copy-to-clipboard, context dl (model/elapsed/run/session/task/target), and a linked-plan block for refine_* calls resolved by `target_task_id` + time proximity. Judge spans continue to route through `JudgeInvocationDetail`.

Pure-function layer: new `src/lib/goldfiveSpan.ts` exposes `isGoldfiveSpan`, `resolveGoldfiveSpanInfo`, `goldfiveCallFill`, `bareGoldfiveAgentName`, `truncatePreview`. Theme variables `--hg-goldfive-*` added to dark / light / amoled / high-contrast.

## Forward-compat with sibling PRs

Reads the span attributes stamped by the parallel harmonograf-client sink PR (`goldfive.call_name`, `goldfive.decision_summary`, `goldfive.input_preview`, `goldfive.output_preview`, `goldfive.target_agent_id`, `goldfive.target_task_id`). Every read is defensive — pre-merge sessions render the fallback headline (`goldfive: <call_name>`), skip the previews, and still show the context list. A pre-Option-X session on the `__goldfive__` synthetic actor row still renders the Detail with its empty-state placeholders (no crash).

## Notes

- **Synthetic-actor retirement (partial)** — the task suggested dropping `ensureSyntheticActor(GOLDFIVE_ACTOR_ID)` from `goldfiveEvent.ts`. Left in place: the synthesized drift + refine spans still target `GOLDFIVE_ACTOR_ID`, and dropping the ensure call would orphan them (no row to render on). Migrating those synthesizers to the compound `<client>:goldfive` id requires discovering the client id from the agent registry — out of scope for this rendering-focused PR and would break the existing `goldfiveEventLanes.test.ts` expectations. Flag for a follow-up.
- **PlanRevised-link lookup** — today's in-browser `SessionStore` exposes `tasks.listPlans()` + `tasks.allRevsForPlan()`, so the refine-span → PlanRevised lookup runs entirely client-side with no server work. Uses a score function that prefers plans whose task list contains `target_task_id` and whose `createdAtMs` is nearest the span's `startMs`. Works on today's DB; no server-side index needed.
- **Synthetic `__goldfive__` lane vs sink-translated `<client>:goldfive` lane** — currently both rows exist (the synthesizers still land on `__goldfive__`, the sink lands on `<client>:goldfive`). The new Gantt coloring + popover/drawer detail work for both rows because `isGoldfiveSpan` matches either shape.

DO NOT MERGE UNTIL [sibling harmonograf-client sink-stamp PR] lands — this code reads the attributes that PR stamps. Until then the fallback headline shows and the preview disclosures are hidden (graceful degradation, but the sink-stamp PR is what makes the feature actually surface new content).

## Test plan

- [x] `pnpm test --run` — 425 passed (61 new across five files: `lib/goldfiveSpan.test.ts`, `gantt/goldfiveBarColors.test.ts`, `components/SpanPopover.goldfive.test.tsx`, `components/GoldfiveSpanDetail.test.tsx`, `components/Drawer.goldfive.test.tsx`)
- [x] `pnpm tsc -b` — clean
- [x] `pnpm lint` — clean (one pre-existing GanttView warning unrelated to this PR)
- [ ] Manual: open a session with translated goldfive spans; verify color coding + popover decision summary + drawer input/output previews render
- [ ] Manual: open a pre-merge session; verify no crashes and fallback headlines render