### PR TITLE
feat(ui): trajectory evolution + goldfive-steering arrows with annotated targets

### DIFF
--- a/frontend/src/__tests__/components/TrajectoryView.evolution.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.evolution.test.tsx
@@ -1,0 +1,355 @@
+/**
+ * harmonograf#197: TrajectoryView plan-evolution + goldfive-steering redesign.
+ *
+ * Covers the eight tier-1 behaviors specified in the issue:
+ *
+ *  1. Cumulative DAG — superseded tasks retained as historical nodes.
+ *  2. Superseded styling — muted opacity, border dashed, still clickable.
+ *  3. Generation badge — `REV N` corner badge derived from taskRevisionMeta.
+ *  4. Goldfive steering arrow — dashed goldfive-colored arrow from a gutter
+ *     node to the replacement task, labeled with kind → target-agent.
+ *  5. User-steer arrow — distinct purple-dashed style + "user steer" label.
+ *  6. Arrowhead endpoint — lands on the target agent's task node (the
+ *     `data-testid="steer-edge-<taskId>"` attribute is our asserted anchor).
+ *  7. Supersedes edge — old → new, dashed muted, annotated with kind.
+ *  8. Revision scrubber — filters out tasks introduced after the pinned rev.
+ *  9. Steering detail panel — opens on click with Trigger / Steering / Target.
+ */
+
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionStore } from '../../gantt/index';
+import type { Task, TaskPlan } from '../../gantt/types';
+
+vi.mock('../../components/shell/views/views.css', () => ({}));
+
+let mockStore = new SessionStore();
+const mockSessionId: string = 'sess-evo';
+
+vi.mock('../../rpc/hooks', () => ({
+  useSessionWatch: () => ({
+    store: mockStore,
+    connected: true,
+    initialBurstComplete: true,
+    error: null,
+    sessionStatus: 'LIVE' as const,
+    lastEventAtMs: Date.now(),
+  }),
+  getSessionStore: () => mockStore,
+}));
+
+const uiStoreState = {
+  currentSessionId: mockSessionId as string | null,
+  selectSpan: vi.fn(),
+};
+vi.mock('../../state/uiStore', () => ({
+  useUiStore: <T,>(selector: (s: typeof uiStoreState) => T) =>
+    selector(uiStoreState),
+}));
+
+vi.mock('../../state/annotationStore', () => ({
+  useAnnotationStore: Object.assign(() => ({ list: () => [] }), {
+    getState: () => ({ list: () => [] }),
+    subscribe: () => () => {},
+  }),
+}));
+
+import { TrajectoryView } from '../../components/shell/views/TrajectoryView';
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+function mkTask(
+  id: string,
+  status: Task['status'],
+  assignee = 'agent-a',
+  title = id,
+): Task {
+  return {
+    id,
+    title,
+    description: '',
+    assigneeAgentId: assignee,
+    status,
+    predictedStartMs: 0,
+    predictedDurationMs: 0,
+    boundSpanId: '',
+    cancelReason: '',
+  };
+}
+
+function mkPlan(
+  id: string,
+  tasks: Task[],
+  revisionIndex = 0,
+  revisionReason = '',
+  revisionKind = '',
+  triggerEventId = '',
+): TaskPlan {
+  return {
+    id,
+    invocationSpanId: `inv-${id}`,
+    plannerAgentId: 'planner-agent',
+    createdAtMs: revisionIndex,
+    summary: `plan ${id}`,
+    tasks,
+    edges: [],
+    revisionReason,
+    revisionKind,
+    revisionSeverity: 'warning',
+    revisionIndex,
+    triggerEventId,
+  };
+}
+
+// Seed two revisions and the supersession event so the cumulative +
+// supersedes + steering paths all fire. Shared by several tests below.
+function seedTwoRevsWithReplacement(): {
+  rev0: TaskPlan;
+  rev1: TaskPlan;
+} {
+  const rev0 = mkPlan('p1', [
+    mkTask('t1', 'COMPLETED', 'agent-a', 'build outline'),
+  ]);
+  mockStore.tasks.upsertPlan(rev0);
+  const rev1 = mkPlan(
+    'p1',
+    [mkTask('t1_corrected', 'PENDING', 'research_agent', 'research paper')],
+    1,
+    'coordinator looped on status queries',
+    'off_topic',
+    'drift-42',
+  );
+  mockStore.tasks.upsertPlan(rev1);
+  mockStore.agents.upsert({
+    id: '__goldfive__',
+    name: 'goldfive',
+    framework: 'CUSTOM',
+    capabilities: [],
+    status: 'CONNECTED',
+    connectedAtMs: 1,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+  });
+  mockStore.agents.upsert({
+    id: 'research_agent',
+    name: 'research_agent',
+    framework: 'ADK',
+    capabilities: [],
+    status: 'CONNECTED',
+    connectedAtMs: 1,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+  });
+  // Seed a drift so the "Jump to Gantt" deep-link has a triggerDriftAtMs.
+  mockStore.drifts.append({
+    kind: 'off_topic',
+    severity: 'warning',
+    detail: 'coordinator looped on status queries',
+    taskId: 't1',
+    agentId: 'agent-a',
+    recordedAtMs: 10,
+    annotationId: '',
+    driftId: 'drift-42',
+  });
+  return { rev0, rev1 };
+}
+
+beforeEach(() => {
+  mockStore = new SessionStore();
+  uiStoreState.currentSessionId = mockSessionId;
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('<TrajectoryView /> plan-evolution + steering', () => {
+  it('renders both generations of tasks in the cumulative DAG', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    // Rev 0's task AND rev 1's replacement task are both rendered.
+    expect(screen.getByTestId('task-node-t1')).toBeInTheDocument();
+    expect(screen.getByTestId('task-node-t1_corrected')).toBeInTheDocument();
+  });
+
+  it('marks the superseded task with reduced opacity and keeps it clickable', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    const superseded = screen.getByTestId('task-node-t1');
+    expect(superseded).toHaveAttribute('data-superseded', 'true');
+    expect(superseded.getAttribute('opacity')).toBe('0.4');
+    // The node is still a click target — the onClick-bearing <g> receives
+    // pointer events (cursor: pointer via .hg-traj__node) even when the
+    // task isn't present in the latest rev. Verified by mousedown firing
+    // without throwing: React event wiring doesn't drop superseded nodes.
+    fireEvent.click(superseded);
+    // After click the detail region reflects "Task not present in this rev"
+    // because the latest-rev view doesn't carry the superseded task body;
+    // the selection state still moved — the panel shows *something* from
+    // the detail pane family.
+    expect(
+      screen.getByText(/Task not present in this rev|detail-task/i),
+    ).toBeInTheDocument();
+  });
+
+  it('stamps a REV N generation badge based on introducedInRevision', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    const rev0Badge = screen.getByTestId('task-node-t1-rev-badge');
+    expect(rev0Badge).toHaveAttribute('data-rev', '0');
+    expect(rev0Badge).toHaveTextContent('R0');
+    const rev1Badge = screen.getByTestId('task-node-t1_corrected-rev-badge');
+    expect(rev1Badge).toHaveAttribute('data-rev', '1');
+    expect(rev1Badge).toHaveTextContent('R1');
+  });
+
+  it('draws a goldfive steering arrow to the replacement task with kind → agent label', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    const edges = screen.getByTestId('trajectory-steer-edges');
+    expect(edges).toBeInTheDocument();
+    // The arrowhead lands ON the replacement task node — asserted via the
+    // data-testid that the steering-arrow render attaches to the group
+    // that terminates at the target task node.
+    const arrow = screen.getByTestId('steer-edge-t1_corrected');
+    expect(arrow).toHaveAttribute('data-authored-by', 'goldfive');
+    // The short tail label names the target agent + kind.
+    expect(arrow).toHaveTextContent(/OFF_TOPIC/i);
+    expect(arrow).toHaveTextContent(/research_agent/);
+  });
+
+  it('draws a user-styled arrow for user_steer drifts', () => {
+    // rev 0
+    const rev0 = mkPlan('p1', [mkTask('t1', 'RUNNING', 'agent-a')]);
+    mockStore.tasks.upsertPlan(rev0);
+    // rev 1 — originated by the user via a STEER annotation. Goldfive
+    // stamps `kind=user_steer` on the PlanRevised.
+    const rev1 = mkPlan(
+      'p1',
+      [mkTask('t1', 'RUNNING', 'agent-a'), mkTask('t2', 'PENDING', 'agent-b')],
+      1,
+      'switch focus to section 3',
+      'user_steer',
+      'ann-7',
+    );
+    mockStore.tasks.upsertPlan(rev1);
+    render(<TrajectoryView />);
+    const arrow = screen.getByTestId('steer-edge-t2');
+    expect(arrow).toHaveAttribute('data-authored-by', 'user');
+    expect(arrow).toHaveTextContent(/user steer/i);
+    expect(arrow).toHaveTextContent(/agent-b/);
+  });
+
+  it('draws a supersedes edge from the old task to its replacement, annotated with drift kind', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    const supersedes = screen.getByTestId('trajectory-supersedes-edges');
+    expect(supersedes).toBeInTheDocument();
+    const edge = screen.getByTestId('supersedes-edge-t1');
+    expect(edge).toHaveTextContent(/goldfive: off_topic/i);
+  });
+
+  it('revision scrubber hides tasks introduced after the pinned revision', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    // Before scrubbing: both tasks visible.
+    expect(screen.getByTestId('task-node-t1')).toBeInTheDocument();
+    expect(screen.getByTestId('task-node-t1_corrected')).toBeInTheDocument();
+    // Click the REV 0 scrubber notch.
+    const notch = screen.getByTestId('scrubber-notch-0');
+    fireEvent.click(notch);
+    // After scrubbing to rev 0: rev-1 task is hidden.
+    expect(screen.getByTestId('task-node-t1')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-node-t1_corrected')).not.toBeInTheDocument();
+    // "Latest" returns the full cumulative view.
+    fireEvent.click(screen.getByTestId('scrubber-notch-latest'));
+    expect(screen.getByTestId('task-node-t1_corrected')).toBeInTheDocument();
+  });
+
+  it('clicking a steering arrow opens the detail panel with Trigger / Steering / Target', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    const arrow = screen.getByTestId('steer-edge-t1_corrected');
+    fireEvent.click(arrow);
+    const panel = screen.getByTestId('steering-detail-panel');
+    expect(panel).toBeInTheDocument();
+    // Three sections: Trigger, Steering, Target.
+    expect(within(panel).getByTestId('steering-detail-trigger')).toBeInTheDocument();
+    expect(within(panel).getByTestId('steering-detail-steering')).toBeInTheDocument();
+    const targetSec = within(panel).getByTestId('steering-detail-target');
+    // Target section names the agent explicitly — the primary UX guarantee.
+    expect(
+      within(targetSec).getByTestId('steering-detail-target-agent'),
+    ).toHaveTextContent('research_agent');
+    expect(
+      within(targetSec).getByTestId('steering-detail-target-task'),
+    ).toHaveTextContent(/research paper/);
+    // Kind + reason surface in the Trigger section.
+    expect(
+      within(panel).getByTestId('steering-detail-trigger'),
+    ).toHaveTextContent('off_topic');
+    expect(
+      within(panel).getByTestId('steering-detail-trigger'),
+    ).toHaveTextContent('coordinator looped on status queries');
+  });
+
+  it('clicking a supersedes edge opens the same detail panel with the old / new task pair', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    const edge = screen.getByTestId('supersedes-edge-t1');
+    // SVG-native click — fireEvent dispatches to the parent <g>.
+    fireEvent.click(edge);
+    const panel = screen.getByTestId('steering-detail-panel');
+    expect(panel).toBeInTheDocument();
+    expect(panel).toHaveTextContent('t1');
+    expect(panel).toHaveTextContent('t1_corrected');
+  });
+
+  it('steering panel close button dismisses the panel and restores task-detail pane', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    fireEvent.click(screen.getByTestId('steer-edge-t1_corrected'));
+    expect(screen.getByTestId('steering-detail-panel')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('steering-detail-close'));
+    expect(screen.queryByTestId('steering-detail-panel')).not.toBeInTheDocument();
+  });
+
+  it('scrubber keyboard navigation steps through revisions and returns to Latest', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    const scrubber = screen.getByTestId('revision-scrubber');
+    // Seed the scrubber with a pinned rev 1 first so we can verify left-arrow.
+    fireEvent.click(screen.getByTestId('scrubber-notch-1'));
+    // ArrowLeft → rev 0.
+    fireEvent.keyDown(scrubber, { key: 'ArrowLeft' });
+    expect(screen.getByTestId('scrubber-notch-0')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    // End → Latest.
+    fireEvent.keyDown(scrubber, { key: 'End' });
+    expect(screen.getByTestId('scrubber-notch-latest')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    // Home → rev 0.
+    fireEvent.keyDown(scrubber, { key: 'Home' });
+    expect(screen.getByTestId('scrubber-notch-0')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  it('does NOT draw a steering edge when the plan has only rev 0', () => {
+    const rev0 = mkPlan('p1', [mkTask('t1', 'PENDING', 'agent-a')]);
+    mockStore.tasks.upsertPlan(rev0);
+    render(<TrajectoryView />);
+    expect(screen.queryByTestId('trajectory-steer-edges')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('trajectory-supersedes-edges')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/shell/views/RevisionScrubber.tsx
+++ b/frontend/src/components/shell/views/RevisionScrubber.tsx
@@ -1,0 +1,131 @@
+// RevisionScrubber — horizontal timeline of plan revisions. Rendered at
+// the top of the Trajectory view (and intended for reuse by the Task/Plan
+// panel sibling). One notch per PlanRevisionRecord; clicking a notch pins
+// the view to that revision so tasks introduced later are hidden. The
+// "Latest" sentinel (cumulative, all tasks including superseded) is the
+// default; selecting any earlier notch sets `pinned = revision number`.
+//
+// Keyboard: left/right arrows move between notches; Home jumps to the
+// initial revision, End returns to "Latest". The buttons are tab-stopped
+// so the full scrubber is operable without a mouse.
+//
+// This is a primitive: no store lookups, no session watching. Callers
+// own the `pinnedRevision` state and pass `history` derived from
+// `usePlanHistory(sessionId, planId)`.
+
+import type React from 'react';
+import { useCallback } from 'react';
+import type { PlanRevisionRecord } from '../../../state/planHistoryStore';
+
+export interface RevisionScrubberProps {
+  /** Oldest → newest. Empty array renders nothing. */
+  history: readonly PlanRevisionRecord[];
+  /** Revision number the caller has pinned; null means "Latest" (cumulative). */
+  pinnedRevision: number | null;
+  /** Invoked with the revision number clicked, or null for "Latest". */
+  onPinRevision: (revision: number | null) => void;
+}
+
+// Short human-readable label for a revision's trigger. Falls back to the
+// bare kind and finally to "initial" on rev 0.
+function triggerLabel(rec: PlanRevisionRecord): string {
+  if (rec.revision === 0) return 'initial';
+  if (rec.kind) return rec.kind;
+  if (rec.reason) return rec.reason.slice(0, 32);
+  return `rev ${rec.revision}`;
+}
+
+// Severity inferred from the drift kind — user steers bucket as "user",
+// goldfive-authored as "goldfive", initial plan has no authorship.
+function authorshipClass(rec: PlanRevisionRecord): string {
+  if (rec.revision === 0) return 'initial';
+  if (rec.kind.startsWith('user_')) return 'user';
+  return 'goldfive';
+}
+
+export function RevisionScrubber(props: RevisionScrubberProps): React.ReactElement | null {
+  const { history, pinnedRevision, onPinRevision } = props;
+
+  const onKey = useCallback(
+    (e: React.KeyboardEvent<HTMLElement>) => {
+      if (history.length === 0) return;
+      const currentIdx =
+        pinnedRevision == null
+          ? history.length
+          : history.findIndex((r) => r.revision === pinnedRevision);
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        const nextIdx = Math.max(0, currentIdx - 1);
+        const next = history[nextIdx];
+        onPinRevision(next ? next.revision : null);
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        if (currentIdx >= history.length - 1) {
+          onPinRevision(null);
+        } else {
+          const next = history[currentIdx + 1];
+          onPinRevision(next ? next.revision : null);
+        }
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        onPinRevision(history[0].revision);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        onPinRevision(null);
+      }
+    },
+    [history, pinnedRevision, onPinRevision],
+  );
+
+  if (history.length === 0) return null;
+
+  return (
+    <div
+      className="hg-traj__scrubber"
+      data-testid="revision-scrubber"
+      role="tablist"
+      aria-label="Plan revisions"
+      onKeyDown={onKey}
+    >
+      <span className="hg-traj__scrubber-label" aria-hidden="true">
+        Revisions
+      </span>
+      {history.map((rec) => {
+        const selected = pinnedRevision === rec.revision;
+        const cls = authorshipClass(rec);
+        return (
+          <button
+            key={`scrub-${rec.plan.id}-${rec.revision}`}
+            type="button"
+            role="tab"
+            className="hg-traj__scrubber-notch"
+            aria-selected={selected}
+            data-authorship={cls}
+            data-testid={`scrubber-notch-${rec.revision}`}
+            onClick={() => onPinRevision(rec.revision)}
+            title={
+              rec.reason
+                ? `rev ${rec.revision} · ${rec.kind || 'initial'}: ${rec.reason}`
+                : `rev ${rec.revision} · ${rec.kind || 'initial'}`
+            }
+          >
+            <span className="hg-traj__scrubber-tick" />
+            <span className="hg-traj__scrubber-num">REV {rec.revision}</span>
+            <span className="hg-traj__scrubber-kind">{triggerLabel(rec)}</span>
+          </button>
+        );
+      })}
+      <button
+        type="button"
+        role="tab"
+        className="hg-traj__scrubber-latest"
+        aria-selected={pinnedRevision === null}
+        data-testid="scrubber-notch-latest"
+        onClick={() => onPinRevision(null)}
+        title="Show the cumulative view across every revision"
+      >
+        Latest
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/shell/views/SteeringDetailPanel.tsx
+++ b/frontend/src/components/shell/views/SteeringDetailPanel.tsx
@@ -1,0 +1,219 @@
+// SteeringDetailPanel — side panel opened when the operator clicks a
+// steering arrow or a supersedes edge on the Trajectory DAG. Renders the
+// three questions the user explicitly asked for:
+//
+//   1. Trigger  — what goldfive observed (drift kind + reason; or for
+//                 user steers, the annotation body).
+//   2. Steering — what goldfive decided (refine reason; decision_summary
+//                 from the refine span when the sibling goldfive PR has
+//                 landed and stamped that attribute).
+//   3. Target   — the agent + task that got steered. The target agent
+//                 is named here AND on the arrow label — so it's
+//                 visible without a click.
+//
+// Reads optional refine-span attributes (input_preview, output_preview,
+// decision_summary, target_agent_id) that the sibling goldfive-render
+// and sink-stamp worktrees stamp. Degrades to the bare PlanRevised
+// reason + drift detail when those attrs are absent.
+
+import type React from 'react';
+import { useEffect } from 'react';
+import type { SessionStore } from '../../../gantt/index';
+import { bareAgentName } from '../../../gantt/index';
+import type { Span, Task, TaskPlan } from '../../../gantt/types';
+import type {
+  PlanRevisionRecord,
+  SupersessionLink,
+} from '../../../state/planHistoryStore';
+
+export interface SteeringSelection {
+  kind: 'revision' | 'supersedes';
+  revision: number;
+  oldTaskId?: string;
+  targetTaskId?: string;
+}
+
+export interface SteeringDetailPanelProps {
+  selection: SteeringSelection | null;
+  plan: TaskPlan | null;
+  history: readonly PlanRevisionRecord[];
+  supersedes: Map<string, SupersessionLink>;
+  store: SessionStore | null;
+  onClose: () => void;
+  onJumpToGantt: (atMs: number | null, driftId: string) => void;
+}
+
+function readStringAttr(span: Span | null, key: string): string {
+  if (!span) return '';
+  const attr = span.attributes[key];
+  if (!attr || attr.kind !== 'string') return '';
+  return attr.value;
+}
+
+function findRefineSpan(store: SessionStore | null, revision: number): Span | null {
+  if (!store || revision <= 0) return null;
+  const spans: Span[] = [];
+  store.spans.queryAgent('__goldfive__', 0, Number.POSITIVE_INFINITY, spans);
+  for (const s of spans) {
+    if (!s.name.startsWith('refine:')) continue;
+    const attr = s.attributes['refine.index'];
+    if (attr && attr.kind === 'string' && attr.value === String(revision)) return s;
+  }
+  return null;
+}
+
+function taskById(plan: TaskPlan | null, id: string | undefined): Task | null {
+  if (!plan || !id) return null;
+  return plan.tasks.find((t) => t.id === id) ?? null;
+}
+
+function agentDisplayName(store: SessionStore | null, id: string): string {
+  if (!id) return '';
+  return store?.agents.get(id)?.name || bareAgentName(id) || id;
+}
+
+export function SteeringDetailPanel(
+  props: SteeringDetailPanelProps,
+): React.ReactElement | null {
+  const { selection, plan, history, supersedes, store, onClose, onJumpToGantt } = props;
+
+  // Esc closes the panel.
+  useEffect(() => {
+    if (!selection) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selection, onClose]);
+
+  if (!selection) return null;
+
+  const record: PlanRevisionRecord | undefined = history.find(
+    (r) => r.revision === selection.revision,
+  );
+  const link: SupersessionLink | undefined =
+    selection.kind === 'supersedes' && selection.oldTaskId
+      ? supersedes.get(selection.oldTaskId)
+      : undefined;
+
+  const refineSpan = findRefineSpan(store, selection.revision);
+  const decisionSummary = readStringAttr(refineSpan, 'goldfive.decision_summary');
+  const inputPreview = readStringAttr(refineSpan, 'goldfive.input_preview');
+  const outputPreview = readStringAttr(refineSpan, 'goldfive.output_preview');
+  const targetAgentFromSpan = readStringAttr(refineSpan, 'refine.target_agent_id');
+
+  const reason = record?.reason || link?.reason || '';
+  const kind = record?.kind || link?.kind || '';
+  const triggerEventId = record?.triggerEventId || link?.triggerEventId || '';
+  const authoredBy = kind.startsWith('user_') ? 'user' : 'goldfive';
+
+  const targetTask =
+    taskById(plan, selection.targetTaskId) ??
+    taskById(plan, link?.newTaskId) ??
+    (targetAgentFromSpan
+      ? plan?.tasks.find((t) => t.assigneeAgentId === targetAgentFromSpan) ?? null
+      : null);
+  const targetAgentId = targetTask?.assigneeAgentId || targetAgentFromSpan || '';
+  const targetAgentName = agentDisplayName(store, targetAgentId);
+
+  let triggerDriftAtMs: number | null = null;
+  if (store && triggerEventId) {
+    for (const d of store.drifts.list()) {
+      if (d.driftId === triggerEventId || d.annotationId === triggerEventId) {
+        triggerDriftAtMs = d.recordedAtMs;
+        break;
+      }
+    }
+  }
+
+  return (
+    <aside
+      className="hg-traj__steering-panel"
+      data-testid="steering-detail-panel"
+      role="dialog"
+      aria-label="Steering decision detail"
+    >
+      <header className="hg-traj__steering-panel-head">
+        <div>
+          <span className="hg-traj__steering-panel-kicker" data-authored-by={authoredBy}>
+            {authoredBy === 'user' ? 'user steer' : 'goldfive steer'} · rev {selection.revision}
+          </span>
+          <h3 className="hg-traj__steering-panel-title">{kind || 'plan revised'}</h3>
+        </div>
+        <button
+          type="button"
+          className="hg-traj__steering-panel-close"
+          onClick={onClose}
+          aria-label="Close steering detail"
+          data-testid="steering-detail-close"
+        >
+          ×
+        </button>
+      </header>
+
+      <section
+        className="hg-traj__steering-panel-section"
+        data-testid="steering-detail-trigger"
+      >
+        <h4>Trigger</h4>
+        {kind && <div><strong>kind:</strong> {kind}</div>}
+        {reason && <div className="hg-traj__steering-panel-body">{reason}</div>}
+        {inputPreview && (
+          <div className="hg-traj__steering-panel-preview">{inputPreview}</div>
+        )}
+      </section>
+
+      <section
+        className="hg-traj__steering-panel-section"
+        data-testid="steering-detail-steering"
+      >
+        <h4>Steering</h4>
+        <div className="hg-traj__steering-panel-body">
+          {decisionSummary || reason || '(no summary recorded)'}
+        </div>
+        {outputPreview && (
+          <div className="hg-traj__steering-panel-preview">{outputPreview}</div>
+        )}
+      </section>
+
+      <section
+        className="hg-traj__steering-panel-section"
+        data-testid="steering-detail-target"
+      >
+        <h4>Target</h4>
+        <div data-testid="steering-detail-target-agent" title={targetAgentId}>
+          <strong>agent:</strong> {targetAgentName || '(unknown)'}
+        </div>
+        {targetTask && (
+          <div data-testid="steering-detail-target-task">
+            <strong>task:</strong> {targetTask.title || targetTask.id}
+          </div>
+        )}
+        {link?.oldTaskId && (
+          <div>
+            <strong>supersedes:</strong> <code>{link.oldTaskId}</code>
+            {link.newTaskId && (
+              <>
+                {' → '}
+                <code>{link.newTaskId}</code>
+              </>
+            )}
+          </div>
+        )}
+      </section>
+
+      <footer className="hg-traj__steering-panel-foot">
+        <button
+          type="button"
+          className="hg-traj__steering-panel-jump"
+          data-testid="steering-detail-jump-gantt"
+          disabled={!triggerEventId}
+          onClick={() => onJumpToGantt(triggerDriftAtMs, triggerEventId)}
+        >
+          Jump to drift in Gantt
+        </button>
+      </footer>
+    </aside>
+  );
+}

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -1,6 +1,6 @@
 import './views.css';
 import type React from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useUiStore } from '../../../state/uiStore';
 import { useSessionWatch } from '../../../rpc/hooks';
 import type { Span, Task, TaskEdge, TaskPlan, TaskStatus } from '../../../gantt/types';
@@ -20,6 +20,22 @@ import {
   resolveDriftDetail,
   type InterventionDetail,
 } from '../../../lib/interventionDetail';
+import {
+  useCumulativePlan,
+  usePlanHistory,
+  useSupersedesMap,
+} from '../../../state/planHistoryHooks';
+import type {
+  CumulativePlan,
+  CumulativeTaskMeta,
+  PlanRevisionRecord,
+  SupersessionLink,
+} from '../../../state/planHistoryStore';
+import { RevisionScrubber } from './RevisionScrubber';
+import {
+  SteeringDetailPanel,
+  type SteeringSelection,
+} from './SteeringDetailPanel';
 
 // ── Palette ────────────────────────────────────────────────────────────────
 // Aligned with GanttView's status palette so a task's status reads the same
@@ -366,6 +382,31 @@ export function TrajectoryView() {
   const [compareRevIdx, setCompareRevIdx] = useState<number | null>(null);
   const [selection, setSelection] = useState<Selection>(null);
 
+  // harmonograf#197: scrubber pins the cumulative view to a specific
+  // revision number (tasks introduced after are hidden); null → "Latest".
+  const [pinnedRevision, setPinnedRevision] = useState<number | null>(null);
+  // Steering-arrow / supersedes-edge click target. Separate from
+  // `selection` so the arrow panel can coexist with a task-detail selection.
+  const [steeringSelection, setSteeringSelection] =
+    useState<SteeringSelection | null>(null);
+
+  // Plan-history primary id: same fallback as vm.planId. Used to key the
+  // cumulative + supersedes + history hooks.
+  const primaryPlanId = vm.planId;
+  const cumulativePlan = useCumulativePlan(sessionId, primaryPlanId);
+  const planHistoryRecords = usePlanHistory(sessionId, primaryPlanId);
+  const supersedesMap = useSupersedesMap(sessionId, primaryPlanId);
+
+  // "At this revision" filter on the cumulative plan: when the user pins
+  // a revision with the scrubber, tasks introduced later are hidden. This
+  // yields a new CumulativePlan with a pruned task+edge list so the DAG
+  // layout engine runs unchanged.
+  const filteredCumulative = useMemo(() => {
+    if (!cumulativePlan) return null;
+    if (pinnedRevision === null) return cumulativePlan;
+    return filterCumulativeAtRevision(cumulativePlan, pinnedRevision);
+  }, [cumulativePlan, pinnedRevision]);
+
   const latestIdx = Math.max(0, vm.revs.length - 1);
   const revIdx = pinnedRevIdx === null ? latestIdx : Math.min(pinnedRevIdx, latestIdx);
   const currentRev = vm.revs[revIdx] ?? null;
@@ -455,6 +496,14 @@ export function TrajectoryView() {
         )}
         {sessionId && vm.revs.length > 0 && (
           <>
+            <RevisionScrubber
+              history={planHistoryRecords}
+              pinnedRevision={pinnedRevision}
+              onPinRevision={(rev) => {
+                setPinnedRevision(rev);
+                setSteeringSelection(null);
+              }}
+            />
             <Ribbon
               revs={vm.revs}
               driftsByRev={vm.driftsByRev}
@@ -476,6 +525,10 @@ export function TrajectoryView() {
             <div className="hg-traj__split">
               <DagPane
                 plan={currentRev}
+                cumulative={filteredCumulative}
+                history={planHistoryRecords}
+                supersedes={supersedesMap}
+                pinnedRevision={pinnedRevision}
                 marks={marks}
                 compareRev={compareRev}
                 driftsOnRev={vm.driftsByRev[revIdx] ?? []}
@@ -487,14 +540,35 @@ export function TrajectoryView() {
                   const task = currentRev.tasks.find((t) => t.id === taskId);
                   if (task?.boundSpanId) selectSpan(task.boundSpanId);
                 }}
+                onSelectSteering={setSteeringSelection}
                 store={store}
               />
-              <DetailPane
-                selection={selection}
-                plan={currentRev}
-                drifts={vm.allDrifts}
-                store={store}
-              />
+              {steeringSelection ? (
+                <SteeringDetailPanel
+                  selection={steeringSelection}
+                  plan={filteredCumulative ?? currentRev}
+                  history={planHistoryRecords}
+                  supersedes={supersedesMap}
+                  store={store}
+                  onClose={() => setSteeringSelection(null)}
+                  onJumpToGantt={() => {
+                    // Hand off to the app-level Gantt jump handler. Today
+                    // we simply close the panel so the user can eyeball
+                    // the drift on the existing ribbon; the sibling
+                    // `useUiStore.selectSpan` is the nav primitive most
+                    // views use. If the refine span is the closest thing
+                    // the view has to "this drift", select it.
+                    setSteeringSelection(null);
+                  }}
+                />
+              ) : (
+                <DetailPane
+                  selection={selection}
+                  plan={currentRev}
+                  drifts={vm.allDrifts}
+                  store={store}
+                />
+              )}
             </div>
           </>
         )}
@@ -609,12 +683,26 @@ function Ribbon(props: RibbonProps) {
 
 interface DagProps {
   plan: TaskPlan | null;
+  // harmonograf#197: cumulative-plan view from PlanHistoryRegistry. When
+  // present, the DAG renders the union of tasks across every revision
+  // (superseded tasks dimmed, REV-N generation badges). `plan` is kept
+  // as a fallback for the one-revision case so the pane renders even
+  // before the plan-history RPC wires up.
+  cumulative: CumulativePlan | null;
+  history: readonly PlanRevisionRecord[];
+  supersedes: Map<string, SupersessionLink>;
+  /** Null = "Latest" cumulative view; otherwise hide tasks introduced
+   *  after this revision number. Controlled by the scrubber. */
+  pinnedRevision: number | null;
   marks: DiffMarks | null;
   compareRev: TaskPlan | null;
   driftsOnRev: DriftRecord[];
   delegations: DelegationRecord[];
   selection: Selection;
   onSelectTask: (taskId: string) => void;
+  // Click target for steering arrow / supersedes edge. Opens the
+  // SteeringDetailPanel.
+  onSelectSteering: (selection: SteeringSelection) => void;
   // Optional session handle used only to resolve the assignee agent's
   // bare display name. Passing null preserves the previous fallback
   // (strip the compound prefix; else render the raw id).
@@ -725,55 +813,235 @@ function findUserGoalSpan(store: SessionStore): Span | null {
   return chosen;
 }
 
+// ── Cumulative filter + steering events ───────────────────────────────────
+
+interface SteeringEvent {
+  /** Revision number the steering produced. */
+  revision: number;
+  /** "user" for USER_STEER / USER_PAUSE / USER_CANCEL originators,
+   *  "goldfive" otherwise. Drives arrow color + gutter glyph. */
+  authoredBy: 'user' | 'goldfive';
+  /** DriftKind name (e.g. "off_topic", "user_steer"). */
+  kind: string;
+  /** Short display label for the arrow annotation. */
+  kindLabel: string;
+  /** Reason text (tooltip body). */
+  reason: string;
+  /** Task the arrow lands on (the new / replacement task). */
+  targetTaskId: string;
+  /** Assignee of the target task — named in the arrow label. */
+  targetAgentId: string;
+  /** Gutter geometry for the revision's origin node. */
+  gutterCx: number;
+  gutterCy: number;
+}
+
+interface SupersedesEdge {
+  oldId: string;
+  link: SupersessionLink;
+}
+
+// Filter a cumulative plan to "at or before" a given revision — used by
+// the scrubber. Tasks introduced after `pinnedRevision` are removed;
+// their edges are dropped too.
+function filterCumulativeAtRevision(
+  cumulative: CumulativePlan,
+  pinnedRevision: number,
+): CumulativePlan {
+  const visibleIds = new Set<string>();
+  for (const [id, meta] of cumulative.taskRevisionMeta.entries()) {
+    if (meta.introducedInRevision <= pinnedRevision) visibleIds.add(id);
+  }
+  const tasks = cumulative.tasks.filter((t) => visibleIds.has(t.id));
+  const edges = cumulative.edges.filter(
+    (e) => visibleIds.has(e.fromTaskId) && visibleIds.has(e.toTaskId),
+  );
+  const meta = new Map<string, CumulativeTaskMeta>();
+  for (const [id, m] of cumulative.taskRevisionMeta.entries()) {
+    if (visibleIds.has(id)) meta.set(id, m);
+  }
+  return { ...cumulative, tasks, edges, taskRevisionMeta: meta };
+}
+
+// Build per-revision steering events. One arrow per non-zero revision in
+// `history` that points at a concrete task on `renderPlan`. Target
+// priority (matches the goldfive PlanRevised contract):
+//   1. supersedes link's newTaskId — the replacement task.
+//   2. refine-span `refine.target_agent_id` → first task with matching
+//      assignee on the render plan.
+//   3. any task on the revision that wasn't present in the previous rev.
+function buildSteeringEvents(
+  history: readonly PlanRevisionRecord[],
+  supersedes: Map<string, SupersessionLink>,
+  renderPlan: TaskPlan,
+  pinnedRevision: number | null,
+  store: SessionStore | null,
+): SteeringEvent[] {
+  if (history.length === 0) return [];
+  const tasksById = new Map<string, Task>();
+  for (const t of renderPlan.tasks) tasksById.set(t.id, t);
+
+  // Invert supersedes map so we can look up by revision → new task id.
+  const newTaskByRevision = new Map<number, string>();
+  for (const link of supersedes.values()) {
+    if (link.newTaskId && !newTaskByRevision.has(link.revision)) {
+      newTaskByRevision.set(link.revision, link.newTaskId);
+    }
+  }
+
+  const events: SteeringEvent[] = [];
+  let slot = 0;
+  for (const rec of history) {
+    if (rec.revision === 0) continue;
+    if (pinnedRevision !== null && rec.revision > pinnedRevision) continue;
+    let targetTaskId = newTaskByRevision.get(rec.revision) || '';
+    let targetAgentId = '';
+    if (targetTaskId) {
+      targetAgentId = tasksById.get(targetTaskId)?.assigneeAgentId || '';
+    }
+    if (!targetTaskId && store) {
+      const refineSpan = findRefineSpanForPlan(store, rec.plan);
+      const agent = readRefineAttr(refineSpan, 'refine.target_agent_id');
+      if (agent) {
+        const match = findSteeringTargetTask(renderPlan, agent);
+        if (match) {
+          targetTaskId = match.id;
+          targetAgentId = agent;
+        }
+      }
+    }
+    // Last-resort fallback: any task in this revision that wasn't in the
+    // previous revision. Keeps the arrow drawable on history built from
+    // nothing but plan snapshots.
+    if (!targetTaskId) {
+      const prev =
+        history.find((r) => r.revision === rec.revision - 1)?.plan ?? null;
+      const prevIds = new Set(prev?.tasks.map((t) => t.id) ?? []);
+      for (const t of rec.plan.tasks) {
+        if (!prevIds.has(t.id) && tasksById.has(t.id)) {
+          targetTaskId = t.id;
+          targetAgentId = t.assigneeAgentId;
+          break;
+        }
+      }
+    }
+    if (!targetTaskId || !tasksById.has(targetTaskId)) continue;
+    const authoredBy: 'user' | 'goldfive' =
+      rec.kind.startsWith('user_') ? 'user' : 'goldfive';
+    const kindLabel = rec.kind
+      ? (authoredBy === 'user' ? 'user steer' : rec.kind.toUpperCase())
+      : `rev ${rec.revision}`;
+    events.push({
+      revision: rec.revision,
+      authoredBy,
+      kind: rec.kind,
+      kindLabel,
+      reason: rec.reason,
+      targetTaskId,
+      targetAgentId,
+      gutterCx: 12,
+      // Stack gutters vertically: skip the user-goal slot (y=16). First
+      // steering gutter at y=40, then every 24px. Caps visually at a
+      // sensible number but arrows still all draw.
+      gutterCy: 40 + slot * 24,
+    });
+    slot++;
+  }
+  return events;
+}
+
+// Rev-generation palette. Rev 0 is muted, later revs step up the warm
+// channel so the operator can tell at a glance how many refines a given
+// task has survived. Caps at REV 3+ to keep the palette finite.
+function genBadgeFill(rev: number): string {
+  if (rev <= 0) return '#5a5e68';
+  if (rev === 1) return '#b59340';
+  if (rev === 2) return '#d09532';
+  return '#e08a24';
+}
+
 function DagPane(props: DagProps) {
   const {
     plan,
+    cumulative,
+    history,
+    supersedes,
+    pinnedRevision,
     marks,
     compareRev,
     driftsOnRev,
     delegations,
     selection,
     onSelectTask,
+    onSelectSteering,
     store,
   } = props;
-  const layout = plan ? layoutDag(plan) : null;
+  // Prefer the cumulative plan — it retains superseded tasks as historical
+  // nodes. Falls back to `plan` for pre-history-bootstrap renders.
+  const renderPlan: TaskPlan | null = cumulative ?? plan;
+  const layout = renderPlan ? layoutDag(renderPlan) : null;
   const driftsByTaskId = buildDriftsByTaskId(driftsOnRev);
   const delegationsByTaskId = buildDelegationsByTaskId(delegations);
+  const taskMeta: Map<string, CumulativeTaskMeta> =
+    cumulative?.taskRevisionMeta ?? new Map();
 
-  if (!plan || !layout) {
+  if (!renderPlan || !layout) {
     return <div className="hg-traj__dag hg-traj__dag--empty">No plan to render.</div>;
   }
 
-  // harmonograf#196 steering arrow: find the current rev's refine target
-  // and, if one exists, draw a distinct arrow from a small "goldfive"
-  // gutter node on the DAG's left edge to the matching task node. The
-  // target agent lives on the synthesized refine span the ingest layer
-  // stamps on the goldfive actor row at plan.createdAtMs.
-  const revIdx = plan.revisionIndex ?? 0;
-  const refineSpan = store && revIdx > 0 ? findRefineSpanForPlan(store, plan) : null;
-  const steerTargetAgent = refineSpan ? readRefineAttr(refineSpan, 'refine.target_agent_id') : '';
-  const steerKind = refineSpan ? readRefineAttr(refineSpan, 'refine.kind') : plan.revisionKind || '';
-  const steerReason = refineSpan ? readRefineAttr(refineSpan, 'refine.reason') : plan.revisionReason || '';
+  // Current-rev steering event (legacy #196 single-arrow path). Retained
+  // so the pre-history tests that only seed a single refine synth span
+  // still see `trajectory-steer-edges` + `steer-edge-<id>` at the same
+  // testids. Under the new history-driven path, the steering-events list
+  // below additively renders one arrow per rev.
+  const revIdx = renderPlan.revisionIndex ?? 0;
+  const refineSpan = store && revIdx > 0 ? findRefineSpanForPlan(store, renderPlan) : null;
+  const steerTargetAgent = refineSpan
+    ? readRefineAttr(refineSpan, 'refine.target_agent_id')
+    : '';
   const steerTargetTask = steerTargetAgent
-    ? findSteeringTargetTask(plan, steerTargetAgent)
+    ? findSteeringTargetTask(renderPlan, steerTargetAgent)
     : null;
-  // Gutter node coordinates — small circles in the left margin of the
-  // DAG's SVG viewport. Chosen so they never overlap the first-layer
-  // task column (which starts at DAG_PAD + 0 = 24). The goldfive node
-  // sits mid-height (steering origin); the user node sits higher and
-  // points to the first layer-0 task (representing the RunStarted goal
-  // that seeded the plan).
-  const GOLDFIVE_NODE = { cx: 12, cy: layout.height / 2, r: 7 };
-  const USER_NODE = { cx: 12, cy: 16, r: 7 };
 
-  // User → first-task arrow: represents "this plan exists because the
-  // user asked for <goal>". Only drawn on the initial rev (rev 0) so
-  // rev 1+ panes don't accumulate a user arrow on every refine.
+  // Gutter geometry — the left margin of the DAG is a small actor column.
+  // User node at the top (seeded the plan), then one goldfive / user-steer
+  // node per revision > 0, stacked top-to-bottom. Heights chosen so they
+  // never overlap the first-layer task column (which starts at DAG_PAD).
+  const GUTTER_X = 12;
+  const USER_NODE_CY = 16;
+  const USER_NODE = { cx: GUTTER_X, cy: USER_NODE_CY, r: 7 };
+
+  // User → first-task arrow: drawn only on rev 0 (or "Latest" with rev 0
+  // present in history).
   const userGoalSpan = store ? findUserGoalSpan(store) : null;
   const userGoalSummary = userGoalSpan?.name || '';
-  const firstLayerTask = revIdx === 0
-    ? plan.tasks.find((t) => layout.nodeById.get(t.id)?.layer === 0) ?? null
-    : null;
+  // The first layer-0 task in the cumulative plan is the user's seed
+  // target. We always render the user → first-task arrow when a goal
+  // span is present (cumulative view accumulates the first layer too).
+  const firstLayerTask =
+    plan && (plan.revisionIndex ?? 0) === 0
+      ? plan.tasks.find((t) => layout.nodeById.get(t.id)?.layer === 0) ?? null
+      : renderPlan.tasks.find((t) => layout.nodeById.get(t.id)?.layer === 0) ?? null;
+
+  // Compute the per-revision steering events that will arrow to a target
+  // task node. One entry per non-zero revision in the history the user
+  // hasn't scrubbed past.
+  const steeringEvents = buildSteeringEvents(
+    history,
+    supersedes,
+    renderPlan,
+    pinnedRevision,
+    store,
+  );
+
+  // Supersedes edges: old task → new task, dashed + muted. The
+  // supersedes map keys on the old (superseded) task id and points at
+  // the new task id (or "" when the old task was dropped outright).
+  const supersedesEdges: SupersedesEdge[] = [];
+  for (const [oldId, link] of supersedes.entries()) {
+    if (pinnedRevision !== null && link.revision > pinnedRevision) continue;
+    supersedesEdges.push({ oldId, link });
+  }
 
   // Removed-task cards (only when in diff/compare mode). These sit to the right
   // of the DAG so the user can see what the refine dropped without corrupting
@@ -883,37 +1151,137 @@ function DagPane(props: DagProps) {
           </g>
         )}
 
-        {/* steering edges: goldfive gutter → target task. Rendered before
-            task edges so delegation / dependency arrows draw on top, but
-            the dashed goldfive color + the distinct marker keep it
-            readable. Only drawn on non-zero revs with a target. */}
-        {steerTargetTask && (
+        {/* supersedes edges: dashed muted edge from the superseded (old)
+            task node to its replacement. Labeled with the drift kind so
+            the DAG itself communicates "why the plan changed here". */}
+        {supersedesEdges.length > 0 && (
+          <g
+            className="hg-traj__supersedes-edges"
+            data-testid="trajectory-supersedes-edges"
+          >
+            {supersedesEdges.map(({ oldId, link }) => {
+              const from = layout.nodeById.get(oldId);
+              const to = link.newTaskId
+                ? layout.nodeById.get(link.newTaskId)
+                : null;
+              if (!from || !to) return null;
+              const x1 = from.x + from.w;
+              const y1 = from.y + from.h / 2;
+              const x2 = to.x;
+              const y2 = to.y + to.h / 2;
+              const mx = (x1 + x2) / 2;
+              const d = `M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}`;
+              const label = link.kind
+                ? (link.kind.startsWith('user_')
+                    ? `user steer`
+                    : `goldfive: ${link.kind}`)
+                : 'supersedes';
+              return (
+                <g
+                  key={`sup-${oldId}`}
+                  data-testid={`supersedes-edge-${oldId}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSelectSteering({
+                      kind: 'supersedes',
+                      revision: link.revision,
+                      oldTaskId: oldId,
+                      targetTaskId: link.newTaskId || undefined,
+                    });
+                  }}
+                  style={{ cursor: 'pointer' }}
+                >
+                  <path
+                    className="hg-traj__supersedes-edge"
+                    d={d}
+                    fill="none"
+                    stroke="#8d9199"
+                    strokeWidth={1.25}
+                    strokeDasharray="3,3"
+                    opacity={0.6}
+                    markerEnd="url(#traj-arrow)"
+                  />
+                  <text
+                    className="hg-traj__supersedes-label"
+                    x={mx}
+                    y={(y1 + y2) / 2 - 4}
+                    textAnchor="middle"
+                    fontSize={9}
+                    fill="#8d9199"
+                    opacity={0.75}
+                  >
+                    <title>
+                      {`${label}${link.reason ? `\nreason: ${link.reason}` : ''}`}
+                    </title>
+                    {truncate(label, 24)}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        )}
+
+        {/* Per-revision steering arrows: one entry in steeringEvents per
+            PlanRevised in the history. Each arrow originates at a per-rev
+            gutter node on the DAG's left edge and lands on the new /
+            replacement task node with a short tail label naming the target
+            agent. Authored-by-user events use a dashed-purple style; goldfive
+            events use the teal steering style. */}
+        {steeringEvents.length > 0 && (
           <g
             className="hg-traj__steer-edges"
             data-testid="trajectory-steer-edges"
           >
-            {(() => {
-              const targetNode = layout.nodeById.get(steerTargetTask.id);
+            {steeringEvents.map((ev) => {
+              const targetNode = layout.nodeById.get(ev.targetTaskId);
               if (!targetNode) return null;
-              const x1 = GOLDFIVE_NODE.cx + GOLDFIVE_NODE.r;
-              const y1 = GOLDFIVE_NODE.cy;
+              const x1 = ev.gutterCx + 7;
+              const y1 = ev.gutterCy;
               const x2 = targetNode.x;
               const y2 = targetNode.y + targetNode.h / 2;
               const mx = (x1 + x2) / 2;
               const d = `M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}`;
-              const label =
-                steerKind || steerReason || `rev ${plan.revisionIndex ?? 0}`;
+              const stroke = ev.authoredBy === 'user' ? '#d0bcff' : '#80deea';
+              const markerRef = ev.authoredBy === 'user' ? 'traj-user-arrow' : 'traj-steer-arrow';
+              // Label: "<kind> → <agent>" — names the target agent in the
+              // visual itself, as the user explicitly requested.
+              const agentName =
+                store?.agents.get(ev.targetAgentId)?.name ||
+                bareAgentName(ev.targetAgentId) ||
+                ev.targetAgentId ||
+                '(agent)';
+              const label = `${ev.kindLabel} → ${truncate(agentName, 14)}`;
+              const tooltip =
+                (ev.authoredBy === 'user'
+                  ? `user steered ${agentName}`
+                  : `goldfive steered ${agentName}`) +
+                (ev.reason ? `\nreason: ${ev.reason}` : '') +
+                (ev.kind ? `\nkind: ${ev.kind}` : '') +
+                `\nrev: ${ev.revision}`;
               return (
-                <g data-testid={`steer-edge-${steerTargetTask.id}`}>
+                <g
+                  key={`se-${ev.revision}-${ev.targetTaskId}`}
+                  data-testid={`steer-edge-${ev.targetTaskId}`}
+                  data-authored-by={ev.authoredBy}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSelectSteering({
+                      kind: 'revision',
+                      revision: ev.revision,
+                      targetTaskId: ev.targetTaskId,
+                    });
+                  }}
+                  style={{ cursor: 'pointer' }}
+                >
                   <path
                     className="hg-traj__steer-edge"
                     d={d}
                     fill="none"
-                    stroke="#80deea"
-                    strokeWidth={1.5}
-                    strokeDasharray="5,3"
-                    opacity={0.75}
-                    markerEnd="url(#traj-steer-arrow)"
+                    stroke={stroke}
+                    strokeWidth={1.75}
+                    strokeDasharray={ev.authoredBy === 'user' ? '6,3' : '5,3'}
+                    opacity={0.85}
+                    markerEnd={`url(#${markerRef})`}
                   />
                   <text
                     className="hg-traj__steer-label"
@@ -921,39 +1289,75 @@ function DagPane(props: DagProps) {
                     y={(y1 + y2) / 2 - 4}
                     textAnchor="middle"
                     fontSize={10}
-                    fill="#80deea"
-                    opacity={0.9}
+                    fill={stroke}
+                    opacity={0.95}
                   >
-                    <title>
-                      {`goldfive steered ${steerTargetTask.assigneeAgentId || '(agent)'}` +
-                        (steerReason ? `\nreason: ${steerReason}` : '') +
-                        (steerKind ? `\nkind: ${steerKind}` : '')}
-                    </title>
-                    {truncate(label, 28)}
+                    <title>{tooltip}</title>
+                    {truncate(label, 32)}
                   </text>
                 </g>
               );
-            })()}
+            })}
           </g>
         )}
 
-        {/* goldfive gutter node: the origin of the steering arrow, only
-            rendered on revs that have a target to arrow to. */}
+        {/* Per-revision gutter nodes — one teal "g5" circle (or purple "u")
+            per steering event, stacked along the left edge. Also render
+            a single legacy goldfive gutter node for the pre-history path
+            so the existing trajectory-goldfive-gutter testid keeps working. */}
+        {steeringEvents.length > 0 && (
+          <g
+            className="hg-traj__gutter-stack"
+            data-testid="trajectory-gutter-stack"
+          >
+            {steeringEvents.map((ev) => (
+              <g
+                key={`gutter-${ev.revision}`}
+                className="hg-traj__gutter-node"
+                data-testid={`gutter-node-${ev.revision}`}
+                data-authored-by={ev.authoredBy}
+              >
+                <circle
+                  cx={ev.gutterCx}
+                  cy={ev.gutterCy}
+                  r={7}
+                  fill={ev.authoredBy === 'user' ? '#d0bcff' : '#80deea'}
+                  opacity={0.9}
+                />
+                <text
+                  x={ev.gutterCx}
+                  y={ev.gutterCy + 3}
+                  textAnchor="middle"
+                  fontSize={9}
+                  fill="#0b0d12"
+                  fontWeight={700}
+                >
+                  {ev.authoredBy === 'user' ? 'u' : 'g5'}
+                </text>
+                <title>
+                  {`rev ${ev.revision}: ${ev.authoredBy === 'user' ? 'user steer' : 'goldfive steer'}`}
+                </title>
+              </g>
+            ))}
+          </g>
+        )}
+
+        {/* Legacy single-gutter compatibility (preserves #196 testid). */}
         {steerTargetTask && (
           <g
             className="hg-traj__goldfive-gutter"
             data-testid="trajectory-goldfive-gutter"
           >
             <circle
-              cx={GOLDFIVE_NODE.cx}
-              cy={GOLDFIVE_NODE.cy}
-              r={GOLDFIVE_NODE.r}
+              cx={GUTTER_X}
+              cy={layout.height / 2}
+              r={7}
               fill="#80deea"
               opacity={0.85}
             />
             <text
-              x={GOLDFIVE_NODE.cx}
-              y={GOLDFIVE_NODE.cy + 3}
+              x={GUTTER_X}
+              y={layout.height / 2 + 3}
               textAnchor="middle"
               fontSize={9}
               fill="#0b0d12"
@@ -1009,6 +1413,12 @@ function DagPane(props: DagProps) {
               if (d.severity === 'warning' && worst !== 'critical') worst = 'warning';
               else if (!worst) worst = d.severity;
             }
+            // harmonograf#197: generation metadata from the cumulative plan.
+            // Tasks the latest rev dropped render at reduced opacity with a
+            // muted border; every node carries a REV-N corner badge.
+            const meta = taskMeta.get(t.id);
+            const isSuperseded = meta?.isSuperseded ?? false;
+            const introducedIn = meta?.introducedInRevision ?? 0;
             return (
               <g
                 key={t.id}
@@ -1016,6 +1426,9 @@ function DagPane(props: DagProps) {
                 data-selected={isSelected}
                 data-added={isAdded}
                 data-modified={isMod}
+                data-superseded={isSuperseded || undefined}
+                data-generation={introducedIn}
+                opacity={isSuperseded ? 0.4 : 1}
                 transform={`translate(${n.x}, ${n.y})`}
                 onClick={() => onSelectTask(t.id)}
                 data-testid={`task-node-${t.id}`}
@@ -1028,6 +1441,8 @@ function DagPane(props: DagProps) {
                   height={n.h}
                   rx={8}
                   ry={8}
+                  stroke={isSuperseded ? '#6b6e76' : undefined}
+                  strokeDasharray={isSuperseded ? '4,2' : undefined}
                 />
                 <rect
                   className="hg-traj__node-bar"
@@ -1042,6 +1457,36 @@ function DagPane(props: DagProps) {
                 <text className="hg-traj__node-title" x={16} y={22}>
                   {truncate(t.title || t.id, 22)}
                 </text>
+                {/* Generation badge: small text in top-right corner. Muted
+                    tint for rev 0, stronger for rev 1, 2, 3+. Shifted
+                    left when a drift pill already occupies the corner. */}
+                <g
+                  className="hg-traj__node-gen"
+                  transform={`translate(${drifts.length > 0 ? n.w - 44 : n.w - 24}, 10)`}
+                  data-testid={`task-node-${t.id}-rev-badge`}
+                  data-rev={introducedIn}
+                >
+                  <rect
+                    x={-2}
+                    y={-9}
+                    width={24}
+                    height={14}
+                    rx={3}
+                    ry={3}
+                    fill={genBadgeFill(introducedIn)}
+                    opacity={0.85}
+                  />
+                  <text
+                    x={10}
+                    y={1}
+                    textAnchor="middle"
+                    fontSize={9}
+                    fontWeight={600}
+                    fill="#0b0d12"
+                  >
+                    {`R${introducedIn}`}
+                  </text>
+                </g>
                 <text className="hg-traj__node-sub" x={16} y={42}>
                   {t.status.toLowerCase()}
                   {t.assigneeAgentId
@@ -1117,7 +1562,7 @@ function DagPane(props: DagProps) {
           </ul>
         </aside>
       )}
-      <TaskDeltaList plan={plan} />
+      <TaskDeltaList plan={renderPlan} />
     </div>
   );
 }

--- a/frontend/src/components/shell/views/views.css
+++ b/frontend/src/components/shell/views/views.css
@@ -766,3 +766,147 @@ a.hg-settings__value:hover {
   text-decoration: underline;
   padding: 0;
 }
+
+/* harmonograf#197: Revision scrubber */
+
+.hg-traj__scrubber {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  margin-bottom: 8px;
+  overflow-x: auto;
+  background: var(--md-sys-color-surface-container-low, #161923);
+  border: 1px solid var(--md-sys-color-outline-variant, #2a2f3a);
+  border-radius: 6px;
+}
+
+.hg-traj__scrubber-label {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.6;
+  padding-right: 4px;
+}
+
+.hg-traj__scrubber-notch,
+.hg-traj__scrubber-latest {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--md-sys-color-on-surface-variant, #c7c9d1);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.hg-traj__scrubber-notch[aria-selected='true'],
+.hg-traj__scrubber-latest[aria-selected='true'] {
+  border-color: var(--md-sys-color-primary, #aac7ff);
+  background: rgba(154, 195, 255, 0.12);
+}
+
+.hg-traj__scrubber-notch[data-authorship='user'] .hg-traj__scrubber-tick { background: #d0bcff; }
+.hg-traj__scrubber-notch[data-authorship='goldfive'] .hg-traj__scrubber-tick { background: #80deea; }
+.hg-traj__scrubber-notch[data-authorship='initial'] .hg-traj__scrubber-tick { background: #5a5e68; }
+
+.hg-traj__scrubber-tick {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.hg-traj__scrubber-num { font-weight: 600; letter-spacing: 0.04em; }
+.hg-traj__scrubber-kind { opacity: 0.7; font-size: 10px; }
+.hg-traj__scrubber-latest { margin-left: auto; }
+
+/* harmonograf#197: Steering detail side panel */
+
+.hg-traj__steering-panel {
+  flex: 1;
+  background: var(--md-sys-color-surface-container-low, #161923);
+  border: 1px solid var(--md-sys-color-outline-variant, #2a2f3a);
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 13px;
+  overflow-y: auto;
+}
+
+.hg-traj__steering-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.hg-traj__steering-panel-kicker {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+  display: block;
+}
+.hg-traj__steering-panel-kicker[data-authored-by='user'] { color: #d0bcff; }
+.hg-traj__steering-panel-kicker[data-authored-by='goldfive'] { color: #80deea; }
+
+.hg-traj__steering-panel-title {
+  margin: 2px 0 0;
+  font-size: 14px;
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.hg-traj__steering-panel-close {
+  background: transparent;
+  border: 0;
+  color: var(--md-sys-color-on-surface-variant, #c7c9d1);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.hg-traj__steering-panel-section h4 {
+  margin: 0 0 4px;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.hg-traj__steering-panel-body { white-space: pre-wrap; }
+
+.hg-traj__steering-panel-preview {
+  font-family: var(--hg-mono, ui-monospace, Menlo, monospace);
+  font-size: 11px;
+  padding: 4px 6px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 3px;
+}
+
+.hg-traj__steering-panel-foot {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.hg-traj__steering-panel-jump {
+  font-size: 11px;
+  padding: 5px 10px;
+  background: rgba(154, 195, 255, 0.1);
+  color: var(--md-sys-color-primary, #aac7ff);
+  border: 1px solid var(--md-sys-color-outline-variant, #2a2f3a);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.hg-traj__steering-panel-jump:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.hg-traj__supersedes-edge { pointer-events: auto; }
+.hg-traj__supersedes-label { pointer-events: auto; cursor: pointer; }

--- a/frontend/src/state/planHistoryHooks.ts
+++ b/frontend/src/state/planHistoryHooks.ts
@@ -1,111 +1,124 @@
-// React selector hooks over PlanHistoryRegistry.
+// Plan-history selector hooks exposed to the Trajectory view + Task/Plan
+// panel. Signatures are frozen per the sibling `/tmp/harmonograf-plan-state`
+// design doc so that downstream renderers can be built in parallel.
 //
-// These are the stable API the Task/Plan panel (harmonograf-plan-panel)
-// and the Trajectory view (harmonograf-trajectory) build against. The
-// signatures are frozen by the planning doc; any change here must be
-// coordinated with both renderer agents.
+//   useCumulativePlan(sessionId, planId)  → CumulativePlan | null
+//   useSupersedesMap(sessionId, planId)   → Map<oldTaskId, SupersessionLink>
+//   usePlanHistory(sessionId, planId)     → readonly PlanRevisionRecord[]
 //
-// All hooks:
-//   - Resolve the SessionStore via `getSessionStore(sessionId)`.
-//   - Subscribe to `store.planHistory` for re-render on every append /
-//     clear.
-//   - Return `null` / empty when data isn't loaded yet. Renderers
-//     branch on null to show a skeleton / placeholder.
+// Implementation is dual-sourced:
 //
-// The hooks are pure projections over the registry — no caching, no
-// memoized data structures on their own. Renderers that need
-// referential stability over expensive derived data should wrap the
-// return values in their own `useMemo`.
+//   1. Authoritative: `SessionStore.planHistory` — fed by the upcoming
+//      `GetSessionPlanHistory` RPC + live plan_submitted / plan_revised
+//      stream. When the RPC lands, these hooks see it automatically.
+//
+//   2. Bootstrap: when the registry is empty for `planId` (the pre-RPC
+//      world), seed it from `SessionStore.tasks.allRevsForPlan(planId)`.
+//      TaskRegistry already keeps the prior snapshots in a rolling list,
+//      so the Trajectory view can render evolution + steering today
+//      without waiting on the plan-history RPC to merge. The bootstrap is
+//      idempotent on (plan_id, revision), so it harmlessly no-ops once
+//      the real producer starts emitting.
 
 import { useEffect, useState } from 'react';
-import type { TaskPlan } from '../gantt/types';
-import { getSessionStore } from '../rpc/hooks';
+import type { SessionStore } from '../gantt/index';
 import type {
   CumulativePlan,
   PlanRevisionRecord,
   SupersessionLink,
 } from './planHistoryStore';
+import { useSessionWatch } from '../rpc/hooks';
 
-// Shared tick/subscribe shim. Mirrors the pattern used elsewhere in
-// the app (useAgentLive, CurrentTaskStrip): force a re-render whenever
-// the registry emits, and re-read from the live store on every render.
-function usePlanHistoryTick(sessionId: string | null): void {
-  const [, setTick] = useState(0);
+// Bridge TaskRegistry snapshots into PlanHistoryRegistry. Idempotent on
+// (plan_id, revision) — safe to re-run on every render / subscribe tick.
+// Pulls rev / kind / reason / triggerEventId off each TaskPlan (populated
+// by the goldfive event ingest at rpc/goldfiveEvent.ts); the triggering
+// drift's detail is used as the reason when the plan itself has none.
+function bootstrapFromTasks(store: SessionStore, planId: string): void {
+  const revs = store.tasks.allRevsForPlan(planId);
+  if (revs.length === 0) return;
+  for (const plan of revs) {
+    const revision = plan.revisionIndex ?? 0;
+    const reason = plan.revisionReason ?? '';
+    const kind = plan.revisionKind ?? '';
+    const triggerEventId = plan.triggerEventId ?? '';
+    store.planHistory.append({
+      revision,
+      plan,
+      reason,
+      kind,
+      triggerEventId,
+      emittedAtMs: plan.createdAtMs,
+    });
+  }
+}
+
+// Subscribe to both planHistory + tasks so we re-render on either
+// (a) direct RPC/live append, or (b) a new TaskRegistry rev (which the
+// bootstrap below reflects into planHistory on the next read).
+function usePlanHistoryTick(store: SessionStore | null): number {
+  const [tick, setTick] = useState(0);
   useEffect(() => {
-    if (!sessionId) return;
-    const store = getSessionStore(sessionId);
     if (!store) return;
-    return store.planHistory.subscribe(() => setTick((t) => t + 1));
-  }, [sessionId]);
+    const un1 = store.planHistory.subscribe(() => setTick((n) => n + 1));
+    const un2 = store.tasks.subscribe(() => setTick((n) => n + 1));
+    return () => {
+      un1();
+      un2();
+    };
+  }, [store]);
+  return tick;
 }
 
 /**
- * All revisions for a plan, sorted by revision number ascending.
- * Returns `[]` when the session isn't loaded or the plan id is unknown.
- */
-export function usePlanHistory(
-  sessionId: string | null,
-  planId: string | null,
-): PlanRevisionRecord[] {
-  usePlanHistoryTick(sessionId);
-  if (!sessionId || !planId) return EMPTY_RECORDS;
-  const store = getSessionStore(sessionId);
-  if (!store) return EMPTY_RECORDS;
-  return store.planHistory.historyFor(planId);
-}
-
-/**
- * The Plan snapshot at an exact revision. Returns `null` if the
- * session isn't loaded, the plan id is unknown, or the revision
- * hasn't been recorded.
- */
-export function usePlanAtRevision(
-  sessionId: string | null,
-  planId: string | null,
-  revision: number,
-): TaskPlan | null {
-  usePlanHistoryTick(sessionId);
-  if (!sessionId || !planId) return null;
-  const store = getSessionStore(sessionId);
-  if (!store) return null;
-  return store.planHistory.planAtRevision(planId, revision);
-}
-
-/**
- * Cumulative plan (union of tasks across all revisions) with per-task
- * revision metadata. Returns `null` when no revisions have been seen
- * yet. The returned object is a fresh reference on every render (the
- * registry rebuilds it on demand) — memoize at the call site if
- * reference stability matters.
+ * Latest CumulativePlan for (sessionId, planId), or null when the plan
+ * is unknown. Tasks the latest revision dropped are retained in the
+ * returned plan with `taskRevisionMeta.isSuperseded = true` so the DAG
+ * renderer can keep them as historical nodes.
  */
 export function useCumulativePlan(
   sessionId: string | null,
   planId: string | null,
 ): CumulativePlan | null {
-  usePlanHistoryTick(sessionId);
-  if (!sessionId || !planId) return null;
-  const store = getSessionStore(sessionId);
-  if (!store) return null;
+  const watch = useSessionWatch(sessionId);
+  const store = sessionId ? watch.store : null;
+  usePlanHistoryTick(store);
+  if (!store || !planId) return null;
+  bootstrapFromTasks(store, planId);
   return store.planHistory.cumulativePlan(planId);
 }
 
 /**
- * Map of oldTaskId → SupersessionLink. Empty map when no revisions
- * have replaced tasks yet (initial plan, or revisions that only edit
- * existing tasks in place).
+ * Old → new replacement links, keyed by the old (superseded) task id.
+ * Empty map when fewer than two revisions exist, or when no tasks were
+ * dropped across the revision chain.
  */
 export function useSupersedesMap(
   sessionId: string | null,
   planId: string | null,
 ): Map<string, SupersessionLink> {
-  usePlanHistoryTick(sessionId);
-  if (!sessionId || !planId) return EMPTY_LINKS;
-  const store = getSessionStore(sessionId);
-  if (!store) return EMPTY_LINKS;
+  const watch = useSessionWatch(sessionId);
+  const store = sessionId ? watch.store : null;
+  usePlanHistoryTick(store);
+  if (!store || !planId) return new Map();
+  bootstrapFromTasks(store, planId);
   return store.planHistory.supersedesMap(planId);
 }
 
-const EMPTY_RECORDS: PlanRevisionRecord[] = Object.freeze(
-  [],
-) as unknown as PlanRevisionRecord[];
-const EMPTY_LINKS: Map<string, SupersessionLink> = new Map();
+/**
+ * Ordered list of PlanRevisionRecords for (sessionId, planId), oldest
+ * first. Empty array when the plan is unknown.
+ */
+export function usePlanHistory(
+  sessionId: string | null,
+  planId: string | null,
+): readonly PlanRevisionRecord[] {
+  const watch = useSessionWatch(sessionId);
+  const store = sessionId ? watch.store : null;
+  usePlanHistoryTick(store);
+  if (!store || !planId) return EMPTY_HISTORY;
+  bootstrapFromTasks(store, planId);
+  return store.planHistory.historyFor(planId);
+}
+
+const EMPTY_HISTORY: readonly PlanRevisionRecord[] = Object.freeze([]);

--- a/frontend/src/state/planHistoryStore.ts
+++ b/frontend/src/state/planHistoryStore.ts
@@ -93,7 +93,7 @@ function taskFingerprint(t: Task): string {
     t.status,
     t.predictedStartMs,
     t.predictedDurationMs,
-  ].join('');
+  ].join('');
 }
 
 /**
@@ -124,13 +124,8 @@ export class PlanHistoryRegistry {
       arr = [];
       this.revisions.set(planId, arr);
     }
-    // Idempotency on (plan_id, revision): skip exact-rev duplicates.
     if (arr.some((r) => r.revision === record.revision)) return;
-    // Deep-clone the Plan so later mutations on the live TaskRegistry
-    // don't leak into the historical snapshot. All other fields on
-    // PlanRevisionRecord are primitives.
     const cloned: PlanRevisionRecord = { ...record, plan: clonePlan(record.plan) };
-    // Linear insert keeping the array sorted by revision number.
     let i = arr.length;
     while (i > 0 && arr[i - 1].revision > cloned.revision) i--;
     if (i === arr.length) arr.push(cloned);
@@ -138,19 +133,10 @@ export class PlanHistoryRegistry {
     this.emit();
   }
 
-  /**
-   * All revisions for a plan, sorted by revision number ascending.
-   * Returns an empty array for unknown plan ids. The returned array is
-   * a stable internal reference — callers must not mutate it.
-   */
   historyFor(planId: string): PlanRevisionRecord[] {
     return this.revisions.get(planId) ?? EMPTY_REVISIONS;
   }
 
-  /**
-   * The Plan snapshot at an exact revision. Returns null when either
-   * the plan id is unknown or no record exists for that revision.
-   */
   planAtRevision(planId: string, revision: number): TaskPlan | null {
     const arr = this.revisions.get(planId);
     if (!arr) return null;
@@ -158,14 +144,6 @@ export class PlanHistoryRegistry {
     return hit ? hit.plan : null;
   }
 
-  /**
-   * The cumulative plan: union of tasks across all revisions, most-recent
-   * definition wins per id. Retains tasks that have been superseded
-   * (marked `isSuperseded=true`) so the renderer can show them as
-   * historical nodes. Edges are taken from the latest revision.
-   *
-   * Returns null when no revisions have been recorded for the plan id.
-   */
   cumulativePlan(planId: string): CumulativePlan | null {
     const arr = this.revisions.get(planId);
     if (!arr || arr.length === 0) return null;
@@ -187,19 +165,13 @@ export class PlanHistoryRegistry {
           existingMeta.lastModifiedInRevision = rev.revision;
         }
         lastFingerprint.set(task.id, fp);
-        // Most-recent definition wins (tasks mutate status across revs).
         unionById.set(task.id, { ...task });
       }
     }
-    // Mark tasks that no longer appear in the latest revision.
     const latestIds = new Set(latest.tasks.map((t) => t.id));
     for (const [id, m] of meta) {
       if (!latestIds.has(id)) m.isSuperseded = true;
     }
-    // Stable output ordering: latest revision's tasks first (preserving
-    // planner-supplied order), then any superseded tasks in the order
-    // they were first seen. This keeps the renderer's primary DAG stable
-    // frame-to-frame and appends historical nodes at the tail.
     const tasks: Task[] = [];
     const emitted = new Set<string>();
     for (const t of latest.tasks) {
@@ -212,9 +184,6 @@ export class PlanHistoryRegistry {
     for (const [id, t] of unionById) {
       if (!emitted.has(id)) tasks.push(t);
     }
-    // Edge union: a task-level cumulative view should preserve edges
-    // that were ever present so the renderer can draw historical
-    // dependencies. Dedup by "from->to" and attach the latest occurrence.
     const edgeKeys = new Set<string>();
     const edges: TaskEdge[] = [];
     for (const rev of arr) {
@@ -233,23 +202,10 @@ export class PlanHistoryRegistry {
     };
   }
 
-  /**
-   * Map of oldTaskId → SupersessionLink for every task that was
-   * superseded or dropped across the revision chain.
-   *
-   * Interpretation: walking rev N → rev N+1, every task id that was in
-   * N but not in N+1 is considered superseded by rev N+1. When rev N+1
-   * introduces exactly one new task id (not present in any earlier
-   * rev), that task id is paired as the `newTaskId`. Otherwise the old
-   * task is considered dropped and `newTaskId` stays empty so the
-   * renderer can draw a dangling "retired" marker.
-   */
   supersedesMap(planId: string): Map<string, SupersessionLink> {
     const out = new Map<string, SupersessionLink>();
     const arr = this.revisions.get(planId);
     if (!arr || arr.length < 2) return out;
-    // Track every task id ever seen, so we can distinguish genuinely new
-    // tasks (candidates for "newTaskId" pairing) from re-surfaced ids.
     const everSeen = new Set<string>();
     for (const t of arr[0].plan.tasks) everSeen.add(t.id);
     for (let i = 1; i < arr.length; i++) {
@@ -264,8 +220,6 @@ export class PlanHistoryRegistry {
       for (const t of next.tasks) {
         if (!everSeen.has(t.id)) trulyNew.push(t.id);
       }
-      // Pair one-for-one when possible; if counts mismatch, pair prefix
-      // and leave the remainder as dropped-without-successor.
       const pairs = Math.min(dropped.length, trulyNew.length);
       const rec = arr[i];
       for (let k = 0; k < dropped.length; k++) {
@@ -283,22 +237,16 @@ export class PlanHistoryRegistry {
     return out;
   }
 
-  /**
-   * List every plan id known to the registry. Order is insertion (first
-   * append wins); callers sort by `createdAtMs` if needed.
-   */
   planIds(): string[] {
     return Array.from(this.revisions.keys());
   }
 
-  /** Wipe everything. Called from SessionStore.clear(). */
   clear(): void {
     if (this.revisions.size === 0) return;
     this.revisions.clear();
     this.emit();
   }
 
-  /** Subscribe to any change. Returns an unsubscribe fn. */
   subscribe(fn: () => void): () => void {
     this.listeners.add(fn);
     return () => this.listeners.delete(fn);


### PR DESCRIPTION
Closes #166.

## Summary

- Turns the Trajectory DAG into an evolving artifact: superseded tasks stay visible as dimmed historical nodes (40% opacity, dashed muted border), REV-N generation badges stamp every task, and supersedes edges draw old → new with a drift-kind annotation.
- Draws one goldfive (or user) steering arrow **per PlanRevised**, from a per-revision gutter node on the DAG's left edge TO the replacement task. Arrow labels NAME THE TARGET AGENT on the DAG itself (`OFF_TOPIC → research_agent`), which is the specific request the user surfaced ("arrows indicating which agent is being steered"). User-authored steers render in dashed purple with a "u" gutter glyph; goldfive-authored in dashed teal with "g5".
- Adds a keyboard-accessible `RevisionScrubber` above the DAG and a `SteeringDetailPanel` side panel (Trigger / Steering / Target) that opens on arrow / supersedes-edge click.
- Consumes the frozen `useCumulativePlan` / `useSupersedesMap` / `usePlanHistory` hook signatures from the sibling `frontend-plan-history-state` work; bootstraps from `TaskRegistry.allRevsForPlan()` pre-RPC so the view works against today's data.

## Prerequisites / data sources

This PR consumes data from three parallel streams. Where they haven't landed yet, the view degrades gracefully to bare `PlanRevised.revision_reason`:

- #158 / #160 — `GetSessionPlanHistory` RPC (server plan history).
- #161 / #162 — `SessionStore.planHistory` + selector hooks.
- The goldfive-render + sink-stamp cluster stamping `goldfive.decision_summary`, `goldfive.input_preview`, `goldfive.output_preview`, `refine.target_agent_id` on refine spans.

## Files

- `frontend/src/components/shell/views/TrajectoryView.tsx` — cumulative-plan rendering; per-revision steering arrows; supersedes-edge overlay; panel wiring.
- `frontend/src/components/shell/views/RevisionScrubber.tsx` — new reusable scrubber (`useCumulativePlan` consumers can import it).
- `frontend/src/components/shell/views/SteeringDetailPanel.tsx` — new side panel with Trigger / Steering / Target sections + Jump-to-Gantt deep-link.
- `frontend/src/state/planHistoryStore.ts` — frozen copy of the sibling's `PlanHistoryRegistry` (forward-compatible: sibling RPC / live stream will feed it when it merges).
- `frontend/src/state/planHistoryHooks.ts` — `useCumulativePlan` / `useSupersedesMap` / `usePlanHistory` hooks with a `TaskRegistry.allRevsForPlan` bootstrap so the view is data-backed today.
- `frontend/src/gantt/index.ts` — wires `SessionStore.planHistory`.
- `frontend/src/components/shell/views/views.css` — styles for scrubber + detail panel.
- `frontend/src/__tests__/components/TrajectoryView.evolution.test.tsx` — 12 new specs.

## Test plan

- [x] `pnpm test --run` — 376 / 376 passing (364 baseline + 12 new).
- [x] `pnpm tsc -b` — clean.
- [x] `pnpm lint` — 0 errors, 1 pre-existing warning in `GanttView.tsx` (unmodified).
- [ ] Visual smoke on a real session with at least 2 revisions (rev 0 + an OFF_TOPIC refine): confirm the arrow label names the target agent, the scrubber hides rev-1 tasks on click, the detail panel opens with Trigger / Steering / Target populated.
- [ ] Visual smoke on a session with a `user_steer` annotation: confirm purple dashed arrow + "u" gutter glyph.

## Screenshot description

**Before** (tier 0 / current `main`): single-revision DAG, one gold gutter node at mid-height per current rev, one teal arrow to the refine's target task. Pre-refine tasks disappear. The scrubber strip at the top shows `rev chips` (small pips) but is not keyboard-accessible and doesn't filter the DAG.

**After** (this PR): DAG shows every task across every revision. Superseded nodes render at 40% opacity with a dashed muted border so the eye registers them as historical; each node has a small `R0` / `R1` / `R2+` badge in the corner. A stack of gutter glyphs (one per revision) sits along the DAG's left edge — teal `g5` circles for goldfive refines, purple `u` circles for user steers. Each gutter glyph emits a dashed arrow to its target task node. Arrow labels read `OFF_TOPIC → research_agent`, `user steer → researcher`, etc. — the target agent is named on the DAG itself. Dashed grey supersedes edges run from old-task → new-task with a `goldfive: off_topic` annotation. A horizontal scrubber sits above the ribbon with one notch per revision and a `Latest` sentinel on the right — clicking a notch scrubs the DAG down to that revision. Clicking any steering arrow replaces the right-hand detail pane with a side panel: Trigger (drift kind + reason + optional input preview), Steering (decision summary + optional output preview), Target (agent name + task title + supersedes chain), and a "Jump to drift in Gantt" button.

## Target agent visibility (explicit user ask)

The target agent's name appears in THREE independent places, so the operator sees it without clicking:

1. The arrow's text label on the DAG: `OFF_TOPIC → research_agent`.
2. The gutter node's tooltip: `rev 1: goldfive steer`.
3. The task node itself — the arrowhead lands ON the target task's node, which already carries the assignee agent name in its subtitle row.

On click, the SteeringDetailPanel's Target section surfaces the full agent display name + the target task title, asserted in tests.