### PR TITLE
feat(ui): verdict banner + input/verdict sections in judge-invocation popover + drawer

### DIFF
--- a/frontend/src/__tests__/components/JudgeInvocationDetail.test.tsx
+++ b/frontend/src/__tests__/components/JudgeInvocationDetail.test.tsx
@@ -20,13 +20,19 @@ function detail(over: Partial<JudgeDetail> = {}): JudgeDetail {
     model: 'claude-haiku-4',
     elapsedMs: 248,
     subjectAgentId: 'client:agent-a',
+    targetAgentId: 'client:agent-a',
     taskId: 't1',
     verdictBucket: 'on_task',
+    verdictTone: 'on_task',
     onTask: true,
     severity: '',
     reason: '',
     reasoningInput: '',
     rawResponse: '',
+    parseSuccessful: true,
+    inputPreview: '',
+    outputPreview: '',
+    decisionSummary: '',
     steeredPlan: null,
     steeringSummary: '',
     taskSummaries: [],
@@ -133,7 +139,10 @@ describe('<JudgeInvocationDetail />', () => {
     expect(screen.getByText('haiku')).toBeTruthy();
   });
 
-  it('collapses the reasoning-input section by default and expands on click', () => {
+  it('expands the reasoning-input section by default and collapses on click', () => {
+    // Drawer variant: reasoning-input is the primary context, rendered
+    // expanded by default so the operator doesn't have to click to see
+    // what the judge was evaluating.
     render(
       <JudgeInvocationDetail
         detail={detail({
@@ -143,29 +152,32 @@ describe('<JudgeInvocationDetail />', () => {
       />,
     );
     const reasoning = screen.getByTestId('judge-detail-reasoning');
-    expect(reasoning.getAttribute('data-open')).toBe('false');
-    expect(screen.queryByTestId('judge-detail-reasoning-body')).toBeNull();
+    expect(reasoning.getAttribute('data-open')).toBe('true');
+    expect(screen.getByTestId('judge-detail-reasoning-body').textContent)
+      .toContain('rank them by size');
     fireEvent.click(screen.getByTestId('judge-detail-reasoning-toggle'));
     expect(
       screen.getByTestId('judge-detail-reasoning').getAttribute('data-open'),
-    ).toBe('true');
-    expect(screen.getByTestId('judge-detail-reasoning-body').textContent)
-      .toContain('rank them by size');
+    ).toBe('false');
+    expect(screen.queryByTestId('judge-detail-reasoning-body')).toBeNull();
   });
 
-  it('collapses the raw-response section by default and expands on click', () => {
+  it('expands the raw-response section by default and collapses on click', () => {
+    // Drawer variant: raw-response is expanded by default so operators
+    // diagnosing a malformed verdict see the LLM's output without extra
+    // clicks.
     render(
       <JudgeInvocationDetail
         detail={detail({ rawResponse: '{"on_task": false, "severity": "warning"}' })}
       />,
     );
     const raw = screen.getByTestId('judge-detail-raw');
-    expect(raw.getAttribute('data-open')).toBe('false');
-    expect(screen.queryByTestId('judge-detail-raw-body')).toBeNull();
-    fireEvent.click(screen.getByTestId('judge-detail-raw-toggle'));
+    expect(raw.getAttribute('data-open')).toBe('true');
     expect(screen.getByTestId('judge-detail-raw-body').textContent).toContain(
       '"severity": "warning"',
     );
+    fireEvent.click(screen.getByTestId('judge-detail-raw-toggle'));
+    expect(screen.queryByTestId('judge-detail-raw-body')).toBeNull();
   });
 
   it('wires the copy-to-clipboard button', () => {
@@ -249,7 +261,7 @@ describe('<JudgeInvocationDetail />', () => {
       />,
     );
     const link = screen.getByTestId('judge-detail-steering-link');
-    expect(link.textContent).toMatch(/refined plan/i);
+    expect(link.textContent).toMatch(/refined the plan/i);
     expect(link.textContent).toMatch(/r3/);
     fireEvent.click(link);
     expect(onOpenSteering).toHaveBeenCalledWith('plan-x', 3);
@@ -257,5 +269,433 @@ describe('<JudgeInvocationDetail />', () => {
       .toContain('verify widget count');
     expect(screen.getByTestId('judge-detail-steering-tasks').textContent)
       .toContain('cancelled: old widget step');
+  });
+
+  // -----------------------------------------------------------------
+  // Drawer variant — Section A / B / C coverage.
+  // -----------------------------------------------------------------
+
+  describe('drawer variant — Section A (what was being judged)', () => {
+    it('renders the reasoning_input text in full (no truncation)', () => {
+      const long =
+        'Step 1 — search widgets. Step 2 — filter by size. '.repeat(40);
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail({ reasoningInput: long })}
+        />,
+      );
+      const body = screen.getByTestId('judge-detail-reasoning-body');
+      expect(body.textContent).toBe(long);
+    });
+
+    it('renders taskTitle + taskDescription when supplied', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail()}
+          taskTitle="Plan weekend trip"
+          taskDescription="Draft a 3-day itinerary for Big Sur."
+        />,
+      );
+      const card = screen.getByTestId('judge-drawer-task-context');
+      expect(card.textContent).toContain('Plan weekend trip');
+      expect(card.textContent).toContain('Big Sur');
+    });
+
+    it('renders goals as a bulleted list when goals are present', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail()}
+          goals={['Book lodging', 'Plan hikes']}
+        />,
+      );
+      const goalsBlock = screen.getByTestId('judge-drawer-goals');
+      expect(goalsBlock).toBeTruthy();
+      const items = screen.getAllByTestId('judge-drawer-goal');
+      expect(items.length).toBe(2);
+      expect(items[0].textContent).toContain('Book lodging');
+      expect(items[1].textContent).toContain('Plan hikes');
+    });
+
+    it('omits the goals section when no goals are supplied', () => {
+      render(
+        <JudgeInvocationDetail variant="drawer" detail={detail()} />,
+      );
+      expect(screen.queryByTestId('judge-drawer-goals')).toBeNull();
+    });
+
+    it('omits the goals section when all goals are empty strings', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail()}
+          goals={['', '   ']}
+        />,
+      );
+      expect(screen.queryByTestId('judge-drawer-goals')).toBeNull();
+    });
+
+    it('falls back to "Reasoning input not recorded" when judge.reasoning_input is empty', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail({ reasoningInput: '' })}
+        />,
+      );
+      expect(screen.getByTestId('judge-detail-reasoning-empty').textContent)
+        .toMatch(/not recorded/i);
+    });
+
+    it('falls back to "Unknown agent" when subjectAgentId is empty', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail({ subjectAgentId: '', targetAgentId: '' })}
+        />,
+      );
+      expect(screen.getByTestId('judge-detail-agent').textContent)
+        .toMatch(/Unknown agent/i);
+    });
+  });
+
+  describe('drawer variant — Section B (what the judgement is)', () => {
+    it('renders the raw response in full when rawResponse is set', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail({
+            verdictBucket: 'off_task',
+            verdictTone: 'off_task_warning',
+            severity: 'warning',
+            reason: 'Drifting toward unrelated topic.',
+            rawResponse: '{"on_task": false, "severity": "warning"}',
+          })}
+        />,
+      );
+      expect(screen.getByTestId('judge-detail-raw-body').textContent).toBe(
+        '{"on_task": false, "severity": "warning"}',
+      );
+    });
+
+    it('falls back to "Raw response not recorded" when rawResponse is empty', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail({
+            verdictBucket: 'off_task',
+            verdictTone: 'off_task_warning',
+            severity: 'warning',
+            reason: 'whoops',
+          })}
+        />,
+      );
+      expect(screen.getByTestId('judge-detail-raw-empty').textContent)
+        .toMatch(/not recorded/i);
+    });
+
+    it('renders parsed on_task + severity when parseSuccessful=true', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail({
+            verdictBucket: 'off_task',
+            verdictTone: 'off_task_info',
+            parseSuccessful: true,
+            onTask: false,
+            severity: 'info',
+          })}
+        />,
+      );
+      expect(
+        screen.getByTestId('judge-drawer-parsed-on-task').textContent,
+      ).toBe('false');
+      expect(
+        screen.getByTestId('judge-drawer-parsed-severity').textContent,
+      ).toBe('info');
+      const diag = screen.getByTestId('judge-drawer-parse-diagnostic');
+      expect(diag.getAttribute('data-ok')).toBe('true');
+      expect(diag.textContent).toMatch(/successfully parsed/i);
+    });
+
+    it('shows the malformed-response diagnostic when parseSuccessful=false', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail({
+            verdictBucket: 'no_verdict',
+            verdictTone: 'no_verdict',
+            parseSuccessful: false,
+            onTask: false,
+            severity: '',
+            rawResponse: 'not json',
+          })}
+        />,
+      );
+      const diag = screen.getByTestId('judge-drawer-parse-diagnostic');
+      expect(diag.getAttribute('data-ok')).toBe('false');
+      expect(diag.textContent).toMatch(/malformed/i);
+      // on_task dash when parse failed.
+      expect(
+        screen.getByTestId('judge-drawer-parsed-on-task').textContent,
+      ).toBe('—');
+    });
+  });
+
+  describe('drawer variant — Section C (steering outcome)', () => {
+    it('renders the steering link and decision summary when a PlanRevised matched', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail({
+            verdictBucket: 'off_task',
+            verdictTone: 'off_task_warning',
+            onTask: false,
+            severity: 'warning',
+            steeredPlan: {
+              id: 'plan-a',
+              invocationSpanId: '',
+              plannerAgentId: '',
+              createdAtMs: 200,
+              summary: '',
+              tasks: [],
+              edges: [],
+              revisionReason: 'verify outputs',
+              revisionKind: 'reasoning_drift',
+              revisionSeverity: 'warning',
+              revisionIndex: 2,
+              triggerEventId: 'ev-1',
+            },
+            steeringSummary: 'verify outputs',
+            decisionSummary: 'Inserted a verification step after step 3.',
+          })}
+          onOpenSteering={() => {}}
+        />,
+      );
+      expect(screen.getByTestId('judge-detail-steering-link').textContent)
+        .toMatch(/refined the plan/i);
+      expect(
+        screen.getByTestId('judge-drawer-decision-summary').textContent,
+      ).toContain('verification step');
+    });
+
+    it('does not render the steering section for on_task verdicts', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail({ verdictBucket: 'on_task' })}
+        />,
+      );
+      expect(screen.queryByTestId('judge-detail-steering')).toBeNull();
+    });
+  });
+
+  describe('drawer variant — graceful degradation', () => {
+    it('renders without crashing when all optional attributes are missing', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="drawer"
+          detail={detail({
+            subjectAgentId: '',
+            targetAgentId: '',
+            taskId: '',
+            model: '',
+            reason: '',
+            reasoningInput: '',
+            rawResponse: '',
+            severity: '',
+            verdictBucket: 'no_verdict',
+            verdictTone: 'no_verdict',
+            onTask: false,
+            parseSuccessful: false,
+            elapsedMs: 0,
+          })}
+        />,
+      );
+      expect(screen.getByTestId('judge-invocation-detail')).toBeTruthy();
+      expect(screen.getByTestId('judge-detail-reasoning-empty')).toBeTruthy();
+      expect(screen.getByTestId('judge-detail-raw-empty')).toBeTruthy();
+    });
+  });
+
+  // -----------------------------------------------------------------
+  // Popover variant — banner + context row + input preview.
+  // -----------------------------------------------------------------
+
+  describe('popover variant', () => {
+    it('renders a green "On task" banner for on_task verdicts', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="popover"
+          detail={detail({ verdictBucket: 'on_task', verdictTone: 'on_task' })}
+        />,
+      );
+      const banner = screen.getByTestId('judge-popover-banner');
+      expect(banner.getAttribute('data-tone')).toBe('on_task');
+      expect(banner.textContent).toMatch(/On task/i);
+    });
+
+    it('renders an amber "Off task (warning)" banner for off_task warning', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="popover"
+          detail={detail({
+            verdictBucket: 'off_task',
+            verdictTone: 'off_task_warning',
+            severity: 'warning',
+            reason: 'paraphrasing',
+          })}
+        />,
+      );
+      const banner = screen.getByTestId('judge-popover-banner');
+      expect(banner.getAttribute('data-tone')).toBe('off_task_warning');
+      expect(banner.textContent).toMatch(/Off task.*warning/i);
+    });
+
+    it('renders a red "Off task (critical)" banner for off_task critical', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="popover"
+          detail={detail({
+            verdictBucket: 'off_task',
+            verdictTone: 'off_task_critical',
+            severity: 'critical',
+            reason: 'invented tool output',
+          })}
+        />,
+      );
+      const banner = screen.getByTestId('judge-popover-banner');
+      expect(banner.getAttribute('data-tone')).toBe('off_task_critical');
+      expect(banner.textContent).toMatch(/Off task.*critical/i);
+    });
+
+    it('renders a grey "No verdict" banner for no_verdict buckets', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="popover"
+          detail={detail({
+            verdictBucket: 'no_verdict',
+            verdictTone: 'no_verdict',
+            rawResponse: '{"bad_json":',
+          })}
+        />,
+      );
+      const banner = screen.getByTestId('judge-popover-banner');
+      expect(banner.getAttribute('data-tone')).toBe('no_verdict');
+      expect(banner.textContent).toMatch(/No verdict/i);
+    });
+
+    it('renders the lead reason just below the banner', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="popover"
+          detail={detail({
+            verdictBucket: 'off_task',
+            verdictTone: 'off_task_warning',
+            reason: 'Agent is summarising instead of citing tool output.',
+          })}
+        />,
+      );
+      expect(screen.getByTestId('judge-popover-lead').textContent).toContain(
+        'summarising',
+      );
+    });
+
+    it('falls through to the first 140 chars of rawResponse when reason is empty', () => {
+      const raw = 'X'.repeat(300);
+      render(
+        <JudgeInvocationDetail
+          variant="popover"
+          detail={detail({
+            verdictBucket: 'no_verdict',
+            verdictTone: 'no_verdict',
+            reason: '',
+            rawResponse: raw,
+          })}
+        />,
+      );
+      expect(
+        screen.getByTestId('judge-popover-lead').textContent?.length,
+      ).toBeLessThanOrEqual(140);
+    });
+
+    it('renders the context row with subject, task, model, and elapsed', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="popover"
+          detail={detail({
+            subjectAgentId: 'client:agent-zeta',
+            taskId: 'task-99',
+            model: 'haiku-4',
+            elapsedMs: 315,
+          })}
+        />,
+      );
+      expect(
+        screen.getByTestId('judge-popover-subject').textContent,
+      ).toContain('agent-zeta');
+      expect(screen.getByTestId('judge-popover-task').textContent).toContain(
+        'task-99',
+      );
+      expect(screen.getByTestId('judge-popover-model').textContent).toContain(
+        'haiku-4',
+      );
+      expect(
+        screen.getByTestId('judge-popover-elapsed').textContent,
+      ).toContain('315ms');
+    });
+
+    it('renders the input-preview section collapsed by default with a drawer hint', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="popover"
+          detail={detail({
+            reasoningInput: 'A'.repeat(500),
+          })}
+        />,
+      );
+      const preview = screen.getByTestId('judge-popover-input');
+      expect(preview.getAttribute('data-open')).toBe('false');
+      // Body not in the DOM until expanded.
+      expect(screen.queryByTestId('judge-popover-input-body')).toBeNull();
+      fireEvent.click(screen.getByTestId('judge-popover-input-toggle'));
+      const body = screen.getByTestId('judge-popover-input-body');
+      // Truncated to POPOVER_PREVIEW_CHARS (200) + trailing ellipsis.
+      expect(body.textContent?.endsWith('…')).toBe(true);
+      expect((body.textContent ?? '').length).toBeLessThanOrEqual(205);
+      expect(
+        screen.getByTestId('judge-popover-drawer-hint').textContent,
+      ).toMatch(/drawer/i);
+    });
+
+    it('prefers goldfive.input_preview over judge.reasoning_input for the popover preview', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="popover"
+          detail={detail({
+            reasoningInput: 'LONG UNTRIMMED TEXT',
+            inputPreview: 'short preview',
+          })}
+        />,
+      );
+      fireEvent.click(screen.getByTestId('judge-popover-input-toggle'));
+      expect(
+        screen.getByTestId('judge-popover-input-body').textContent,
+      ).toBe('short preview');
+    });
+
+    it('shows "Reasoning input not recorded" placeholder when no input is available', () => {
+      render(
+        <JudgeInvocationDetail
+          variant="popover"
+          detail={detail({ reasoningInput: '', inputPreview: '' })}
+        />,
+      );
+      fireEvent.click(screen.getByTestId('judge-popover-input-toggle'));
+      expect(
+        screen.getByTestId('judge-popover-input-empty').textContent,
+      ).toMatch(/not recorded/i);
+    });
   });
 });

--- a/frontend/src/__tests__/components/SpanPopover.test.tsx
+++ b/frontend/src/__tests__/components/SpanPopover.test.tsx
@@ -1,0 +1,295 @@
+// Judge-span layout tests for SpanPopover (harmonograf#judge-detail-clarify).
+//
+// Focus: the popover's judge-specific layout — verdict banner, lead
+// reason, context row, and input-preview section — composes correctly
+// with the generic span-popover chrome (pin / close / open-drawer / copy
+// id). Tests feed a real SessionStore with a synthesized judge span and
+// mount the SpanPopover overlay with a tiny stub renderer.
+//
+// Co-routing note (sibling agent /tmp/harmonograf-goldfive-render): the
+// SpanPopover routes to the judge layout iff `isJudgeSpan(span)` is
+// true. These tests lock that invariant so their GoldfiveSpanDetail
+// routing lands alongside without regressing the judge path.
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock CSS imports and the RPC hooks before importing SpanPopover.
+vi.mock('../../components/Interventions/JudgeInvocationDetail.css', () => ({}));
+
+const sendControlSpy = vi.fn().mockResolvedValue(undefined);
+const postAnnotationSpy = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../rpc/hooks', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../rpc/hooks')
+  >('../../rpc/hooks');
+  return {
+    ...actual,
+    useSendControl: () => sendControlSpy,
+    usePostAnnotation: () => postAnnotationSpy,
+    useAgentLive: (_sess: string | null, agentId: string | null) => ({
+      id: agentId ?? '',
+      name: agentId ?? '',
+      currentActivity: '',
+      taskReport: '',
+    }),
+  };
+});
+
+import { SessionStore } from '../../gantt/index';
+import type { Span } from '../../gantt/types';
+import { SpanPopover } from '../../components/Interaction/SpanPopover';
+import { usePopoverStore } from '../../state/popoverStore';
+import { isJudgeSpan } from '../../lib/interventionDetail';
+import type { OverlayContext } from '../../gantt/GanttCanvas';
+
+// Tiny stub renderer — SpanPopover only uses rectFor() to reposition
+// the card; everything else is unused on the popover path. We return a
+// fixed rect so the popover lays out at a predictable coordinate.
+function makeStubRenderer() {
+  return {
+    rectFor: () => ({ x: 100, y: 120, w: 80, h: 18 }),
+  };
+}
+
+function makeJudgeSpan(over: Partial<Span> = {}): Span {
+  return {
+    id: 'span-judge-1',
+    sessionId: 'sess-1',
+    agentId: '__goldfive__',
+    parentSpanId: null,
+    kind: 'CUSTOM',
+    status: 'COMPLETED',
+    name: 'judge: reasoning',
+    startMs: 1_000,
+    endMs: 1_250,
+    links: [],
+    attributes: {
+      'judge.kind': { kind: 'string', value: 'judge' },
+      'judge.verdict': { kind: 'string', value: 'reasoning_drift_detected' },
+      'judge.on_task': { kind: 'bool', value: false },
+      'judge.severity': { kind: 'string', value: 'warning' },
+      'judge.reason': {
+        kind: 'string',
+        value: 'Agent is summarising instead of citing tool output.',
+      },
+      'judge.reasoning_input': {
+        kind: 'string',
+        value: 'I will now summarise based on what I remember.',
+      },
+      'judge.raw_response': {
+        kind: 'string',
+        value: '{"on_task": false, "severity": "warning"}',
+      },
+      'judge.model': { kind: 'string', value: 'haiku-4' },
+      'judge.elapsed_ms': { kind: 'string', value: '248' },
+      'judge.subject_agent_id': { kind: 'string', value: 'client:agent-a' },
+      'judge.target_task_id': { kind: 'string', value: 'task-42' },
+    },
+    payloadRefs: [],
+    error: null,
+    lane: -1,
+    replaced: false,
+    ...over,
+  };
+}
+
+function makeCtx(store: SessionStore): OverlayContext {
+  return {
+    // Cast — we only use rectFor on the popover path.
+    renderer: makeStubRenderer() as unknown as OverlayContext['renderer'],
+    store,
+    widthCss: 1200,
+    heightCss: 600,
+    tick: 0,
+  };
+}
+
+beforeEach(() => {
+  usePopoverStore.setState({ popovers: new Map() });
+  sendControlSpy.mockClear();
+  postAnnotationSpy.mockClear();
+});
+
+describe('<SpanPopover /> — judge span routing', () => {
+  it('renders the judge popover layout when the selected span is a judge span', () => {
+    const store = new SessionStore();
+    const span = makeJudgeSpan();
+    store.spans.append(span);
+    usePopoverStore.getState().openForSpan(span.id, 100, 120);
+
+    render(<SpanPopover ctx={makeCtx(store)} sessionId="sess-1" />);
+
+    // The popover card carries the judge-mode data attribute.
+    const card = screen.getByTestId('span-popover');
+    expect(card.getAttribute('data-judge')).toBe('true');
+    // The judge body subtree is present.
+    expect(screen.getByTestId('span-popover-judge-body')).toBeTruthy();
+    // The verdict banner renders with the correct tone.
+    const banner = screen.getByTestId('judge-popover-banner');
+    expect(banner.getAttribute('data-tone')).toBe('off_task_warning');
+    expect(banner.textContent).toMatch(/Off task.*warning/i);
+  });
+
+  it('shows the lead reason directly below the banner', () => {
+    const store = new SessionStore();
+    const span = makeJudgeSpan();
+    store.spans.append(span);
+    usePopoverStore.getState().openForSpan(span.id, 100, 120);
+
+    render(<SpanPopover ctx={makeCtx(store)} sessionId="sess-1" />);
+
+    expect(screen.getByTestId('judge-popover-lead').textContent).toMatch(
+      /summarising instead of citing/i,
+    );
+  });
+
+  it('shows the context row with judging-subject + task + model + elapsed', () => {
+    const store = new SessionStore();
+    const span = makeJudgeSpan();
+    store.spans.append(span);
+    usePopoverStore.getState().openForSpan(span.id, 100, 120);
+
+    render(<SpanPopover ctx={makeCtx(store)} sessionId="sess-1" />);
+
+    expect(
+      screen.getByTestId('judge-popover-subject').textContent,
+    ).toContain('agent-a');
+    expect(screen.getByTestId('judge-popover-task').textContent).toContain(
+      'task-42',
+    );
+    expect(screen.getByTestId('judge-popover-model').textContent).toContain(
+      'haiku-4',
+    );
+    expect(
+      screen.getByTestId('judge-popover-elapsed').textContent,
+    ).toContain('248ms');
+  });
+
+  it('renders the input-preview section collapsed, expandable on click', () => {
+    const store = new SessionStore();
+    const span = makeJudgeSpan();
+    store.spans.append(span);
+    usePopoverStore.getState().openForSpan(span.id, 100, 120);
+
+    render(<SpanPopover ctx={makeCtx(store)} sessionId="sess-1" />);
+
+    const section = screen.getByTestId('judge-popover-input');
+    expect(section.getAttribute('data-open')).toBe('false');
+    fireEvent.click(screen.getByTestId('judge-popover-input-toggle'));
+    expect(screen.getByTestId('judge-popover-input-body').textContent).toContain(
+      'summarise',
+    );
+  });
+
+  it('does NOT render Steer or Annotate buttons on a judge popover', () => {
+    const store = new SessionStore();
+    const span = makeJudgeSpan();
+    store.spans.append(span);
+    usePopoverStore.getState().openForSpan(span.id, 100, 120);
+
+    render(<SpanPopover ctx={makeCtx(store)} sessionId="sess-1" />);
+
+    const card = screen.getByTestId('span-popover');
+    // Neither button should be present anywhere in the card subtree.
+    expect(card.textContent).not.toMatch(/\bSteer\b/);
+    expect(card.textContent).not.toMatch(/\bAnnotate\b/);
+  });
+
+  it('keeps Open drawer + Copy id action buttons for judge spans', () => {
+    const store = new SessionStore();
+    const span = makeJudgeSpan();
+    store.spans.append(span);
+    usePopoverStore.getState().openForSpan(span.id, 100, 120);
+
+    render(<SpanPopover ctx={makeCtx(store)} sessionId="sess-1" />);
+
+    const card = screen.getByTestId('span-popover');
+    expect(card.textContent).toContain('Open drawer');
+    expect(card.textContent).toContain('Copy id');
+  });
+
+  // Parametrized: verdict-banner color per severity bucket.
+  const banners: Array<{
+    label: string;
+    over: Partial<Span>;
+    expectedTone: string;
+    expectedLabel: RegExp;
+  }> = [
+    {
+      label: 'on-task (green)',
+      over: {
+        attributes: {
+          'judge.kind': { kind: 'string', value: 'judge' },
+          'judge.verdict': { kind: 'string', value: 'on_task' },
+          'judge.on_task': { kind: 'bool', value: true },
+          'judge.severity': { kind: 'string', value: '' },
+          'judge.reason': {
+            kind: 'string',
+            value: 'Agent is making expected progress.',
+          },
+        },
+      },
+      expectedTone: 'on_task',
+      expectedLabel: /On task/i,
+    },
+    {
+      label: 'off-task critical (red)',
+      over: {
+        attributes: {
+          'judge.kind': { kind: 'string', value: 'judge' },
+          'judge.verdict': {
+            kind: 'string',
+            value: 'reasoning_drift_detected',
+          },
+          'judge.on_task': { kind: 'bool', value: false },
+          'judge.severity': { kind: 'string', value: 'critical' },
+          'judge.reason': { kind: 'string', value: 'Invented tool output.' },
+        },
+      },
+      expectedTone: 'off_task_critical',
+      expectedLabel: /Off task.*critical/i,
+    },
+    {
+      label: 'no-verdict (grey)',
+      over: {
+        attributes: {
+          'judge.kind': { kind: 'string', value: 'judge' },
+          'judge.raw_response': { kind: 'string', value: '{"bad_json":' },
+        },
+      },
+      expectedTone: 'no_verdict',
+      expectedLabel: /No verdict/i,
+    },
+  ];
+  for (const b of banners) {
+    it(`renders the ${b.label} banner with the correct tone + label`, () => {
+      const store = new SessionStore();
+      const span = makeJudgeSpan({ ...b.over, id: `span-${b.expectedTone}` });
+      store.spans.append(span);
+      usePopoverStore.getState().openForSpan(span.id, 100, 120);
+
+      render(<SpanPopover ctx={makeCtx(store)} sessionId="sess-1" />);
+
+      const banner = screen.getByTestId('judge-popover-banner');
+      expect(banner.getAttribute('data-tone')).toBe(b.expectedTone);
+      expect(banner.textContent).toMatch(b.expectedLabel);
+    });
+  }
+
+  it('isJudgeSpan predicate still matches synthesized judge spans (co-routing invariant)', () => {
+    // Co-ordination with /tmp/harmonograf-goldfive-render: their
+    // GoldfiveSpanDetail branch also touches SpanPopover.tsx and will
+    // rebase onto this one. The two paths diverge solely on
+    // isJudgeSpan(span) — verify that predicate hasn't regressed.
+    const span = makeJudgeSpan();
+    expect(isJudgeSpan(span)).toBe(true);
+    const nonJudge = makeJudgeSpan({
+      id: 'other',
+      name: 'tool: search',
+      agentId: 'client:agent-b',
+      attributes: { 'judge.kind': { kind: 'string', value: 'drift' } },
+    });
+    expect(isJudgeSpan(nonJudge)).toBe(false);
+  });
+});

--- a/frontend/src/components/Interaction/SpanPopover.tsx
+++ b/frontend/src/components/Interaction/SpanPopover.tsx
@@ -252,11 +252,16 @@ function PopoverCard({
     void post({ sessionId, spanId: span.id, body: text, kind: 'COMMENT' }).catch(() => {});
   };
 
-  // Judge popovers + generic goldfive popovers carry more content
-  // (reasoning input, raw response, steering outcome, input/output
-  // previews); widen them so the sections don't truncate the reader's
-  // eye on typical laptops.
-  const popoverWidth = judgeMode || goldfiveMode ? POPOVER_WIDTH + 80 : POPOVER_WIDTH;
+  // Judge popovers carry the most content (verdict banner + reasoning
+  // input + context row — banner alone needs ~380px to stay single-line
+  // on a typical laptop). Generic goldfive popovers are less heavy but
+  // still carry decision summary + target row + input/output previews;
+  // widen them moderately. Everything else stays compact.
+  const popoverWidth = judgeMode
+    ? POPOVER_WIDTH + 100
+    : goldfiveMode
+      ? POPOVER_WIDTH + 80
+      : POPOVER_WIDTH;
 
   return (
     <div
@@ -292,14 +297,24 @@ function PopoverCard({
           alignItems: 'center',
           justifyContent: 'space-between',
           gap: 8,
-          marginBottom: 4,
+          marginBottom: judgeMode ? 8 : 4,
         }}
       >
         <div
           data-testid="span-popover-title"
-          style={{ fontWeight: 600, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          style={{
+            fontWeight: 600,
+            fontSize: 13,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
         >
-          {goldfiveInfo ? goldfiveInfo.callName : span.name}
+          {judgeMode
+            ? 'Judge invocation'
+            : goldfiveInfo
+              ? goldfiveInfo.callName
+              : span.name}
         </div>
         <div style={{ display: 'flex', gap: 4 }}>
           <IconButton
@@ -315,79 +330,66 @@ function PopoverCard({
           </IconButton>
         </div>
       </div>
-      <div
-        data-testid="span-popover-summary"
-        style={{ opacity: 0.85, lineHeight: 1.5, marginBottom: 6 }}
-      >
-        {goldfiveInfo ? goldfiveInfo.decisionSummary : summary}
-      </div>
-      {goldfiveInfo && (goldfiveInfo.targetAgentId || goldfiveInfo.targetTaskId) && (
-        <div
-          data-testid="span-popover-goldfive-context"
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: '2px 10px',
-            marginBottom: 6,
-            fontSize: 11,
-            opacity: 0.85,
-          }}
-        >
-          {goldfiveInfo.targetAgentId && (
-            <span data-testid="span-popover-goldfive-target-agent">
-              <span style={{ opacity: 0.6 }}>target </span>
-              {goldfiveInfo.targetAgentId}
-            </span>
+      {!judgeMode && (
+        <>
+          <div
+            data-testid="span-popover-summary"
+            style={{ opacity: 0.85, lineHeight: 1.5, marginBottom: 6 }}
+          >
+            {goldfiveInfo ? goldfiveInfo.decisionSummary : summary}
+          </div>
+          {goldfiveInfo && (goldfiveInfo.targetAgentId || goldfiveInfo.targetTaskId) && (
+            <div
+              data-testid="span-popover-goldfive-context"
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: '2px 10px',
+                marginBottom: 6,
+                fontSize: 11,
+                opacity: 0.85,
+              }}
+            >
+              {goldfiveInfo.targetAgentId && (
+                <span data-testid="span-popover-goldfive-target-agent">
+                  <span style={{ opacity: 0.6 }}>target </span>
+                  {goldfiveInfo.targetAgentId}
+                </span>
+              )}
+              {goldfiveInfo.targetTaskId && (
+                <span data-testid="span-popover-goldfive-target-task">
+                  <span style={{ opacity: 0.6 }}>task </span>
+                  <code style={{ fontSize: 10 }}>{goldfiveInfo.targetTaskId}</code>
+                </span>
+              )}
+            </div>
           )}
-          {goldfiveInfo.targetTaskId && (
-            <span data-testid="span-popover-goldfive-target-task">
-              <span style={{ opacity: 0.6 }}>task </span>
-              <code style={{ fontSize: 10 }}>{goldfiveInfo.targetTaskId}</code>
-            </span>
-          )}
-        </div>
+          <div style={{ opacity: 0.85, lineHeight: 1.5 }}>
+            <div>
+              <span style={{ opacity: 0.7 }}>kind </span>
+              {span.kind}
+              <span style={{ opacity: 0.7, marginLeft: 8 }}>status </span>
+              {span.status}
+            </div>
+            <div>
+              <span style={{ opacity: 0.7 }}>agent </span>
+              {agentName}
+            </div>
+            <div>
+              <span style={{ opacity: 0.7 }}>duration </span>
+              {duration}
+            </div>
+          </div>
+        </>
       )}
-      <div style={{ opacity: 0.85, lineHeight: 1.5 }}>
-        <div>
-          <span style={{ opacity: 0.7 }}>kind </span>
-          {span.kind}
-          <span style={{ opacity: 0.7, marginLeft: 8 }}>status </span>
-          {span.status}
-        </div>
-        <div>
-          <span style={{ opacity: 0.7 }}>agent </span>
-          {agentName}
-        </div>
-        <div>
-          <span style={{ opacity: 0.7 }}>duration </span>
-          {duration}
-        </div>
-      </div>
       {judgeMode && judgeDetail && (
-        <div style={{ marginTop: 10 }}>
+        <div data-testid="span-popover-judge-body">
           <JudgeInvocationDetail
             detail={judgeDetail}
-            resolveAgentName={(id) => store.agents.get(id)?.name || bareAgentName(id) || id}
-            onFocusAgent={(id) => {
-              useUiStore.getState().setFocusedAgent(id);
-            }}
-            onFocusTask={(id) => {
-              useUiStore.getState().selectTask(id);
-            }}
-            onOpenSteering={(_planId, _revIdx) => {
-              // Today the intervention-detail panel lives in TrajectoryView;
-              // the cleanest hand-off is to surface the plan revision there.
-              // The PlanRevised event is already rendered as a separate
-              // "refine:" span on the goldfive lane (goldfiveEvent.ts), so
-              // we select that span — clicking opens its own popover with
-              // the existing Trigger/Steering/Target panel for plan revs.
-              void _planId;
-              void _revIdx;
-              // Leave close-before-open so the popover doesn't visually
-              // stack; the user can click the refine span to see its
-              // details.
-              onClose();
-            }}
+            variant="popover"
+            resolveAgentName={(id) =>
+              store.agents.get(id)?.name || bareAgentName(id) || id
+            }
           />
         </div>
       )}
@@ -491,11 +493,13 @@ function PopoverCard({
           </>
         )}
         <ActionButton onClick={copyId}>Copy id</ActionButton>
-        {(!judgeMode || goldfiveMode) && (
-          <ActionButton onClick={openInDrawer} primary>
-            Open drawer
-          </ActionButton>
-        )}
+        {/* Both judge and non-judge popovers open the inspector drawer;
+            judge spans route to the JudgeDrawerPanel (Drawer.tsx), and
+            generic goldfive spans route to GoldfiveSpanDetail inside the
+            Summary tab via useGoldfiveDetailSection. */}
+        <ActionButton onClick={openInDrawer} primary>
+          Open drawer
+        </ActionButton>
       </div>
       {!judgeMode && !goldfiveMode && steerOpen && (
         <div

--- a/frontend/src/components/Interventions/JudgeInvocationDetail.css
+++ b/frontend/src/components/Interventions/JudgeInvocationDetail.css
@@ -272,3 +272,204 @@
 .hg-judge-detail__tasks li {
   margin-bottom: 1px;
 }
+
+/* ----------------------------------------------------------------
+   Section headings (drawer variant) — one per Section A / B / C.
+   Deliberately larger than the tiny uppercase section-labels so the
+   reader's eye lands on the top-level break first.
+   ---------------------------------------------------------------- */
+.hg-judge-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 8px;
+  margin-top: 2px;
+  border-top: 1px solid var(--md-sys-color-outline-variant, #43474e);
+}
+
+.hg-judge-detail__section:first-of-type {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.hg-judge-detail__section-heading {
+  margin: 0 0 2px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  color: var(--md-sys-color-on-surface, #e2e2e9);
+  opacity: 0.92;
+}
+
+/* Task context card (title + description) in Section A. */
+.hg-judge-detail__task-context {
+  padding: 6px 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hg-judge-detail__task-title {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.hg-judge-detail__task-desc {
+  font-size: 11px;
+  opacity: 0.8;
+}
+
+/* Goals list — surfaces the user's goal summaries the judge was
+   evaluating progress against. */
+.hg-judge-detail__goals {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hg-judge-detail__goals-list {
+  list-style: disc;
+  margin: 2px 0 0;
+  padding-left: 18px;
+  font-size: 11px;
+}
+
+.hg-judge-detail__goals-list li {
+  margin-bottom: 2px;
+  line-height: 1.4;
+}
+
+/* Parsed fields + diagnostic. */
+.hg-judge-detail__parsed {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px 6px;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 4px;
+}
+
+.hg-judge-detail__parsed-list {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 10px;
+  margin: 0;
+  font-size: 11px;
+}
+
+.hg-judge-detail__parsed-list dt {
+  font-weight: 600;
+  opacity: 0.7;
+  font-variant: small-caps;
+}
+
+.hg-judge-detail__parsed-list dd {
+  margin: 0;
+  font-family: var(--hg-mono, ui-monospace, Menlo, monospace);
+}
+
+.hg-judge-detail__diagnostic {
+  font-size: 10px;
+  opacity: 0.75;
+  font-style: italic;
+}
+
+.hg-judge-detail__diagnostic--warn {
+  color: #f59e0b;
+  opacity: 1;
+}
+
+/* ----------------------------------------------------------------
+   Popover variant — compact layout with a big verdict banner.
+   ---------------------------------------------------------------- */
+.hg-judge-detail--popover {
+  gap: 8px;
+}
+
+.hg-judge-detail__banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: #0b0d12;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.12);
+  min-height: 36px;
+}
+
+.hg-judge-detail__banner[data-tone='on_task'] {
+  background: #3bb273;
+}
+.hg-judge-detail__banner[data-tone='off_task_info'] {
+  background: #5b8def;
+  color: #e8f0ff;
+}
+.hg-judge-detail__banner[data-tone='off_task_warning'] {
+  background: #f59e0b;
+}
+.hg-judge-detail__banner[data-tone='off_task_critical'] {
+  background: #e06070;
+  color: #140608;
+}
+.hg-judge-detail__banner[data-tone='no_verdict'] {
+  background: #8d9199;
+}
+
+.hg-judge-detail__banner-label {
+  display: inline-block;
+}
+
+.hg-judge-detail__lead {
+  font-size: 13px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+  /* Soft 2-line clamp with ellipsis. Falls back to wrap on browsers
+     that lack -webkit-line-clamp support. */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.hg-judge-detail__lead--empty {
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.hg-judge-detail__context-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  font-size: 11px;
+  opacity: 0.85;
+}
+
+.hg-judge-detail__ctx-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hg-judge-detail__pre--excerpt {
+  max-height: 120px;
+}
+
+.hg-judge-detail__drawer-hint {
+  margin-top: 4px;
+  font-size: 10px;
+  font-style: italic;
+  opacity: 0.65;
+}

--- a/frontend/src/components/Interventions/JudgeInvocationDetail.tsx
+++ b/frontend/src/components/Interventions/JudgeInvocationDetail.tsx
@@ -7,29 +7,38 @@
 // reads `judge.*` attributes directly off the span; nothing here
 // depends on the event-side synthesizer that Option X retired.
 //
-// Surfaces the six questions an operator asks about an LLM-as-judge
-// invocation:
+// Two layout variants share the same data model:
 //
-//   1. when did it fire, which model, how long did it take
-//   2. which agent + task was being judged
-//   3. what reasoning did the judge see (reasoning_input, collapsible)
-//   4. what did it decide (on_task / off_task + severity + reason)
-//   5. raw LLM response, for debugging malformed verdicts (collapsible)
-//   6. did the verdict actually trigger steering (PlanRevised lookup)
+//   * `variant="popover"` — quick-look card that sits in SpanPopover.
+//     Leads with a large colour-coded verdict banner, then the reason as
+//     a lead sentence, then a compact context row (agent / task / model /
+//     elapsed), then a collapsed-by-default "Reasoning under review"
+//     preview (first ~200 chars of the judge's input).
 //
-// The component is deliberately layout-light — it reuses the existing
-// CSS language from InterventionsList (data-severity / swatches / tiny
-// uppercase labels) so it slots into the goldfive panel without its own
-// theme. The parent container (currently SpanPopover) supplies the box
-// chrome; this component contributes the inner sections.
+//   * `variant="drawer"` — full "what was judged / what the judgement
+//     is / steering outcome" breakdown rendered inside the Inspector
+//     Drawer. Section A surfaces the full reasoning input + task context
+//     + goals; Section B the verdict + raw response + parse diagnostic;
+//     Section C the plan-revised link (when the verdict actually drove
+//     steering).
+//
+// Fallbacks are explicit: missing reasoning_input / raw_response / goals
+// render as subdued placeholders rather than blank space, so pre-#234
+// sessions still tell the operator "we don't have that recorded" without
+// looking broken.
 
 import { useState } from 'react';
 import type { JudgeDetail } from '../../lib/interventionDetail';
 import { bareAgentName } from '../../gantt/index';
 import './JudgeInvocationDetail.css';
 
+type Variant = 'popover' | 'drawer';
+
 interface Props {
   detail: JudgeDetail;
+  // Popover (compact) or drawer (full). Defaults to `drawer` so existing
+  // call sites (tests that rely on the pre-#234 layout) continue to work.
+  variant?: Variant;
   // Optional: agent-id → display-name resolver (SessionStore agents).
   // When omitted the component falls back to `bareAgentName(id)`.
   resolveAgentName?: (agentId: string) => string;
@@ -42,6 +51,14 @@ interface Props {
   // route the click into the existing intervention-detail pane (the one
   // that renders Trigger / Steering / Target for PlanRevised rows).
   onOpenSteering?: (planId: string, revisionIndex: number) => void;
+  // Drawer-only contextual fields. Provided by the Drawer container,
+  // which resolves them from the SessionStore. Omitted on the popover
+  // variant — those sections simply don't render there.
+  taskTitle?: string;
+  taskDescription?: string;
+  // Session-level goals (the user's run goal summaries). Each entry is a
+  // short sentence; the drawer lists them verbatim under "Goals".
+  goals?: readonly string[];
 }
 
 function fmtTime(ms: number): string {
@@ -60,18 +77,239 @@ function copyToClipboard(text: string): void {
   void navigator.clipboard?.writeText(text).catch(() => {});
 }
 
+// Maps the verdict tone to a short banner label. Used by both variants;
+// the popover renders it in a big banner, the drawer in a pill badge.
+function verdictBannerLabel(detail: JudgeDetail): string {
+  switch (detail.verdictTone) {
+    case 'on_task':
+      return 'On task';
+    case 'off_task_info':
+      return 'Off task (info)';
+    case 'off_task_warning':
+      return 'Off task (warning)';
+    case 'off_task_critical':
+      return 'Off task (critical)';
+    case 'no_verdict':
+    default:
+      return 'No verdict';
+  }
+}
+
+// Popover input-preview chars. Kept short because the popover is a
+// quick-look surface; the full text is one click away in the drawer.
+const POPOVER_PREVIEW_CHARS = 200;
+
+// Popover reason fallback chars — when the judge didn't emit a `reason`
+// we pull from the raw response so the popover isn't empty.
+const POPOVER_REASON_FALLBACK_CHARS = 140;
+
 export function JudgeInvocationDetail({
+  detail,
+  variant = 'drawer',
+  resolveAgentName,
+  onFocusAgent,
+  onFocusTask,
+  onOpenSteering,
+  taskTitle,
+  taskDescription,
+  goals,
+}: Props) {
+  if (variant === 'popover') {
+    return (
+      <PopoverVariant
+        detail={detail}
+        resolveAgentName={resolveAgentName}
+      />
+    );
+  }
+  return (
+    <DrawerVariant
+      detail={detail}
+      resolveAgentName={resolveAgentName}
+      onFocusAgent={onFocusAgent}
+      onFocusTask={onFocusTask}
+      onOpenSteering={onOpenSteering}
+      taskTitle={taskTitle}
+      taskDescription={taskDescription}
+      goals={goals}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------
+// Popover variant — compact quick-look card.
+// ---------------------------------------------------------------------
+
+function PopoverVariant({
+  detail,
+  resolveAgentName,
+}: {
+  detail: JudgeDetail;
+  resolveAgentName?: (id: string) => string;
+}) {
+  const [inputOpen, setInputOpen] = useState(false);
+
+  const displayAgent = (id: string): string => {
+    if (!id) return 'Unknown agent';
+    if (resolveAgentName) return resolveAgentName(id) || bareAgentName(id) || id;
+    return bareAgentName(id) || id;
+  };
+
+  // Lead sentence: prefer the judge's explicit reason. Fall back to the
+  // first chunk of the raw response so the popover never shows a blank
+  // lead on malformed verdicts.
+  const leadSource = detail.reason
+    || detail.decisionSummary
+    || (detail.rawResponse
+      ? detail.rawResponse.slice(0, POPOVER_REASON_FALLBACK_CHARS)
+      : '');
+  const lead = leadSource.trim();
+
+  // Input preview — prefer the richer goldfive.input_preview (already
+  // trimmed upstream) and fall back to the raw reasoning input.
+  const rawInput = detail.inputPreview || detail.reasoningInput;
+  const inputExcerpt = rawInput
+    ? rawInput.slice(0, POPOVER_PREVIEW_CHARS)
+    : '';
+  const inputTruncated = rawInput.length > POPOVER_PREVIEW_CHARS;
+
+  return (
+    <div
+      className="hg-judge-detail hg-judge-detail--popover"
+      data-testid="judge-invocation-detail"
+      data-variant="popover"
+      data-verdict={detail.verdictBucket}
+      data-tone={detail.verdictTone}
+    >
+      {/* Top: verdict banner — large, colour-coded. */}
+      <div
+        className="hg-judge-detail__banner"
+        data-testid="judge-popover-banner"
+        data-tone={detail.verdictTone}
+        role="status"
+        aria-live="polite"
+      >
+        <span className="hg-judge-detail__banner-label">
+          {verdictBannerLabel(detail)}
+        </span>
+      </div>
+
+      {/* Lead sentence — judge's short explanation. */}
+      {lead ? (
+        <div
+          className="hg-judge-detail__lead"
+          data-testid="judge-popover-lead"
+        >
+          {lead}
+        </div>
+      ) : (
+        <div
+          className="hg-judge-detail__lead hg-judge-detail__lead--empty"
+          data-testid="judge-popover-lead-empty"
+        >
+          Judge returned no explanation.
+        </div>
+      )}
+
+      {/* Context row. */}
+      <div
+        className="hg-judge-detail__context-row"
+        data-testid="judge-popover-context"
+      >
+        <ContextChip
+          label="Judging"
+          value={displayAgent(detail.subjectAgentId)}
+          title={detail.subjectAgentId || undefined}
+          testId="judge-popover-subject"
+        />
+        {detail.taskId && (
+          <ContextChip
+            label="Task"
+            value={detail.taskId}
+            mono
+            testId="judge-popover-task"
+          />
+        )}
+        {detail.model && (
+          <ContextChip
+            label="Model"
+            value={detail.model}
+            testId="judge-popover-model"
+          />
+        )}
+        {detail.elapsedMs > 0 && (
+          <ContextChip
+            label="Elapsed"
+            value={`${detail.elapsedMs}ms`}
+            testId="judge-popover-elapsed"
+          />
+        )}
+      </div>
+
+      {/* Input preview — collapsed by default. */}
+      <Collapsible
+        label="Reasoning under review"
+        open={inputOpen}
+        onToggle={() => setInputOpen((v) => !v)}
+        testId="judge-popover-input"
+      >
+        {inputExcerpt ? (
+          <>
+            <pre
+              className="hg-judge-detail__pre hg-judge-detail__pre--excerpt"
+              data-testid="judge-popover-input-body"
+            >
+              {inputExcerpt}
+              {inputTruncated ? '…' : ''}
+            </pre>
+            <div
+              className="hg-judge-detail__drawer-hint"
+              data-testid="judge-popover-drawer-hint"
+            >
+              See full in drawer.
+            </div>
+          </>
+        ) : (
+          <div
+            className="hg-judge-detail__empty"
+            data-testid="judge-popover-input-empty"
+          >
+            Reasoning input not recorded.
+          </div>
+        )}
+      </Collapsible>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------
+// Drawer variant — full A / B / C breakdown.
+// ---------------------------------------------------------------------
+
+function DrawerVariant({
   detail,
   resolveAgentName,
   onFocusAgent,
   onFocusTask,
   onOpenSteering,
-}: Props) {
-  const [inputOpen, setInputOpen] = useState(false);
-  const [rawOpen, setRawOpen] = useState(false);
+  taskTitle,
+  taskDescription,
+  goals,
+}: {
+  detail: JudgeDetail;
+  resolveAgentName?: (id: string) => string;
+  onFocusAgent?: (agentId: string) => void;
+  onFocusTask?: (taskId: string) => void;
+  onOpenSteering?: (planId: string, revisionIndex: number) => void;
+  taskTitle?: string;
+  taskDescription?: string;
+  goals?: readonly string[];
+}) {
+  const [inputOpen, setInputOpen] = useState(true);
+  const [rawOpen, setRawOpen] = useState(true);
 
   const displayAgent = (id: string): string => {
-    if (!id) return '';
+    if (!id) return 'Unknown agent';
     if (resolveAgentName) return resolveAgentName(id) || bareAgentName(id) || id;
     return bareAgentName(id) || id;
   };
@@ -83,11 +321,15 @@ export function JudgeInvocationDetail({
         ? 'Off task'
         : 'No verdict';
 
+  const goalsList = (goals ?? []).filter((g) => g && g.trim().length > 0);
+
   return (
     <div
       className="hg-judge-detail"
       data-testid="judge-invocation-detail"
+      data-variant="drawer"
       data-verdict={detail.verdictBucket}
+      data-tone={detail.verdictTone}
     >
       <header className="hg-judge-detail__header">
         <div className="hg-judge-detail__title">Judge invocation</div>
@@ -116,6 +358,7 @@ export function JudgeInvocationDetail({
             className="hg-judge-detail__verdict"
             data-testid="judge-detail-verdict"
             data-bucket={detail.verdictBucket}
+            data-tone={detail.verdictTone}
           >
             {verdictLabel}
           </span>
@@ -131,28 +374,35 @@ export function JudgeInvocationDetail({
         </div>
       </header>
 
-      {(detail.subjectAgentId || detail.taskId) && (
-        <section
+      {/* ================================================================
+          Section A — What was being judged
+          ================================================================ */}
+      <section
+        className="hg-judge-detail__section"
+        data-testid="judge-drawer-section-a"
+      >
+        <h3 className="hg-judge-detail__section-heading">
+          A. What was being judged
+        </h3>
+
+        <div
           className="hg-judge-detail__context"
           data-testid="judge-detail-context"
         >
-          <span className="hg-judge-detail__section-label">Context</span>
-          {detail.subjectAgentId && (
-            <ContextLink
-              label="agent"
-              value={displayAgent(detail.subjectAgentId)}
-              title={detail.subjectAgentId}
-              testId="judge-detail-agent"
-              onClick={
-                onFocusAgent
-                  ? () => onFocusAgent(detail.subjectAgentId)
-                  : undefined
-              }
-            />
-          )}
+          <ContextLink
+            label="Subject"
+            value={displayAgent(detail.subjectAgentId)}
+            title={detail.subjectAgentId || 'Unknown agent'}
+            testId="judge-detail-agent"
+            onClick={
+              detail.subjectAgentId && onFocusAgent
+                ? () => onFocusAgent(detail.subjectAgentId)
+                : undefined
+            }
+          />
           {detail.taskId && (
             <ContextLink
-              label="task"
+              label="Task"
               value={detail.taskId}
               title={detail.taskId}
               testId="judge-detail-task"
@@ -160,12 +410,42 @@ export function JudgeInvocationDetail({
               mono
             />
           )}
-        </section>
-      )}
+        </div>
 
-      {(detail.reasoningInput || detail.verdictBucket === 'no_verdict') && (
+        {(taskTitle || taskDescription) && (
+          <div
+            className="hg-judge-detail__task-context"
+            data-testid="judge-drawer-task-context"
+          >
+            {taskTitle && (
+              <div className="hg-judge-detail__task-title">{taskTitle}</div>
+            )}
+            {taskDescription && (
+              <div className="hg-judge-detail__task-desc">
+                {taskDescription}
+              </div>
+            )}
+          </div>
+        )}
+
+        {goalsList.length > 0 && (
+          <div
+            className="hg-judge-detail__goals"
+            data-testid="judge-drawer-goals"
+          >
+            <span className="hg-judge-detail__section-label">Goals</span>
+            <ul className="hg-judge-detail__goals-list">
+              {goalsList.map((g, i) => (
+                <li key={i} data-testid="judge-drawer-goal">
+                  {g}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
         <Collapsible
-          label="Reasoning input"
+          label="Reasoning text (judge input)"
           open={inputOpen}
           onToggle={() => setInputOpen((v) => !v)}
           testId="judge-detail-reasoning"
@@ -183,65 +463,130 @@ export function JudgeInvocationDetail({
               {detail.reasoningInput}
             </pre>
           ) : (
-            <div className="hg-judge-detail__empty">No reasoning captured.</div>
+            <div
+              className="hg-judge-detail__empty"
+              data-testid="judge-detail-reasoning-empty"
+            >
+              Reasoning input not recorded.
+            </div>
           )}
         </Collapsible>
-      )}
-
-      <section
-        className="hg-judge-detail__verdict-section"
-        data-testid="judge-detail-response"
-      >
-        <span className="hg-judge-detail__section-label">Judge response</span>
-        {detail.verdictBucket === 'on_task' && (
-          <>
-            {detail.reason ? (
-              <div className="hg-judge-detail__reason">{detail.reason}</div>
-            ) : (
-              <div className="hg-judge-detail__empty">
-                No explanation provided.
-              </div>
-            )}
-          </>
-        )}
-        {detail.verdictBucket === 'off_task' && (
-          <div className="hg-judge-detail__reason hg-judge-detail__reason--off">
-            {detail.reason || '(no explanation from judge)'}
-          </div>
-        )}
-        {detail.verdictBucket === 'no_verdict' && (
-          <div
-            className="hg-judge-detail__reason hg-judge-detail__reason--none"
-            data-testid="judge-detail-no-verdict"
-          >
-            The judge returned no parseable verdict. Raw response below.
-          </div>
-        )}
       </section>
 
-      {detail.rawResponse && (
+      {/* ================================================================
+          Section B — What the judgement is
+          ================================================================ */}
+      <section
+        className="hg-judge-detail__section"
+        data-testid="judge-drawer-section-b"
+      >
+        <h3 className="hg-judge-detail__section-heading">
+          B. What the judgement is
+        </h3>
+
+        <div
+          className="hg-judge-detail__verdict-section"
+          data-testid="judge-detail-response"
+        >
+          {detail.verdictBucket === 'on_task' && (
+            <>
+              {detail.reason ? (
+                <div className="hg-judge-detail__reason">{detail.reason}</div>
+              ) : (
+                <div className="hg-judge-detail__empty">
+                  No explanation provided.
+                </div>
+              )}
+            </>
+          )}
+          {detail.verdictBucket === 'off_task' && (
+            <div className="hg-judge-detail__reason hg-judge-detail__reason--off">
+              {detail.reason || '(no explanation from judge)'}
+            </div>
+          )}
+          {detail.verdictBucket === 'no_verdict' && (
+            <div
+              className="hg-judge-detail__reason hg-judge-detail__reason--none"
+              data-testid="judge-detail-no-verdict"
+            >
+              The judge returned no parseable verdict. Raw response below.
+            </div>
+          )}
+        </div>
+
+        {/* Parsed fields — always render so the user can see what the
+            resolver extracted. The diagnostic line below explains whether
+            the parse was successful. */}
+        <div
+          className="hg-judge-detail__parsed"
+          data-testid="judge-drawer-parsed"
+        >
+          <span className="hg-judge-detail__section-label">Parsed fields</span>
+          <dl className="hg-judge-detail__parsed-list">
+            <dt>on_task</dt>
+            <dd data-testid="judge-drawer-parsed-on-task">
+              {detail.parseSuccessful ? String(detail.onTask) : '—'}
+            </dd>
+            <dt>severity</dt>
+            <dd data-testid="judge-drawer-parsed-severity">
+              {detail.severity || '—'}
+            </dd>
+          </dl>
+          <div
+            className={
+              detail.parseSuccessful
+                ? 'hg-judge-detail__diagnostic'
+                : 'hg-judge-detail__diagnostic hg-judge-detail__diagnostic--warn'
+            }
+            data-testid="judge-drawer-parse-diagnostic"
+            data-ok={detail.parseSuccessful ? 'true' : 'false'}
+          >
+            {detail.parseSuccessful
+              ? 'Successfully parsed JSON with on_task + severity.'
+              : 'Malformed response — treating as no verdict.'}
+          </div>
+        </div>
+
         <Collapsible
           label="Raw LLM response"
           open={rawOpen}
           onToggle={() => setRawOpen((v) => !v)}
           testId="judge-detail-raw"
-          onCopy={() => copyToClipboard(detail.rawResponse)}
+          onCopy={
+            detail.rawResponse
+              ? () => copyToClipboard(detail.rawResponse)
+              : undefined
+          }
         >
-          <pre
-            className="hg-judge-detail__pre"
-            data-testid="judge-detail-raw-body"
-          >
-            {detail.rawResponse}
-          </pre>
+          {detail.rawResponse ? (
+            <pre
+              className="hg-judge-detail__pre"
+              data-testid="judge-detail-raw-body"
+            >
+              {detail.rawResponse}
+            </pre>
+          ) : (
+            <div
+              className="hg-judge-detail__empty"
+              data-testid="judge-detail-raw-empty"
+            >
+              Raw response not recorded.
+            </div>
+          )}
         </Collapsible>
-      )}
+      </section>
 
+      {/* ================================================================
+          Section C — Steering outcome (off-task only)
+          ================================================================ */}
       {detail.verdictBucket === 'off_task' && (
         <section
-          className="hg-judge-detail__steering"
+          className="hg-judge-detail__section hg-judge-detail__steering"
           data-testid="judge-detail-steering"
         >
-          <span className="hg-judge-detail__section-label">Steering outcome</span>
+          <h3 className="hg-judge-detail__section-heading">
+            C. Steering outcome
+          </h3>
           {detail.steeredPlan ? (
             <>
               <button
@@ -260,12 +605,21 @@ export function JudgeInvocationDetail({
                 disabled={!onOpenSteering}
                 title="Open the plan-revision detail"
               >
-                Goldfive steering: refined plan → r
+                Goldfive refined the plan → r
                 {detail.steeredPlan.revisionIndex ?? 0}
               </button>
               {detail.steeringSummary && (
                 <div className="hg-judge-detail__steering-summary">
                   {detail.steeringSummary}
+                </div>
+              )}
+              {detail.decisionSummary
+                && detail.decisionSummary !== detail.steeringSummary && (
+                <div
+                  className="hg-judge-detail__steering-summary"
+                  data-testid="judge-drawer-decision-summary"
+                >
+                  {detail.decisionSummary}
                 </div>
               )}
               {detail.taskSummaries.length > 0 && (
@@ -293,6 +647,10 @@ export function JudgeInvocationDetail({
     </div>
   );
 }
+
+// ---------------------------------------------------------------------
+// Shared sub-components.
+// ---------------------------------------------------------------------
 
 function ContextLink({
   label,
@@ -327,6 +685,34 @@ function ContextLink({
   return (
     <span
       className="hg-judge-detail__ctx-plain"
+      data-testid={testId}
+      title={title}
+    >
+      <span className="hg-judge-detail__ctx-label">{label}</span>
+      {body}
+    </span>
+  );
+}
+
+// Popover-only chip — denser than ContextLink and always plain-text (the
+// popover's context is "at a glance" metadata, not a click-through).
+function ContextChip({
+  label,
+  value,
+  title,
+  testId,
+  mono,
+}: {
+  label: string;
+  value: string;
+  title?: string;
+  testId?: string;
+  mono?: boolean;
+}) {
+  const body = mono ? <code>{value}</code> : value;
+  return (
+    <span
+      className="hg-judge-detail__ctx-chip"
       data-testid={testId}
       title={title}
     >

--- a/frontend/src/components/shell/Drawer.tsx
+++ b/frontend/src/components/shell/Drawer.tsx
@@ -139,7 +139,17 @@ export function Drawer() {
         </div>
         <CurrentTaskSection sessionId={sessionId} selectedSpan={span} />
         {span ? (
-          <DrawerTabs key={span.id} span={span} sessionId={sessionId} />
+          isJudgeSpan(span) && store ? (
+            <JudgeDrawerPanel
+              key={span.id}
+              span={span}
+              store={store}
+              sessionId={sessionId}
+              onClose={close}
+            />
+          ) : (
+            <DrawerTabs key={span.id} span={span} sessionId={sessionId} />
+          )
         ) : (
           <div className="hg-drawer__body">
             <p>Select a span on the Gantt to inspect it.</p>
@@ -195,6 +205,140 @@ function DrawerTabs({ span, sessionId }: { span: Span; sessionId: string | null 
         )}
       </div>
     </>
+  );
+}
+
+// --- Judge drawer panel ----------------------------------------------------
+//
+// When the selected span is a goldfive LLM-as-judge invocation we bypass
+// the generic tab strip (Summary / Task / Payload / …) and mount the
+// JudgeInvocationDetail component in its `drawer` variant instead. The
+// ordinary drawer tabs are not useful here — the span has no payload,
+// no trajectory children of its own, and the "Task" tab would point at
+// the wrong task context (the subject's, not the judge's).
+//
+// Section A (what was being judged) wants the plan's task title +
+// description and the session's goal summaries. We pull both from the
+// SessionStore synchronously: task lookup via tasks.findPlanForTask,
+// goals via the USER_MESSAGE spans stamped by the goldfive event sink
+// (see rpc/goldfiveEvent.ts:synthesizeUserGoalSpan). When a piece is
+// missing we pass undefined / [] and the component renders a fallback
+// placeholder or omits the row.
+
+function JudgeDrawerPanel({
+  span,
+  store,
+  sessionId,
+  onClose,
+}: {
+  span: Span;
+  store: SessionStore;
+  sessionId: string | null;
+  onClose: () => void;
+}) {
+  // Keep the panel live — plan revisions arrive asynchronously, so the
+  // steering-outcome link only materializes after the PlanRevised event
+  // reaches the store. Bumping the version on task mutations retriggers
+  // resolveJudgeDetail so the link pops in without a reselection.
+  const [, bump] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => {
+    return store.tasks.subscribe(() => bump());
+  }, [store]);
+  void sessionId;
+
+  const detail = useMemo(() => {
+    const plans: TaskPlan[] = [];
+    const seen = new Set<TaskPlan>();
+    for (const live of store.tasks.listPlans()) {
+      for (const snap of store.tasks.allRevsForPlan(live.id)) {
+        if (seen.has(snap)) continue;
+        seen.add(snap);
+        plans.push(snap);
+      }
+    }
+    return resolveJudgeDetail(span, plans);
+  }, [span, store]);
+
+  // Resolve the task's title / description (Section A). The judge span
+  // carries `judge.target_task_id`, which interventionDetail also
+  // surfaces as detail.taskId; look it up in the live plans.
+  const taskLookup = detail.taskId
+    ? store.tasks.findPlanForTask(detail.taskId)
+    : undefined;
+  const taskTitle = taskLookup?.task.title || undefined;
+  const taskDescription = taskLookup?.task.description || undefined;
+
+  // Resolve the session's goal summaries (Section A). Goals arrive as
+  // USER_MESSAGE spans on the __user__ actor, one per RunStarted. We
+  // de-duplicate by text (a user can re-kick the same goal) and keep
+  // earliest-first order so the list reads chronologically.
+  const goals = useMemo(() => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    const scratch: Span[] = [];
+    store.spans.queryAgent('__user__', 0, Number.POSITIVE_INFINITY, scratch);
+    scratch.sort((a, b) => a.startMs - b.startMs);
+    for (const s of scratch) {
+      if (s.kind !== 'USER_MESSAGE') continue;
+      const marker = s.attributes['user.goal_summary'];
+      if (!marker || marker.kind !== 'string') continue;
+      const text = marker.value.trim();
+      if (!text || seen.has(text)) continue;
+      seen.add(text);
+      out.push(text);
+    }
+    return out;
+  }, [store]);
+
+  const selectSpan = useUiStore((s) => s.selectSpan);
+
+  return (
+    <div
+      className="hg-drawer__body hg-drawer__body--judge"
+      data-testid="drawer-judge-panel"
+    >
+      <JudgeInvocationDetail
+        detail={detail}
+        variant="drawer"
+        resolveAgentName={(id) =>
+          store.agents.get(id)?.name || bareAgentName(id) || id
+        }
+        onFocusAgent={(id) => {
+          useUiStore.getState().setFocusedAgent(id);
+        }}
+        onFocusTask={(id) => {
+          useUiStore.getState().selectTask(id);
+        }}
+        onOpenSteering={(_planId, _revIdx) => {
+          // Jump into the refine: span on the goldfive lane so the user
+          // lands on the existing plan-revision detail panel. The refine
+          // synthesizer stamps `refine.index = <revIdx>` on a
+          // __goldfive__ span (see rpc/goldfiveEvent.ts).
+          void _planId;
+          const spans: Span[] = [];
+          store.spans.queryAgent(
+            '__goldfive__',
+            0,
+            Number.POSITIVE_INFINITY,
+            spans,
+          );
+          const targetRefine = spans.find(
+            (s) =>
+              s.name.startsWith('refine:') &&
+              s.attributes['refine.index']?.kind === 'string' &&
+              s.attributes['refine.index'].value === String(_revIdx),
+          );
+          if (targetRefine) {
+            selectSpan(targetRefine.id);
+          } else {
+            onClose();
+          }
+        }}
+        taskTitle={taskTitle}
+        taskDescription={taskDescription}
+        goals={goals}
+      />
+    </div>
   );
 }
 

--- a/frontend/src/lib/interventionDetail.ts
+++ b/frontend/src/lib/interventionDetail.ts
@@ -191,6 +191,22 @@ export function resolvePlanRevisionDetail(
 // `onTask` / `verdict` / `rawResponse` in that order to decide the bucket.
 export type JudgeVerdictBucket = 'on_task' | 'off_task' | 'no_verdict';
 
+// Fine-grained verdict tone used by the popover banner and the drawer's
+// verdict badge. Derived from `verdictBucket` + `severity`:
+//   on_task           → green banner "On task"
+//   off_task + info   → blue   banner "Off task (info)"
+//   off_task + warn   → amber  banner "Off task (warning)"
+//   off_task + crit   → red    banner "Off task (critical)"
+//   no_verdict / ''   → grey   banner "No verdict"
+// Kept as a separate field (rather than reconstructed in each view) so
+// the popover and drawer agree on colour without duplicating the ladder.
+export type JudgeVerdictTone =
+  | 'on_task'
+  | 'off_task_info'
+  | 'off_task_warning'
+  | 'off_task_critical'
+  | 'no_verdict';
+
 export interface JudgeDetail {
   // Span that triggered the detail lookup. Held so the view can key off
   // its id (copy-to-clipboard, deep-link) without a second query.
@@ -201,13 +217,25 @@ export interface JudgeDetail {
   elapsedMs: number;
   subjectAgentId: string;
   taskId: string;
+  targetAgentId: string; // usually == subjectAgentId for reasoning judges
   verdictBucket: JudgeVerdictBucket;
+  verdictTone: JudgeVerdictTone;
   // Parsed verdict fields.
   onTask: boolean;
   severity: string; // empty when on_task or no_verdict
   reason: string;   // judge's short explanation
   reasoningInput: string; // what the judge saw (chain-of-thought)
   rawResponse: string;    // raw LLM output before JSON parse
+  // True when the judge's response parsed cleanly to on_task + severity.
+  // False when the parser could not extract an on_task boolean — the drawer
+  // surfaces this with a diagnostic line under the parsed fields.
+  parseSuccessful: boolean;
+  // Optional richer context sourced from the pending goldfive.* sibling
+  // attributes (harmonograf#234+). When absent these stay empty and the
+  // drawer falls back to the plain judge.* fields.
+  inputPreview: string;    // goldfive.input_preview
+  outputPreview: string;   // goldfive.output_preview
+  decisionSummary: string; // goldfive.decision_summary
   // Steering outcome: the plan-revision this judge invocation triggered,
   // if any. Resolved via PlanRevised.trigger_event_id == this event id.
   steeredPlan: TaskPlan | null;
@@ -230,6 +258,20 @@ function classifyVerdict(
   return 'off_task';
 }
 
+function verdictToneFor(
+  bucket: JudgeVerdictBucket,
+  severity: string,
+): JudgeVerdictTone {
+  if (bucket === 'on_task') return 'on_task';
+  if (bucket === 'no_verdict') return 'no_verdict';
+  const s = (severity || '').toLowerCase();
+  if (s === 'critical') return 'off_task_critical';
+  if (s === 'warning' || s === 'warn') return 'off_task_warning';
+  // info / missing-severity / anything else on an off-task verdict treat
+  // as "info" rather than upgrading silently to warning.
+  return 'off_task_info';
+}
+
 // Resolve detail for a judge-span click. The caller finds the clicked
 // span by id; this helper reads its attributes + scans the plan list
 // for a PlanRevised whose trigger_event_id matches the judge event id.
@@ -240,6 +282,8 @@ export function resolveJudgeDetail(
   const eventId = readStringAttr(span, 'judge.event_id');
   const verdict = readStringAttr(span, 'judge.verdict');
   const onTaskAttr = span.attributes['judge.on_task'];
+  const parseSuccessful =
+    onTaskAttr?.kind === 'bool' || verdict === 'on_task' || verdict !== '';
   const onTask =
     onTaskAttr?.kind === 'bool'
       ? onTaskAttr.value
@@ -247,16 +291,34 @@ export function resolveJudgeDetail(
   const severity = readStringAttr(span, 'judge.severity');
   const reason = readStringAttr(span, 'judge.reason')
     || readStringAttr(span, 'judge.reasoning');
+  // Prefer the richer `goldfive.input_preview` (harmonograf#234+) when
+  // present — it carries the agent's reasoning with preamble trimmed and
+  // is shorter than `judge.reasoning_input` for the popover preview. The
+  // drawer still renders the full `judge.reasoning_input` for fidelity.
+  const inputPreview = readStringAttr(span, 'goldfive.input_preview');
+  const outputPreview = readStringAttr(span, 'goldfive.output_preview');
+  const decisionSummary = readStringAttr(span, 'goldfive.decision_summary');
   const reasoningInput = readStringAttr(span, 'judge.reasoning_input')
     || readStringAttr(span, 'judge.reasoning');
   const rawResponse = readStringAttr(span, 'judge.raw_response');
   const model = readStringAttr(span, 'judge.model');
-  const elapsedStr = readStringAttr(span, 'judge.elapsed_ms');
-  const elapsedMs = elapsedStr ? Number(elapsedStr) || 0 : 0;
+  const elapsedAttr = span.attributes['judge.elapsed_ms'];
+  let elapsedMs = 0;
+  if (elapsedAttr?.kind === 'int') {
+    elapsedMs = Number(elapsedAttr.value) || 0;
+  } else if (elapsedAttr?.kind === 'double') {
+    elapsedMs = Number(elapsedAttr.value) || 0;
+  } else {
+    const elapsedStr = readStringAttr(span, 'judge.elapsed_ms');
+    elapsedMs = elapsedStr ? Number(elapsedStr) || 0 : 0;
+  }
   const subjectAgentId = readStringAttr(span, 'judge.subject_agent_id')
     || readStringAttr(span, 'judge.target_agent_id');
+  const targetAgentId = readStringAttr(span, 'judge.target_agent_id')
+    || subjectAgentId;
   const taskId = readStringAttr(span, 'judge.target_task_id');
   const verdictBucket = classifyVerdict(onTask, verdict, rawResponse);
+  const verdictTone = verdictToneFor(verdictBucket, severity);
 
   let steeredPlan: TaskPlan | null = null;
   if (eventId && verdictBucket === 'off_task') {
@@ -302,13 +364,19 @@ export function resolveJudgeDetail(
     model,
     elapsedMs,
     subjectAgentId,
+    targetAgentId,
     taskId,
     verdictBucket,
+    verdictTone,
     onTask,
     severity,
     reason,
     reasoningInput,
     rawResponse,
+    parseSuccessful,
+    inputPreview,
+    outputPreview,
+    decisionSummary,
     steeredPlan,
     steeringSummary,
     taskSummaries,


### PR DESCRIPTION
Closes #167.

## User feedback (verbatim)

> "it's not clear that the judge invocation detail has enough information of what is being judged and what the judgement is. make sure that is being displayed in the span popover and details drawer"

## Before / after

### Popover — before

```
┌──── judge: reasoning ──────── 📌 ✕ ┐
│ __goldfive__ is handling judge…    │
│ kind CUSTOM   status COMPLETED     │
│ agent __goldfive__                 │
│ duration 248ms                     │
│                                    │
│  [JudgeInvocationDetail — buried]  │
│  Judge invocation                  │
│    [on_task pill]                  │
│  Context: agent / task             │
│  Reasoning input ▸ (collapsed)     │
│  Judge response: "..."             │
│  Raw LLM response ▸ (collapsed)    │
│                                    │
│ [Copy id]                          │
└────────────────────────────────────┘
```

Information buried. No colour coding on severity. User cannot tell
what the agent was doing or what the judge decided without clicking
twice.

### Popover — after (judge spans only; non-judge popovers unchanged)

```
┌──── Judge invocation ──────── 📌 ✕ ┐
│                                    │
│  ┌──────────────────────────────┐  │
│  │   OFF TASK (WARNING)         │  │ ← amber, ~36px tall, huge
│  └──────────────────────────────┘  │
│                                    │
│  Agent is summarising instead of   │ ← lead reason, 2-3 lines
│  citing tool output.               │
│                                    │
│  Judging: client:agent-a  ·        │ ← context row
│  Task: task-42  ·                  │
│  Model: haiku-4  ·  Elapsed: 248ms │
│                                    │
│  ▸ Reasoning under review          │ ← collapsed; expands to show
│                                    │   first 200 chars + "see full
│                                    │   in drawer" hint
│                                    │
│ [Copy id]  [Open drawer]           │ ← no Steer/Annotate for judges
└────────────────────────────────────┘
```

Widened to ~420px so the banner stays on one line. Banner colour
maps to verdict tone:
- on_task → green
- off_task + info → blue
- off_task + warning → amber
- off_task + critical → red
- no_verdict → grey

### Drawer — before

Generic tab strip (Summary / Task / Payload / Timeline / Links /
Annotations / Control). The reasoning_input lives inside the Summary
tab's attribute table as a raw string row. The raw_response same.
No structured "what was judged / what the judgement is".

### Drawer — after (judge spans bypass the tab strip entirely)

```
┌─── Judge invocation · 0:12 · 248ms · haiku-4   [OFF TASK] [warning]
│
│ A. WHAT WAS BEING JUDGED
│    Subject: client:agent-a    Task: task-42
│    ┌──────────────────────────────────────┐
│    │ Plan weekend trip                    │ ← task context card
│    │ Draft a 3-day itinerary for Big Sur. │
│    └──────────────────────────────────────┘
│    GOALS
│      · Book lodging in Big Sur
│      · Plan 3 day hikes
│    ▾ Reasoning text (judge input)    [copy]
│    ┌──────────────────────────────────────┐
│    │ I will now summarise based on what   │ ← full reasoning_input
│    │ I remember. The widgets were...      │   in monospace pre
│    └──────────────────────────────────────┘
│
│ B. WHAT THE JUDGEMENT IS
│    Agent is summarising instead of citing tool output.
│    PARSED FIELDS
│      on_task   false
│      severity  warning
│    Successfully parsed JSON with on_task + severity.
│    ▾ Raw LLM response    [copy]
│    ┌──────────────────────────────────────┐
│    │ {"on_task": false, "severity":       │
│    │  "warning", "reason": "..."}         │
│    └──────────────────────────────────────┘
│
│ C. STEERING OUTCOME
│    Goldfive refined the plan → r2
│    verify outputs
│    Inserted a verification step after step 3.
│    · verify widget count
│    · cancelled: old widget step
└──────────────────────────────────────────────
```

Section A / B / C headings in uppercase letter-spacing so the
reader's eye lands on the top-level break first.

Fallbacks render explicit placeholders: "Reasoning input not
recorded", "Raw response not recorded", "Unknown agent", or the
Goals row is omitted entirely when none are present.

## Forward-compat with goldfive proto

Reads the pending `goldfive.input_preview`, `goldfive.output_preview`,
`goldfive.decision_summary` attributes (from the goldfive-proto
sibling branch that populates them) and falls back to the existing
`judge.*` attributes when absent — today's sessions render cleanly;
the richer context appears the moment the sibling PR lands.

## Co-ordination

`/tmp/harmonograf-goldfive-render` (branch
`feat/goldfive-span-visual-popover-drawer`) is actively adding
`GoldfiveSpanDetail` for non-judge goldfive spans and will rebase onto
this one. The two paths diverge solely on `isJudgeSpan(span)`. The
new `SpanPopover.test.tsx` includes a co-routing-invariant test that
locks the predicate in place so their rebase is low-friction.

## Test plan

- [x] `pnpm test --run` — 398 passed (34 new: 24 in JudgeInvocationDetail, 10 in SpanPopover).
- [x] `pnpm tsc -b` — clean.
- [x] `pnpm lint` — clean (one pre-existing warning in `GanttView.tsx` untouched).
- [x] Popover: verdict banner renders with correct colour per severity, parametrized.
- [x] Popover: context row shows subject + task + model + elapsed.
- [x] Popover: input preview truncates with "see full" hint.
- [x] Drawer: Section A renders reasoning_input in full, task context card, goals list.
- [x] Drawer: Section B renders verdict + raw_response + parse diagnostic.
- [x] Drawer: malformed-response diagnostic shows when on_task is missing.
- [x] Drawer: steering-outcome link appears when a matching plan_revised exists.
- [x] Graceful degradation: span with missing attributes renders without crashing.

Do **not** merge — user approves.