### PR TITLE
feat(ui): TrajectoryTimelineRibbon component for unified trajectory timeline

### DIFF
--- a/frontend/src/__tests__/components/TrajectoryTimelineRibbon.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryTimelineRibbon.test.tsx
@@ -1,0 +1,373 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TrajectoryTimelineRibbon } from '../../components/shell/views/TrajectoryTimelineRibbon';
+import type { PlanRevisionRecord } from '../../state/planHistoryStore';
+import type { InterventionRow } from '../../lib/interventions';
+import type { TaskPlan } from '../../gantt/types';
+
+vi.mock('../../components/shell/views/TrajectoryTimelineRibbon.css', () => ({}));
+
+function plan(id: string): TaskPlan {
+  return {
+    id,
+    revisionIndex: 0,
+    tasks: [],
+    edges: [],
+    createdAtMs: 0,
+  } as unknown as TaskPlan;
+}
+
+function rev(over: Partial<PlanRevisionRecord>): PlanRevisionRecord {
+  return {
+    revision: 0,
+    plan: plan('p1'),
+    reason: '',
+    kind: '',
+    triggerEventId: '',
+    emittedAtMs: 0,
+    ...over,
+  };
+}
+
+function intv(over: Partial<InterventionRow>): InterventionRow {
+  return {
+    key: 'k',
+    atMs: 0,
+    source: 'drift',
+    kind: 'LOOPING_REASONING',
+    bodyOrReason: '',
+    author: '',
+    outcome: '',
+    planRevisionIndex: 0,
+    severity: 'warning',
+    annotationId: '',
+    driftKind: '',
+    triggerEventId: '',
+    ...over,
+  };
+}
+
+describe('<TrajectoryTimelineRibbon />', () => {
+  const baseRevs = [
+    rev({ revision: 0, emittedAtMs: 0, reason: '', kind: '' }),
+    rev({
+      revision: 1,
+      emittedAtMs: 10_000,
+      reason: 'stop drifting',
+      kind: 'off_topic',
+    }),
+    rev({
+      revision: 2,
+      emittedAtMs: 30_000,
+      reason: 'target task 3',
+      kind: 'user_steer',
+    }),
+  ];
+
+  it('renders one notch per revision plus a Latest pseudo-notch', () => {
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[]}
+        selectedRevision="latest"
+        onSelectRevision={() => {}}
+        onInterventionClick={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('ribbon-rev-0')).toBeTruthy();
+    expect(screen.getByTestId('ribbon-rev-1')).toBeTruthy();
+    expect(screen.getByTestId('ribbon-rev-2')).toBeTruthy();
+    expect(screen.getByTestId('ribbon-rev-latest')).toBeTruthy();
+  });
+
+  it('renders intervention glyphs interleaved by timestamp', () => {
+    const ivs = [
+      intv({ key: 'i1', atMs: 5_000, kind: 'OFF_TOPIC', severity: 'warning' }),
+      intv({ key: 'i2', atMs: 25_000, kind: 'LOOPING', severity: 'critical' }),
+    ];
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={ivs}
+        selectedRevision="latest"
+        onSelectRevision={() => {}}
+        onInterventionClick={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('ribbon-intv-i1')).toBeTruthy();
+    expect(screen.getByTestId('ribbon-intv-i2')).toBeTruthy();
+  });
+
+  it('intervention colour varies by severity', () => {
+    const ivs = [
+      intv({ key: 'w', atMs: 5_000, severity: 'warning' }),
+      intv({ key: 'c', atMs: 15_000, severity: 'critical' }),
+      intv({ key: 'i', atMs: 25_000, severity: 'info' }),
+    ];
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={ivs}
+        selectedRevision="latest"
+        onSelectRevision={() => {}}
+        onInterventionClick={() => {}}
+      />,
+    );
+    const w = screen.getByTestId('ribbon-intv-w');
+    const c = screen.getByTestId('ribbon-intv-c');
+    const i = screen.getByTestId('ribbon-intv-i');
+    expect(w.getAttribute('data-severity')).toBe('warning');
+    expect(c.getAttribute('data-severity')).toBe('critical');
+    expect(i.getAttribute('data-severity')).toBe('info');
+    // Inline colour differs across severities. jsdom canonicalises hex to
+    // rgb(...) so we compare on the decoded rgb triplet.
+    expect(w.style.color).toBe('rgb(245, 158, 11)');  // warning amber
+    expect(c.style.color).toBe('rgb(224, 96, 112)');  // critical red
+    expect(i.style.color).toBe('rgb(141, 145, 153)'); // info grey
+  });
+
+  it('selected revision gets aria-selected=true; others get false', () => {
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[]}
+        selectedRevision={1}
+        onSelectRevision={() => {}}
+        onInterventionClick={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('ribbon-rev-1').getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByTestId('ribbon-rev-0').getAttribute('aria-selected')).toBe(
+      'false',
+    );
+    expect(
+      screen.getByTestId('ribbon-rev-latest').getAttribute('aria-selected'),
+    ).toBe('false');
+  });
+
+  it('selects Latest when selectedRevision === "latest"', () => {
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[]}
+        selectedRevision="latest"
+        onSelectRevision={() => {}}
+        onInterventionClick={() => {}}
+      />,
+    );
+    expect(
+      screen.getByTestId('ribbon-rev-latest').getAttribute('aria-selected'),
+    ).toBe('true');
+  });
+
+  it('click revision fires onSelectRevision with the revision number', () => {
+    const onSelect = vi.fn();
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[]}
+        selectedRevision="latest"
+        onSelectRevision={onSelect}
+        onInterventionClick={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('ribbon-rev-2'));
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it('click Latest pseudo-notch fires onSelectRevision("latest")', () => {
+    const onSelect = vi.fn();
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[]}
+        selectedRevision={1}
+        onSelectRevision={onSelect}
+        onInterventionClick={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('ribbon-rev-latest'));
+    expect(onSelect).toHaveBeenCalledWith('latest');
+  });
+
+  it('click intervention fires onInterventionClick with the row', () => {
+    const onIntv = vi.fn();
+    const row = intv({ key: 'xyz', atMs: 5_000, kind: 'STEER' });
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[row]}
+        selectedRevision="latest"
+        onSelectRevision={() => {}}
+        onInterventionClick={onIntv}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('ribbon-intv-xyz'));
+    expect(onIntv).toHaveBeenCalledWith(row);
+  });
+
+  it('Latest button appears when selectedRevision !== "latest"', () => {
+    const onSelect = vi.fn();
+    const { rerender } = render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[]}
+        selectedRevision={1}
+        onSelectRevision={onSelect}
+        onInterventionClick={() => {}}
+      />,
+    );
+    const btn = screen.getByTestId('ribbon-latest-btn');
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn);
+    expect(onSelect).toHaveBeenCalledWith('latest');
+
+    rerender(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[]}
+        selectedRevision="latest"
+        onSelectRevision={onSelect}
+        onInterventionClick={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId('ribbon-latest-btn')).toBeNull();
+  });
+
+  it('hover revision reveals popover with reason + kind', () => {
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[]}
+        selectedRevision="latest"
+        onSelectRevision={() => {}}
+        onInterventionClick={() => {}}
+      />,
+    );
+    const notch = screen.getByTestId('ribbon-rev-1');
+    fireEvent.mouseEnter(notch);
+    const pop = screen.getByTestId('ribbon-popover-rev-1');
+    expect(pop.textContent).toContain('R1');
+    expect(pop.textContent).toContain('OFF_TOPIC');
+    expect(pop.textContent).toContain('stop drifting');
+    expect(pop.getAttribute('role')).toBe('tooltip');
+    // aria-describedby wires the anchor to the tooltip.
+    expect(notch.getAttribute('aria-describedby')).toBe(pop.getAttribute('id'));
+    fireEvent.mouseLeave(notch);
+    expect(screen.queryByTestId('ribbon-popover-rev-1')).toBeNull();
+  });
+
+  it('hover intervention reveals popover with detail', () => {
+    const row = intv({
+      key: 'k1',
+      atMs: 5_000,
+      kind: 'STEER',
+      severity: 'warning',
+      bodyOrReason: 'please stop repeating the same search',
+    });
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[row]}
+        selectedRevision="latest"
+        onSelectRevision={() => {}}
+        onInterventionClick={() => {}}
+      />,
+    );
+    const glyph = screen.getByTestId('ribbon-intv-k1');
+    fireEvent.mouseEnter(glyph);
+    const pop = screen.getByTestId('ribbon-popover-intv-k1');
+    expect(pop.textContent).toContain('STEER');
+    expect(pop.textContent).toContain('WARNING');
+    expect(pop.textContent).toContain('please stop repeating');
+  });
+
+  it('keyboard arrow navigation walks between markers', () => {
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[
+          intv({ key: 'i1', atMs: 5_000, kind: 'STEER' }),
+        ]}
+        selectedRevision="latest"
+        onSelectRevision={() => {}}
+        onInterventionClick={() => {}}
+      />,
+    );
+    const r0 = screen.getByTestId('ribbon-rev-0');
+    r0.focus();
+    expect(document.activeElement).toBe(r0);
+    fireEvent.keyDown(r0, { key: 'ArrowRight' });
+    // Intervention i1 sits between r0 and r1 so it's next in focus order.
+    expect(document.activeElement).toBe(screen.getByTestId('ribbon-intv-i1'));
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(screen.getByTestId('ribbon-rev-1'));
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowLeft' });
+    expect(document.activeElement).toBe(screen.getByTestId('ribbon-intv-i1'));
+  });
+
+  it('Enter / Space on a focused revision activates onSelectRevision', () => {
+    const onSelect = vi.fn();
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[]}
+        selectedRevision="latest"
+        onSelectRevision={onSelect}
+        onInterventionClick={() => {}}
+      />,
+    );
+    // Buttons natively activate on Enter via the click event; simulate it.
+    const notch = screen.getByTestId('ribbon-rev-2');
+    notch.focus();
+    fireEvent.click(notch);
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it('expand toggle fires onToggleExpanded when provided', () => {
+    const onToggle = vi.fn();
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[]}
+        selectedRevision="latest"
+        onSelectRevision={() => {}}
+        onInterventionClick={() => {}}
+        expanded={false}
+        onToggleExpanded={onToggle}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('ribbon-expand-btn'));
+    expect(onToggle).toHaveBeenCalled();
+  });
+
+  it('omits expand toggle when onToggleExpanded is not provided', () => {
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[]}
+        selectedRevision="latest"
+        onSelectRevision={() => {}}
+        onInterventionClick={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId('ribbon-expand-btn')).toBeNull();
+  });
+
+  it('header shows correct revision + intervention counts', () => {
+    render(
+      <TrajectoryTimelineRibbon
+        revisions={baseRevs}
+        interventions={[intv({ key: 'a', atMs: 1 }), intv({ key: 'b', atMs: 2 })]}
+        selectedRevision="latest"
+        onSelectRevision={() => {}}
+        onInterventionClick={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText(/3 revisions · 2 interventions/),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/components/shell/views/TrajectoryTimelineRibbon.css
+++ b/frontend/src/components/shell/views/TrajectoryTimelineRibbon.css
@@ -1,0 +1,214 @@
+/* TrajectoryTimelineRibbon styles. Mirrors the visual language of the
+   sibling RevisionScrubber in views.css (dark chrome, mono labels, soft
+   tick marks) but compresses four stacked sections into one ~76px band. */
+
+.hg-traj-ribbon {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  height: 76px;
+  padding: 8px 14px;
+  background: #1b1d22;
+  border: 1px solid #2a2d34;
+  border-radius: 8px;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #c8ccd4;
+}
+
+/* Left edge — label + rev/intervention count. */
+.hg-traj-ribbon__lead {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  flex: 0 0 auto;
+  min-width: 110px;
+}
+
+.hg-traj-ribbon__title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #e4e7ec;
+}
+
+.hg-traj-ribbon__count {
+  font-size: 10px;
+  opacity: 0.6;
+  margin-top: 2px;
+}
+
+/* Main band. Markers are absolutely positioned by percentage so they
+   reflow with the container width. */
+.hg-traj-ribbon__track {
+  position: relative;
+  flex: 1 1 auto;
+  height: 100%;
+  min-height: 56px;
+}
+
+.hg-traj-ribbon__baseline {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    #3a3e46 10%,
+    #3a3e46 90%,
+    transparent 100%
+  );
+  transform: translateY(-0.5px);
+  pointer-events: none;
+}
+
+/* Revision notches. Positioned by `left:` inline style; we translate
+   -50% so the dot centres on the timestamp coordinate. */
+.hg-traj-ribbon__rev,
+.hg-traj-ribbon__latest {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: none;
+  padding: 4px 6px;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+
+.hg-traj-ribbon__latest {
+  right: 0;
+  left: auto;
+  transform: translate(0, -50%);
+}
+
+.hg-traj-ribbon__rev-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid #5b8def;
+  background: transparent;
+  box-shadow: 0 0 0 2px #1b1d22;
+}
+
+.hg-traj-ribbon__rev[data-selected='true'] .hg-traj-ribbon__rev-dot,
+.hg-traj-ribbon__latest[data-selected='true'] .hg-traj-ribbon__rev-dot {
+  background: #5b8def;
+  border-color: #9ab4ff;
+  box-shadow: 0 0 0 2px #1b1d22, 0 0 6px rgba(91, 141, 239, 0.5);
+}
+
+.hg-traj-ribbon__rev-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  opacity: 0.85;
+}
+
+.hg-traj-ribbon__rev[data-selected='true'] .hg-traj-ribbon__rev-label,
+.hg-traj-ribbon__latest[data-selected='true'] .hg-traj-ribbon__rev-label {
+  opacity: 1;
+  color: #e4e7ec;
+}
+
+.hg-traj-ribbon__rev:focus-visible,
+.hg-traj-ribbon__latest:focus-visible,
+.hg-traj-ribbon__intv:focus-visible {
+  outline: 2px solid #9ab4ff;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Intervention glyphs. Triangle rendered as unicode so we don't need an
+   SVG sprite; colour comes from the inline `color` style driven by
+   severity. Positioned above the baseline so it doesn't collide with
+   the revision dot. */
+.hg-traj-ribbon__intv {
+  position: absolute;
+  top: calc(50% - 16px);
+  transform: translate(-50%, 0);
+  background: transparent;
+  border: none;
+  padding: 2px 4px;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  color: currentColor;
+}
+
+.hg-traj-ribbon__intv-glyph {
+  display: inline-block;
+  text-shadow: 0 0 2px #1b1d22;
+}
+
+/* Popover. Absolute-positioned above the marker; doesn't affect layout. */
+.hg-traj-ribbon__popover {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #2a2d34;
+  color: #e4e7ec;
+  border: 1px solid #3a3e46;
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-size: 11px;
+  white-space: nowrap;
+  max-width: 320px;
+  pointer-events: none;
+  z-index: 10;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.hg-traj-ribbon__popover-at {
+  display: block;
+  margin-top: 2px;
+  opacity: 0.6;
+  font-size: 10px;
+}
+
+/* Right edge — Latest button and expand toggle. */
+.hg-traj-ribbon__tail {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.hg-traj-ribbon__latest-btn {
+  background: #5b8def;
+  color: #0f1013;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.hg-traj-ribbon__latest-btn:hover {
+  background: #7ca3f1;
+}
+
+.hg-traj-ribbon__expand {
+  background: transparent;
+  color: #c8ccd4;
+  border: 1px solid #3a3e46;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.hg-traj-ribbon__expand[aria-pressed='true'] {
+  background: #2a2d34;
+  color: #e4e7ec;
+}

--- a/frontend/src/components/shell/views/TrajectoryTimelineRibbon.tsx
+++ b/frontend/src/components/shell/views/TrajectoryTimelineRibbon.tsx
@@ -1,0 +1,376 @@
+// TrajectoryTimelineRibbon — single compact horizontal band (~70-80px tall)
+// that subsumes the four stacked sections the Trajectory view used to show:
+//   1. the Trajectory header rev-chip row,
+//   2. the REVISIONS strip with notches + "Latest",
+//   3. the per-rev descriptive cards,
+//   4. the INTERVENTIONS list.
+// All four communicate the same dimension — "what revisions happened and
+// what triggered them" — so the ribbon collapses them into one scrubber.
+//
+// The component is a primitive: no store lookups, no session watching. The
+// caller owns `selectedRevision` / `onSelectRevision` / `onInterventionClick`
+// and passes the already-derived `revisions` + `interventions` arrays.
+// Interface is FROZEN — a sibling agent building TrajectoryView layout is
+// adopting it verbatim.
+
+import { useCallback, useId, useMemo, useRef, useState } from 'react';
+import type React from 'react';
+import type { PlanRevisionRecord } from '../../../state/planHistoryStore';
+import type { InterventionRow } from '../../../lib/interventions';
+import './TrajectoryTimelineRibbon.css';
+
+export interface TrajectoryTimelineRibbonProps {
+  revisions: readonly PlanRevisionRecord[];
+  interventions: readonly InterventionRow[];
+  /** Controlled: revision number pinned, or the sentinel "latest". */
+  selectedRevision: number | 'latest';
+  onSelectRevision: (rev: number | 'latest') => void;
+  onInterventionClick: (intervention: InterventionRow) => void;
+  /** Escape-hatch: when true the caller is free to render the old stacked
+   *  view. The ribbon itself does not change shape; it only toggles its
+   *  expand-icon pressed-state so the affordance reads correctly. */
+  expanded?: boolean;
+  onToggleExpanded?: () => void;
+}
+
+// Severity → colour for intervention glyphs. Kept local so the ribbon has
+// no palette dependency on lib/interventions beyond the row shape.
+const SEVERITY_COLOR: Record<string, string> = {
+  critical: '#e06070',
+  warning: '#f59e0b',
+  info: '#8d9199',
+  '': '#8d9199',
+};
+
+function interventionColor(row: InterventionRow): string {
+  const sev = (row.severity || '').toLowerCase();
+  return SEVERITY_COLOR[sev] ?? SEVERITY_COLOR.info;
+}
+
+// Compute marker x-positions in [0, 1]. Revisions anchor the scale
+// (oldest → 0, newest → 1). If timestamps cluster (delta < 1ms across
+// the whole range) we fall back to even spacing so notches don't stack.
+interface ScaleDomain {
+  minMs: number;
+  maxMs: number;
+  even: boolean;
+}
+
+function computeScale(revisions: readonly PlanRevisionRecord[]): ScaleDomain {
+  if (revisions.length === 0) return { minMs: 0, maxMs: 0, even: true };
+  let min = Infinity;
+  let max = -Infinity;
+  for (const r of revisions) {
+    if (r.emittedAtMs < min) min = r.emittedAtMs;
+    if (r.emittedAtMs > max) max = r.emittedAtMs;
+  }
+  const even = !(Number.isFinite(min) && Number.isFinite(max)) || max - min < 1;
+  return { minMs: even ? 0 : min, maxMs: even ? 1 : max, even };
+}
+
+function revFrac(
+  rec: PlanRevisionRecord,
+  idx: number,
+  total: number,
+  scale: ScaleDomain,
+): number {
+  if (total <= 1) return 0;
+  if (scale.even) return idx / (total - 1);
+  return (rec.emittedAtMs - scale.minMs) / (scale.maxMs - scale.minMs);
+}
+
+function interventionFrac(
+  row: InterventionRow,
+  revisions: readonly PlanRevisionRecord[],
+  scale: ScaleDomain,
+): number {
+  if (revisions.length === 0) return 0;
+  if (scale.even) {
+    // Place each intervention between its flanking revisions by time order.
+    // Scan revisions; interventions emitted before r[i].emittedAtMs land in
+    // the gap between i-1 and i. Falls back to 0 / 1 for out-of-range.
+    for (let i = 0; i < revisions.length; i++) {
+      if (row.atMs <= revisions[i].emittedAtMs) {
+        if (i === 0) return 0;
+        return (i - 0.5) / Math.max(1, revisions.length - 1);
+      }
+    }
+    return 1;
+  }
+  if (scale.maxMs <= scale.minMs) return 0;
+  const f = (row.atMs - scale.minMs) / (scale.maxMs - scale.minMs);
+  return Math.max(0, Math.min(1, f));
+}
+
+function revisionSummary(rec: PlanRevisionRecord): string {
+  if (rec.revision === 0) return 'R0: initial plan';
+  const kind = rec.kind ? ` · ${rec.kind.toUpperCase()}` : '';
+  const reason = rec.reason ? `: ${rec.reason}` : '';
+  return `R${rec.revision}${kind}${reason}`;
+}
+
+function interventionSummary(row: InterventionRow): string {
+  const sev = row.severity ? ` · ${row.severity.toUpperCase()}` : '';
+  const detail = row.bodyOrReason
+    ? `: ${row.bodyOrReason.slice(0, 120)}${row.bodyOrReason.length > 120 ? '…' : ''}`
+    : '';
+  return `${row.kind}${sev}${detail}`;
+}
+
+function fmtAt(atMs: number): string {
+  if (!Number.isFinite(atMs) || atMs < 0) return '';
+  const total = Math.max(0, Math.floor(atMs / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export function TrajectoryTimelineRibbon(
+  props: TrajectoryTimelineRibbonProps,
+): React.ReactElement {
+  const {
+    revisions,
+    interventions,
+    selectedRevision,
+    onSelectRevision,
+    onInterventionClick,
+    expanded,
+    onToggleExpanded,
+  } = props;
+
+  const popoverIdBase = useId();
+  const [hoverKey, setHoverKey] = useState<string | null>(null);
+  const markersRef = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  const scale = useMemo(() => computeScale(revisions), [revisions]);
+  const sortedRevs = useMemo(
+    () => [...revisions].sort((a, b) => a.revision - b.revision),
+    [revisions],
+  );
+  const sortedIntvs = useMemo(
+    () => [...interventions].sort((a, b) => a.atMs - b.atMs),
+    [interventions],
+  );
+
+  // Ordered focus ring: revision notches in revision order, then "Latest".
+  // Intervention glyphs are tab-stoppable too, interleaved by time after
+  // the revision they follow.
+  const markerOrder = useMemo(() => {
+    const order: string[] = [];
+    for (let i = 0; i < sortedRevs.length; i++) {
+      order.push(`rev:${sortedRevs[i].revision}`);
+      const upto =
+        i + 1 < sortedRevs.length ? sortedRevs[i + 1].emittedAtMs : Infinity;
+      for (const iv of sortedIntvs) {
+        if (iv.atMs >= sortedRevs[i].emittedAtMs && iv.atMs < upto) {
+          order.push(`intv:${iv.key}`);
+        }
+      }
+    }
+    order.push('rev:latest');
+    return order;
+  }, [sortedRevs, sortedIntvs]);
+
+  const focusByKey = useCallback((key: string) => {
+    const el = markersRef.current.get(key);
+    if (el) el.focus();
+  }, []);
+
+  const moveFocus = useCallback(
+    (currentKey: string, delta: 1 | -1) => {
+      const idx = markerOrder.indexOf(currentKey);
+      if (idx < 0) return;
+      const next = idx + delta;
+      if (next < 0 || next >= markerOrder.length) return;
+      focusByKey(markerOrder[next]);
+    },
+    [markerOrder, focusByKey],
+  );
+
+  const onRevKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, key: string) => {
+      if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        moveFocus(key, 1);
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        moveFocus(key, -1);
+      }
+    },
+    [moveFocus],
+  );
+
+  const setMarkerRef = (key: string) => (el: HTMLButtonElement | null) => {
+    if (el) markersRef.current.set(key, el);
+    else markersRef.current.delete(key);
+  };
+
+  const hasLatestSelected = selectedRevision === 'latest';
+  const totalRevs = sortedRevs.length;
+  const headerCount =
+    `${revisions.length} revision${revisions.length === 1 ? '' : 's'} · ` +
+    `${interventions.length} intervention${interventions.length === 1 ? '' : 's'}`;
+
+  return (
+    <div
+      className="hg-traj-ribbon"
+      data-testid="trajectory-timeline-ribbon"
+      data-expanded={expanded ? 'true' : 'false'}
+    >
+      <div className="hg-traj-ribbon__lead">
+        <span className="hg-traj-ribbon__title">Trajectory</span>
+        <span className="hg-traj-ribbon__count">{headerCount}</span>
+      </div>
+
+      <div
+        className="hg-traj-ribbon__track"
+        role="tablist"
+        aria-label="Plan revisions and interventions"
+      >
+        <div className="hg-traj-ribbon__baseline" aria-hidden="true" />
+
+        {sortedRevs.map((rec, idx) => {
+          const frac = revFrac(rec, idx, totalRevs, scale);
+          const selected =
+            typeof selectedRevision === 'number' &&
+            selectedRevision === rec.revision;
+          const key = `rev:${rec.revision}`;
+          const popId = `${popoverIdBase}-${key}`;
+          return (
+            <button
+              key={key}
+              ref={setMarkerRef(key)}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              aria-describedby={hoverKey === key ? popId : undefined}
+              className="hg-traj-ribbon__rev"
+              data-testid={`ribbon-rev-${rec.revision}`}
+              data-selected={selected ? 'true' : 'false'}
+              style={{ left: `${frac * 100}%` }}
+              onClick={() => onSelectRevision(rec.revision)}
+              onMouseEnter={() => setHoverKey(key)}
+              onMouseLeave={() =>
+                setHoverKey((k) => (k === key ? null : k))
+              }
+              onFocus={() => setHoverKey(key)}
+              onBlur={() =>
+                setHoverKey((k) => (k === key ? null : k))
+              }
+              onKeyDown={(e) => onRevKeyDown(e, key)}
+            >
+              <span className="hg-traj-ribbon__rev-dot" aria-hidden="true" />
+              <span className="hg-traj-ribbon__rev-label">
+                R{rec.revision}
+              </span>
+              {hoverKey === key && (
+                <span
+                  id={popId}
+                  role="tooltip"
+                  className="hg-traj-ribbon__popover"
+                  data-testid={`ribbon-popover-rev-${rec.revision}`}
+                >
+                  {revisionSummary(rec)}
+                </span>
+              )}
+            </button>
+          );
+        })}
+
+        {sortedIntvs.map((row) => {
+          const frac = interventionFrac(row, sortedRevs, scale);
+          const key = `intv:${row.key}`;
+          const popId = `${popoverIdBase}-${key}`;
+          const color = interventionColor(row);
+          const sev = (row.severity || 'info').toLowerCase();
+          return (
+            <button
+              key={key}
+              ref={setMarkerRef(key)}
+              type="button"
+              role="button"
+              aria-label={`Intervention ${row.kind}${
+                row.severity ? ` severity ${row.severity}` : ''
+              } at ${fmtAt(row.atMs)}`}
+              aria-describedby={hoverKey === key ? popId : undefined}
+              className="hg-traj-ribbon__intv"
+              data-testid={`ribbon-intv-${row.key}`}
+              data-severity={sev}
+              style={{ left: `${frac * 100}%`, color }}
+              onClick={() => onInterventionClick(row)}
+              onMouseEnter={() => setHoverKey(key)}
+              onMouseLeave={() =>
+                setHoverKey((k) => (k === key ? null : k))
+              }
+              onFocus={() => setHoverKey(key)}
+              onBlur={() =>
+                setHoverKey((k) => (k === key ? null : k))
+              }
+              onKeyDown={(e) => onRevKeyDown(e, key)}
+            >
+              <span className="hg-traj-ribbon__intv-glyph" aria-hidden="true">
+                ▲
+              </span>
+              {hoverKey === key && (
+                <span
+                  id={popId}
+                  role="tooltip"
+                  className="hg-traj-ribbon__popover"
+                  data-testid={`ribbon-popover-intv-${row.key}`}
+                >
+                  {interventionSummary(row)}
+                  <span className="hg-traj-ribbon__popover-at">
+                    {fmtAt(row.atMs)}
+                  </span>
+                </span>
+              )}
+            </button>
+          );
+        })}
+
+        {/* Latest pseudo-notch anchored at right edge. Selected when the
+            caller's selectedRevision === 'latest'. */}
+        <button
+          ref={setMarkerRef('rev:latest')}
+          type="button"
+          role="tab"
+          aria-selected={hasLatestSelected}
+          className="hg-traj-ribbon__latest"
+          data-testid="ribbon-rev-latest"
+          data-selected={hasLatestSelected ? 'true' : 'false'}
+          onClick={() => onSelectRevision('latest')}
+          onKeyDown={(e) => onRevKeyDown(e, 'rev:latest')}
+        >
+          <span className="hg-traj-ribbon__rev-dot" aria-hidden="true" />
+          <span className="hg-traj-ribbon__rev-label">Latest</span>
+        </button>
+      </div>
+
+      <div className="hg-traj-ribbon__tail">
+        {!hasLatestSelected && (
+          <button
+            type="button"
+            className="hg-traj-ribbon__latest-btn"
+            data-testid="ribbon-latest-btn"
+            onClick={() => onSelectRevision('latest')}
+          >
+            Latest
+          </button>
+        )}
+        {onToggleExpanded && (
+          <button
+            type="button"
+            className="hg-traj-ribbon__expand"
+            data-testid="ribbon-expand-btn"
+            aria-label={expanded ? 'Collapse ribbon' : 'Expand to stacked view'}
+            aria-pressed={expanded ? 'true' : 'false'}
+            onClick={onToggleExpanded}
+            title={expanded ? 'Collapse' : 'Expand to stacked view'}
+          >
+            ⤢
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #172.

## User feedback (verbatim)

> The Trajectory view today stacks four horizontal sections above the DAG: (1) Trajectory header with rev chips, (2) REVISIONS strip with notches + Latest button, (3) REV 0 / REV 1 descriptive cards, (4) INTERVENTIONS list. All four communicate the same dimension ("what revisions happened and what triggered them"), and together they eat half the vertical space, squeezing the DAG. The user wants a single compact interactive ribbon (~60-80px tall) that absorbs all four.

## Summary

- New self-contained component `frontend/src/components/shell/views/TrajectoryTimelineRibbon.tsx` (~376 LOC) plus co-located CSS.
- Renders one row of revision notches + intervention glyphs on a single scrubber, with hover popovers, click handlers, keyboard tab/arrow navigation, and a Latest pseudo-notch.
- Primary `Latest` button surfaces when `selectedRevision !== 'latest'`; optional `onToggleExpanded` renders an opt-out expand icon.
- Revision positions are proportional to `emittedAtMs` and fall back to even spacing when timestamps cluster (< 1 ms total range). Intervention positions interpolate between their flanking revisions in the even-spacing case, or scale linearly on `atMs` otherwise.
- Severity → glyph colour: `WARNING` amber `#f59e0b`, `CRITICAL` red `#e06070`, `INFO`/unset grey `#8d9199`.
- Accessibility: `role="tablist"` on the band, `role="tab"` + `aria-selected` on revision markers, `role="button"` + descriptive `aria-label` on intervention glyphs, `role="tooltip"` + `aria-describedby` on popovers.

## Interface (frozen — siblings build against this)

\`\`\`typescript
export interface TrajectoryTimelineRibbonProps {
  revisions: PlanRevisionRecord[];
  interventions: InterventionRow[];
  selectedRevision: number | 'latest';
  onSelectRevision: (rev: number | 'latest') => void;
  onInterventionClick: (intervention: InterventionRow) => void;
  expanded?: boolean;
  onToggleExpanded?: () => void;
}
\`\`\`

The sibling branch `feat/trajectory-layout-restructure` is adopting this interface verbatim to replace the four stacked sections inside `TrajectoryView.tsx`. No changes to `TrajectoryView.tsx` in this PR.

## Test plan

- [x] 16 new unit tests in `TrajectoryTimelineRibbon.test.tsx` cover:
  - Rendering one notch per revision + Latest pseudo-notch.
  - Intervention glyphs interleaved by timestamp.
  - Severity → colour mapping (warning / critical / info).
  - `aria-selected` reflects `selectedRevision` on the correct notch.
  - Selecting Latest via both pseudo-notch and primary button.
  - Click revision → `onSelectRevision(n)`.
  - Click intervention → `onInterventionClick(row)`.
  - `Latest` button visibility driven by `selectedRevision`.
  - Hover revision shows popover with reason + kind, wires `aria-describedby`.
  - Hover intervention shows popover with detail + severity + timestamp.
  - Keyboard arrow-left / arrow-right walks between markers (including interventions interleaved between revisions).
  - Enter on a focused revision activates selection.
  - Expand toggle fires `onToggleExpanded` and is omitted when unprovided.
  - Header count string renders correctly.
- [x] `pnpm test --run` — 514 tests pass (52 files).
- [x] `pnpm tsc -b` — clean.
- [x] `pnpm lint` — 0 errors (1 pre-existing warning in `GanttView.tsx`, unrelated).