### PR TITLE
feat(ui): floating drawer for trajectory detail panes

### DIFF
--- a/frontend/src/__tests__/components/TrajectoryFloatingDrawer.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryFloatingDrawer.test.tsx
@@ -1,0 +1,356 @@
+/**
+ * TrajectoryFloatingDrawer + SteeringDetailBody + TaskNodeDetail tests.
+ *
+ * Covers the floating-drawer refactor of the trajectory detail pane:
+ *   - drawer visibility / slide transform / backdrop + esc close
+ *   - focus trap + focus restore
+ *   - SteeringDetailBody section testids match the legacy panel (so the
+ *     TrajectoryView integration tests keep passing)
+ *   - TaskNodeDetail metadata + jump-to-gantt handler
+ *   - Integration: SteeringDetailBody mounted inside the drawer
+ */
+
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+import { TrajectoryFloatingDrawer } from '../../components/shell/views/TrajectoryFloatingDrawer';
+import {
+  SteeringDetailBody,
+  type SteeringSelection,
+} from '../../components/shell/views/SteeringDetailPanel';
+import { TaskNodeDetail } from '../../components/shell/views/TaskNodeDetail';
+import type { Task, TaskPlan } from '../../gantt/types';
+import type {
+  PlanRevisionRecord,
+  SupersessionLink,
+} from '../../state/planHistoryStore';
+
+vi.mock('../../components/shell/views/views.css', () => ({}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+function mkTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 't1',
+    title: 'build outline',
+    description: 'lay out the doc structure',
+    assigneeAgentId: 'agent-a',
+    status: 'RUNNING',
+    predictedStartMs: 0,
+    predictedDurationMs: 0,
+    boundSpanId: 'span-abcdef12',
+    cancelReason: '',
+    ...overrides,
+  };
+}
+
+function mkPlan(tasks: Task[]): TaskPlan {
+  return {
+    id: 'p1',
+    invocationSpanId: 'inv-p1',
+    plannerAgentId: 'planner',
+    createdAtMs: 0,
+    summary: 'plan p1',
+    tasks,
+    edges: [],
+    revisionReason: '',
+  };
+}
+
+function mkRevisionRecord(overrides: Partial<PlanRevisionRecord> = {}): PlanRevisionRecord {
+  return {
+    revision: 1,
+    plan: mkPlan([mkTask()]),
+    reason: 'coordinator drifted off topic',
+    kind: 'off_topic',
+    triggerEventId: '',
+    emittedAtMs: 0,
+    ...overrides,
+  };
+}
+
+// ── Drawer base ───────────────────────────────────────────────────────────
+
+describe('TrajectoryFloatingDrawer', () => {
+  it('renders nothing when open=false', () => {
+    render(
+      <TrajectoryFloatingDrawer open={false} onClose={() => {}}>
+        <button>inside</button>
+      </TrajectoryFloatingDrawer>,
+    );
+    expect(screen.queryByTestId('trajectory-drawer')).not.toBeInTheDocument();
+  });
+
+  it('renders dialog with role/aria when open=true', () => {
+    render(
+      <TrajectoryFloatingDrawer open={true} onClose={() => {}} title="Detail">
+        <button>inside</button>
+      </TrajectoryFloatingDrawer>,
+    );
+    const drawer = screen.getByTestId('trajectory-drawer');
+    expect(drawer).toHaveAttribute('role', 'dialog');
+    expect(drawer).toHaveAttribute('aria-modal', 'true');
+    expect(drawer).toHaveAttribute('aria-labelledby');
+    const titleEl = document.getElementById(drawer.getAttribute('aria-labelledby')!);
+    expect(titleEl?.textContent).toBe('Detail');
+  });
+
+  it('applies slide-in transform (animation class present on open)', () => {
+    render(
+      <TrajectoryFloatingDrawer open={true} onClose={() => {}}>
+        <div>body</div>
+      </TrajectoryFloatingDrawer>,
+    );
+    const drawer = screen.getByTestId('trajectory-drawer');
+    expect(drawer).toHaveAttribute('data-open', 'true');
+    // transform is set to translateX(0) by CSS; we assert the drawer class
+    // is present so the ~200ms slide-in keyframe applies.
+    expect(drawer.className).toContain('hg-traj__drawer');
+  });
+
+  it('backdrop click invokes onClose', () => {
+    const onClose = vi.fn();
+    render(
+      <TrajectoryFloatingDrawer open={true} onClose={onClose}>
+        <div>body</div>
+      </TrajectoryFloatingDrawer>,
+    );
+    fireEvent.click(screen.getByTestId('trajectory-drawer-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape key invokes onClose', () => {
+    const onClose = vi.fn();
+    render(
+      <TrajectoryFloatingDrawer open={true} onClose={onClose}>
+        <div>body</div>
+      </TrajectoryFloatingDrawer>,
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('close button in header invokes onClose', () => {
+    const onClose = vi.fn();
+    render(
+      <TrajectoryFloatingDrawer open={true} onClose={onClose} title="T">
+        <div>body</div>
+      </TrajectoryFloatingDrawer>,
+    );
+    fireEvent.click(screen.getByTestId('trajectory-drawer-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('focus trap: Tab at last element wraps to first, Shift-Tab at first wraps to last', () => {
+    render(
+      <TrajectoryFloatingDrawer open={true} onClose={() => {}}>
+        <button data-testid="a">A</button>
+        <button data-testid="b">B</button>
+        <button data-testid="c">C</button>
+      </TrajectoryFloatingDrawer>,
+    );
+    const a = screen.getByTestId('a');
+    const c = screen.getByTestId('c');
+    c.focus();
+    expect(document.activeElement).toBe(c);
+    fireEvent.keyDown(window, { key: 'Tab' });
+    expect(document.activeElement).toBe(a);
+    fireEvent.keyDown(window, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(c);
+  });
+
+  it('focus restored to trigger on close', () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <div>
+          <button data-testid="trigger" onClick={() => setOpen(true)}>
+            open
+          </button>
+          <TrajectoryFloatingDrawer open={open} onClose={() => setOpen(false)}>
+            <button data-testid="inside-btn">inside</button>
+          </TrajectoryFloatingDrawer>
+        </div>
+      );
+    }
+    render(<Harness />);
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+    fireEvent.click(trigger);
+    // Drawer mounted; focus moved inside.
+    expect(document.activeElement).toBe(screen.getByTestId('inside-btn'));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByTestId('trajectory-drawer')).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(trigger);
+  });
+});
+
+// ── SteeringDetailBody ────────────────────────────────────────────────────
+
+describe('SteeringDetailBody', () => {
+  const selection: SteeringSelection = {
+    kind: 'revision',
+    revision: 1,
+    targetTaskId: 't1',
+  };
+  const plan = mkPlan([mkTask({ id: 't1', title: 'research paper', assigneeAgentId: 'research_agent' })]);
+  const history: PlanRevisionRecord[] = [mkRevisionRecord({ plan })];
+  const supersedes = new Map<string, SupersessionLink>();
+
+  it('renders Trigger / Steering / Target sections with preserved testids', () => {
+    render(
+      <SteeringDetailBody
+        selection={selection}
+        plan={plan}
+        history={history}
+        supersedes={supersedes}
+        store={null}
+        onJumpToGantt={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('steering-detail-body')).toBeInTheDocument();
+    expect(screen.getByTestId('steering-detail-trigger')).toBeInTheDocument();
+    expect(screen.getByTestId('steering-detail-steering')).toBeInTheDocument();
+    expect(screen.getByTestId('steering-detail-target')).toBeInTheDocument();
+    expect(screen.getByTestId('steering-detail-target-agent')).toHaveTextContent(
+      'research_agent',
+    );
+    expect(screen.getByTestId('steering-detail-target-task')).toHaveTextContent(
+      'research paper',
+    );
+    expect(screen.getByTestId('steering-detail-trigger')).toHaveTextContent(
+      'off_topic',
+    );
+  });
+
+  it('jump-to-gantt is disabled when no triggerEventId and fires callback otherwise', () => {
+    const onJump = vi.fn();
+    const { rerender } = render(
+      <SteeringDetailBody
+        selection={selection}
+        plan={plan}
+        history={history}
+        supersedes={supersedes}
+        store={null}
+        onJumpToGantt={onJump}
+      />,
+    );
+    const btn = screen.getByTestId('steering-detail-jump-gantt');
+    expect(btn).toBeDisabled();
+
+    rerender(
+      <SteeringDetailBody
+        selection={selection}
+        plan={plan}
+        history={[mkRevisionRecord({ plan, triggerEventId: 'drift-xyz' })]}
+        supersedes={supersedes}
+        store={null}
+        onJumpToGantt={onJump}
+      />,
+    );
+    const btn2 = screen.getByTestId('steering-detail-jump-gantt');
+    expect(btn2).not.toBeDisabled();
+    fireEvent.click(btn2);
+    expect(onJump).toHaveBeenCalledTimes(1);
+    expect(onJump).toHaveBeenCalledWith(null, 'drift-xyz');
+  });
+});
+
+// ── TaskNodeDetail ────────────────────────────────────────────────────────
+
+describe('TaskNodeDetail', () => {
+  it('renders assignee / description / status / bound span', () => {
+    const task = mkTask({
+      assigneeAgentId: 'spec://research_agent',
+      description: 'do the research',
+      status: 'RUNNING',
+      boundSpanId: 'deadbeef1234',
+    });
+    render(<TaskNodeDetail task={task} plan={mkPlan([task])} store={null} />);
+    expect(screen.getByTestId('task-node-detail-title')).toHaveTextContent(
+      'build outline',
+    );
+    expect(screen.getByTestId('task-node-detail-status')).toHaveTextContent('running');
+    expect(screen.getByTestId('task-node-detail-description')).toHaveTextContent(
+      'do the research',
+    );
+    // First 8 chars of bound span id.
+    expect(screen.getByTestId('task-node-detail-bound-span')).toHaveTextContent(
+      'deadbeef',
+    );
+    // Assignee falls back to bareAgentName / raw id when no store entry.
+    expect(screen.getByTestId('task-node-detail-assignee')).toBeInTheDocument();
+  });
+
+  it('renders cancel reason for CANCELLED tasks', () => {
+    const task = mkTask({ status: 'CANCELLED', cancelReason: 'superseded_by_revision' });
+    render(<TaskNodeDetail task={task} plan={mkPlan([task])} />);
+    expect(screen.getByTestId('task-node-detail-cancel-reason')).toHaveTextContent(
+      'superseded_by_revision',
+    );
+  });
+
+  it('jump-to-gantt button calls onJumpToGantt with the task id', () => {
+    const task = mkTask({ id: 'task-7' });
+    const onJump = vi.fn();
+    render(
+      <TaskNodeDetail task={task} plan={mkPlan([task])} onJumpToGantt={onJump} />,
+    );
+    fireEvent.click(screen.getByTestId('task-node-detail-jump-gantt'));
+    expect(onJump).toHaveBeenCalledWith('task-7');
+  });
+
+  it('omits jump-to-gantt button when no handler supplied', () => {
+    const task = mkTask();
+    render(<TaskNodeDetail task={task} plan={mkPlan([task])} />);
+    expect(screen.queryByTestId('task-node-detail-jump-gantt')).not.toBeInTheDocument();
+  });
+});
+
+// ── Integration: body mounted inside drawer ──────────────────────────────
+
+describe('SteeringDetailBody inside TrajectoryFloatingDrawer', () => {
+  it('open/close works end-to-end; body visible only while open', () => {
+    const selection: SteeringSelection = {
+      kind: 'revision',
+      revision: 1,
+      targetTaskId: 't1',
+    };
+    const plan = mkPlan([mkTask({ id: 't1' })]);
+    const history: PlanRevisionRecord[] = [mkRevisionRecord({ plan })];
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <div>
+          <button data-testid="opener" onClick={() => setOpen(true)}>
+            open
+          </button>
+          <TrajectoryFloatingDrawer
+            open={open}
+            onClose={() => setOpen(false)}
+            title="Steering"
+            testId="integration-drawer"
+            closeTestId="integration-drawer-close"
+          >
+            <SteeringDetailBody
+              selection={selection}
+              plan={plan}
+              history={history}
+              supersedes={new Map()}
+              store={null}
+              onJumpToGantt={() => {}}
+            />
+          </TrajectoryFloatingDrawer>
+        </div>
+      );
+    }
+    render(<Harness />);
+    expect(screen.queryByTestId('steering-detail-body')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('opener'));
+    const drawer = screen.getByTestId('integration-drawer');
+    expect(within(drawer).getByTestId('steering-detail-body')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('integration-drawer-close'));
+    expect(screen.queryByTestId('steering-detail-body')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/shell/views/SteeringDetailPanel.tsx
+++ b/frontend/src/components/shell/views/SteeringDetailPanel.tsx
@@ -13,11 +13,18 @@
 //
 // Reads optional refine-span attributes (input_preview, output_preview,
 // decision_summary, target_agent_id) that the sibling goldfive-render
-// and sink-stamp worktrees stamp. Degrades to the bare PlanRevised
+// and sink-stamp worktreees stamp. Degrades to the bare PlanRevised
 // reason + drift detail when those attrs are absent.
+//
+// Refactor (harmonograf — floating-drawer): the content is split into a
+// pure `<SteeringDetailBody>` that renders the three sections + jump
+// footer, and a thin `<SteeringDetailPanel>` adapter that wraps the body
+// in a `<TrajectoryFloatingDrawer>` (backward-compat for existing call
+// sites and tests that expect a panel with data-testid
+// "steering-detail-panel"). New layouts should mount SteeringDetailBody
+// inside their own TrajectoryFloatingDrawer.
 
 import type React from 'react';
-import { useEffect } from 'react';
 import type { SessionStore } from '../../../gantt/index';
 import { bareAgentName } from '../../../gantt/index';
 import type { Span, Task, TaskPlan } from '../../../gantt/types';
@@ -25,12 +32,22 @@ import type {
   PlanRevisionRecord,
   SupersessionLink,
 } from '../../../state/planHistoryStore';
+import { TrajectoryFloatingDrawer } from './TrajectoryFloatingDrawer';
 
 export interface SteeringSelection {
   kind: 'revision' | 'supersedes';
   revision: number;
   oldTaskId?: string;
   targetTaskId?: string;
+}
+
+export interface SteeringDetailBodyProps {
+  selection: SteeringSelection;
+  plan: TaskPlan | null;
+  history: readonly PlanRevisionRecord[];
+  supersedes: Map<string, SupersessionLink>;
+  store: SessionStore | null;
+  onJumpToGantt: (atMs: number | null, driftId: string) => void;
 }
 
 export interface SteeringDetailPanelProps {
@@ -72,22 +89,10 @@ function agentDisplayName(store: SessionStore | null, id: string): string {
   return store?.agents.get(id)?.name || bareAgentName(id) || id;
 }
 
-export function SteeringDetailPanel(
-  props: SteeringDetailPanelProps,
-): React.ReactElement | null {
-  const { selection, plan, history, supersedes, store, onClose, onJumpToGantt } = props;
-
-  // Esc closes the panel.
-  useEffect(() => {
-    if (!selection) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [selection, onClose]);
-
-  if (!selection) return null;
+export function SteeringDetailBody(
+  props: SteeringDetailBodyProps,
+): React.ReactElement {
+  const { selection, plan, history, supersedes, store, onJumpToGantt } = props;
 
   const record: PlanRevisionRecord | undefined = history.find(
     (r) => r.revision === selection.revision,
@@ -128,29 +133,16 @@ export function SteeringDetailPanel(
   }
 
   return (
-    <aside
-      className="hg-traj__steering-panel"
-      data-testid="steering-detail-panel"
-      role="dialog"
-      aria-label="Steering decision detail"
+    <div
+      className="hg-traj__steering-panel-inner"
+      data-testid="steering-detail-body"
     >
-      <header className="hg-traj__steering-panel-head">
-        <div>
-          <span className="hg-traj__steering-panel-kicker" data-authored-by={authoredBy}>
-            {authoredBy === 'user' ? 'user steer' : 'goldfive steer'} · rev {selection.revision}
-          </span>
-          <h3 className="hg-traj__steering-panel-title">{kind || 'plan revised'}</h3>
-        </div>
-        <button
-          type="button"
-          className="hg-traj__steering-panel-close"
-          onClick={onClose}
-          aria-label="Close steering detail"
-          data-testid="steering-detail-close"
-        >
-          ×
-        </button>
-      </header>
+      <div className="hg-traj__steering-panel-kicker-row">
+        <span className="hg-traj__steering-panel-kicker" data-authored-by={authoredBy}>
+          {authoredBy === 'user' ? 'user steer' : 'goldfive steer'} · rev {selection.revision}
+        </span>
+        <span className="hg-traj__steering-panel-kind">{kind || 'plan revised'}</span>
+      </div>
 
       <section
         className="hg-traj__steering-panel-section"
@@ -203,7 +195,7 @@ export function SteeringDetailPanel(
         )}
       </section>
 
-      <footer className="hg-traj__steering-panel-foot">
+      <div className="hg-traj__steering-panel-foot">
         <button
           type="button"
           className="hg-traj__steering-panel-jump"
@@ -213,7 +205,43 @@ export function SteeringDetailPanel(
         >
           Jump to drift in Gantt
         </button>
-      </footer>
-    </aside>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Backward-compat adapter: mounts SteeringDetailBody inside a
+ * TrajectoryFloatingDrawer and forwards close/jump. Existing call sites
+ * (TrajectoryView today, plus the evolution tests) keep working
+ * unchanged — testids like `steering-detail-panel` and
+ * `steering-detail-close` are re-stamped on the drawer wrapper.
+ */
+export function SteeringDetailPanel(
+  props: SteeringDetailPanelProps,
+): React.ReactElement | null {
+  const { selection, onClose, ...bodyRest } = props;
+  const title = selection
+    ? `${selection.kind === 'supersedes' ? 'supersedes' : 'revision'} · rev ${selection.revision}`
+    : undefined;
+  return (
+    <TrajectoryFloatingDrawer
+      open={selection !== null}
+      onClose={onClose}
+      title={title}
+      testId="steering-detail-panel"
+      closeTestId="steering-detail-close"
+    >
+      {selection && (
+        <SteeringDetailBody
+          selection={selection}
+          plan={bodyRest.plan}
+          history={bodyRest.history}
+          supersedes={bodyRest.supersedes}
+          store={bodyRest.store}
+          onJumpToGantt={bodyRest.onJumpToGantt}
+        />
+      )}
+    </TrajectoryFloatingDrawer>
   );
 }

--- a/frontend/src/components/shell/views/TaskNodeDetail.tsx
+++ b/frontend/src/components/shell/views/TaskNodeDetail.tsx
@@ -1,0 +1,116 @@
+// TaskNodeDetail — pure content component for the trajectory task-node
+// detail pane. Extracted from TrajectoryView.DetailPane so it can be
+// mounted inside a `<TrajectoryFloatingDrawer>` by the layout-restructure
+// worktree without pulling in the rest of the view's state.
+//
+// Props are intentionally plain: the caller hands in the resolved task +
+// plan + optional jump handler. The component itself does not reach into
+// the UI store, so it stays easy to test and reuse.
+
+import type React from 'react';
+import { bareAgentName } from '../../../gantt/index';
+import type { SessionStore } from '../../../gantt/index';
+import type { Task, TaskPlan } from '../../../gantt/types';
+
+export interface TaskNodeDetailProps {
+  task: Task;
+  plan: TaskPlan;
+  /** Optional store for agent-name lookup + bound-span start time. */
+  store?: SessionStore | null;
+  /**
+   * Called when the user presses the "Jump to Gantt" button. Parent
+   * decides how to navigate (typically selectSpan on the task's bound
+   * span or scrolling the Gantt to the task's row).
+   */
+  onJumpToGantt?: (taskId: string) => void;
+}
+
+function fmtTime(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  const totalSec = Math.floor(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export function TaskNodeDetail(props: TaskNodeDetailProps): React.ReactElement {
+  const { task, plan, store, onJumpToGantt } = props;
+  const span =
+    task.boundSpanId && store ? store.spans.get(task.boundSpanId) : null;
+  const assigneeName = task.assigneeAgentId
+    ? store?.agents.get(task.assigneeAgentId)?.name ||
+      bareAgentName(task.assigneeAgentId) ||
+      task.assigneeAgentId
+    : '—';
+  // Keep the plan reference live — currently unused beyond context, but
+  // callers pass it so future enhancements (sibling-task links, edge
+  // summary) can use it without a prop signature change.
+  void plan;
+
+  return (
+    <div className="hg-traj__task-detail" data-testid="task-node-detail">
+      <header className="hg-traj__task-detail-head">
+        <span className="hg-traj__detail-kind">task</span>
+        <h3 data-testid="task-node-detail-title">{task.title || task.id}</h3>
+        <span
+          className="hg-traj__detail-status"
+          data-status={task.status}
+          data-testid="task-node-detail-status"
+        >
+          {task.status.toLowerCase()}
+        </span>
+      </header>
+      {task.description && (
+        <p
+          className="hg-traj__detail-desc"
+          data-testid="task-node-detail-description"
+        >
+          {task.description}
+        </p>
+      )}
+      <dl className="hg-traj__detail-meta">
+        <dt>assignee</dt>
+        <dd
+          data-testid="task-node-detail-assignee"
+          title={task.assigneeAgentId || undefined}
+        >
+          {assigneeName}
+        </dd>
+        <dt>bound span</dt>
+        <dd data-testid="task-node-detail-bound-span">
+          {task.boundSpanId ? task.boundSpanId.slice(0, 8) : '—'}
+        </dd>
+        {span && (
+          <>
+            <dt>started</dt>
+            <dd data-testid="task-node-detail-started">{fmtTime(span.startMs)}</dd>
+          </>
+        )}
+      </dl>
+      {(task.status === 'CANCELLED' || task.status === 'FAILED') &&
+        task.cancelReason && (
+          <section
+            className="hg-traj__detail-cancel-reason"
+            data-testid="task-node-detail-cancel-reason"
+          >
+            <strong>
+              {task.status === 'FAILED' ? 'failed:' : 'cancelled:'}
+            </strong>{' '}
+            <span>{task.cancelReason}</span>
+          </section>
+        )}
+      {onJumpToGantt && (
+        <div className="hg-traj__task-detail-foot">
+          <button
+            type="button"
+            className="hg-traj__task-detail-jump"
+            data-testid="task-node-detail-jump-gantt"
+            onClick={() => onJumpToGantt(task.id)}
+          >
+            Jump to Gantt
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/shell/views/TrajectoryFloatingDrawer.tsx
+++ b/frontend/src/components/shell/views/TrajectoryFloatingDrawer.tsx
@@ -1,0 +1,167 @@
+// TrajectoryFloatingDrawer — overlay drawer pinned to the right edge of
+// the Trajectory view. Lets the DAG stay full-width by default while
+// detail panes slide in on demand rather than permanently consuming a
+// right column.
+//
+// Absolute-positioned within the nearest relatively-positioned ancestor
+// (the trajectory view's root). The backdrop covers only that ancestor,
+// not the full viewport — so opening a drawer does not dim unrelated
+// chrome.
+//
+// Enter/exit is a 200ms translateX slide. When `open=false` the drawer
+// unmounts entirely (cheaper than keeping it around + translated off
+// screen, and side-steps focus-trap bookkeeping when idle).
+
+import type React from 'react';
+import { useCallback, useEffect, useId, useRef } from 'react';
+
+export interface TrajectoryFloatingDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+  /** Width override in px. Default 400. */
+  width?: number;
+  /** Optional stable id for the drawer root, useful in tests. */
+  testId?: string;
+  /** Optional stable id for the close button. Defaults to `${testId}-close`. */
+  closeTestId?: string;
+}
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function collectFocusable(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) => !el.hasAttribute('data-focus-trap-exit'),
+  );
+}
+
+export function TrajectoryFloatingDrawer(
+  props: TrajectoryFloatingDrawerProps,
+): React.ReactElement | null {
+  const { open, onClose, title, children, width = 400, testId, closeTestId } = props;
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const autoTitleId = useId();
+  const titleId = title ? `${autoTitleId}-title` : undefined;
+
+  // Track the element focused before the drawer opened so we can restore
+  // focus on close (WCAG 2.4.3 — focus order / reasonable return point).
+  useEffect(() => {
+    if (!open) return;
+    previousFocusRef.current =
+      (document.activeElement as HTMLElement | null) ?? null;
+    // Move focus into the drawer on open so keyboard users land inside.
+    const drawer = drawerRef.current;
+    if (drawer) {
+      const focusables = collectFocusable(drawer);
+      const first = focusables[0] ?? drawer;
+      first.focus();
+    }
+    return () => {
+      const prev = previousFocusRef.current;
+      if (prev && typeof prev.focus === 'function') {
+        prev.focus();
+      }
+      previousFocusRef.current = null;
+    };
+  }, [open]);
+
+  // Esc closes. Tab / Shift-Tab wrap within the drawer.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const drawer = drawerRef.current;
+      if (!drawer) return;
+      const focusables = collectFocusable(drawer);
+      if (focusables.length === 0) {
+        e.preventDefault();
+        drawer.focus();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || !drawer.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [open, onClose]);
+
+  const onBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        className="hg-traj__drawer-backdrop"
+        data-testid={testId ? `${testId}-backdrop` : 'trajectory-drawer-backdrop'}
+        onClick={onBackdropClick}
+        // The backdrop is decorative click-surface, not a dialog trigger.
+        aria-hidden="true"
+      />
+      <div
+        ref={drawerRef}
+        className="hg-traj__drawer"
+        data-testid={testId ?? 'trajectory-drawer'}
+        data-open="true"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        style={{ width: `${width}px` }}
+      >
+        {title && (
+          <header className="hg-traj__drawer-head">
+            <h3 id={titleId} className="hg-traj__drawer-title">
+              {title}
+            </h3>
+            <button
+              type="button"
+              className="hg-traj__drawer-close"
+              onClick={onClose}
+              aria-label="Close"
+              data-testid={
+                closeTestId ??
+                (testId ? `${testId}-close` : 'trajectory-drawer-close')
+              }
+            >
+              ×
+            </button>
+          </header>
+        )}
+        <div className="hg-traj__drawer-body">{children}</div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/shell/views/views.css
+++ b/frontend/src/components/shell/views/views.css
@@ -910,3 +910,103 @@ a.hg-settings__value:hover {
 
 .hg-traj__supersedes-edge { pointer-events: auto; }
 .hg-traj__supersedes-label { pointer-events: auto; cursor: pointer; }
+
+/* ── Floating drawer (overlay detail pane) ──────────────────────────── */
+
+.hg-traj__drawer-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  z-index: 20;
+  animation: hg-traj-drawer-fade-in 120ms ease forwards;
+}
+
+.hg-traj__drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 21;
+  background: var(--md-sys-color-surface-container-low, #161923);
+  border-left: 1px solid var(--md-sys-color-outline-variant, #2a2f3a);
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  transform: translateX(0);
+  animation: hg-traj-drawer-slide-in 200ms ease forwards;
+  outline: none;
+}
+
+@keyframes hg-traj-drawer-slide-in {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+@keyframes hg-traj-drawer-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.hg-traj__drawer-head {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 14px;
+  background: var(--md-sys-color-surface-container-low, #161923);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant, #2a2f3a);
+}
+
+.hg-traj__drawer-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.hg-traj__drawer-close {
+  background: transparent;
+  border: 0;
+  color: var(--md-sys-color-on-surface-variant, #c7c9d1);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 6px;
+  line-height: 1;
+}
+
+.hg-traj__drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.hg-traj__steering-panel-kicker-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.hg-traj__steering-panel-kind {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.hg-traj__task-detail { display: flex; flex-direction: column; gap: 10px; }
+.hg-traj__task-detail-head { display: flex; align-items: center; gap: 8px; }
+.hg-traj__task-detail-head h3 { margin: 0; font-size: 14px; }
+.hg-traj__task-detail-foot { display: flex; justify-content: flex-end; }
+.hg-traj__task-detail-jump {
+  font-size: 11px;
+  padding: 5px 10px;
+  background: rgba(154, 195, 255, 0.1);
+  color: var(--md-sys-color-primary, #aac7ff);
+  border: 1px solid var(--md-sys-color-outline-variant, #2a2f3a);
+  border-radius: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
Closes #174.

## User feedback

> The Trajectory view's DAG needs horizontal breathing room. Today `SteeringDetailPanel` lives as a right-column sibling that permanently consumes ~25% of horizontal space. The task-node detail pane (when a task is clicked) similarly takes right-column space. The user wants: DAG full-width by default; detail content slides in as an overlay only when explicitly invoked, and overlays over the DAG rather than reflowing it.

## Summary

- New `TrajectoryFloatingDrawer` base: absolute-positioned to the right edge of the Trajectory view's root container (so the DAG stays full-width underneath), 200ms slide-in, semi-transparent backdrop over just the view, `role="dialog"` / `aria-modal` / `aria-labelledby`. Esc closes, backdrop click closes, focus trap, focus restored to the trigger on close.
- `SteeringDetailPanel.tsx` split into `SteeringDetailBody` (pure content) plus a thin backward-compat adapter that mounts the body inside a `TrajectoryFloatingDrawer` with the legacy testids (`steering-detail-panel`, `steering-detail-close`, `steering-detail-trigger`, `steering-detail-steering`, `steering-detail-target`, ...). All existing `TrajectoryView` evolution / steering / cancel-reason tests keep passing unchanged.
- New `TaskNodeDetail.tsx`: extracts the task-click detail content (assignee / description / status / bound span / optional cancel reason / "Jump to Gantt" button) from `TrajectoryView.DetailPane` into a standalone component the layout-restructure worktree can mount inside its own `TrajectoryFloatingDrawer`.

## Back-compat

`SteeringDetailPanel`'s public API is unchanged. The adapter renders the body inside the floating drawer with the same testids the legacy tests rely on, so no downstream test had to change shape.

## Scope

Self-contained. Does NOT modify `TrajectoryView.tsx` — the sibling `feat/trajectory-layout-restructure` worktree will rewire the layout.

## Test plan

- [x] `pnpm test --run` -> 52 files / 513 tests green (15 new + 498 pre-existing).
- [x] `pnpm tsc -b` clean.
- [x] `pnpm lint` clean (only the pre-existing GanttView warning remains).
- [ ] Manual smoke on the Trajectory view once the layout-restructure PR lands and consumes the drawer.