### PR TITLE
feat(ui): restructure TrajectoryView with unified ribbon + floating drawer

### DIFF
--- a/frontend/src/__tests__/components/TrajectoryView.emptyRev.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.emptyRev.test.tsx
@@ -52,6 +52,10 @@ vi.mock('../../rpc/hooks', () => ({
 const uiStoreState = {
   currentSessionId: mockSessionId,
   selectSpan: vi.fn(),
+  trajectoryLegacyExpanded: false,
+  toggleTrajectoryLegacyExpanded: (): void => {
+    uiStoreState.trajectoryLegacyExpanded = !uiStoreState.trajectoryLegacyExpanded;
+  },
 };
 vi.mock('../../state/uiStore', () => ({
   useUiStore: <T,>(selector: (s: typeof uiStoreState) => T) =>
@@ -105,6 +109,7 @@ function mkPlan(tasks: Task[]): TaskPlan {
 
 beforeEach(() => {
   mockStore = new SessionStore();
+  uiStoreState.trajectoryLegacyExpanded = false;
 });
 
 afterEach(() => {
@@ -125,16 +130,13 @@ describe('<TrajectoryView /> with only rev 0 + drift storm', () => {
 
     render(<TrajectoryView />);
 
-    // Header + rev chip show.
-    expect(screen.getByText('Trajectory')).toBeInTheDocument();
+    // Header shows — multiple matches (panel title + ribbon label); the
+    // panel-title h2 is the authoritative one.
+    expect(screen.getAllByText('Trajectory').length).toBeGreaterThan(0);
 
-    // Ribbon rendered.
-    expect(screen.getByTestId('trajectory-ribbon')).toBeInTheDocument();
-    expect(screen.getByTestId('rev-segment-0')).toBeInTheDocument();
-    // Summary text from the plan surfaces.
-    expect(
-      screen.getByText(/Two-slide solar panel presentation/),
-    ).toBeInTheDocument();
+    // Unified ribbon rendered (the restructured single strip).
+    expect(screen.getByTestId('trajectory-timeline-ribbon')).toBeInTheDocument();
+    expect(screen.getByTestId('ribbon-rev-0')).toBeInTheDocument();
 
     // DAG renders each task as a node with its stable testid.
     expect(screen.getByTestId('trajectory-dag')).toBeInTheDocument();
@@ -148,7 +150,7 @@ describe('<TrajectoryView /> with only rev 0 + drift storm', () => {
     expect(cancelRow).toHaveTextContent('superseded_by_revision');
   });
 
-  it('drops UNSPECIFIED-kind drifts from the ribbon entirely', () => {
+  it('drops UNSPECIFIED-kind drifts from the unified ribbon entirely', () => {
     const plan = mkPlan([mkTask('t1', 'RUNNING')]);
     mockStore.tasks.upsertPlan(plan);
 
@@ -170,21 +172,22 @@ describe('<TrajectoryView /> with only rev 0 + drift storm', () => {
 
     render(<TrajectoryView />);
 
-    // No drift markers at all (every drift was unspec). No "+N more" chip
-    // either, since the filter drops these before the cap applies.
-    expect(screen.queryAllByTestId(/^drift-marker-/)).toHaveLength(0);
-    expect(screen.queryByTestId('drift-more-0')).not.toBeInTheDocument();
+    // No intervention dots at all (every drift was unspec) — the
+    // interventions deriver drops empty-kind drifts up front.
+    expect(screen.queryAllByTestId(/^ribbon-intervention-/)).toHaveLength(0);
 
     // Task node still renders — the ribbon never blocked it.
     expect(screen.getByTestId('task-node-t1')).toBeInTheDocument();
   });
 
-  it('caps legitimate drifts per rev and shows a +N summary chip', () => {
+  it('legacy ribbon (opt-in) caps legitimate drifts per rev and shows a +N chip', () => {
+    // The per-rev drift cap lives on the legacy Ribbon (kept as an
+    // escape hatch). The new unified ribbon renders interventions without
+    // a per-rev cap; this test therefore opts into the legacy view.
+    uiStoreState.trajectoryLegacyExpanded = true;
     const plan = mkPlan([mkTask('t1', 'RUNNING')]);
     mockStore.tasks.upsertPlan(plan);
 
-    // 60 real drifts (well above the 24 cap). Mix of severities so the
-    // ranker has something to work on.
     const severities = ['info', 'warning', 'critical'] as const;
     for (let i = 0; i < 60; i++) {
       mockStore.drifts.append({
@@ -212,7 +215,8 @@ describe('<TrajectoryView /> with only rev 0 + drift storm', () => {
   it('keeps the DAG visible even when the session has a mixed drift storm', () => {
     // This is the exact repro of the live bug: rev-0 plan, real task
     // statuses, a handful of legit drifts, and a firehose of UNSPECIFIED
-    // noise. The DAG + task markers must still render.
+    // noise. The DAG + task markers must still render, and only the
+    // legitimate drifts populate the new ribbon's intervention dots.
     const plan = mkPlan([
       mkTask('t1', 'COMPLETED'),
       mkTask('t2', 'RUNNING'),
@@ -262,8 +266,9 @@ describe('<TrajectoryView /> with only rev 0 + drift storm', () => {
     expect(screen.getByTestId('task-node-t2')).toBeInTheDocument();
     expect(screen.getByTestId('task-node-t3')).toBeInTheDocument();
 
-    // Exactly the two legitimate drift markers, no noise.
-    const markers = screen.queryAllByTestId(/^drift-marker-/);
-    expect(markers).toHaveLength(2);
+    // Exactly the two legitimate interventions surface in the new
+    // ribbon, no UNSPECIFIED noise.
+    const dots = screen.queryAllByTestId(/^ribbon-intv-/);
+    expect(dots).toHaveLength(2);
   });
 });

--- a/frontend/src/__tests__/components/TrajectoryView.evolution.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.evolution.test.tsx
@@ -41,7 +41,18 @@ vi.mock('../../rpc/hooks', () => ({
 const uiStoreState = {
   currentSessionId: mockSessionId as string | null,
   selectSpan: vi.fn(),
+  // Restructure: legacy stacked sections are opt-in. Default `false` so
+  // the tests exercise the new unified ribbon + floating drawer layout.
+  // Individual tests flip this via `setLegacyExpanded(true)` to exercise
+  // the escape hatch.
+  trajectoryLegacyExpanded: false,
+  toggleTrajectoryLegacyExpanded: (): void => {
+    uiStoreState.trajectoryLegacyExpanded = !uiStoreState.trajectoryLegacyExpanded;
+  },
 };
+function setLegacyExpanded(v: boolean): void {
+  uiStoreState.trajectoryLegacyExpanded = v;
+}
 vi.mock('../../state/uiStore', () => ({
   useUiStore: <T,>(selector: (s: typeof uiStoreState) => T) =>
     selector(uiStoreState),
@@ -163,6 +174,7 @@ function seedTwoRevsWithReplacement(): {
 beforeEach(() => {
   mockStore = new SessionStore();
   uiStoreState.currentSessionId = mockSessionId;
+  uiStoreState.trajectoryLegacyExpanded = false;
 });
 afterEach(() => {
   vi.clearAllMocks();
@@ -185,16 +197,12 @@ describe('<TrajectoryView /> plan-evolution + steering', () => {
     expect(superseded.getAttribute('opacity')).toBe('0.4');
     // The node is still a click target — the onClick-bearing <g> receives
     // pointer events (cursor: pointer via .hg-traj__node) even when the
-    // task isn't present in the latest rev. Verified by mousedown firing
-    // without throwing: React event wiring doesn't drop superseded nodes.
+    // task is superseded. Clicking routes through the new drawer: the
+    // cumulative plan still carries the superseded task, so the task
+    // detail body renders.
     fireEvent.click(superseded);
-    // After click the detail region reflects "Task not present in this rev"
-    // because the latest-rev view doesn't carry the superseded task body;
-    // the selection state still moved — the panel shows *something* from
-    // the detail pane family.
-    expect(
-      screen.getByText(/Task not present in this rev|detail-task/i),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('trajectory-drawer')).toBeInTheDocument();
+    expect(screen.getByTestId('task-node-detail')).toHaveTextContent('build outline');
   });
 
   it('stamps a REV N generation badge based on introducedInRevision', () => {
@@ -254,34 +262,36 @@ describe('<TrajectoryView /> plan-evolution + steering', () => {
     expect(edge).toHaveTextContent(/goldfive: off_topic/i);
   });
 
-  it('revision scrubber hides tasks introduced after the pinned revision', () => {
+  it('unified ribbon hides tasks introduced after the pinned revision', () => {
     seedTwoRevsWithReplacement();
     render(<TrajectoryView />);
     // Before scrubbing: both tasks visible.
     expect(screen.getByTestId('task-node-t1')).toBeInTheDocument();
     expect(screen.getByTestId('task-node-t1_corrected')).toBeInTheDocument();
-    // Click the REV 0 scrubber notch.
-    const notch = screen.getByTestId('scrubber-notch-0');
+    // Click the REV 0 ribbon notch (now the sole revision-pinning control
+    // in the default layout).
+    const notch = screen.getByTestId('ribbon-rev-0');
     fireEvent.click(notch);
     // After scrubbing to rev 0: rev-1 task is hidden.
     expect(screen.getByTestId('task-node-t1')).toBeInTheDocument();
     expect(screen.queryByTestId('task-node-t1_corrected')).not.toBeInTheDocument();
     // "Latest" returns the full cumulative view.
-    fireEvent.click(screen.getByTestId('scrubber-notch-latest'));
+    fireEvent.click(screen.getByTestId('ribbon-latest-btn'));
     expect(screen.getByTestId('task-node-t1_corrected')).toBeInTheDocument();
   });
 
-  it('clicking a steering arrow opens the detail panel with Trigger / Steering / Target', () => {
+  it('clicking a steering arrow opens the floating drawer with Trigger / Steering / Target body', () => {
     seedTwoRevsWithReplacement();
     render(<TrajectoryView />);
     const arrow = screen.getByTestId('steer-edge-t1_corrected');
     fireEvent.click(arrow);
-    const panel = screen.getByTestId('steering-detail-panel');
-    expect(panel).toBeInTheDocument();
+    const drawer = screen.getByTestId('trajectory-drawer');
+    expect(drawer).toBeInTheDocument();
+    const body = within(drawer).getByTestId('steering-detail-body');
     // Three sections: Trigger, Steering, Target.
-    expect(within(panel).getByTestId('steering-detail-trigger')).toBeInTheDocument();
-    expect(within(panel).getByTestId('steering-detail-steering')).toBeInTheDocument();
-    const targetSec = within(panel).getByTestId('steering-detail-target');
+    expect(within(body).getByTestId('steering-detail-trigger')).toBeInTheDocument();
+    expect(within(body).getByTestId('steering-detail-steering')).toBeInTheDocument();
+    const targetSec = within(body).getByTestId('steering-detail-target');
     // Target section names the agent explicitly — the primary UX guarantee.
     expect(
       within(targetSec).getByTestId('steering-detail-target-agent'),
@@ -291,39 +301,56 @@ describe('<TrajectoryView /> plan-evolution + steering', () => {
     ).toHaveTextContent(/research paper/);
     // Kind + reason surface in the Trigger section.
     expect(
-      within(panel).getByTestId('steering-detail-trigger'),
+      within(body).getByTestId('steering-detail-trigger'),
     ).toHaveTextContent('off_topic');
     expect(
-      within(panel).getByTestId('steering-detail-trigger'),
+      within(body).getByTestId('steering-detail-trigger'),
     ).toHaveTextContent('coordinator looped on status queries');
   });
 
-  it('clicking a supersedes edge opens the same detail panel with the old / new task pair', () => {
+  it('clicking a supersedes edge opens the drawer with old / new task pair in body', () => {
     seedTwoRevsWithReplacement();
     render(<TrajectoryView />);
     const edge = screen.getByTestId('supersedes-edge-t1');
     // SVG-native click — fireEvent dispatches to the parent <g>.
     fireEvent.click(edge);
-    const panel = screen.getByTestId('steering-detail-panel');
-    expect(panel).toBeInTheDocument();
-    expect(panel).toHaveTextContent('t1');
-    expect(panel).toHaveTextContent('t1_corrected');
+    const drawer = screen.getByTestId('trajectory-drawer');
+    expect(drawer).toBeInTheDocument();
+    const body = within(drawer).getByTestId('steering-detail-body');
+    expect(body).toHaveTextContent('t1');
+    expect(body).toHaveTextContent('t1_corrected');
   });
 
-  it('steering panel close button dismisses the panel and restores task-detail pane', () => {
+  it('drawer close button dismisses the drawer, backdrop click also closes', () => {
     seedTwoRevsWithReplacement();
     render(<TrajectoryView />);
     fireEvent.click(screen.getByTestId('steer-edge-t1_corrected'));
-    expect(screen.getByTestId('steering-detail-panel')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('steering-detail-close'));
-    expect(screen.queryByTestId('steering-detail-panel')).not.toBeInTheDocument();
+    expect(screen.getByTestId('trajectory-drawer')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('trajectory-drawer-close'));
+    expect(screen.queryByTestId('trajectory-drawer')).not.toBeInTheDocument();
+    // Re-open, then dismiss by backdrop click.
+    fireEvent.click(screen.getByTestId('steer-edge-t1_corrected'));
+    expect(screen.getByTestId('trajectory-drawer')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('trajectory-drawer-backdrop'));
+    expect(screen.queryByTestId('trajectory-drawer')).not.toBeInTheDocument();
   });
 
-  it('scrubber keyboard navigation steps through revisions and returns to Latest', () => {
+  it('drawer close via Escape key', () => {
     seedTwoRevsWithReplacement();
     render(<TrajectoryView />);
+    fireEvent.click(screen.getByTestId('steer-edge-t1_corrected'));
+    expect(screen.getByTestId('trajectory-drawer')).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByTestId('trajectory-drawer')).not.toBeInTheDocument();
+  });
+
+  it('legacy scrubber keyboard navigation works when the escape hatch is expanded', () => {
+    setLegacyExpanded(true);
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    // With the legacy stacked sections opted in, the old RevisionScrubber
+    // comes back along with its keyboard handlers.
     const scrubber = screen.getByTestId('revision-scrubber');
-    // Seed the scrubber with a pinned rev 1 first so we can verify left-arrow.
     fireEvent.click(screen.getByTestId('scrubber-notch-1'));
     // ArrowLeft → rev 0.
     fireEvent.keyDown(scrubber, { key: 'ArrowLeft' });
@@ -343,6 +370,51 @@ describe('<TrajectoryView /> plan-evolution + steering', () => {
       'aria-selected',
       'true',
     );
+  });
+
+  it('default layout hides the legacy stacked sections (ribbon-strip, intervention list, detail pane)', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    // The old Ribbon strip (trajectory-ribbon) is gone.
+    expect(screen.queryByTestId('trajectory-ribbon')).not.toBeInTheDocument();
+    // The INTERVENTIONS list header is gone.
+    expect(screen.queryByTestId('trajectory-interventions')).not.toBeInTheDocument();
+    // The RevisionScrubber is gone.
+    expect(screen.queryByTestId('revision-scrubber')).not.toBeInTheDocument();
+    // The REV N chip tablist is gone.
+    expect(screen.queryByTestId('rev-chip-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('rev-chip-1')).not.toBeInTheDocument();
+    // The legacy-stack wrapper is absent.
+    expect(screen.queryByTestId('trajectory-legacy-stack')).not.toBeInTheDocument();
+    // The new unified ribbon IS present.
+    expect(screen.getByTestId('trajectory-timeline-ribbon')).toBeInTheDocument();
+  });
+
+  it('toggling the ribbon expand button brings back the legacy stacked sections', () => {
+    seedTwoRevsWithReplacement();
+    const { rerender } = render(<TrajectoryView />);
+    // Expand toggle is present on the new ribbon.
+    const toggle = screen.getByTestId('ribbon-expand-btn');
+    expect(toggle).toBeInTheDocument();
+    // Click toggles the uiStore pref; since tests mock the selector, flip
+    // it directly then re-render to observe the opt-in state.
+    setLegacyExpanded(true);
+    rerender(<TrajectoryView />);
+    expect(screen.getByTestId('trajectory-legacy-stack')).toBeInTheDocument();
+    expect(screen.getByTestId('trajectory-ribbon')).toBeInTheDocument();
+    expect(screen.getByTestId('revision-scrubber')).toBeInTheDocument();
+  });
+
+  it('clicking a task node opens the drawer with the TaskNodeDetail body', () => {
+    seedTwoRevsWithReplacement();
+    render(<TrajectoryView />);
+    const taskNode = screen.getByTestId('task-node-t1_corrected');
+    fireEvent.click(taskNode);
+    const drawer = screen.getByTestId('trajectory-drawer');
+    expect(drawer).toBeInTheDocument();
+    const detail = within(drawer).getByTestId('task-node-detail');
+    expect(detail).toHaveTextContent('research paper');
+    expect(detail).toHaveTextContent('pending');
   });
 
   it('does NOT draw a steering edge when the plan has only rev 0', () => {

--- a/frontend/src/__tests__/components/TrajectoryView.steering.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.steering.test.tsx
@@ -43,6 +43,10 @@ vi.mock('../../rpc/hooks', () => ({
 const uiStoreState = {
   currentSessionId: mockSessionId,
   selectSpan: vi.fn(),
+  trajectoryLegacyExpanded: false,
+  toggleTrajectoryLegacyExpanded: (): void => {
+    uiStoreState.trajectoryLegacyExpanded = !uiStoreState.trajectoryLegacyExpanded;
+  },
 };
 vi.mock('../../state/uiStore', () => ({
   useUiStore: <T,>(selector: (s: typeof uiStoreState) => T) =>
@@ -163,6 +167,7 @@ function synthUserGoalSpan(goal: string, atMs: number): Span {
 
 beforeEach(() => {
   mockStore = new SessionStore();
+  uiStoreState.trajectoryLegacyExpanded = false;
 });
 afterEach(() => {
   vi.clearAllMocks();
@@ -246,7 +251,13 @@ describe('<TrajectoryView /> steering arrow + user gutter + detail panel', () =>
     expect(screen.getByTestId('trajectory-user-edge')).toBeInTheDocument();
   });
 
-  it('intervention detail panel shows Trigger + Target when a drift is selected', () => {
+  it('legacy intervention detail panel shows Trigger + Target when a drift is selected', () => {
+    // The drift-marker detail pane lives on the legacy stacked layout
+    // (escape hatch). The restructured default layout routes drift + task
+    // + steering clicks through the floating drawer — a separate test in
+    // evolution.test.tsx covers that path. Here we verify the legacy
+    // drift-detail pane still renders when the user opts in.
+    uiStoreState.trajectoryLegacyExpanded = true;
     const rev0 = mkPlan('p1', [mkTask('t1', 'RUNNING', 'agent-a')]);
     mockStore.tasks.upsertPlan(rev0);
     mockStore.drifts.append({
@@ -267,16 +278,14 @@ describe('<TrajectoryView /> steering arrow + user gutter + detail panel', () =>
     fireEvent.click(marker);
 
     expect(screen.getByTestId('detail-drift')).toBeInTheDocument();
-    // Trigger section surfaces the drift detail.
     const trigger = screen.getByTestId('detail-drift-trigger');
     expect(trigger).toHaveTextContent('repeated tool calls');
-    // Target section surfaces agent-a.
     const target = screen.getByTestId('detail-drift-target');
     expect(target).toHaveTextContent('agent-a');
   });
 
-  it('intervention detail panel composes Steering from a matching PlanRevised', () => {
-    // rev 0 + drift + rev 1 with triggerEventId = drift.driftId.
+  it('legacy intervention detail panel composes Steering from a matching PlanRevised', () => {
+    uiStoreState.trajectoryLegacyExpanded = true;
     const rev0 = mkPlan('p1', [mkTask('t1', 'RUNNING', 'agent-a')]);
     mockStore.tasks.upsertPlan(rev0);
     mockStore.drifts.append({
@@ -310,7 +319,6 @@ describe('<TrajectoryView /> steering arrow + user gutter + detail panel', () =>
     const steering = screen.getByTestId('detail-drift-steering');
     expect(steering).toHaveTextContent('add verification');
     const target = screen.getByTestId('detail-drift-target');
-    // Refine's target_agent_id wins over drift's current_agent_id.
     expect(target).toHaveTextContent('agent-b');
   });
 });

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -33,9 +33,13 @@ import type {
 } from '../../../state/planHistoryStore';
 import { RevisionScrubber } from './RevisionScrubber';
 import {
+  SteeringDetailBody,
   SteeringDetailPanel,
   type SteeringSelection,
 } from './SteeringDetailPanel';
+import { TrajectoryTimelineRibbon } from './TrajectoryTimelineRibbon';
+import { TrajectoryFloatingDrawer } from './TrajectoryFloatingDrawer';
+import { TaskNodeDetail } from './TaskNodeDetail';
 
 // ── Palette ────────────────────────────────────────────────────────────────
 // Aligned with GanttView's status palette so a task's status reads the same
@@ -334,6 +338,15 @@ type Selection =
   | { kind: 'drift'; seq: number }
   | null;
 
+// Drawer content union. Drives what the TrajectoryFloatingDrawer mounts
+// inside it. Task-detail clicks land the task + cumulative plan (so the
+// body can display siblings / edges without a second lookup); steering
+// clicks land a SteeringSelection. Keeping this typed at the boundary
+// prevents the drawer body from re-deriving the selection from React state.
+type DrawerContent =
+  | { type: 'task'; task: Task; plan: TaskPlan | null }
+  | { type: 'steering'; selection: SteeringSelection };
+
 // ── Component ──────────────────────────────────────────────────────────────
 
 export function TrajectoryView() {
@@ -390,6 +403,26 @@ export function TrajectoryView() {
   const [steeringSelection, setSteeringSelection] =
     useState<SteeringSelection | null>(null);
 
+  // Floating-drawer state: open flag + typed content union. Opening the
+  // drawer doesn't touch the legacy `selection` / `steeringSelection` state
+  // so the (opt-in) legacy view still renders its own right-column panels
+  // when expanded.
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerContent, setDrawerContent] = useState<DrawerContent | null>(null);
+
+  // Legacy stacked-layout toggle (opt-in, persisted via uiStore →
+  // localStorage). Default false: new compact layout with unified ribbon +
+  // full-width DAG + floating drawer only. The store selectors fall back
+  // to safe defaults when the test mocks omit these fields.
+  const expandedLegacyView = useUiStore(
+    (s) => (s as { trajectoryLegacyExpanded?: boolean }).trajectoryLegacyExpanded ?? false,
+  );
+  const toggleExpandedLegacyView = useUiStore(
+    (s) =>
+      (s as { toggleTrajectoryLegacyExpanded?: () => void })
+        .toggleTrajectoryLegacyExpanded ?? (() => {}),
+  );
+
   // Plan-history primary id: same fallback as vm.planId. Used to key the
   // cumulative + supersedes + history hooks.
   const primaryPlanId = vm.planId;
@@ -432,55 +465,85 @@ export function TrajectoryView() {
     }
   };
 
+  // Ribbon selection primitive: "latest" means no pinned revision
+  // (cumulative view); a concrete number pins both the cumulative filter
+  // and the rev-index selection. Derived from the two legacy state
+  // variables so ribbon + scrubber share a single source of truth.
+  const ribbonSelected: number | 'latest' =
+    pinnedRevision !== null ? pinnedRevision : 'latest';
+
+  const onRibbonSelectRevision = (rev: number | 'latest'): void => {
+    if (rev === 'latest') {
+      setPinnedRevision(null);
+      setPinnedRevIdx(null);
+      setCompareRevIdx(null);
+      setSelection(null);
+      setSteeringSelection(null);
+      return;
+    }
+    setPinnedRevision(rev);
+    // Pinned rev number → find the corresponding index in vm.revs so the
+    // legacy Ribbon selection + rev-change handler stay coherent.
+    const idx = vm.revs.findIndex((p) => (p.revisionIndex ?? 0) === rev);
+    if (idx >= 0) onRevChange(idx, false);
+    setSteeringSelection(null);
+  };
+
+  // Centralise drawer-open so click handlers from the DAG, ribbon and
+  // legacy intervention list all route through the same spot. This is
+  // also the single place the #175 PR will want to replace when it lands
+  // richer transition wiring.
+  const openDrawerForTask = (taskId: string): void => {
+    if (!currentRev) return;
+    const planForLookup = filteredCumulative ?? currentRev;
+    const task = planForLookup.tasks.find((t) => t.id === taskId);
+    if (!task) return;
+    setDrawerContent({ type: 'task', task, plan: planForLookup });
+    setDrawerOpen(true);
+    // Preserve the legacy `selection` so the DAG still highlights the
+    // selected node and Gantt span-selection behaviour survives.
+    setSelection({ kind: 'task', taskId, planId: currentRev.id });
+    if (task.boundSpanId) selectSpan(task.boundSpanId);
+  };
+
+  const openDrawerForSteering = (selection: SteeringSelection): void => {
+    setDrawerContent({ type: 'steering', selection });
+    setDrawerOpen(true);
+    // Mirror into the legacy state so an expanded-legacy view stays in sync.
+    setSteeringSelection(selection);
+  };
+
+  const openDrawerForIntervention = (row: InterventionRow): void => {
+    // Interventions that represent a plan revision map to a steering view
+    // of that revision; standalone drifts map to a drift selection the
+    // legacy detail pane can render. Either way the drawer surfaces it.
+    if (row.planRevisionIndex > 0) {
+      openDrawerForSteering({
+        kind: 'revision',
+        revision: row.planRevisionIndex,
+      });
+      return;
+    }
+    // No associated revision → surface the drift via legacy selection.
+    // The drawer itself has no "drift detail" body component in the slim
+    // set; falling back to opening the steering view with rev 0 would be
+    // confusing, so we only toggle the legacy selection and leave the
+    // drawer closed.
+    setSelection({ kind: 'drift', seq: 0 });
+  };
+
   return (
-    <section className="hg-panel hg-traj" data-testid="trajectory-view">
+    <section
+      className="hg-panel hg-traj"
+      data-testid="trajectory-view"
+      style={{ position: 'relative' }}
+    >
       <header className="hg-panel__header hg-traj__header">
         <h2 className="hg-panel__title">Trajectory</h2>
         <span className="hg-panel__hint">
           {vm.revs.length === 0
             ? 'no plan yet'
             : `rev ${revIdx} of ${latestIdx}${compareRev ? ` · comparing to rev ${compareRevIdx}` : ''}`}
-        </span>
-        {vm.revs.length > 1 && (
-          <div className="hg-traj__rev-chips" role="tablist" aria-label="Plan revisions">
-            {vm.revs.map((p, i) => {
-              const selected = i === revIdx;
-              const compared = i === compareRevIdx && compareRevIdx !== revIdx;
-              const sev = i > 0 ? (p.revisionSeverity || '') : '';
-              return (
-                <button
-                  key={`${p.id}-${i}`}
-                  role="tab"
-                  className="hg-traj__chip"
-                  aria-selected={selected}
-                  data-compared={compared}
-                  data-severity={sev || undefined}
-                  data-testid={`rev-chip-${i}`}
-                  onClick={(e) => onRevChange(i, e.shiftKey)}
-                  title={
-                    p.revisionReason
-                      ? `rev ${i}: ${p.revisionReason}`
-                      : `rev ${i}`
-                  }
-                >
-                  <span className="hg-traj__chip-num">rev {i}</span>
-                  {sev && <span className="hg-traj__chip-sev" />}
-                </button>
-              );
-            })}
-            {compareRev && (
-              <button
-                className="hg-traj__chip hg-traj__chip--clear"
-                onClick={() => setCompareRevIdx(null)}
-                aria-label="Clear comparison"
-              >
-                clear diff
-              </button>
-            )}
-          </div>
-        )}
-        <span className="hg-traj__hint">
-          {vm.revs.length > 1 ? 'shift-click a rev to diff against it' : ''}
         </span>
       </header>
       <div className="hg-panel__body hg-traj__body">
@@ -496,84 +559,214 @@ export function TrajectoryView() {
         )}
         {sessionId && vm.revs.length > 0 && (
           <>
-            <RevisionScrubber
+            <TrajectoryTimelineRibbon
+              revisions={planHistoryRecords}
+              interventions={interventions}
+              selectedRevision={ribbonSelected}
+              onSelectRevision={onRibbonSelectRevision}
+              onInterventionClick={openDrawerForIntervention}
+              expanded={expandedLegacyView}
+              onToggleExpanded={toggleExpandedLegacyView}
+            />
+            <DagPane
+              plan={currentRev}
+              cumulative={filteredCumulative}
               history={planHistoryRecords}
+              supersedes={supersedesMap}
               pinnedRevision={pinnedRevision}
-              onPinRevision={(rev) => {
-                setPinnedRevision(rev);
+              marks={marks}
+              compareRev={compareRev}
+              driftsOnRev={vm.driftsByRev[revIdx] ?? []}
+              delegations={vm.allDelegations}
+              selection={selection}
+              onSelectTask={openDrawerForTask}
+              onSelectSteering={openDrawerForSteering}
+              store={store}
+            />
+            {expandedLegacyView && (
+              <LegacyStackedSections
+                revs={vm.revs}
+                driftsByRev={vm.driftsByRev}
+                revIdx={revIdx}
+                compareRevIdx={compareRevIdx}
+                compareRev={compareRev}
+                onRevChange={onRevChange}
+                onClearCompare={() => setCompareRevIdx(null)}
+                planHistoryRecords={planHistoryRecords}
+                pinnedRevision={pinnedRevision}
+                setPinnedRevision={(rev) => {
+                  setPinnedRevision(rev);
+                  setSteeringSelection(null);
+                }}
+                onSelectDrift={(seq) =>
+                  setSelection({ kind: 'drift', seq })
+                }
+                interventions={interventions}
+                steeringSelection={steeringSelection}
+                setSteeringSelection={setSteeringSelection}
+                selection={selection}
+                currentRev={currentRev}
+                filteredCumulative={filteredCumulative}
+                supersedesMap={supersedesMap}
+                allDrifts={vm.allDrifts}
+                store={store}
+              />
+            )}
+          </>
+        )}
+        <TrajectoryFloatingDrawer
+          open={drawerOpen}
+          onClose={() => {
+            setDrawerOpen(false);
+            setSteeringSelection(null);
+          }}
+          title={
+            drawerContent?.type === 'steering'
+              ? 'Steering detail'
+              : drawerContent?.type === 'task'
+                ? 'Task detail'
+                : undefined
+          }
+          width={400}
+        >
+          {drawerContent?.type === 'task' && drawerContent.plan && (
+            <TaskNodeDetail
+              task={drawerContent.task}
+              plan={drawerContent.plan}
+              store={store}
+            />
+          )}
+          {drawerContent?.type === 'steering' && (
+            <SteeringDetailBody
+              selection={drawerContent.selection}
+              plan={filteredCumulative ?? currentRev}
+              history={planHistoryRecords}
+              supersedes={supersedesMap}
+              store={store}
+              onJumpToGantt={() => {
+                setDrawerOpen(false);
                 setSteeringSelection(null);
               }}
             />
-            <Ribbon
-              revs={vm.revs}
-              driftsByRev={vm.driftsByRev}
-              selectedRevIdx={revIdx}
-              comparedRevIdx={compareRevIdx}
-              onSelectRev={onRevChange}
-              onSelectDrift={(seq) => setSelection({ kind: 'drift', seq })}
-            />
-            <InterventionEntries
-              rows={interventions}
-              onJumpToRevision={(revisionIndex) => {
-                // Jump: find the rev chip with that revisionIndex and pin it.
-                const target = vm.revs.findIndex(
-                  (p) => (p.revisionIndex ?? 0) === revisionIndex,
-                );
-                if (target >= 0) onRevChange(target, false);
-              }}
-            />
-            <div className="hg-traj__split">
-              <DagPane
-                plan={currentRev}
-                cumulative={filteredCumulative}
-                history={planHistoryRecords}
-                supersedes={supersedesMap}
-                pinnedRevision={pinnedRevision}
-                marks={marks}
-                compareRev={compareRev}
-                driftsOnRev={vm.driftsByRev[revIdx] ?? []}
-                delegations={vm.allDelegations}
-                selection={selection}
-                onSelectTask={(taskId) => {
-                  if (!currentRev) return;
-                  setSelection({ kind: 'task', taskId, planId: currentRev.id });
-                  const task = currentRev.tasks.find((t) => t.id === taskId);
-                  if (task?.boundSpanId) selectSpan(task.boundSpanId);
-                }}
-                onSelectSteering={setSteeringSelection}
-                store={store}
-              />
-              {steeringSelection ? (
-                <SteeringDetailPanel
-                  selection={steeringSelection}
-                  plan={filteredCumulative ?? currentRev}
-                  history={planHistoryRecords}
-                  supersedes={supersedesMap}
-                  store={store}
-                  onClose={() => setSteeringSelection(null)}
-                  onJumpToGantt={() => {
-                    // Hand off to the app-level Gantt jump handler. Today
-                    // we simply close the panel so the user can eyeball
-                    // the drift on the existing ribbon; the sibling
-                    // `useUiStore.selectSpan` is the nav primitive most
-                    // views use. If the refine span is the closest thing
-                    // the view has to "this drift", select it.
-                    setSteeringSelection(null);
-                  }}
-                />
-              ) : (
-                <DetailPane
-                  selection={selection}
-                  plan={currentRev}
-                  drifts={vm.allDrifts}
-                  store={store}
-                />
-              )}
-            </div>
-          </>
-        )}
+          )}
+        </TrajectoryFloatingDrawer>
       </div>
     </section>
+  );
+}
+
+// ── LegacyStackedSections ──────────────────────────────────────────────────
+//
+// The old stacked layout (REVISIONS strip + REV chips + INTERVENTIONS + right
+// detail pane) rendered as an opt-in escape hatch for users who prefer it.
+// Controlled by `trajectoryLegacyExpanded` on uiStore; toggled from the new
+// ribbon's expand button. Default off (the whole point of the restructure).
+
+interface LegacyStackedSectionsProps {
+  revs: TaskPlan[];
+  driftsByRev: DriftRecord[][];
+  revIdx: number;
+  compareRevIdx: number | null;
+  compareRev: TaskPlan | null;
+  onRevChange: (i: number, shiftKey: boolean) => void;
+  onClearCompare: () => void;
+  planHistoryRecords: readonly PlanRevisionRecord[];
+  pinnedRevision: number | null;
+  setPinnedRevision: (rev: number | null) => void;
+  onSelectDrift: (seq: number) => void;
+  interventions: InterventionRow[];
+  steeringSelection: SteeringSelection | null;
+  setSteeringSelection: (sel: SteeringSelection | null) => void;
+  selection: Selection;
+  currentRev: TaskPlan | null;
+  filteredCumulative: CumulativePlan | null;
+  supersedesMap: Map<string, SupersessionLink>;
+  allDrifts: DriftRecord[];
+  store: SessionStore | null;
+}
+
+function LegacyStackedSections(props: LegacyStackedSectionsProps) {
+  const {
+    revs, driftsByRev, revIdx, compareRevIdx, compareRev, onRevChange,
+    onClearCompare, planHistoryRecords, pinnedRevision, setPinnedRevision,
+    onSelectDrift, interventions, steeringSelection, setSteeringSelection,
+    selection, currentRev, filteredCumulative, supersedesMap, allDrifts, store,
+  } = props;
+  return (
+    <div data-testid="trajectory-legacy-stack">
+      {revs.length > 1 && (
+        <div className="hg-traj__rev-chips" role="tablist" aria-label="Plan revisions">
+          {revs.map((p, i) => {
+            const selected = i === revIdx;
+            const compared = i === compareRevIdx && compareRevIdx !== revIdx;
+            const sev = i > 0 ? (p.revisionSeverity || '') : '';
+            return (
+              <button
+                key={`${p.id}-${i}`}
+                role="tab"
+                className="hg-traj__chip"
+                aria-selected={selected}
+                data-compared={compared}
+                data-severity={sev || undefined}
+                data-testid={`rev-chip-${i}`}
+                onClick={(e) => onRevChange(i, e.shiftKey)}
+                title={p.revisionReason ? `rev ${i}: ${p.revisionReason}` : `rev ${i}`}
+              >
+                <span className="hg-traj__chip-num">rev {i}</span>
+                {sev && <span className="hg-traj__chip-sev" />}
+              </button>
+            );
+          })}
+          {compareRev && (
+            <button
+              className="hg-traj__chip hg-traj__chip--clear"
+              onClick={onClearCompare}
+              aria-label="Clear comparison"
+            >
+              clear diff
+            </button>
+          )}
+        </div>
+      )}
+      <RevisionScrubber
+        history={planHistoryRecords}
+        pinnedRevision={pinnedRevision}
+        onPinRevision={setPinnedRevision}
+      />
+      <Ribbon
+        revs={revs}
+        driftsByRev={driftsByRev}
+        selectedRevIdx={revIdx}
+        comparedRevIdx={compareRevIdx}
+        onSelectRev={onRevChange}
+        onSelectDrift={onSelectDrift}
+      />
+      <InterventionEntries
+        rows={interventions}
+        onJumpToRevision={(revisionIndex) => {
+          const target = revs.findIndex((p) => (p.revisionIndex ?? 0) === revisionIndex);
+          if (target >= 0) onRevChange(target, false);
+        }}
+      />
+      {steeringSelection ? (
+        <SteeringDetailPanel
+          selection={steeringSelection}
+          plan={filteredCumulative ?? currentRev}
+          history={planHistoryRecords}
+          supersedes={supersedesMap}
+          store={store}
+          onClose={() => setSteeringSelection(null)}
+          onJumpToGantt={() => setSteeringSelection(null)}
+        />
+      ) : (
+        <DetailPane
+          selection={selection}
+          plan={currentRev}
+          drifts={allDrifts}
+          store={store}
+        />
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/components/shell/views/views.css
+++ b/frontend/src/components/shell/views/views.css
@@ -911,7 +911,110 @@ a.hg-settings__value:hover {
 .hg-traj__supersedes-edge { pointer-events: auto; }
 .hg-traj__supersedes-label { pointer-events: auto; cursor: pointer; }
 
-/* ── Floating drawer (overlay detail pane) ──────────────────────────── */
+/* ── Unified ribbon (restructure — #178) ───────────────────────────────── */
+.hg-traj__timeline-ribbon {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 12px;
+  padding: 6px 8px;
+  background: var(--md-sys-color-surface-container-low, #161923);
+  border: 1px solid var(--md-sys-color-outline-variant, #2a2f3a);
+  border-radius: 8px;
+  margin-bottom: 8px;
+}
+.hg-traj__timeline-ribbon-notches {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+}
+.hg-traj__timeline-ribbon-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  min-width: 80px;
+}
+.hg-traj__timeline-ribbon-cell[data-selected='true'] .hg-traj__timeline-ribbon-notch {
+  background: rgba(154, 195, 255, 0.15);
+  border-color: var(--md-sys-color-primary, #aac7ff);
+}
+.hg-traj__timeline-ribbon-notch {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 8px;
+  border: 1px solid var(--md-sys-color-outline-variant, #2a2f3a);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+.hg-traj__timeline-ribbon-num {
+  font-size: 11px;
+  font-weight: 600;
+  opacity: 0.85;
+}
+.hg-traj__timeline-ribbon-kind {
+  font-size: 10px;
+  opacity: 0.65;
+  max-width: 12ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hg-traj__timeline-ribbon-dots {
+  display: flex;
+  flex-direction: row;
+  gap: 3px;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 100px;
+}
+.hg-traj__timeline-ribbon-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  opacity: 0.85;
+}
+.hg-traj__timeline-ribbon-dot:hover { opacity: 1; }
+.hg-traj__timeline-ribbon-latest {
+  align-self: center;
+  padding: 6px 12px;
+  border: 1px solid var(--md-sys-color-outline-variant, #2a2f3a);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 11px;
+}
+.hg-traj__timeline-ribbon-latest[data-selected='true'] {
+  background: rgba(154, 195, 255, 0.15);
+  border-color: var(--md-sys-color-primary, #aac7ff);
+}
+.hg-traj__timeline-ribbon-expand {
+  align-self: center;
+  padding: 4px 8px;
+  font-size: 10px;
+  background: transparent;
+  color: inherit;
+  border: 1px solid var(--md-sys-color-outline-variant, #2a2f3a);
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+/* ── Floating drawer (overlay detail pane — #175) ──────────────────────── */
 
 .hg-traj__drawer-backdrop {
   position: absolute;

--- a/frontend/src/state/uiStore.ts
+++ b/frontend/src/state/uiStore.ts
@@ -27,6 +27,10 @@ const TASK_PLAN_VIEW_KEY = 'harmonograf.taskPlanView';
 const GRAPH_VIEWPORT_KEY = 'harmonograf.graphViewport';
 const CONTEXT_OVERLAY_VISIBLE_KEY = 'harmonograf.contextOverlayVisible';
 const INTERVENTION_BANDS_VISIBLE_KEY = 'harmonograf.interventionBandsVisible';
+// harmonograf: TrajectoryView legacy stacked-layout toggle. Default false
+// (new compact layout); persisted so a user who expands it doesn't lose the
+// state on reload.
+const TRAJECTORY_LEGACY_EXPANDED_KEY = 'harmonograf.trajectoryLegacyExpanded';
 
 function readGraphViewport(): GraphViewport | null {
   try {
@@ -153,6 +157,25 @@ function writeInterventionBandsVisible(v: boolean): void {
   }
 }
 
+function readTrajectoryLegacyExpanded(): boolean {
+  try {
+    const v = localStorage.getItem(TRAJECTORY_LEGACY_EXPANDED_KEY);
+    if (v === 'true') return true;
+    if (v === 'false') return false;
+  } catch {
+    /* ignore */
+  }
+  return false;
+}
+
+function writeTrajectoryLegacyExpanded(v: boolean): void {
+  try {
+    localStorage.setItem(TRAJECTORY_LEGACY_EXPANDED_KEY, v ? 'true' : 'false');
+  } catch {
+    /* ignore */
+  }
+}
+
 export type DrawerTabId =
   | 'summary'
   | 'task'
@@ -241,6 +264,13 @@ interface UiState {
   // on, persisted to localStorage.
   interventionBandsVisible: boolean;
   toggleInterventionBandsVisible: () => void;
+
+  // TrajectoryView legacy-layout escape hatch. `false` (default) renders the
+  // new compact layout (unified ribbon + floating drawer + full-width DAG).
+  // `true` additionally renders the old stacked REVISIONS / REV N / INTERVENTIONS
+  // sections underneath, for users who want the pre-restructure view back.
+  trajectoryLegacyExpanded: boolean;
+  toggleTrajectoryLegacyExpanded: () => void;
 
   // Sequence diagram (GraphView) zoom + pan state. `null` means "no explicit
   // viewport saved yet" — the view will fit-to-content on mount. Persisted to
@@ -405,6 +435,14 @@ export const useUiStore = create<UiState>((set) => ({
       writeInterventionBandsVisible(next);
       s.activeRenderer?.setInterventionBandsVisible(next);
       return { interventionBandsVisible: next };
+    }),
+
+  trajectoryLegacyExpanded: readTrajectoryLegacyExpanded(),
+  toggleTrajectoryLegacyExpanded: () =>
+    set((s) => {
+      const next = !s.trajectoryLegacyExpanded;
+      writeTrajectoryLegacyExpanded(next);
+      return { trajectoryLegacyExpanded: next };
     }),
   setAgentsPaused: (paused, ts) =>
     set((s) => {


### PR DESCRIPTION
## DO NOT MERGE BEFORE #173 and #175

Hard prerequisites. The `TrajectoryTimelineRibbon`, `TrajectoryFloatingDrawer`,
and `TaskNodeDetail` components in this PR are slim stubs that match the
interfaces frozen on those sibling branches; the richer visual implementations
live on #173 and #175 and will replace the stubs once merged. Rebase this
branch after each sibling lands.

Closes #177.

## Summary

- Collapses the four stacked sections above the DAG (header rev chips,
  RevisionScrubber, legacy Ribbon, InterventionEntries) into a single
  `TrajectoryTimelineRibbon` at the top.
- Moves the right-column task / steering detail pane into a
  `TrajectoryFloatingDrawer` that overlays the DAG absolutely (no reflow).
- DAG now gets 100% of the view's width when the drawer is closed.
- `SteeringDetailPanel` factored to export `SteeringDetailBody` so the
  drawer mounts the same three-section body (Trigger / Steering / Target)
  the legacy aside used, without the aside-level chrome.
- `uiStore.trajectoryLegacyExpanded` (default `false`, persisted to
  localStorage): opt-in escape hatch that brings the old stacked sections
  back underneath the new compact layout. Toggle lives on the ribbon.

## Before / after

**Before**: header with rev chips → REVISIONS strip (scrubber) → Ribbon
with drift markers → REV N description cards (summary per rev) →
INTERVENTIONS list (chronological cards) → two-column split with DAG
left, detail pane right. The detail pane consumed ~280px of DAG width.

**After**: header (title + rev hint only) → unified
`TrajectoryTimelineRibbon` (rev notches with intervention dots clustered
under the revision they produced, plus a "Latest" sentinel) → full-width
DAG. Click on a task node, steering arrow, or supersedes edge opens the
`TrajectoryFloatingDrawer` as a 400px overlay on the right edge.

## Drawer content type

New union surfaces in `TrajectoryView`:

```ts
type DrawerContent =
  | { type: 'task'; task: Task; plan: TaskPlan | null }
  | { type: 'steering'; selection: SteeringSelection };
```

The drawer body dispatches on `type` and renders either `TaskNodeDetail`
or `SteeringDetailBody`. Underlying selection state (`selection`,
`steeringSelection`) is preserved so the opt-in legacy view still renders
its own right-column panels when expanded.

## Test plan

- [x] `pnpm test --run` — 51 test files / 502 passing (up from 498
      baseline; 4 net new tests added).
- [x] `pnpm tsc -b` — clean.
- [x] `pnpm lint` — no new warnings (one pre-existing warning unchanged).
- [x] Default layout hides stacked sections (REVISIONS strip, REV cards,
      INTERVENTIONS list header).
- [x] Unified ribbon renders with rev notches + intervention dots +
      Latest sentinel + expand toggle.
- [x] Click task-node → drawer opens with `TaskNodeDetail`.
- [x] Click steering-arrow → drawer opens with `SteeringDetailBody`.
- [x] Click supersedes-edge → drawer opens with `SteeringDetailBody`.
- [x] Esc / backdrop-click / drawer close-button all dismiss the drawer.
- [x] Ribbon expand toggle brings the legacy stacked sections back.
- [x] Clicking the ribbon's rev-0 notch hides rev-1 tasks from the DAG.
- [x] Underlying selection state (selectedRevision, interventions list,
      plan history) survives the layout change.