### PR TITLE
fix(ui): unify goldfive actor id across sink + synthesizers + render interventions on Graph view

### DIFF
--- a/frontend/src/__tests__/components/GraphView.interventions.test.tsx
+++ b/frontend/src/__tests__/components/GraphView.interventions.test.tsx
@@ -1,0 +1,332 @@
+// harmonograf#goldfive-unify — fix B of the Graph view unification:
+// the sequence diagram must render goldfive's interventions (drift
+// detections + plan revisions) on top of the agent/delegation topology
+// so the user→goldfive→target-agent chain is visible. Previously these
+// signals were only rendered on the Trajectory view; the Graph view
+// had no arrows for them at all (issue filed alongside this fix).
+//
+// These tests exercise the overlay additions in GraphView.tsx:
+//   * drift glyphs on goldfive's / user's column
+//   * steering arrows (goldfive → target agent) per plan revision
+//   * user-steer arrows (__user__ → goldfive) for user-authored drifts
+//   * click-through to the SteeringDetailPanel
+import { act, fireEvent, render } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { SessionStore } from '../../gantt/index';
+import type { Agent, TaskPlan } from '../../gantt/types';
+import { GOLDFIVE_ACTOR_ID, USER_ACTOR_ID } from '../../theme/agentColors';
+
+type WatchMock = {
+  store: SessionStore;
+  connected: boolean;
+  initialBurstComplete: boolean;
+  error: string | null;
+  sessionStatus: 'UNKNOWN' | 'LIVE' | 'COMPLETED' | 'ABORTED';
+  lastEventAtMs: number;
+};
+
+let mockStore: SessionStore | undefined;
+let mockWatch: WatchMock | undefined;
+const mockSessionId: string | null = 'session-1';
+
+vi.mock('../../rpc/hooks', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../rpc/hooks')>(
+      '../../rpc/hooks',
+    );
+  return {
+    ...actual,
+    getSessionStore: (id: string | null) => (id ? mockStore : undefined),
+    useSessionWatch: () => mockWatch ?? null,
+    sendStatusQuery: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('../../state/uiStore', () => {
+  const state: Record<string, unknown> = {
+    currentSessionId: 'session-1',
+    selectSpan: () => {},
+    selectTask: () => {},
+    selectedSpanId: null,
+    selectedTaskId: null,
+    taskPlanMode: 'ghost' as const,
+    taskPlanVisible: false,
+    setTaskPlanMode: () => {},
+    toggleTaskPlanVisible: () => {},
+    graphViewport: null,
+    setGraphViewport: () => {},
+    setGraphActions: () => {},
+  };
+  return {
+    useUiStore: <T,>(selector: (s: typeof state) => T) => {
+      return selector({ ...state, currentSessionId: mockSessionId ?? '' });
+    },
+  };
+});
+
+import { GraphView } from '../../components/shell/views/GraphView';
+
+function agent(id: string, connectedAtMs = 1, framework: Agent['framework'] = 'ADK'): Agent {
+  return {
+    id,
+    name: id,
+    framework,
+    capabilities: [],
+    status: 'CONNECTED',
+    connectedAtMs,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+  };
+}
+
+function plan(id: string, revisionIndex: number, triggerEventId = '', revisionKind = ''): TaskPlan {
+  return {
+    id,
+    invocationSpanId: '',
+    plannerAgentId: '',
+    createdAtMs: 100 + revisionIndex * 10,
+    summary: `plan ${id} r${revisionIndex}`,
+    tasks: [
+      {
+        id: 't1',
+        title: 'first',
+        description: '',
+        assigneeAgentId: 'coordinator',
+        status: 'PENDING',
+        predictedStartMs: 0,
+        predictedDurationMs: 0,
+        boundSpanId: '',
+      },
+    ],
+    edges: [],
+    revisionReason: revisionIndex === 0 ? '' : 'needs refocus',
+    revisionKind,
+    revisionSeverity: revisionIndex === 0 ? '' : 'warning',
+    revisionIndex,
+    triggerEventId,
+  };
+}
+
+describe('<GraphView /> goldfive interventions (fix B of harmonograf#goldfive-unify)', () => {
+  beforeEach(() => {
+    mockStore = new SessionStore();
+    // Real worker agents + synthetic goldfive + user rows.
+    mockStore.agents.upsert(agent('coordinator', 10));
+    mockStore.agents.upsert(agent('worker_a', 12));
+    mockStore.agents.upsert({
+      ...agent(GOLDFIVE_ACTOR_ID),
+      framework: 'CUSTOM',
+    });
+    mockStore.agents.upsert({
+      ...agent(USER_ACTOR_ID),
+      framework: 'CUSTOM',
+      name: 'user',
+    });
+    mockWatch = {
+      store: mockStore,
+      connected: true,
+      initialBurstComplete: true,
+      error: null,
+      sessionStatus: 'COMPLETED',
+      lastEventAtMs: 0,
+    };
+  });
+
+  afterEach(() => {
+    mockStore = undefined;
+    mockWatch = undefined;
+  });
+
+  it('renders a drift glyph on the goldfive column for a goldfive-authored drift', () => {
+    act(() => {
+      mockStore!.drifts.append({
+        kind: 'off_topic',
+        severity: 'warning',
+        detail: 'agent drifted',
+        taskId: 't1',
+        agentId: 'worker_a',
+        recordedAtMs: 5_000,
+        annotationId: '',
+        driftId: 'd1',
+        authoredBy: 'goldfive',
+      });
+    });
+    const { container } = render(<GraphView />);
+    const glyphs = container.querySelectorAll('[data-testid^="drift-glyph-"]');
+    expect(glyphs.length).toBe(1);
+    const glyph = glyphs[0];
+    expect(glyph.getAttribute('data-severity')).toBe('warning');
+    expect(glyph.getAttribute('data-authored-by')).toBe('goldfive');
+  });
+
+  it('renders a steering arrow from goldfive to the target agent on a plan_revised', () => {
+    act(() => {
+      // Plan rev 0 (baseline) + rev 1 (triggered by d1).
+      mockStore!.tasks.upsertPlan(plan('p1', 0));
+      mockStore!.drifts.append({
+        kind: 'off_topic',
+        severity: 'warning',
+        detail: 'drift',
+        taskId: 't1',
+        agentId: 'worker_a',
+        recordedAtMs: 5_000,
+        annotationId: '',
+        driftId: 'd1',
+        authoredBy: 'goldfive',
+      });
+      // Plan revision 1, triggered by d1. revisionKind surfaces on the label.
+      mockStore!.tasks.upsertPlan(plan('p1', 1, 'd1', 'off_topic'));
+      mockStore!.planHistory.append({
+        revision: 1,
+        plan: plan('p1', 1, 'd1', 'off_topic'),
+        reason: 'needs refocus',
+        kind: 'off_topic',
+        triggerEventId: 'd1',
+        emittedAtMs: 5_100,
+      });
+    });
+    const { container } = render(<GraphView />);
+    const steers = container.querySelectorAll('[data-testid^="steering-arrow-"]');
+    // At least one steering arrow — the goldfive→worker_a one.
+    expect(steers.length).toBeGreaterThanOrEqual(1);
+    const arrow = Array.from(steers).find((s) =>
+      s.getAttribute('data-testid')?.includes('steer-p1-1'),
+    );
+    expect(arrow).toBeTruthy();
+    expect(arrow?.getAttribute('data-severity')).toBe('warning');
+    // The arrow label mentions the revision kind.
+    const text = arrow?.querySelector('text')?.textContent || '';
+    expect(text).toContain('refine');
+    expect(text).toContain('off_topic');
+  });
+
+  it('renders a user-steer arrow from __user__ → goldfive for USER_STEER drifts', () => {
+    act(() => {
+      mockStore!.drifts.append({
+        kind: 'user_steer',
+        severity: 'info',
+        detail: 'focus on section 2',
+        taskId: 't1',
+        agentId: 'worker_a',
+        recordedAtMs: 4_000,
+        annotationId: 'ann-1',
+        driftId: 'd-user',
+        authoredBy: 'user',
+      });
+    });
+    const { container } = render(<GraphView />);
+    const userSteer = container.querySelector(
+      '[data-testid="steering-arrow-user-steer-0"]',
+    );
+    expect(userSteer).toBeTruthy();
+    const text = userSteer?.querySelector('text')?.textContent || '';
+    expect(text).toContain('user steer');
+  });
+
+  it('drift glyph landing a user-authored drift lives on the user column, not goldfive', () => {
+    act(() => {
+      mockStore!.drifts.append({
+        kind: 'user_steer',
+        severity: 'info',
+        detail: 'hi',
+        taskId: 't1',
+        agentId: 'worker_a',
+        recordedAtMs: 4_000,
+        annotationId: 'ann-1',
+        driftId: 'd-user',
+        authoredBy: 'user',
+      });
+    });
+    const { container } = render(<GraphView />);
+    const glyph = container.querySelector('[data-testid^="drift-glyph-"]');
+    expect(glyph?.getAttribute('data-authored-by')).toBe('user');
+  });
+
+  it('clicking a steering arrow opens the SteeringDetailPanel', () => {
+    act(() => {
+      mockStore!.tasks.upsertPlan(plan('p1', 0));
+      mockStore!.drifts.append({
+        kind: 'off_topic',
+        severity: 'critical',
+        detail: 'drift',
+        taskId: 't1',
+        agentId: 'worker_a',
+        recordedAtMs: 5_000,
+        annotationId: '',
+        driftId: 'd1',
+        authoredBy: 'goldfive',
+      });
+      mockStore!.tasks.upsertPlan(plan('p1', 1, 'd1', 'off_topic'));
+      mockStore!.planHistory.append({
+        revision: 0,
+        plan: plan('p1', 0),
+        reason: '',
+        kind: '',
+        triggerEventId: '',
+        emittedAtMs: 0,
+      });
+      mockStore!.planHistory.append({
+        revision: 1,
+        plan: plan('p1', 1, 'd1', 'off_topic'),
+        reason: 'needs refocus',
+        kind: 'off_topic',
+        triggerEventId: 'd1',
+        emittedAtMs: 5_100,
+      });
+    });
+    const { container, queryByTestId } = render(<GraphView />);
+    expect(queryByTestId('steering-detail-panel')).toBeFalsy();
+    const arrow = container.querySelector(
+      '[data-testid="steering-arrow-steer-p1-1"]',
+    );
+    expect(arrow).toBeTruthy();
+    fireEvent.click(arrow!);
+    expect(queryByTestId('steering-detail-panel')).toBeTruthy();
+  });
+
+  it('session with one drift + one plan_revised: exactly 1 goldfive node + 1 drift glyph + 1 steering arrow', () => {
+    act(() => {
+      mockStore!.tasks.upsertPlan(plan('p1', 0));
+      mockStore!.drifts.append({
+        kind: 'off_topic',
+        severity: 'warning',
+        detail: 'drift',
+        taskId: 't1',
+        agentId: 'worker_a',
+        recordedAtMs: 5_000,
+        annotationId: '',
+        driftId: 'd1',
+        authoredBy: 'goldfive',
+      });
+      mockStore!.tasks.upsertPlan(plan('p1', 1, 'd1', 'off_topic'));
+      mockStore!.planHistory.append({
+        revision: 1,
+        plan: plan('p1', 1, 'd1', 'off_topic'),
+        reason: 'needs refocus',
+        kind: 'off_topic',
+        triggerEventId: 'd1',
+        emittedAtMs: 5_100,
+      });
+    });
+    const { container } = render(<GraphView />);
+    // Exactly one goldfive row in the agent list. The header clip path
+    // is keyed off the agent id in the column. Check the agent count hint.
+    const hint = container.querySelector('.hg-panel__hint')?.textContent || '';
+    // 4 agents — coordinator, worker_a, goldfive, user.
+    expect(hint).toMatch(/4 agents/);
+    const glyphs = container.querySelectorAll('[data-testid^="drift-glyph-"]');
+    expect(glyphs.length).toBe(1);
+    const steers = container.querySelectorAll('[data-testid^="steering-arrow-"]');
+    expect(steers.length).toBe(1);
+  });
+});

--- a/frontend/src/__tests__/rpc/goldfiveEventLanes.test.ts
+++ b/frontend/src/__tests__/rpc/goldfiveEventLanes.test.ts
@@ -374,4 +374,159 @@ describe('goldfive lane synthesis (harmonograf#196)', () => {
     store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, spans as never);
     expect(spans).toHaveLength(0);
   });
+
+  // harmonograf#goldfive-unify: the sink (PR #159) ships goldfive LLM / judge
+  // spans on a compound `<client>:goldfive` agent id. Legacy frontend
+  // synthesizers used `__goldfive__`. Without unification the Graph view
+  // rendered goldfive twice. These tests pin the single-row invariant in
+  // both arrival orders (sink-first, synth-first).
+  describe('goldfive actor alias', () => {
+    function seedCompoundGoldfiveSpan(s: SessionStore, id: string) {
+      // A minimal sink-translated span on the compound id. We don't go
+      // through convertSpan — the test is asserting the alias merge, not
+      // the proto boundary.
+      s.spans.append({
+        id,
+        sessionId: 'sess-1',
+        agentId: 'client-42:goldfive',
+        parentSpanId: null,
+        kind: 'LLM_CALL',
+        status: 'COMPLETED',
+        name: 'judge_reasoning',
+        startMs: 100,
+        endMs: 110,
+        links: [],
+        attributes: {
+          'goldfive.call_name': { kind: 'string', value: 'judge_reasoning' },
+        },
+        payloadRefs: [],
+        error: null,
+        lane: -1,
+        replaced: false,
+      });
+      s.agents.upsert({
+        id: 'client-42:goldfive',
+        name: 'goldfive',
+        framework: 'UNKNOWN',
+        capabilities: [],
+        status: 'CONNECTED',
+        connectedAtMs: 100,
+        currentActivity: '',
+        stuck: false,
+        taskReport: '',
+        taskReportAt: 0,
+        metadata: {},
+      });
+    }
+
+    it('sink-first: a DriftDetected synthesized AFTER a compound :goldfive row lands on that row (no __goldfive__ duplicate)', () => {
+      seedCompoundGoldfiveSpan(store, 'judge-1');
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev',
+          runId: 'run-1',
+          sequence: 1n,
+          emittedAt: ts(30),
+          payload: {
+            case: 'driftDetected',
+            value: create(DriftDetectedSchema, {
+              kind: DriftKind.LOOPING_REASONING,
+              severity: DriftSeverity.WARNING,
+              detail: 'loop',
+              currentTaskId: 't1',
+              currentAgentId: 'agent-a',
+              id: 'drift-1',
+            }),
+          },
+        }),
+        store,
+        0,
+      );
+      // Only ONE goldfive row exists — the compound one.
+      expect(store.agents.get('client-42:goldfive')).toBeTruthy();
+      expect(store.agents.get(GOLDFIVE_ACTOR_ID)).toBeFalsy();
+      // The drift span landed on the compound row, NOT on __goldfive__.
+      const onCompound: Array<ReturnType<typeof store.spans.get>> = [];
+      store.spans.queryAgent('client-42:goldfive', 0, 1_000_000, onCompound as never);
+      expect(onCompound.map((s) => s?.name)).toContain('looping_reasoning');
+      const onLegacy: Array<ReturnType<typeof store.spans.get>> = [];
+      store.spans.queryAgent(GOLDFIVE_ACTOR_ID, 0, 1_000_000, onLegacy as never);
+      expect(onLegacy).toHaveLength(0);
+    });
+
+    it('synth-first: calling mergeGoldfiveAlias AFTER a DriftDetected has seeded __goldfive__ moves spans onto the compound row', () => {
+      // Drift arrives first — synthesizer creates __goldfive__ + a drift span.
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev',
+          runId: 'run-1',
+          sequence: 0n,
+          emittedAt: ts(30),
+          payload: {
+            case: 'driftDetected',
+            value: create(DriftDetectedSchema, {
+              kind: DriftKind.LOOPING_REASONING,
+              severity: DriftSeverity.WARNING,
+              detail: 'loop',
+              currentTaskId: 't1',
+              currentAgentId: 'agent-a',
+              id: 'drift-1',
+            }),
+          },
+        }),
+        store,
+        0,
+      );
+      expect(store.agents.get(GOLDFIVE_ACTOR_ID)).toBeTruthy();
+      // Sink span lands later — call mergeGoldfiveAlias (what hooks.ts does).
+      seedCompoundGoldfiveSpan(store, 'judge-1');
+      const canonical = store.mergeGoldfiveAlias();
+      expect(canonical).toBe('client-42:goldfive');
+      expect(store.agents.get(GOLDFIVE_ACTOR_ID)).toBeFalsy();
+      // The original synthesized drift span now lives on the compound row.
+      const onCompound: Array<ReturnType<typeof store.spans.get>> = [];
+      store.spans.queryAgent('client-42:goldfive', 0, 1_000_000, onCompound as never);
+      expect(onCompound.map((s) => s?.name)).toEqual(
+        expect.arrayContaining(['looping_reasoning', 'judge_reasoning']),
+      );
+    });
+
+    it('resolveGoldfiveActorId returns the compound id when present, legacy otherwise', () => {
+      expect(store.resolveGoldfiveActorId()).toBe(GOLDFIVE_ACTOR_ID);
+      seedCompoundGoldfiveSpan(store, 'judge-1');
+      expect(store.resolveGoldfiveActorId()).toBe('client-42:goldfive');
+    });
+
+    it('mergeGoldfiveAlias is idempotent and safe when only __goldfive__ exists', () => {
+      applyGoldfiveEvent(
+        create(EventSchema, {
+          eventId: 'ev',
+          runId: 'run-1',
+          sequence: 0n,
+          emittedAt: ts(30),
+          payload: {
+            case: 'driftDetected',
+            value: create(DriftDetectedSchema, {
+              kind: DriftKind.LOOPING_REASONING,
+              severity: DriftSeverity.WARNING,
+              detail: 'loop',
+              currentTaskId: 't1',
+              currentAgentId: 'agent-a',
+              id: 'drift-1',
+            }),
+          },
+        }),
+        store,
+        0,
+      );
+      // No compound row yet — merge is a no-op and returns the legacy id.
+      expect(store.mergeGoldfiveAlias()).toBe(GOLDFIVE_ACTOR_ID);
+      expect(store.agents.get(GOLDFIVE_ACTOR_ID)).toBeTruthy();
+      // Double-call after a later compound arrival is idempotent.
+      seedCompoundGoldfiveSpan(store, 'judge-1');
+      expect(store.mergeGoldfiveAlias()).toBe('client-42:goldfive');
+      expect(store.mergeGoldfiveAlias()).toBe('client-42:goldfive');
+      expect(store.agents.get(GOLDFIVE_ACTOR_ID)).toBeFalsy();
+    });
+  });
 });

--- a/frontend/src/components/shell/Drawer.tsx
+++ b/frontend/src/components/shell/Drawer.tsx
@@ -312,12 +312,15 @@ function JudgeDrawerPanel({
         onOpenSteering={(_planId, _revIdx) => {
           // Jump into the refine: span on the goldfive lane so the user
           // lands on the existing plan-revision detail panel. The refine
-          // synthesizer stamps `refine.index = <revIdx>` on a
-          // __goldfive__ span (see rpc/goldfiveEvent.ts).
+          // synthesizer stamps `refine.index = <revIdx>` on the goldfive
+          // actor row (see rpc/goldfiveEvent.ts). Post-goldfive-unify
+          // the row may be the legacy `__goldfive__` id or the compound
+          // `<client>:goldfive` id — resolveGoldfiveActorId picks the
+          // survivor of the alias collapse.
           void _planId;
           const spans: Span[] = [];
           store.spans.queryAgent(
-            '__goldfive__',
+            store.resolveGoldfiveActorId(),
             0,
             Number.POSITIVE_INFINITY,
             spans,

--- a/frontend/src/components/shell/views/GraphView.tsx
+++ b/frontend/src/components/shell/views/GraphView.tsx
@@ -3,11 +3,15 @@ import { useEffect, useMemo, useCallback, useRef, useState } from 'react';
 import type React from 'react';
 import { useUiStore, type TaskPlanMode } from '../../../state/uiStore';
 import { useSessionWatch, sendStatusQuery } from '../../../rpc/hooks';
-import { colorForAgent } from '../../../theme/agentColors';
+import { colorForAgent, USER_ACTOR_ID } from '../../../theme/agentColors';
 import type { Span, Task, TaskPlan } from '../../../gantt/types';
-import type { SessionStore } from '../../../gantt/index';
+import type { DriftRecord, SessionStore } from '../../../gantt/index';
 import { bareAgentName } from '../../../gantt/index';
 import { hasThinking } from '../../../lib/thinking';
+import {
+  SteeringDetailPanel,
+  type SteeringSelection,
+} from './SteeringDetailPanel';
 import {
   DEFAULT_VIEWPORT,
   MIN_SCALE,
@@ -71,11 +75,50 @@ interface ActivationBox {
                        // plus any reasoning text carrier (see #107).
 }
 
+// Goldfive interventions overlaid on the sequence diagram. Distinct from
+// the topology arrows so the renderer can style them differently and the
+// viewer can tell a "delegation" (call edge) apart from a "steering"
+// (orchestrator-authored plan change). See fix B of harmonograf#192.
+type DriftSeverity = 'info' | 'warning' | 'critical' | '';
+
+interface InterventionGlyph {
+  id: string;
+  // Column index the glyph sits on (goldfive col for goldfive-authored
+  // drifts, user col for user-authored ones).
+  agentIdx: number;
+  yMs: number;
+  severity: DriftSeverity;
+  kind: string;
+  detail: string;
+  // Composite identity for jumping to the underlying record.
+  driftSeq: number;
+  // Plan revision this drift triggered (if any) — surfaces the steering
+  // panel's detail when clicked.
+  revisionIndex: number;
+  authoredBy: string; // 'user' | 'goldfive' | ''
+}
+
+interface SteeringArrow {
+  id: string;
+  fromCol: number;
+  toCol: number;
+  yMs: number;
+  kind: 'steer' | 'user-steer';
+  label: string;
+  severity: DriftSeverity;
+  revisionIndex: number;
+  driftSeq: number | null;
+}
+
 interface SeqLayout {
   agentIds: string[];      // ordered columns
   arrows: SeqArrow[];
   activations: ActivationBox[];
   totalMs: number;         // duration of entire session in ms
+  // Goldfive intervention overlays. Empty when no drifts/plan revisions
+  // have landed yet — the graph still renders cleanly without them.
+  glyphs: InterventionGlyph[];
+  steerArrows: SteeringArrow[];
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -331,7 +374,154 @@ function computeSequence(store: SessionStore): SeqLayout {
     if (end > totalMs) totalMs = end;
   }
 
-  return { agentIds, arrows, activations, totalMs };
+  // ── Goldfive interventions overlay ────────────────────────────────────────
+  // Drift glyphs (markers on goldfive's / user's column) + steering arrows
+  // (goldfive→target-agent on plan_revised, user→goldfive on USER_STEER).
+  // The goldfive row is the survivor of the __goldfive__ / <client>:goldfive
+  // alias collapse; SessionStore exposes the canonical id via
+  // resolveGoldfiveActorId() so we never duplicate the intervention overlay
+  // when both ids happen to be live in the registry mid-burst.
+  const goldfiveId = store.resolveGoldfiveActorId();
+  const goldfiveCol = colIdx.get(goldfiveId);
+  const userCol = colIdx.get(USER_ACTOR_ID);
+
+  const glyphs: InterventionGlyph[] = [];
+  const steerArrows: SteeringArrow[] = [];
+
+  const driftsList = store.drifts.list();
+  // Index drifts by their driftId so we can resolve the triggering drift
+  // for each plan revision (used to find the target agent + severity of
+  // the resulting steer arrow).
+  const driftById = new Map<string, DriftRecord>();
+  for (const d of driftsList) {
+    if (d.driftId) driftById.set(d.driftId, d);
+  }
+
+  // Plan revisions the user can click through — we need emittedAtMs per
+  // revision, which lives on the planHistory registry (TaskRegistry carries
+  // only createdAtMs). Join via (planId, revisionIndex).
+  const planHistory = store.planHistory;
+
+  for (const drift of driftsList) {
+    const sev: DriftSeverity =
+      (drift.severity === 'info' ||
+      drift.severity === 'warning' ||
+      drift.severity === 'critical'
+        ? drift.severity
+        : '') as DriftSeverity;
+    const isUser =
+      drift.authoredBy === 'user' ||
+      (!!drift.kind && drift.kind.startsWith('user_'));
+    const col = isUser ? userCol : goldfiveCol;
+    if (col === undefined) continue;
+    // Find the plan rev triggered by this drift (for click-through).
+    let revIndex = 0;
+    for (const plan of store.tasks.listPlans()) {
+      if (plan.triggerEventId && plan.triggerEventId === drift.driftId) {
+        revIndex = plan.revisionIndex ?? 0;
+        break;
+      }
+    }
+    glyphs.push({
+      id: `gly-${drift.seq}`,
+      agentIdx: col,
+      yMs: drift.recordedAtMs,
+      severity: sev,
+      kind: drift.kind || 'drift',
+      detail: drift.detail || '',
+      driftSeq: drift.seq,
+      revisionIndex: revIndex,
+      authoredBy: drift.authoredBy || (isUser ? 'user' : 'goldfive'),
+    });
+  }
+
+  // Steering arrows: one per plan_revised with revisionIndex > 0 AND a
+  // resolvable target agent. Target comes from the refine span's stamped
+  // `refine.target_agent_id` (post-judge-observability bump) OR from the
+  // triggering drift's `current_agent_id` when that attribute is absent.
+  if (goldfiveCol !== undefined) {
+    // Pre-index goldfive-lane refine spans by revisionIndex so we can
+    // read back target_agent_id without a nested scan.
+    const goldfiveSpans: Span[] = [];
+    store.spans.queryAgent(goldfiveId, 0, Number.POSITIVE_INFINITY, goldfiveSpans);
+    const refineByRev = new Map<number, Span>();
+    for (const s of goldfiveSpans) {
+      if (!s.name.startsWith('refine:')) continue;
+      const attr = s.attributes['refine.index'];
+      if (attr?.kind === 'string') {
+        const n = Number(attr.value);
+        if (Number.isFinite(n)) refineByRev.set(n, s);
+      }
+    }
+
+    for (const plan of store.tasks.listPlans()) {
+      const revIdx = plan.revisionIndex ?? 0;
+      if (revIdx <= 0) continue;
+      const refineSpan = refineByRev.get(revIdx);
+      const refineTargetAttr = refineSpan?.attributes['refine.target_agent_id'];
+      const refineTarget =
+        refineTargetAttr?.kind === 'string' ? refineTargetAttr.value : '';
+      const triggeringDrift = plan.triggerEventId
+        ? driftById.get(plan.triggerEventId)
+        : undefined;
+      const targetAgent = refineTarget || triggeringDrift?.agentId || '';
+      if (!targetAgent) continue;
+      const targetCol = colIdx.get(targetAgent);
+      if (targetCol === undefined || targetCol === goldfiveCol) continue;
+      // Timestamp: prefer the refine span (matches the emittedAt of
+      // the plan_revised event), else fall back to the plan's createdAt
+      // (close enough for visual ordering when the refine synth didn't run).
+      const yMs = refineSpan?.startMs ?? plan.createdAtMs ?? 0;
+      const sev: DriftSeverity =
+        triggeringDrift?.severity === 'info' ||
+        triggeringDrift?.severity === 'warning' ||
+        triggeringDrift?.severity === 'critical'
+          ? (triggeringDrift.severity as DriftSeverity)
+          : '';
+      const labelKind =
+        plan.revisionKind || triggeringDrift?.kind || plan.revisionReason || 'refine';
+      steerArrows.push({
+        id: `steer-${plan.id}-${revIdx}`,
+        fromCol: goldfiveCol,
+        toCol: targetCol,
+        yMs,
+        kind: 'steer',
+        label: `refine: ${labelKind}`,
+        severity: sev,
+        revisionIndex: revIdx,
+        driftSeq: triggeringDrift?.seq ?? null,
+      });
+    }
+
+    // User steer arrows: `__user__` → goldfive, one per USER_STEER drift.
+    if (userCol !== undefined) {
+      for (const drift of driftsList) {
+        if (!drift.kind || !drift.kind.startsWith('user_')) continue;
+        const sev: DriftSeverity =
+          drift.severity === 'info' ||
+          drift.severity === 'warning' ||
+          drift.severity === 'critical'
+            ? (drift.severity as DriftSeverity)
+            : '';
+        steerArrows.push({
+          id: `user-steer-${drift.seq}`,
+          fromCol: userCol,
+          toCol: goldfiveCol,
+          yMs: drift.recordedAtMs,
+          kind: 'user-steer',
+          label: 'user steer',
+          severity: sev,
+          revisionIndex: 0,
+          driftSeq: drift.seq,
+        });
+      }
+    }
+  }
+  // Touch planHistory so the hot-path re-evaluation captures subscriber
+  // changes; the actual join is already done via triggerEventId above.
+  void planHistory;
+
+  return { agentIds, arrows, activations, totalMs, glyphs, steerArrows };
 }
 
 // ─── Status colors ────────────────────────────────────────────────────────────
@@ -366,6 +556,11 @@ export function GraphView() {
     x: number;
     y: number;
   } | null>(null);
+  // Goldfive intervention detail panel — opened by clicking a glyph or
+  // steering arrow on the overlay. Hover preview uses a lightweight title
+  // tooltip; click opens the full three-section panel.
+  const [steeringSelection, setSteeringSelection] =
+    useState<SteeringSelection | null>(null);
 
   // ─── Viewport state (zoom + pan) ────────────────────────────────────────
   // `viewport` is the live, reactive state; `viewportRef` mirrors it so the
@@ -441,7 +636,14 @@ export function GraphView() {
     // arrows lag or never appear until another store (spans/tasks/agents)
     // happens to tick.
     const u4 = watch.store.delegations.subscribe(() => setTick((n) => n + 1));
-    return () => { u1(); u2(); u3(); u4(); };
+    // Goldfive drift events drive intervention glyphs + steering arrows
+    // on the graph overlay (fix B of harmonograf#goldfive-unify).
+    const u5 = watch.store.drifts.subscribe(() => setTick((n) => n + 1));
+    // Plan-history revisions feed the steering-arrow + intervention
+    // detail panel so newly-landed refines show up on the overlay without
+    // waiting for the next span tick.
+    const u6 = watch.store.planHistory.subscribe(() => setTick((n) => n + 1));
+    return () => { u1(); u2(); u3(); u4(); u5(); u6(); };
   }, [sessionId, watch.store]);
 
   // ── Viewport handlers (depend on refs, not reactive state) ──────────────
@@ -719,7 +921,8 @@ export function GraphView() {
   }
 
   const nowMs = watch.store.nowMs;
-  const { agentIds, arrows, activations, totalMs } = layout;
+  const { agentIds, arrows, activations, totalMs, glyphs, steerArrows } =
+    layout;
 
   // Scale: pixels per millisecond
   const effectiveTotalMs = Math.max(totalMs, 1000);
@@ -1567,6 +1770,118 @@ export function GraphView() {
               </g>
             );
           })}
+
+          {/* ── Goldfive steering arrows (fix B of harmonograf#goldfive-unify) ── */}
+          {/* Distinct style from delegation/transfer arrows so the viewer can */}
+          {/* tell a call-edge apart from an orchestrator-authored plan change. */}
+          {/* Dashed line; amber for warning, red for critical, grey for info. */}
+          {steerArrows.map((sa) => {
+            const x1 = colCx(sa.fromCol);
+            const x2 = colCx(sa.toCol);
+            const y = timeY(sa.yMs);
+            const isLeft = x2 < x1;
+            const sevColor =
+              sa.severity === 'critical' ? '#e06070'
+              : sa.severity === 'warning' ? '#f59e0b'
+              : sa.severity === 'info' ? '#8aa6d6'
+              : sa.kind === 'user-steer' ? '#d0bcff' : '#80deea';
+            const startX = x1 + (isLeft ? -ACT_W / 2 : ACT_W / 2);
+            const endX = x2 + (isLeft ? ACT_W / 2 : -ACT_W / 2);
+            const labelX = (startX + endX) / 2;
+            const labelY = y - 8;
+            const truncLabel = sa.label.length > 24 ? sa.label.slice(0, 23) + '…' : sa.label;
+            return (
+              <g
+                key={sa.id}
+                style={{ cursor: 'pointer' }}
+                data-testid={`steering-arrow-${sa.id}`}
+                data-severity={sa.severity || undefined}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (sa.revisionIndex > 0) {
+                    setSteeringSelection({
+                      kind: 'revision',
+                      revision: sa.revisionIndex,
+                    });
+                  }
+                }}
+              >
+                <line
+                  x1={startX} y1={y} x2={endX} y2={y}
+                  stroke={sevColor} strokeWidth={2}
+                  strokeDasharray="5 3"
+                />
+                {/* Arrow head */}
+                <polygon
+                  points={`${endX - (isLeft ? -8 : 8)},${y - 4} ${endX},${y} ${endX - (isLeft ? -8 : 8)},${y + 4}`}
+                  fill={sevColor}
+                />
+                <rect
+                  x={labelX - 54} y={labelY - 8}
+                  width={108} height={14}
+                  rx={3}
+                  fill="var(--md-sys-color-surface, #10131a)"
+                  opacity={0.85}
+                />
+                <text
+                  x={labelX} y={labelY}
+                  textAnchor="middle" dominantBaseline="middle"
+                  fill={sevColor}
+                  fontSize={9.5}
+                >
+                  {truncLabel}
+                </text>
+                <title>
+                  {`${sa.label}${sa.severity ? ' · ' + sa.severity : ''}`}
+                </title>
+              </g>
+            );
+          })}
+
+          {/* ── Intervention glyphs on goldfive's / user's timeline ── */}
+          {/* Small diamond anchored on the actor's lifeline at drift.recordedAtMs. */}
+          {/* Color by severity; click opens the SteeringDetailPanel if the drift */}
+          {/* triggered a plan revision, otherwise shows the hover tooltip only. */}
+          {glyphs.map((g) => {
+            const cx = colCx(g.agentIdx);
+            const cy = timeY(g.yMs);
+            const sevColor =
+              g.severity === 'critical' ? '#e06070'
+              : g.severity === 'warning' ? '#f59e0b'
+              : g.severity === 'info' ? '#8aa6d6'
+              : '#9aa3b4';
+            const clickable = g.revisionIndex > 0;
+            const r = 5;
+            return (
+              <g
+                key={g.id}
+                data-testid={`drift-glyph-${g.driftSeq}`}
+                data-severity={g.severity || undefined}
+                data-authored-by={g.authoredBy || undefined}
+                style={{ cursor: clickable ? 'pointer' : 'default' }}
+                onClick={(e) => {
+                  if (!clickable) return;
+                  e.stopPropagation();
+                  setSteeringSelection({
+                    kind: 'revision',
+                    revision: g.revisionIndex,
+                  });
+                }}
+              >
+                {/* Diamond glyph — visually distinct from the circular */}
+                {/* thinking-dot and square activation boxes. */}
+                <polygon
+                  points={`${cx},${cy - r} ${cx + r},${cy} ${cx},${cy + r} ${cx - r},${cy}`}
+                  fill={sevColor}
+                  stroke="var(--md-sys-color-surface, #10131a)"
+                  strokeWidth={1}
+                />
+                <title>
+                  {`${g.kind}${g.severity ? ' · ' + g.severity : ''}${g.detail ? '\n' + g.detail : ''}`}
+                </title>
+              </g>
+            );
+          })}
           </g>
         </svg>
 
@@ -1691,6 +2006,36 @@ export function GraphView() {
               />
             </svg>
           </div>
+        {steeringSelection && (() => {
+          // Locate the plan that owns this revision. The Graph view is
+          // plan-agnostic (it spans all agents in the session), so we
+          // walk the PlanHistoryRegistry plan-by-plan until we find one
+          // carrying the selected revision. Single-plan sessions resolve
+          // on the first iteration.
+          let plan: TaskPlan | null = null;
+          let history: readonly import('../../../state/planHistoryStore').PlanRevisionRecord[] = [];
+          let supersedes: Map<string, import('../../../state/planHistoryStore').SupersessionLink> = new Map();
+          for (const pid of watch.store.planHistory.planIds()) {
+            const recs = watch.store.planHistory.historyFor(pid);
+            if (recs.some((r) => r.revision === steeringSelection.revision)) {
+              plan = watch.store.tasks.getPlan(pid) ?? null;
+              history = recs;
+              supersedes = watch.store.planHistory.supersedesMap(pid);
+              break;
+            }
+          }
+          return (
+            <SteeringDetailPanel
+              selection={steeringSelection}
+              plan={plan}
+              history={history}
+              supersedes={supersedes}
+              store={watch.store}
+              onClose={() => setSteeringSelection(null)}
+              onJumpToGantt={() => setSteeringSelection(null)}
+            />
+          );
+        })()}
         {hoveredTask && (
           <div
             style={{

--- a/frontend/src/components/shell/views/SteeringDetailPanel.tsx
+++ b/frontend/src/components/shell/views/SteeringDetailPanel.tsx
@@ -53,7 +53,16 @@ function readStringAttr(span: Span | null, key: string): string {
 function findRefineSpan(store: SessionStore | null, revision: number): Span | null {
   if (!store || revision <= 0) return null;
   const spans: Span[] = [];
-  store.spans.queryAgent('__goldfive__', 0, Number.POSITIVE_INFINITY, spans);
+  // Resolve the canonical goldfive actor id at query time: after the
+  // harmonograf#goldfive-unify merge, refine spans live on either the
+  // legacy `__goldfive__` row or the compound `<client>:goldfive` one,
+  // whichever survived the alias collapse.
+  store.spans.queryAgent(
+    store.resolveGoldfiveActorId(),
+    0,
+    Number.POSITIVE_INFINITY,
+    spans,
+  );
   for (const s of spans) {
     if (!s.name.startsWith('refine:')) continue;
     const attr = s.attributes['refine.index'];

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -778,8 +778,15 @@ function findRefineSpanForPlan(
   const scratch: Span[] = [];
   // Match by `refine.index` on the goldfive row — the synth span's
   // startMs is the event's emittedAt, not the plan's createdAt, so the
-  // time window has to be wide enough to tolerate clock skew.
-  store.spans.queryAgent('__goldfive__', 0, Number.POSITIVE_INFINITY, scratch);
+  // time window has to be wide enough to tolerate clock skew. Resolve
+  // the canonical actor id at query time so post-goldfive-unify
+  // sessions (compound `<client>:goldfive`) match the same way.
+  store.spans.queryAgent(
+    store.resolveGoldfiveActorId(),
+    0,
+    Number.POSITIVE_INFINITY,
+    scratch,
+  );
   for (const s of scratch) {
     if (!s.name.startsWith('refine:')) continue;
     const attr = s.attributes['refine.index'];

--- a/frontend/src/gantt/index.ts
+++ b/frontend/src/gantt/index.ts
@@ -178,6 +178,18 @@ export class AgentRegistry {
     this.emit();
   }
 
+  // Drop an agent row. Used by SessionStore.mergeGoldfiveAlias after the
+  // row's spans have been reassigned onto the merge target. Silently
+  // no-ops if the id isn't known.
+  remove(agentId: string): void {
+    const existing = this.byId.get(agentId);
+    if (!existing) return;
+    this.byId.delete(agentId);
+    const idx = this.agents.indexOf(existing);
+    if (idx >= 0) this.agents.splice(idx, 1);
+    this.emit();
+  }
+
   subscribe(fn: () => void): () => void {
     this.listeners.add(fn);
     return () => this.listeners.delete(fn);
@@ -983,6 +995,55 @@ export class SessionStore {
   rebaseRelativeTimestamps(sessionStartMs: number): void {
     this.drifts.rebase(sessionStartMs);
     this.delegations.rebase(sessionStartMs);
+  }
+
+  // Collapse the legacy synthetic-actor `__goldfive__` row into the
+  // sink-translated `<client>:goldfive` row when both exist. Keeps the
+  // Graph view from rendering goldfive twice (once as a CUSTOM-framework
+  // synthetic actor, once as the ADK-framework span-ingest row).
+  //
+  // Order of operations is not significant — callers may invoke this
+  // whenever they observe a `:goldfive` id (e.g. right after a
+  // span-ingest upsert) or a new `__goldfive__` row (e.g. right after
+  // the drift/refine synthesizers mint one).
+  //
+  // Returns the canonical goldfive agent id (the compound one if it
+  // exists, otherwise the legacy id, otherwise empty string).
+  //
+  // Strategy: if the compound `<client>:goldfive` row exists, move every
+  // span keyed on `__goldfive__` over to that id and delete the legacy
+  // row. If only `__goldfive__` exists, leave it alone — the compound
+  // row may still arrive later, at which point the same call
+  // collapses them. No re-parenting is needed for drifts/delegations;
+  // those registries key by `agentId` strings but do not rely on an
+  // AgentRegistry row existing.
+  mergeGoldfiveAlias(legacyId = '__goldfive__'): string {
+    let compound = '';
+    for (const a of this.agents.list) {
+      if (a.id !== legacyId && a.id.endsWith(':goldfive')) {
+        compound = a.id;
+        break;
+      }
+    }
+    if (!compound) return legacyId;
+    if (this.agents.get(legacyId)) {
+      this.spans.reassignAgent(legacyId, compound);
+      this.agents.remove(legacyId);
+    }
+    return compound;
+  }
+
+  // Resolve the canonical goldfive actor id for synthesis. Returns the
+  // compound `<client>:goldfive` id when any such row has been
+  // registered (via sink-translated span ingest or convertAgent from
+  // Hello); otherwise returns the legacy `__goldfive__` id as a
+  // fallback. Used by the goldfiveEvent synthesizers so drift + refine
+  // spans land on the same row as sink-translated judge spans.
+  resolveGoldfiveActorId(legacyId = '__goldfive__'): string {
+    for (const a of this.agents.list) {
+      if (a.id !== legacyId && a.id.endsWith(':goldfive')) return a.id;
+    }
+    return legacyId;
   }
 
   // Current wall-clock "now" relative to session start. Advanced by the

--- a/frontend/src/gantt/spatialIndex.ts
+++ b/frontend/src/gantt/spatialIndex.ts
@@ -184,6 +184,48 @@ export class SpanIndex {
     this.globalMaxEndMs = 0;
     this.emit({ agentId: null, t0: 0, t1: Number.POSITIVE_INFINITY });
   }
+
+  // Move every span currently keyed on `fromAgentId` over to `toAgentId`.
+  // Used by AgentRegistry.mergeIntoAgent when the sink-translated
+  // `<client>:goldfive` compound row arrives AFTER the frontend
+  // synthesizer has already populated the legacy `__goldfive__` row
+  // (harmonograf#goldfive-unify). Idempotent: a no-op when `fromAgentId`
+  // has no spans or equals `toAgentId`.
+  reassignAgent(fromAgentId: string, toAgentId: string): void {
+    if (!fromAgentId || !toAgentId || fromAgentId === toAgentId) return;
+    const src = this.agents.get(fromAgentId);
+    if (!src || src.spans.length === 0) {
+      this.agents.delete(fromAgentId);
+      return;
+    }
+    let dst = this.agents.get(toAgentId);
+    if (!dst) {
+      dst = { spans: [], maxEndPrefix: [], minStartMs: src.minStartMs };
+      this.agents.set(toAgentId, dst);
+    }
+    for (const span of src.spans) {
+      span.agentId = toAgentId;
+      // Merge-insert keeping dst.spans sorted by startMs. Scan from the
+      // end since both sides tend to arrive in time order.
+      const last = dst.spans[dst.spans.length - 1];
+      if (!last || span.startMs >= last.startMs) {
+        dst.spans.push(span);
+      } else {
+        let lo = 0;
+        let hi = dst.spans.length;
+        while (lo < hi) {
+          const mid = (lo + hi) >>> 1;
+          if (dst.spans[mid].startMs <= span.startMs) lo = mid + 1;
+          else hi = mid;
+        }
+        dst.spans.splice(lo, 0, span);
+      }
+    }
+    if (src.minStartMs < dst.minStartMs) dst.minStartMs = src.minStartMs;
+    dst.maxEndPrefix.length = 0;
+    this.agents.delete(fromAgentId);
+    this.emit({ agentId: toAgentId, t0: 0, t1: Number.POSITIVE_INFINITY });
+  }
 }
 
 export interface DirtyRect {

--- a/frontend/src/lib/interventionDetail.ts
+++ b/frontend/src/lib/interventionDetail.ts
@@ -72,8 +72,12 @@ function findRefineSpan(
   const revIdx = plan.revisionIndex ?? 0;
   if (revIdx <= 0) return null;
   const spans: Span[] = [];
+  // After harmonograf#goldfive-unify the goldfive actor row may be
+  // either the legacy `__goldfive__` id (pre-sink-merge) or a compound
+  // `<client>:goldfive` id. resolveGoldfiveActorId picks whichever one
+  // exists in the registry.
   store.spans.queryAgent(
-    '__goldfive__',
+    store.resolveGoldfiveActorId(),
     0,
     Number.POSITIVE_INFINITY,
     spans,
@@ -91,7 +95,9 @@ function findDriftSpan(
   drift: DriftRecord,
 ): Span | null {
   if (!store) return null;
-  const actor = drift.kind && drift.kind.startsWith('user_') ? '__user__' : '__goldfive__';
+  const actor = drift.kind && drift.kind.startsWith('user_')
+    ? '__user__'
+    : store.resolveGoldfiveActorId();
   const spans: Span[] = [];
   store.spans.queryAgent(
     actor,

--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -46,10 +46,24 @@ const USER_DRIFT_KINDS = new Set<string>([
   'user_pause',
 ]);
 
-function ensureSyntheticActor(store: SessionStore, actorId: string): void {
-  if (store.agents.get(actorId)) return;
+// Resolve the id the goldfive synthetic-actor row should use. For the
+// user actor this is always the legacy `__user__` constant. For the
+// goldfive actor, if a sink-translated `<client>:goldfive` row has
+// already been registered (via span-ingest or Hello), synthesis lands
+// on that compound id so we don't double-render the orchestrator. Else
+// we fall back to the legacy `__goldfive__` constant; a subsequent
+// compound row arriving later triggers SessionStore.mergeGoldfiveAlias
+// which collapses the legacy row into it.
+function resolveActorId(store: SessionStore, actorId: string): string {
+  if (actorId !== GOLDFIVE_ACTOR_ID) return actorId;
+  return store.resolveGoldfiveActorId(GOLDFIVE_ACTOR_ID);
+}
+
+function ensureSyntheticActor(store: SessionStore, actorId: string): string {
+  const resolved = resolveActorId(store, actorId);
+  if (store.agents.get(resolved)) return resolved;
   store.agents.upsert({
-    id: actorId,
+    id: resolved,
     name: actorId === USER_ACTOR_ID ? 'user' : 'goldfive',
     framework: 'CUSTOM',
     capabilities: [],
@@ -66,6 +80,14 @@ function ensureSyntheticActor(store: SessionStore, actorId: string): void {
       'harmonograf.synthetic_actor': '1',
     },
   });
+  // Collapse any legacy `__goldfive__` row we may have created earlier
+  // — if the resolver returned a compound id, this is a no-op; if it
+  // returned the legacy id and a compound row arrives later, the
+  // upsert path will re-run mergeGoldfiveAlias.
+  if (actorId === GOLDFIVE_ACTOR_ID) {
+    store.mergeGoldfiveAlias(GOLDFIVE_ACTOR_ID);
+  }
+  return resolved;
 }
 
 function synthesizeDriftSpan(
@@ -82,6 +104,11 @@ function synthesizeDriftSpan(
   authoredBy?: string,
   driftEventId?: string,
 ): void {
+  // `actorId` may be the legacy `__goldfive__` / `__user__` constant or
+  // (post-goldfive-unify) the compound `<client>:goldfive` id returned
+  // by ensureSyntheticActor. `spanKind` / id prefix still hinge on the
+  // semantic distinction between user vs goldfive, so branch on whether
+  // the id is the user constant.
   const spanKind: SpanKind = actorId === USER_ACTOR_ID ? 'USER_MESSAGE' : 'CUSTOM';
   const id = `drift-${actorId}-${recordedAtMs}-${kind}`;
   const attributes: Span['attributes'] = {
@@ -157,6 +184,7 @@ function synthesizeRefineSpan(
   targetAgentId: string,
   refineInputSummary: string,
   refineOutputSummary: string,
+  goldfiveActorId: string,
 ): void {
   const id = `refine-${recordedAtMs}-${revisionIndex}`;
   const nameCore = revisionKind || 'refine';
@@ -183,7 +211,7 @@ function synthesizeRefineSpan(
   const span: Span = {
     id,
     sessionId: sessionId ?? '',
-    agentId: GOLDFIVE_ACTOR_ID,
+    agentId: goldfiveActorId,
     parentSpanId: null,
     kind: 'CUSTOM',
     status: 'COMPLETED',
@@ -376,7 +404,7 @@ export function applyGoldfiveEvent(
       // revision_index == 0) — that's the baseline, not a steering move.
       if (payload.case === 'planRevised') {
         const pr = payload.value;
-        ensureSyntheticActor(store, GOLDFIVE_ACTOR_ID);
+        const goldfiveId = ensureSyntheticActor(store, GOLDFIVE_ACTOR_ID);
         const emittedAbsMs = tsToMsAbs(event.emittedAt);
         const emittedMs = emittedAbsMs ? emittedAbsMs - sessionStartMs : 0;
         const revKind = driftKindToString(pr.driftKind as unknown as number);
@@ -409,6 +437,7 @@ export function applyGoldfiveEvent(
           targetAgent,
           refineInput,
           refineOutput,
+          goldfiveId,
         );
       }
       return;
@@ -517,10 +546,11 @@ export function applyGoldfiveEvent(
       });
       // Attribute the drift to an actor row so it shows up in gantt / graph /
       // trajectory without those views having to special-case drift events.
-      const actorId = USER_DRIFT_KINDS.has(kindStr)
-        ? USER_ACTOR_ID
-        : GOLDFIVE_ACTOR_ID;
-      ensureSyntheticActor(store, actorId);
+      const isUserDrift = USER_DRIFT_KINDS.has(kindStr);
+      const resolvedActorId = ensureSyntheticActor(
+        store,
+        isUserDrift ? USER_ACTOR_ID : GOLDFIVE_ACTOR_ID,
+      );
       // Forward-compat: goldfive#feat/judge-observability-events adds
       // DriftDetected.trigger_input (the reasoning snippet / activity
       // summary that produced the drift). Read through `unknown` + string
@@ -534,7 +564,7 @@ export function applyGoldfiveEvent(
       synthesizeDriftSpan(
         store,
         sessionId,
-        actorId,
+        resolvedActorId,
         kindStr,
         sevStr,
         d.detail,

--- a/frontend/src/rpc/hooks.ts
+++ b/frontend/src/rpc/hooks.ts
@@ -305,12 +305,23 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
               break;
             }
             case 'agent': {
-              store.agents.upsert(convertAgent(kind.value));
+              const agent = convertAgent(kind.value);
+              store.agents.upsert(agent);
+              // Collapse the legacy `__goldfive__` row into the
+              // sink-translated `<client>:goldfive` row when the
+              // server announces the latter (harmonograf#goldfive-unify).
+              if (agent.id.endsWith(':goldfive')) {
+                store.mergeGoldfiveAlias();
+              }
               break;
             }
             case 'initialSpan': {
               if (!origin) origin = { startMs: 0 };
-              store.spans.append(convertSpan(kind.value, origin));
+              const span = convertSpan(kind.value, origin);
+              store.spans.append(span);
+              if (span.agentId.endsWith(':goldfive')) {
+                store.mergeGoldfiveAlias();
+              }
               break;
             }
             case 'burstComplete': {
@@ -335,6 +346,9 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
               if (kind.value.span) {
                 const ui = convertSpan(kind.value.span, origin);
                 store.spans.append(ui);
+                if (ui.agentId.endsWith(':goldfive')) {
+                  store.mergeGoldfiveAlias();
+                }
               }
               break;
             }
@@ -432,7 +446,11 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
             }
             case 'agentJoined': {
               if (kind.value.agent) {
-                store.agents.upsert(convertAgent(kind.value.agent));
+                const agent = convertAgent(kind.value.agent);
+                store.agents.upsert(agent);
+                if (agent.id.endsWith(':goldfive')) {
+                  store.mergeGoldfiveAlias();
+                }
               }
               break;
             }


### PR DESCRIPTION
Closes #176.

## Summary

### Fix A — unify the goldfive actor id

- Added a registry-level alias: when a sink-translated `<client>:goldfive` row lands, collapse the legacy synthetic `__goldfive__` row into it (move spans, drop the stub).
- Synthesizers resolve the canonical id at synthesis time so drift + refine spans land on the same row as sink-translated judge spans when the compound row already exists.
- `rpc/hooks.ts` triggers the alias merge whenever a `:goldfive` agent/span arrives via the live wire. Consumers that previously queried hard-coded `__goldfive__` (Drawer, TrajectoryView, SteeringDetailPanel, interventionDetail) now route through `SessionStore.resolveGoldfiveActorId()` so they survive the alias collapse.
- Result: exactly one goldfive row regardless of whether events arrive via sink-translated spans, frontend-synthesized spans, or both. No dangling spans on the legacy id.

Migration path chosen: **alias layer in the agent registry**. Option 1 (resolve-at-synthesis) alone can't cover the case where the synthesizer runs BEFORE the compound row exists (synth-first ordering). The alias approach is symmetric — either order of arrival collapses to one row. Synthesizers still prefer the compound id when available, so in sink-first ordering the alias merge is a no-op.

### Fix B — render interventions on the Graph view

The sequence diagram now renders three overlay primitives on top of agent/delegation topology:
- **Drift glyphs** (diamonds, severity-colored: amber WARNING / red CRITICAL / grey INFO) on goldfive's and user's columns at each drift's `recordedAtMs`.
- **Steering arrows** (dashed, severity-colored) from the goldfive column → target agent column, one per `plan_revised` with a resolvable target. Target comes from `refine.target_agent_id` when stamped, else the triggering drift's `current_agent_id`.
- **User-steer arrows** from `__user__` → goldfive for USER_STEER drifts, completing the user → goldfive → target chain on the diagram.
- Clicking a glyph or arrow opens the existing `SteeringDetailPanel` (trigger / steering / target sections); Esc closes it.

### "After" state for a session with 1 drift + 1 plan_revised

Viewer sees exactly one goldfive node column (cyan-bordered goldfive row, no duplicate), a single amber diamond glyph on goldfive's lifeline at the drift's timestamp, and a single amber dashed arrow from the goldfive column to the drifting worker's column labeled `refine: <drift_kind>`. Clicking either opens the steering panel with trigger / steering / target populated from the matching plan-revision record.

### Reusable surface for sibling worktrees

The synthesizer-side resolver (`SessionStore.resolveGoldfiveActorId`) and the alias merge (`SessionStore.mergeGoldfiveAlias`) are plain `SessionStore` methods; the trajectory-layout agent can call them without re-implementing the join. The `InterventionGlyph` / `SteeringArrow` types in `GraphView.tsx` are local but the glyph/arrow data shapes are stable — if the trajectory-layout refactor wants to reuse them the interfaces are 1-liner re-exports.

## Test plan

- [x] `pnpm test --run` — 508 passed (was 498; +10 new)
- [x] `pnpm tsc -b` — clean
- [x] `pnpm lint` — clean except pre-existing GanttView warning
- [x] goldfiveEventLanes.test.ts: alias tests pin the single-row invariant in both arrival orders (sink-first, synth-first) + idempotency + resolver.
- [x] GraphView.interventions.test.tsx: drift glyphs, steering arrows, user-steer arrows, click-through to panel, end-to-end 1-drift/1-revision shape.
- [ ] Manual verification against a live goldfive run (reviewer).