### PR TITLE
feat(ui): collapse supersedes chains into single positional DAG slots (3-agent team)

### DIFF
--- a/frontend/src/__tests__/components/CurrentTaskStrip.test.tsx
+++ b/frontend/src/__tests__/components/CurrentTaskStrip.test.tsx
@@ -35,6 +35,7 @@ function task(id: string, status: TaskStatus, title = id, agent = 'agent-a'): Ta
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/components/Drawer.goldfive.test.tsx
+++ b/frontend/src/__tests__/components/Drawer.goldfive.test.tsx
@@ -194,6 +194,7 @@ describe('Drawer SummaryTab — goldfive routing', () => {
           predictedStartMs: 0,
           predictedDurationMs: 0,
           boundSpanId: '',
+          supersedes: '',
         },
       ],
       edges: [],

--- a/frontend/src/__tests__/components/GoldfiveSpanDetail.test.tsx
+++ b/frontend/src/__tests__/components/GoldfiveSpanDetail.test.tsx
@@ -205,6 +205,7 @@ describe('<GoldfiveSpanDetail />', () => {
           predictedStartMs: 0,
           predictedDurationMs: 0,
           boundSpanId: '',
+          supersedes: '',
         },
       ],
       edges: [],

--- a/frontend/src/__tests__/components/GraphView.interventions.test.tsx
+++ b/frontend/src/__tests__/components/GraphView.interventions.test.tsx
@@ -106,6 +106,7 @@ function plan(id: string, revisionIndex: number, triggerEventId = '', revisionKi
         predictedStartMs: 0,
         predictedDurationMs: 0,
         boundSpanId: '',
+        supersedes: '',
       },
     ],
     edges: [],

--- a/frontend/src/__tests__/components/PlanRevisionBanner.extended.test.tsx
+++ b/frontend/src/__tests__/components/PlanRevisionBanner.extended.test.tsx
@@ -33,6 +33,7 @@ function mkTask(id: string, overrides: Partial<Task> = {}): Task {
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
     ...overrides,
   };
 }

--- a/frontend/src/__tests__/components/PlanRevisionBanner.test.tsx
+++ b/frontend/src/__tests__/components/PlanRevisionBanner.test.tsx
@@ -33,6 +33,7 @@ function mkTask(id: string): Task {
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/components/TaskStages/RevisionHistoryBadge.test.tsx
+++ b/frontend/src/__tests__/components/TaskStages/RevisionHistoryBadge.test.tsx
@@ -1,0 +1,246 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  RevisionHistoryBadge,
+  type TaskRevisionChain,
+} from '../../../components/TaskStages/RevisionHistoryBadge';
+import type { Task, TaskStatus } from '../../../gantt/types';
+
+vi.mock('../../../components/TaskStages/RevisionHistoryBadge.css', () => ({}));
+
+function mkTask(id: string, title: string, status: TaskStatus = 'PENDING'): Task {
+  return {
+    id,
+    title,
+    description: '',
+    assigneeAgentId: 'agent-a',
+    status,
+    predictedStartMs: 0,
+    predictedDurationMs: 0,
+    boundSpanId: '',
+  };
+}
+
+interface MakeChainOpts {
+  titles?: string[];
+  revisions?: number[];
+}
+
+// Build a chain from a list of revision indices. Oldest→newest. The last
+// member is the canonical one.
+function makeChain(opts: MakeChainOpts = {}): TaskRevisionChain {
+  const revisions = opts.revisions ?? [0, 1, 2];
+  const titles =
+    opts.titles ?? revisions.map((r, i) => `Task at R${r} (member ${i})`);
+  if (titles.length !== revisions.length) {
+    throw new Error('makeChain: titles / revisions length mismatch');
+  }
+  const members = revisions.map((r, i) => mkTask(`t-r${r}-${i}`, titles[i]));
+  return {
+    canonical: members[members.length - 1],
+    members,
+    revisions,
+  };
+}
+
+describe('<RevisionHistoryBadge />', () => {
+  it('singleton chain: renders a single rev chip and no toggle', () => {
+    const chain = makeChain({ revisions: [2], titles: ['only one'] });
+    render(<RevisionHistoryBadge chain={chain} currentRevision={null} />);
+
+    expect(screen.getByText('R2')).toBeInTheDocument();
+    // No toggle button for singletons.
+    expect(screen.queryByRole('button')).toBeNull();
+    // No history list rendered.
+    expect(screen.queryByRole('list')).toBeNull();
+  });
+
+  it('3-member chain collapsed by default: shows chain pill with aria-expanded=false', () => {
+    const chain = makeChain({ revisions: [0, 1, 2] });
+    render(<RevisionHistoryBadge chain={chain} currentRevision={null} />);
+
+    const toggle = screen.getByRole('button');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle.textContent).toContain('R0→R1→R2');
+    expect(toggle).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('Revision history'),
+    );
+    // History not rendered yet.
+    expect(screen.queryByRole('list')).toBeNull();
+  });
+
+  it('3-member chain: click toggle expands, shows 2 predecessor rows newest-first', () => {
+    const chain = makeChain({
+      revisions: [0, 1, 2],
+      titles: ['alpha', 'bravo', 'charlie-canonical'],
+    });
+    render(<RevisionHistoryBadge chain={chain} currentRevision={null} />);
+
+    const toggle = screen.getByRole('button');
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    const list = screen.getByRole('list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    // Newest-first: R1 row first, then R0.
+    expect(items[0].textContent).toContain('R1');
+    expect(items[0].textContent).toContain('bravo');
+    expect(items[1].textContent).toContain('R0');
+    expect(items[1].textContent).toContain('alpha');
+    // Canonical is NOT listed.
+    expect(list.textContent).not.toContain('charlie-canonical');
+  });
+
+  it('expand then collapse: back to compact, toggle retains focus', () => {
+    const chain = makeChain({ revisions: [0, 1, 2] });
+    render(<RevisionHistoryBadge chain={chain} currentRevision={null} />);
+
+    const toggle = screen.getByRole('button');
+    toggle.focus();
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('list')).toBeNull();
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it('controlled-expansion mode: parent owns state, internal state untouched', () => {
+    const chain = makeChain({ revisions: [0, 1, 2] });
+    const onToggle = vi.fn();
+    const { rerender } = render(
+      <RevisionHistoryBadge
+        chain={chain}
+        currentRevision={null}
+        expanded={true}
+        onToggleExpanded={onToggle}
+      />,
+    );
+
+    const toggle = screen.getByRole('button', { name: /revision history/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    // Still expanded because parent hasn't flipped the prop — component
+    // does not manage its own state when controlled.
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    rerender(
+      <RevisionHistoryBadge
+        chain={chain}
+        currentRevision={null}
+        expanded={false}
+        onToggleExpanded={onToggle}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /revision history/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('onClickMember wired: clicking a history row fires handler with the right task', () => {
+    const chain = makeChain({
+      revisions: [0, 1, 2],
+      titles: ['alpha', 'bravo', 'charlie'],
+    });
+    const onClickMember = vi.fn();
+    render(
+      <RevisionHistoryBadge
+        chain={chain}
+        currentRevision={null}
+        onClickMember={onClickMember}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /revision history/i }));
+    // Rows now rendered as buttons.
+    const predButtons = screen.getAllByRole('button', {
+      name: /open predecessor/i,
+    });
+    expect(predButtons).toHaveLength(2);
+    // Newest-first — first predecessor is R1 ("bravo").
+    fireEvent.click(predButtons[0]);
+    expect(onClickMember).toHaveBeenCalledTimes(1);
+    expect(onClickMember.mock.calls[0][0]).toMatchObject({
+      id: chain.members[1].id,
+      title: 'bravo',
+    });
+  });
+
+  it('onClickMember NOT wired: history rows are inert (not buttons)', () => {
+    const chain = makeChain({ revisions: [0, 1, 2] });
+    render(<RevisionHistoryBadge chain={chain} currentRevision={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /revision history/i }));
+    // Only the toggle button should be present; no per-row buttons.
+    expect(
+      screen.queryAllByRole('button', { name: /open predecessor/i }),
+    ).toHaveLength(0);
+    // Rows still rendered as listitems.
+    const list = screen.getByRole('list');
+    expect(within(list).getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('currentRevision matches a predecessor: (pinned) annotation on that row', () => {
+    const chain = makeChain({
+      revisions: [0, 1, 2],
+      titles: ['alpha', 'bravo', 'charlie'],
+    });
+    render(<RevisionHistoryBadge chain={chain} currentRevision={1} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /revision history/i }));
+    const items = within(screen.getByRole('list')).getAllByRole('listitem');
+    // Newest-first → items[0] is R1 (bravo), the pinned predecessor.
+    expect(items[0].textContent).toContain('(pinned)');
+    expect(items[1].textContent).not.toContain('(pinned)');
+    // Summary on the pill mentions the pin, too.
+    const toggle = screen.getByRole('button', { name: /revision history/i });
+    expect(toggle.textContent).toContain('pinned R1');
+  });
+
+  it('currentRevision at or after canonical: no (pinned) annotation', () => {
+    const chain = makeChain({ revisions: [0, 1, 2] });
+    const { rerender } = render(
+      <RevisionHistoryBadge chain={chain} currentRevision={2} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /revision history/i }));
+    expect(screen.queryByText('(pinned)')).toBeNull();
+
+    rerender(<RevisionHistoryBadge chain={chain} currentRevision={5} />);
+    expect(screen.queryByText('(pinned)')).toBeNull();
+  });
+
+  it('currentRevision earlier than every member: "not yet introduced"', () => {
+    const chain = makeChain({ revisions: [3, 5, 7] });
+    render(<RevisionHistoryBadge chain={chain} currentRevision={0} />);
+    const toggle = screen.getByRole('button', { name: /revision history/i });
+    expect(toggle.textContent?.toLowerCase()).toContain('not yet introduced');
+    // No (pinned) rows when expanded.
+    fireEvent.click(toggle);
+    expect(screen.queryByText('(pinned)')).toBeNull();
+  });
+
+  it('keyboard toggle: Enter and Space both expand; Tab moves focus', () => {
+    const chain = makeChain({ revisions: [0, 1, 2] });
+    render(<RevisionHistoryBadge chain={chain} currentRevision={null} />);
+    const toggle = screen.getByRole('button');
+
+    toggle.focus();
+    expect(document.activeElement).toBe(toggle);
+
+    fireEvent.keyDown(toggle, { key: 'Enter' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(toggle, { key: 'Enter' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.keyDown(toggle, { key: ' ' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/frontend/src/__tests__/components/TaskStages/RevisionHistoryBadge.test.tsx
+++ b/frontend/src/__tests__/components/TaskStages/RevisionHistoryBadge.test.tsx
@@ -1,9 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import {
-  RevisionHistoryBadge,
-  type TaskRevisionChain,
-} from '../../../components/TaskStages/RevisionHistoryBadge';
+import { RevisionHistoryBadge } from '../../../components/TaskStages/RevisionHistoryBadge';
+import type { TaskRevisionChain } from '../../../components/TaskStages/collapsedLayout';
 import type { Task, TaskStatus } from '../../../gantt/types';
 
 vi.mock('../../../components/TaskStages/RevisionHistoryBadge.css', () => ({}));
@@ -18,6 +16,7 @@ function mkTask(id: string, title: string, status: TaskStatus = 'PENDING'): Task
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/components/TaskStages/collapsedLayout.test.ts
+++ b/frontend/src/__tests__/components/TaskStages/collapsedLayout.test.ts
@@ -22,6 +22,7 @@ function makeTask(id: string, title?: string): Task {
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/components/TaskStages/collapsedLayout.test.ts
+++ b/frontend/src/__tests__/components/TaskStages/collapsedLayout.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collapseCumulativePlan,
+  filterCollapsedAtRevision,
+} from '../../../components/TaskStages/collapsedLayout';
+import type { Task, TaskEdge } from '../../../gantt/types';
+import type {
+  CumulativePlan,
+  CumulativeTaskMeta,
+  SupersessionLink,
+} from '../../../state/planHistoryStore';
+
+// ── Fixture helpers ────────────────────────────────────────────────────
+
+function makeTask(id: string, title?: string): Task {
+  return {
+    id,
+    title: title ?? `Task ${id}`,
+    description: '',
+    assigneeAgentId: 'agent-a',
+    status: 'PENDING',
+    predictedStartMs: 0,
+    predictedDurationMs: 0,
+    boundSpanId: '',
+  };
+}
+
+interface PlanFixtureInput {
+  id?: string;
+  /** [task, revisionIntroduced] pairs in cumulative-task-list order. */
+  tasks: Array<[Task, number]>;
+  edges?: TaskEdge[];
+}
+
+function makeCumulativePlan(input: PlanFixtureInput): CumulativePlan {
+  const taskRevisionMeta = new Map<string, CumulativeTaskMeta>();
+  for (const [t, rev] of input.tasks) {
+    taskRevisionMeta.set(t.id, {
+      introducedInRevision: rev,
+      lastModifiedInRevision: rev,
+      isSuperseded: false,
+    });
+  }
+  return {
+    id: input.id ?? 'plan-1',
+    invocationSpanId: '',
+    plannerAgentId: '',
+    createdAtMs: 0,
+    summary: '',
+    tasks: input.tasks.map(([t]) => t),
+    edges: input.edges ?? [],
+    revisionReason: '',
+    revisionKind: '',
+    revisionSeverity: '',
+    revisionIndex: 0,
+    triggerEventId: '',
+    taskRevisionMeta,
+  };
+}
+
+function makeSupersedesMap(
+  entries: Array<[string, string, number?]>,
+): Map<string, SupersessionLink> {
+  // [oldId, newId, revision?]. newId="" represents a dangling drop.
+  const out = new Map<string, SupersessionLink>();
+  for (const [oldId, newId, rev] of entries) {
+    out.set(oldId, {
+      oldTaskId: oldId,
+      newTaskId: newId,
+      revision: rev ?? 1,
+      kind: '',
+      reason: '',
+      triggerEventId: '',
+    });
+  }
+  return out;
+}
+
+// ── collapseCumulativePlan ─────────────────────────────────────────────
+
+describe('collapseCumulativePlan', () => {
+  it('returns empty chains/edges for an empty plan', () => {
+    const plan = makeCumulativePlan({ tasks: [] });
+    const result = collapseCumulativePlan(plan, new Map());
+    expect(result.chains).toEqual([]);
+    expect(result.edges).toEqual([]);
+    expect(result.chainByTaskId.size).toBe(0);
+    expect(result.planId).toBe('plan-1');
+  });
+
+  it('emits one singleton chain per unrelated task', () => {
+    const plan = makeCumulativePlan({
+      tasks: [
+        [makeTask('a'), 0],
+        [makeTask('b'), 0],
+        [makeTask('c'), 1],
+      ],
+    });
+    const result = collapseCumulativePlan(plan, new Map());
+    expect(result.chains).toHaveLength(3);
+    for (const chain of result.chains) {
+      expect(chain.members).toHaveLength(1);
+      expect(chain.canonical).toBe(chain.members[0]);
+    }
+    expect(result.chains.map((c) => c.canonical.id)).toEqual(['a', 'b', 'c']);
+    expect(result.chains[2].revisions).toEqual([1]);
+  });
+
+  it('collapses a simple 2-member chain a→b', () => {
+    const plan = makeCumulativePlan({
+      tasks: [
+        [makeTask('a'), 0],
+        [makeTask('b'), 1],
+      ],
+    });
+    const supersedes = makeSupersedesMap([['a', 'b', 1]]);
+    const result = collapseCumulativePlan(plan, supersedes);
+    expect(result.chains).toHaveLength(1);
+    const chain = result.chains[0];
+    expect(chain.members.map((m) => m.id)).toEqual(['a', 'b']);
+    expect(chain.canonical.id).toBe('b');
+    expect(chain.revisions).toEqual([0, 1]);
+    expect(result.chainByTaskId.get('a')).toBe(chain);
+    expect(result.chainByTaskId.get('b')).toBe(chain);
+  });
+
+  it('collapses a 3-member chain a→b→c', () => {
+    const plan = makeCumulativePlan({
+      tasks: [
+        [makeTask('a'), 0],
+        [makeTask('b'), 1],
+        [makeTask('c'), 2],
+      ],
+    });
+    const supersedes = makeSupersedesMap([
+      ['a', 'b', 1],
+      ['b', 'c', 2],
+    ]);
+    const result = collapseCumulativePlan(plan, supersedes);
+    expect(result.chains).toHaveLength(1);
+    const chain = result.chains[0];
+    expect(chain.members.map((m) => m.id)).toEqual(['a', 'b', 'c']);
+    expect(chain.canonical.id).toBe('c');
+    expect(chain.revisions).toEqual([0, 1, 2]);
+  });
+
+  it('handles mixed plans with singletons + a chain', () => {
+    const plan = makeCumulativePlan({
+      tasks: [
+        [makeTask('x'), 0],
+        [makeTask('a'), 0],
+        [makeTask('b'), 1],
+        [makeTask('c'), 2],
+        [makeTask('y'), 0],
+      ],
+    });
+    const supersedes = makeSupersedesMap([
+      ['a', 'b', 1],
+      ['b', 'c', 2],
+    ]);
+    const result = collapseCumulativePlan(plan, supersedes);
+    expect(result.chains).toHaveLength(3);
+    const ids = result.chains.map((c) => c.canonical.id);
+    expect(ids).toContain('x');
+    expect(ids).toContain('y');
+    expect(ids).toContain('c');
+    const abcChain = result.chains.find((c) => c.canonical.id === 'c')!;
+    expect(abcChain.members.map((m) => m.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('rewrites edges whose target is a superseded member to the canonical', () => {
+    // A → B, and B is superseded by B'. Result: A → B'.
+    const plan = makeCumulativePlan({
+      tasks: [
+        [makeTask('A'), 0],
+        [makeTask('B'), 0],
+        [makeTask('Bp'), 1],
+      ],
+      edges: [{ fromTaskId: 'A', toTaskId: 'B' }],
+    });
+    const supersedes = makeSupersedesMap([['B', 'Bp', 1]]);
+    const result = collapseCumulativePlan(plan, supersedes);
+    expect(result.edges).toEqual([{ fromTaskId: 'A', toTaskId: 'Bp' }]);
+  });
+
+  it('drops self-edges where both endpoints collapse to the same chain', () => {
+    // a → b where a and b are members of the same chain.
+    const plan = makeCumulativePlan({
+      tasks: [
+        [makeTask('a'), 0],
+        [makeTask('b'), 1],
+      ],
+      edges: [{ fromTaskId: 'a', toTaskId: 'b' }],
+    });
+    const supersedes = makeSupersedesMap([['a', 'b', 1]]);
+    const result = collapseCumulativePlan(plan, supersedes);
+    expect(result.edges).toEqual([]);
+  });
+
+  it('dedups edges that target different members of the same chain', () => {
+    // A → B, A → B' (B superseded by B'). Both rewrite to A → B' — keep
+    // one.
+    const plan = makeCumulativePlan({
+      tasks: [
+        [makeTask('A'), 0],
+        [makeTask('B'), 0],
+        [makeTask('Bp'), 1],
+      ],
+      edges: [
+        { fromTaskId: 'A', toTaskId: 'B' },
+        { fromTaskId: 'A', toTaskId: 'Bp' },
+      ],
+    });
+    const supersedes = makeSupersedesMap([['B', 'Bp', 1]]);
+    const result = collapseCumulativePlan(plan, supersedes);
+    expect(result.edges).toEqual([{ fromTaskId: 'A', toTaskId: 'Bp' }]);
+  });
+
+  it('treats a dangling drop (newTaskId === "") as a singleton chain', () => {
+    const plan = makeCumulativePlan({
+      tasks: [
+        [makeTask('x'), 0],
+        [makeTask('y'), 0],
+      ],
+    });
+    const supersedes = makeSupersedesMap([['x', '', 1]]);
+    const result = collapseCumulativePlan(plan, supersedes);
+    expect(result.chains).toHaveLength(2);
+    for (const chain of result.chains) {
+      expect(chain.members).toHaveLength(1);
+    }
+  });
+
+  it('ignores orphan supersedes links (ids absent from cumulative.tasks)', () => {
+    // Link references "ghost" which isn't in the plan — treat as if the
+    // link didn't exist; "a" stays a singleton chain.
+    const plan = makeCumulativePlan({
+      tasks: [[makeTask('a'), 0]],
+    });
+    const supersedes = makeSupersedesMap([['a', 'ghost', 1]]);
+    const result = collapseCumulativePlan(plan, supersedes);
+    expect(result.chains).toHaveLength(1);
+    expect(result.chains[0].members.map((m) => m.id)).toEqual(['a']);
+  });
+});
+
+// ── filterCollapsedAtRevision ──────────────────────────────────────────
+
+describe('filterCollapsedAtRevision', () => {
+  it('revision=null leaves everything visible with no muting', () => {
+    const plan = makeCumulativePlan({
+      tasks: [
+        [makeTask('a'), 0],
+        [makeTask('b'), 1],
+      ],
+    });
+    const supersedes = makeSupersedesMap([['a', 'b', 1]]);
+    const collapsed = collapseCumulativePlan(plan, supersedes);
+    const filtered = filterCollapsedAtRevision(collapsed, null);
+    expect(filtered.chains).toBe(collapsed.chains);
+    expect(filtered.edges).toBe(collapsed.edges);
+    expect(filtered.hiddenChainIds.size).toBe(0);
+    expect(filtered.mutedChainIds.size).toBe(0);
+  });
+
+  it('renders a chain entirely introduced in rev 0 as visible and unmuted at rev 0', () => {
+    const plan = makeCumulativePlan({
+      tasks: [[makeTask('a'), 0]],
+    });
+    const collapsed = collapseCumulativePlan(plan, new Map());
+    const filtered = filterCollapsedAtRevision(collapsed, 0);
+    expect(filtered.hiddenChainIds.size).toBe(0);
+    expect(filtered.mutedChainIds.size).toBe(0);
+  });
+
+  it('mutes a chain whose root exists at rev 0 but canonical was introduced later', () => {
+    const plan = makeCumulativePlan({
+      tasks: [
+        [makeTask('a'), 0],
+        [makeTask('b'), 1],
+      ],
+    });
+    const supersedes = makeSupersedesMap([['a', 'b', 1]]);
+    const collapsed = collapseCumulativePlan(plan, supersedes);
+    const filtered = filterCollapsedAtRevision(collapsed, 0);
+    // Chain canonical is 'b' (introduced in rev 1); root 'a' is rev 0.
+    expect(filtered.hiddenChainIds.size).toBe(0);
+    expect(filtered.mutedChainIds.has('b')).toBe(true);
+  });
+
+  it('hides a chain whose members were all introduced after the pinned revision', () => {
+    const plan = makeCumulativePlan({
+      tasks: [
+        [makeTask('a'), 0],
+        [makeTask('new'), 1],
+      ],
+    });
+    const collapsed = collapseCumulativePlan(plan, new Map());
+    const filtered = filterCollapsedAtRevision(collapsed, 0);
+    expect(filtered.hiddenChainIds.has('new')).toBe(true);
+    expect(filtered.hiddenChainIds.has('a')).toBe(false);
+    expect(filtered.mutedChainIds.size).toBe(0);
+  });
+});

--- a/frontend/src/__tests__/components/TaskStagesGraph.evolution.test.tsx
+++ b/frontend/src/__tests__/components/TaskStagesGraph.evolution.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
 import type { Task, TaskEdge, TaskPlan, TaskStatus } from '../../gantt/types';
 import { SessionStore } from '../../gantt/index';
 
@@ -14,6 +15,7 @@ vi.mock('../../rpc/hooks', () => ({
 // Mock CSS so vitest's "css: false" doesn't complain about side-effect
 // imports on the component under test.
 vi.mock('../../components/TaskStages/TaskStagesGraph.css', () => ({}));
+vi.mock('../../components/TaskStages/RevisionHistoryBadge.css', () => ({}));
 
 // Imported AFTER the mock so the hooks bind to our fake getSessionStore.
 import { TaskStagesGraph } from '../../components/TaskStages/TaskStagesGraph';
@@ -156,8 +158,8 @@ describe('plan-evolution · pure derivation', () => {
   });
 });
 
-describe('<TaskStagesGraph /> cumulative mode', () => {
-  it('renders both live and superseded tasks with muted styling for superseded', () => {
+describe('<TaskStagesGraph /> cumulative mode (collapsed chains)', () => {
+  it('collapses a supersedes chain into one canonical card; singleton tasks render as their own card', () => {
     const store = seedTwoRevPlan();
     const cum = __internal.deriveCumulative('plan-1', store.tasks.allRevsForPlan('plan-1'));
     const supersedes = __internal.deriveSupersedes(
@@ -172,26 +174,51 @@ describe('<TaskStagesGraph /> cumulative mode', () => {
       />,
     );
     const cards = container.querySelectorAll('g.hg-stages__card');
-    expect(cards.length).toBe(3); // t1, t2 (superseded), t3
-    const superseded = Array.from(cards).filter(
-      (c) => c.getAttribute('data-superseded') === 'true',
-    );
-    expect(superseded).toHaveLength(1);
+    // t1 (singleton) + {t2, t3} collapsed into one chain card = 2 cards.
+    expect(cards.length).toBe(2);
   });
 
-  it('renders one generation badge per task with the right revision number', () => {
+  it('attaches a RevisionHistoryBadge to the multi-member chain card only', () => {
     const store = seedTwoRevPlan();
     const cum = __internal.deriveCumulative('plan-1', store.tasks.allRevsForPlan('plan-1'));
+    const supersedes = __internal.deriveSupersedes(
+      store.tasks.allRevsForPlan('plan-1'),
+      new Map([['drift-abc', store.drifts.list()[0]]]),
+    );
     const { container } = render(
-      <TaskStagesGraph plan={mkPlan(0, [])} cumulative={cum} />,
+      <TaskStagesGraph
+        plan={mkPlan(0, [])}
+        cumulative={cum}
+        supersedesMap={supersedes}
+      />,
+    );
+    // One chain-badge slot for the {t2,t3} canonical card. t1 is
+    // singleton so has no badge.
+    const badges = container.querySelectorAll('[data-testid^="chain-badge-for-"]');
+    expect(badges.length).toBe(1);
+    // The canonical of the {t2,t3} chain is t3 (latest member).
+    expect(badges[0].getAttribute('data-testid')).toBe('chain-badge-for-t3');
+  });
+
+  it('renders one generation badge per collapsed card', () => {
+    const store = seedTwoRevPlan();
+    const cum = __internal.deriveCumulative('plan-1', store.tasks.allRevsForPlan('plan-1'));
+    const supersedes = __internal.deriveSupersedes(
+      store.tasks.allRevsForPlan('plan-1'),
+      new Map([['drift-abc', store.drifts.list()[0]]]),
+    );
+    const { container } = render(
+      <TaskStagesGraph
+        plan={mkPlan(0, [])}
+        cumulative={cum}
+        supersedesMap={supersedes}
+      />,
     );
     const badges = container.querySelectorAll('g.hg-stages__gen-badge');
-    expect(badges.length).toBe(3);
-    const revs = Array.from(badges).map((b) => b.getAttribute('data-rev'));
-    expect(revs.sort()).toEqual(['0', '0', '1']);
+    expect(badges.length).toBe(2);
   });
 
-  it('renders a supersedes edge with a drift-kind annotation', () => {
+  it('no longer renders visible "supersedes-edge" elements (chain badge replaces them)', () => {
     const store = seedTwoRevPlan();
     const cum = __internal.deriveCumulative('plan-1', store.tasks.allRevsForPlan('plan-1'));
     const supersedes = __internal.deriveSupersedes(
@@ -205,103 +232,53 @@ describe('<TaskStagesGraph /> cumulative mode', () => {
         supersedesMap={supersedes}
       />,
     );
-    const edges = container.querySelectorAll('[data-testid="supersedes-edge"]');
-    expect(edges.length).toBe(1);
-    const label = edges[0].querySelector('.hg-stages__supersedes-label');
-    expect(label?.textContent).toContain('off_topic');
-    expect(label?.textContent).toContain('goldfive');
-  });
-
-  it('fires onSupersedesEdgeClick with the link payload when clicked', () => {
-    const store = seedTwoRevPlan();
-    const cum = __internal.deriveCumulative('plan-1', store.tasks.allRevsForPlan('plan-1'));
-    const supersedes = __internal.deriveSupersedes(
-      store.tasks.allRevsForPlan('plan-1'),
-      new Map([['drift-abc', store.drifts.list()[0]]]),
-    );
-    const handler = vi.fn();
-    const { container } = render(
-      <TaskStagesGraph
-        plan={mkPlan(0, [])}
-        cumulative={cum}
-        supersedesMap={supersedes}
-        onSupersedesEdgeClick={handler}
-      />,
-    );
-    const edge = container.querySelector('[data-testid="supersedes-edge"]');
-    expect(edge).toBeTruthy();
-    fireEvent.click(edge!);
-    expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler.mock.calls[0][0].oldTaskId).toBe('t2');
-    expect(handler.mock.calls[0][0].newTaskId).toBe('t3');
+    expect(container.querySelectorAll('[data-testid="supersedes-edge"]')).toHaveLength(0);
   });
 });
 
-describe('<TaskPlanPanel /> integration', () => {
-  it('defaults to cumulative view and renders the scrubber + both task revs', () => {
+describe('<TaskPlanPanel /> integration (collapsed chains)', () => {
+  it('defaults to cumulative view and renders one card per logical slot after collapse', () => {
     const store = seedTwoRevPlan();
     const plan = store.tasks.getPlan('plan-1')!;
     render(<TaskPlanPanel sessionId="sess-1" plan={plan} />);
     expect(screen.getByTestId('task-stages-graph')).toBeInTheDocument();
     expect(screen.getByTestId('plan-revision-scrubber')).toBeInTheDocument();
-    // cumulative → shows t1, t2 (muted), t3
+    // cumulative → t1 + {t2,t3}-chain = 2 cards after collapse.
     const cards = document
       .querySelector('[data-testid="task-stages-graph"]')!
       .querySelectorAll('g.hg-stages__card');
-    expect(cards.length).toBe(3);
+    expect(cards.length).toBe(2);
   });
 
-  it('opens the steering-detail side panel on supersedes-edge click', () => {
-    const store = seedTwoRevPlan();
-    const plan = store.tasks.getPlan('plan-1')!;
-    render(<TaskPlanPanel sessionId="sess-1" plan={plan} />);
-    const edges = document.querySelectorAll('[data-testid="supersedes-edge"]');
-    expect(edges.length).toBe(1);
-    fireEvent.click(edges[0]);
-    const panel = screen.getByTestId('steering-detail-panel');
-    expect(panel).toBeInTheDocument();
-    // Trigger / Steering / Target sections populated.
-    expect(screen.getByTestId('steering-detail-trigger').textContent).toContain(
-      'off_topic',
-    );
-    expect(screen.getByTestId('steering-detail-steering').textContent).toContain(
-      'goldfive',
-    );
-    expect(screen.getByTestId('steering-detail-target').textContent).toContain('agent-a');
-  });
-
-  it('revision scrubber filter mutes tasks introduced in later revisions', () => {
+  it('revision scrubber hides chains whose earliest member is introduced after the pinned rev', () => {
     const store = seedThreeRevPlan();
     const plan = store.tasks.getPlan('plan-1')!;
     render(<TaskPlanPanel sessionId="sess-3" plan={plan} />);
-    // Default selection is 'Latest' → nothing muted from the scrubber
-    // (cards may still be superseded in the no-superseded path here; t3
-    // is the tail so no tasks are superseded). Click rev 0.
+    // Click rev 0. t1 was intro'd at rev 0 → visible. t2 (rev 1) + t3
+    // (rev 2) are singleton chains whose firstRev > 0 → hidden (not
+    // rendered at all, per filterCollapsedAtRevision contract).
     fireEvent.click(screen.getByTestId('scrubber-notch-0'));
     const cards = document
       .querySelector('[data-testid="task-stages-graph"]')!
       .querySelectorAll('g.hg-stages__card');
-    const muted = Array.from(cards).filter((c) =>
-      c.classList.contains('hg-stages__card--muted'),
-    );
-    // t2 + t3 were introduced after rev 0 → muted.
-    expect(muted.length).toBe(2);
+    expect(cards.length).toBe(1);
   });
 
-  it('Latest-only toggle drops the cumulative rendering (no supersedes edges)', () => {
+  it('Latest-only toggle drops the cumulative rendering (no chain badges, no gen badges)', () => {
     const store = seedTwoRevPlan();
     const plan = store.tasks.getPlan('plan-1')!;
     render(<TaskPlanPanel sessionId="sess-1" plan={plan} />);
     // Switch to Latest only.
     const toggle = screen.getByTestId('task-plan-view-toggle') as HTMLSelectElement;
     fireEvent.change(toggle, { target: { value: 'latest' } });
-    // Latest only → just t1 + t3 (the live rev 1 shape). No gen badges.
+    // Latest only → just t1 + t3 (the live rev 1 shape). No gen badges,
+    // no chain badges (singleton tasks don't get a badge).
     const cards = document
       .querySelector('[data-testid="task-stages-graph"]')!
       .querySelectorAll('g.hg-stages__card');
     expect(cards.length).toBe(2);
     expect(
-      document.querySelectorAll('[data-testid="supersedes-edge"]'),
+      document.querySelectorAll('[data-testid^="chain-badge-for-"]'),
     ).toHaveLength(0);
     expect(document.querySelectorAll('g.hg-stages__gen-badge')).toHaveLength(0);
   });

--- a/frontend/src/__tests__/components/TaskStagesGraph.evolution.test.tsx
+++ b/frontend/src/__tests__/components/TaskStagesGraph.evolution.test.tsx
@@ -34,6 +34,7 @@ function mkTask(id: string, status: TaskStatus = 'PENDING', title?: string): Tas
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/components/TaskStagesGraph.test.tsx
+++ b/frontend/src/__tests__/components/TaskStagesGraph.test.tsx
@@ -15,6 +15,7 @@ function mkTask(id: string, status: TaskStatus = 'PENDING'): Task {
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/components/TrajectoryFloatingDrawer.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryFloatingDrawer.test.tsx
@@ -40,6 +40,7 @@ function mkTask(overrides: Partial<Task> = {}): Task {
     predictedDurationMs: 0,
     boundSpanId: 'span-abcdef12',
     cancelReason: '',
+    supersedes: '',
     ...overrides,
   };
 }

--- a/frontend/src/__tests__/components/TrajectoryView.cancelReason.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.cancelReason.test.tsx
@@ -62,6 +62,7 @@ function mkTask(
     predictedDurationMs: 0,
     boundSpanId: '',
     cancelReason,
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/components/TrajectoryView.collapseChains.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.collapseChains.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * Acceptance test for the 5-revision supersedes-collapse integration.
+ *
+ * NOTE: the brief filename mentions TrajectoryView, but TrajectoryView's
+ * DAG renderer (DagPane, custom SVG) is a separate code path that does
+ * not call into the new collapsedLayout — the `TaskStagesGraph` /
+ * `TaskPlanPanel` renderer is where SUPE+LAY+BAG land. We test that
+ * path here, since it's the one the integration rewires. A follow-up
+ * can extend the collapse to DagPane (see PR body / TODO below).
+ */
+
+import { fireEvent, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Task, TaskEdge, TaskPlan, TaskStatus } from '../../gantt/types';
+import { SessionStore } from '../../gantt/index';
+
+const storesById = new Map<string, SessionStore>();
+vi.mock('../../rpc/hooks', () => ({
+  getSessionStore: (id: string | null) => (id ? storesById.get(id) : undefined),
+}));
+vi.mock('../../components/TaskStages/TaskStagesGraph.css', () => ({}));
+vi.mock('../../components/TaskStages/RevisionHistoryBadge.css', () => ({}));
+
+import { TaskStagesGraph } from '../../components/TaskStages/TaskStagesGraph';
+import { __internal } from '../../state/planHistory';
+
+function mkTask(
+  id: string,
+  title: string,
+  status: TaskStatus = 'PENDING',
+  supersedes: string = '',
+): Task {
+  return {
+    id,
+    title,
+    description: '',
+    assigneeAgentId: 'agent-a',
+    status,
+    predictedStartMs: 0,
+    predictedDurationMs: 0,
+    boundSpanId: '',
+    supersedes,
+  };
+}
+
+function mkPlan(
+  rev: number,
+  tasks: Task[],
+  edges: Array<[string, string]>,
+  opts: Partial<TaskPlan> = {},
+): TaskPlan {
+  return {
+    id: 'plan-5',
+    invocationSpanId: '',
+    plannerAgentId: '',
+    createdAtMs: rev * 1000,
+    summary: '',
+    tasks,
+    edges: edges.map<TaskEdge>(([f, t]) => ({ fromTaskId: f, toTaskId: t })),
+    revisionReason: opts.revisionReason ?? `rev ${rev}`,
+    revisionKind: opts.revisionKind,
+    revisionIndex: rev,
+    triggerEventId: opts.triggerEventId,
+  };
+}
+
+beforeEach(() => {
+  storesById.clear();
+});
+
+/**
+ * 5-revision fixture:
+ *   R0: A, B, C. Edges A→B, B→C.
+ *   R1: A' supersedes A (slot A chain: A→A').
+ *   R2: A'' supersedes A'  AND  B' supersedes B.
+ *   R3: A''' supersedes A''.
+ *   R4: A'''' supersedes A'''.
+ *
+ *   After collapse we expect 3 chains: {A, A', A'', A''', A''''},
+ *   {B, B'}, {C}. Three cards in the rendered DAG.
+ */
+function seedFiveRevSession(): {
+  cumulative: ReturnType<typeof __internal.deriveCumulative>;
+  supersedes: ReturnType<typeof __internal.deriveSupersedes>;
+} {
+  const R0 = mkPlan(
+    0,
+    [mkTask('A0', 'Research topic'), mkTask('B0', 'Draft plan'), mkTask('C0', 'Ship')],
+    [
+      ['A0', 'B0'],
+      ['B0', 'C0'],
+    ],
+  );
+
+  const R1 = mkPlan(
+    1,
+    [
+      mkTask('A1', 'Research topic v2', 'PENDING', 'A0'),
+      mkTask('B0', 'Draft plan'),
+      mkTask('C0', 'Ship'),
+    ],
+    [
+      ['A1', 'B0'],
+      ['B0', 'C0'],
+    ],
+    { revisionKind: 'off_topic' },
+  );
+
+  const R2 = mkPlan(
+    2,
+    [
+      mkTask('A2', 'Research topic v3', 'PENDING', 'A1'),
+      mkTask('B1', 'Draft plan v2', 'PENDING', 'B0'),
+      mkTask('C0', 'Ship'),
+    ],
+    [
+      ['A2', 'B1'],
+      ['B1', 'C0'],
+    ],
+    { revisionKind: 'user_steer' },
+  );
+
+  const R3 = mkPlan(
+    3,
+    [
+      mkTask('A3', 'Research topic v4', 'PENDING', 'A2'),
+      mkTask('B1', 'Draft plan v2'),
+      mkTask('C0', 'Ship'),
+    ],
+    [
+      ['A3', 'B1'],
+      ['B1', 'C0'],
+    ],
+  );
+
+  const R4 = mkPlan(
+    4,
+    [
+      mkTask('A4', 'Research topic v5', 'PENDING', 'A3'),
+      mkTask('B1', 'Draft plan v2'),
+      mkTask('C0', 'Ship'),
+    ],
+    [
+      ['A4', 'B1'],
+      ['B1', 'C0'],
+    ],
+  );
+
+  const plans = [R0, R1, R2, R3, R4];
+  const cumulative = __internal.deriveCumulative('plan-5', plans);
+  // deriveSupersedes needs a driftsById map; we don't seed drifts so pass empty.
+  const supersedes = __internal.deriveSupersedes(plans, new Map());
+  return { cumulative, supersedes };
+}
+
+describe('<TaskStagesGraph /> acceptance — 5-revision supersedes chain collapse', () => {
+  it('renders exactly one card per logical slot (3 cards, not 8+ stacked)', () => {
+    const { cumulative, supersedes } = seedFiveRevSession();
+    expect(cumulative).not.toBeNull();
+    const { container } = render(
+      <TaskStagesGraph
+        plan={mkPlan(0, [], [])}
+        cumulative={cumulative}
+        supersedesMap={supersedes}
+      />,
+    );
+    const cards = container.querySelectorAll('g.hg-stages__card');
+    // Three logical slots: A-chain, B-chain, C. Not 5+3+1=9 stacked.
+    expect(cards.length).toBe(3);
+  });
+
+  it('A-chain card carries a RevisionHistoryBadge covering all 5 members', () => {
+    const { cumulative, supersedes } = seedFiveRevSession();
+    const { container } = render(
+      <TaskStagesGraph
+        plan={mkPlan(0, [], [])}
+        cumulative={cumulative}
+        supersedesMap={supersedes}
+      />,
+    );
+    // Canonical of the A chain is A4 (latest).
+    const aBadgeSlot = container.querySelector(
+      '[data-testid="chain-badge-for-A4"]',
+    );
+    expect(aBadgeSlot).toBeTruthy();
+    // Chain size: 5 members — check the card's data attribute we added
+    // to the card <g>. The badge itself renders "R0→R1→R2→R3→R4"
+    // inside its label span.
+    const aCard = container.querySelector(
+      'g.hg-stages__card[data-chain-size="5"]',
+    );
+    expect(aCard).toBeTruthy();
+  });
+
+  it('B-chain card carries a badge with 2 members; C is a singleton (no badge)', () => {
+    const { cumulative, supersedes } = seedFiveRevSession();
+    const { container } = render(
+      <TaskStagesGraph
+        plan={mkPlan(0, [], [])}
+        cumulative={cumulative}
+        supersedesMap={supersedes}
+      />,
+    );
+    // Canonical of B chain is B1.
+    expect(container.querySelector('[data-testid="chain-badge-for-B1"]')).toBeTruthy();
+    // Canonical of C chain is C0, singleton → NO badge.
+    expect(container.querySelector('[data-testid="chain-badge-for-C0"]')).toBeNull();
+    // Exactly two chain badges overall (A and B chains).
+    expect(
+      container.querySelectorAll('[data-testid^="chain-badge-for-"]').length,
+    ).toBe(2);
+  });
+
+  it('clicking a predecessor row in the expanded A badge fires onTaskClick with that predecessor id', () => {
+    const { cumulative, supersedes } = seedFiveRevSession();
+    const handleTaskClick = vi.fn();
+    const { container } = render(
+      <TaskStagesGraph
+        plan={mkPlan(0, [], [])}
+        cumulative={cumulative}
+        supersedesMap={supersedes}
+        onTaskClick={handleTaskClick}
+      />,
+    );
+    // Expand the A-chain badge.
+    const aBadge = container.querySelector('[data-testid="chain-badge-for-A4"]');
+    expect(aBadge).toBeTruthy();
+    // The badge pill exposes a toggle button when members.length > 1.
+    const toggle = aBadge!.querySelector('button');
+    expect(toggle).toBeTruthy();
+    fireEvent.click(toggle!);
+    // Expanded trail renders role="list" with one item per PREDECESSOR
+    // (canonical is excluded — it's the card itself). 5 members →
+    // 4 predecessor rows (newest-first per component contract).
+    const list = aBadge!.querySelector('[role="list"]');
+    expect(list).toBeTruthy();
+    const items = list!.querySelectorAll('[role="listitem"]');
+    expect(items.length).toBe(4);
+    // Click the oldest predecessor — with newest-first ordering that's
+    // the LAST item, which corresponds to members[0] = A0 (R0).
+    const lastItem = items[items.length - 1];
+    expect(lastItem.getAttribute('data-task-id')).toBe('A0');
+    const rowBtn = lastItem.querySelector('button');
+    expect(rowBtn).toBeTruthy();
+    fireEvent.click(rowBtn!);
+    expect(handleTaskClick).toHaveBeenCalled();
+    const clickedTask = handleTaskClick.mock.calls[0][0] as Task;
+    expect(clickedTask.id).toBe('A0');
+  });
+
+  it('pinning to R2 via revisionFilter: A-chain and B-chain stay visible (born at R0); C stays visible', () => {
+    const { cumulative, supersedes } = seedFiveRevSession();
+    const { container } = render(
+      <TaskStagesGraph
+        plan={mkPlan(0, [], [])}
+        cumulative={cumulative}
+        supersedesMap={supersedes}
+        revisionFilter={2}
+      />,
+    );
+    // All three chains are born at/before R2 (firstRev=0 for all of
+    // them). LAY's `filterCollapsedAtRevision` muting trade-off: when a
+    // chain's latest canonical is introduced > pinned rev the chain is
+    // MUTED but still rendered. For the A chain, latest canonical A4
+    // was introduced at R4 > 2 → muted. B chain canonical B1 introduced
+    // at R2 → not muted. C canonical C0 introduced at R0 → not muted.
+    const cards = container.querySelectorAll('g.hg-stages__card');
+    expect(cards.length).toBe(3);
+    const mutedCards = Array.from(cards).filter((c) =>
+      c.classList.contains('hg-stages__card--muted'),
+    );
+    // A chain is muted (canonical = A4 @ R4, pinned R2); B + C are not.
+    // This is the current LAY contract: muted, not canonical-swapped to
+    // the R2-era member. A follow-up issue can tighten this to swap the
+    // displayed canonical to the newest member ≤ R — tracked in the
+    // collapsedLayout docstring.
+    expect(mutedCards.length).toBe(1);
+    expect(mutedCards[0].querySelector('title')?.textContent).toContain(
+      'Research topic v5',
+    );
+  });
+});

--- a/frontend/src/__tests__/components/TrajectoryView.emptyRev.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.emptyRev.test.tsx
@@ -87,6 +87,7 @@ function mkTask(id: string, status: Task['status'], title = id): Task {
     predictedDurationMs: 0,
     boundSpanId: '',
     cancelReason: '',
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/components/TrajectoryView.evolution.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.evolution.test.tsx
@@ -85,6 +85,7 @@ function mkTask(
     predictedDurationMs: 0,
     boundSpanId: '',
     cancelReason: '',
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/components/TrajectoryView.steering.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.steering.test.tsx
@@ -81,6 +81,7 @@ function mkTask(
     predictedDurationMs: 0,
     boundSpanId: '',
     cancelReason: '',
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/gantt/SessionStore.test.ts
+++ b/frontend/src/__tests__/gantt/SessionStore.test.ts
@@ -25,6 +25,7 @@ function task(id: string, status: TaskStatus): Task {
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/gantt/TaskRegistry.test.ts
+++ b/frontend/src/__tests__/gantt/TaskRegistry.test.ts
@@ -12,6 +12,7 @@ function makeTask(id: string, overrides: Partial<Task> = {}): Task {
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
     ...overrides,
   };
 }

--- a/frontend/src/__tests__/gantt/planDiff.test.ts
+++ b/frontend/src/__tests__/gantt/planDiff.test.ts
@@ -12,6 +12,7 @@ function mkTask(id: string, overrides: Partial<Task> = {}): Task {
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
     ...overrides,
   };
 }

--- a/frontend/src/__tests__/gantt/stages.test.ts
+++ b/frontend/src/__tests__/gantt/stages.test.ts
@@ -12,6 +12,7 @@ function mkTask(id: string): Task {
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
   };
 }
 

--- a/frontend/src/__tests__/lib/interventionDetail.test.ts
+++ b/frontend/src/__tests__/lib/interventionDetail.test.ts
@@ -320,6 +320,7 @@ describe('interventionDetail', () => {
       predictedDurationMs: 0,
       boundSpanId: '',
       cancelReason: 'upstream_failed:t0',
+      supersedes: '',
     };
     const detail = resolveTaskCancelDetail(task);
     expect(detail.steering).toBe('upstream_failed:t0');
@@ -338,6 +339,7 @@ describe('interventionDetail', () => {
       predictedStartMs: 0,
       predictedDurationMs: 0,
       boundSpanId: '',
+      supersedes: '',
     };
     const detail = resolveTaskCancelDetail(task);
     expect(detail.steering).toBe('');

--- a/frontend/src/__tests__/lib/interventions.test.ts
+++ b/frontend/src/__tests__/lib/interventions.test.ts
@@ -172,6 +172,7 @@ describe('deriveInterventions', () => {
               predictedStartMs: 0,
               predictedDurationMs: 0,
               boundSpanId: '',
+              supersedes: '',
             },
             {
               id: 't2',
@@ -182,6 +183,7 @@ describe('deriveInterventions', () => {
               predictedStartMs: 0,
               predictedDurationMs: 0,
               boundSpanId: '',
+              supersedes: '',
             },
           ],
         }),

--- a/frontend/src/__tests__/state/planHistory.test.ts
+++ b/frontend/src/__tests__/state/planHistory.test.ts
@@ -35,6 +35,7 @@ function mkTask(
     predictedStartMs: 0,
     predictedDurationMs: 0,
     boundSpanId: '',
+    supersedes: '',
     ...overrides,
   };
 }

--- a/frontend/src/__tests__/state/planHistoryStore.supersedes.test.ts
+++ b/frontend/src/__tests__/state/planHistoryStore.supersedes.test.ts
@@ -1,0 +1,221 @@
+// Unit tests for PlanHistoryRegistry.supersedesMap's two-pass algorithm:
+//
+//   Pass 1 — authoritative: Task.supersedes (set by goldfive's refine LLM
+//   per goldfive#237) produces a SupersessionLink keyed by the old id.
+//
+//   Pass 2 — positional heuristic fallback: only for dropped ids that
+//   Pass 1 did NOT pair, pair by list order against unpaired truly-new
+//   ids. This exists only for legacy plans / tasks where the LLM
+//   omitted `supersedes`.
+//
+// These tests pin the invariants so the heuristic can't quietly
+// mispair when the authoritative signal is present.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  PlanHistoryRegistry,
+  type PlanRevisionRecord,
+} from '../../state/planHistoryStore';
+import type { Task, TaskPlan } from '../../gantt/types';
+
+function mkTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    title: `Task ${id}`,
+    description: '',
+    assigneeAgentId: 'agent-a',
+    status: 'PENDING',
+    predictedStartMs: 0,
+    predictedDurationMs: 0,
+    boundSpanId: '',
+    supersedes: '',
+    ...overrides,
+  };
+}
+
+function mkPlan(id: string, tasks: Task[], rev = 0): TaskPlan {
+  return {
+    id,
+    invocationSpanId: '',
+    plannerAgentId: '',
+    createdAtMs: 0,
+    summary: '',
+    tasks,
+    edges: [],
+    revisionReason: '',
+    revisionKind: '',
+    revisionSeverity: '',
+    revisionIndex: rev,
+    triggerEventId: '',
+  };
+}
+
+function mkRecord(
+  planId: string,
+  revision: number,
+  tasks: Task[],
+  overrides: Partial<PlanRevisionRecord> = {},
+): PlanRevisionRecord {
+  return {
+    revision,
+    plan: mkPlan(planId, tasks, revision),
+    reason: overrides.reason ?? `reason-${revision}`,
+    kind: overrides.kind ?? (revision === 0 ? '' : 'off_topic'),
+    triggerEventId:
+      overrides.triggerEventId ?? (revision === 0 ? '' : `drift-${revision}`),
+    emittedAtMs: overrides.emittedAtMs ?? revision * 1000,
+  };
+}
+
+describe('PlanHistoryRegistry.supersedesMap (two-pass)', () => {
+  let reg: PlanHistoryRegistry;
+
+  beforeEach(() => {
+    reg = new PlanHistoryRegistry();
+  });
+
+  it('returns an empty map when there is a single revision and no supersessions', () => {
+    reg.append(mkRecord('p1', 0, [mkTask('a'), mkTask('b')]));
+    const m = reg.supersedesMap('p1');
+    expect(m.size).toBe(0);
+  });
+
+  it('authoritative pairing wins over the positional heuristic', () => {
+    // rev 0: [a, b]
+    // rev 1: [a, c] where c.supersedes = b → must pair b→c explicitly.
+    reg.append(mkRecord('p1', 0, [mkTask('a'), mkTask('b')]));
+    reg.append(
+      mkRecord('p1', 1, [mkTask('a'), mkTask('c', { supersedes: 'b' })]),
+    );
+    const m = reg.supersedesMap('p1');
+    expect(m.size).toBe(1);
+    const link = m.get('b');
+    expect(link).toBeDefined();
+    expect(link?.oldTaskId).toBe('b');
+    expect(link?.newTaskId).toBe('c');
+    expect(link?.revision).toBe(1);
+    expect(link?.kind).toBe('off_topic');
+    expect(link?.triggerEventId).toBe('drift-1');
+  });
+
+  it('falls back to the positional heuristic when supersedes is empty', () => {
+    // rev 0: [a, b]
+    // rev 1: [a, c]  (c.supersedes = '' → heuristic pairs b→c)
+    reg.append(mkRecord('p1', 0, [mkTask('a'), mkTask('b')]));
+    reg.append(mkRecord('p1', 1, [mkTask('a'), mkTask('c')]));
+    const m = reg.supersedesMap('p1');
+    expect(m.size).toBe(1);
+    expect(m.get('b')?.newTaskId).toBe('c');
+    expect(m.get('b')?.revision).toBe(1);
+  });
+
+  it('mixes authoritative + heuristic when only some replacements are annotated', () => {
+    // rev 0: [a, b]                 — two tasks.
+    // rev 1: [c, d] — both dropped, two new.
+    //   c.supersedes = 'a' (authoritative)
+    //   d.supersedes = ''  (heuristic must pair d to b)
+    reg.append(mkRecord('p1', 0, [mkTask('a'), mkTask('b')]));
+    reg.append(
+      mkRecord('p1', 1, [
+        mkTask('c', { supersedes: 'a' }),
+        mkTask('d'),
+      ]),
+    );
+    const m = reg.supersedesMap('p1');
+    expect(m.size).toBe(2);
+    expect(m.get('a')?.newTaskId).toBe('c'); // authoritative
+    expect(m.get('b')?.newTaskId).toBe('d'); // heuristic
+    // Both should stamp rev 1's trigger metadata.
+    expect(m.get('a')?.revision).toBe(1);
+    expect(m.get('b')?.revision).toBe(1);
+  });
+
+  it('collapses a chain a → b → c across three revisions', () => {
+    // rev 0: [a]
+    // rev 1: [b] where b.supersedes = 'a'
+    // rev 2: [c] where c.supersedes = 'b'
+    reg.append(mkRecord('p1', 0, [mkTask('a')]));
+    reg.append(
+      mkRecord('p1', 1, [mkTask('b', { supersedes: 'a' })], {
+        kind: 'off_topic',
+        triggerEventId: 'drift-1',
+      }),
+    );
+    reg.append(
+      mkRecord('p1', 2, [mkTask('c', { supersedes: 'b' })], {
+        kind: 'user_steer',
+        triggerEventId: 'ann-2',
+      }),
+    );
+    const m = reg.supersedesMap('p1');
+    expect(m.size).toBe(2);
+
+    const aLink = m.get('a');
+    expect(aLink?.newTaskId).toBe('b');
+    expect(aLink?.revision).toBe(1);
+    expect(aLink?.kind).toBe('off_topic');
+    expect(aLink?.triggerEventId).toBe('drift-1');
+
+    const bLink = m.get('b');
+    expect(bLink?.newTaskId).toBe('c');
+    expect(bLink?.revision).toBe(2);
+    expect(bLink?.kind).toBe('user_steer');
+    expect(bLink?.triggerEventId).toBe('ann-2');
+  });
+
+  it('ignores a genuinely new task that does not replace anything', () => {
+    // rev 0: [a, b]
+    // rev 1: [a, c, d] where d.supersedes='b' and c is entirely new.
+    // → only b appears as a key; c (genuinely new) is never a key.
+    reg.append(mkRecord('p1', 0, [mkTask('a'), mkTask('b')]));
+    reg.append(
+      mkRecord('p1', 1, [
+        mkTask('a'),
+        mkTask('c'), // genuinely new, no supersedes
+        mkTask('d', { supersedes: 'b' }),
+      ]),
+    );
+    const m = reg.supersedesMap('p1');
+    expect(m.size).toBe(1);
+    expect(m.get('b')?.newTaskId).toBe('d');
+    expect(m.has('c')).toBe(false);
+    expect(m.has('a')).toBe(false);
+  });
+
+  it('Pass 1 emits at the revision where the replacement first appears', () => {
+    // rev 0: [a]
+    // rev 1: [b] (b.supersedes=a; should stamp rev 1)
+    // rev 2: [b] (b carries through; must NOT re-stamp rev 2)
+    reg.append(mkRecord('p1', 0, [mkTask('a')]));
+    reg.append(
+      mkRecord('p1', 1, [mkTask('b', { supersedes: 'a' })], {
+        triggerEventId: 'drift-1',
+      }),
+    );
+    reg.append(
+      mkRecord('p1', 2, [mkTask('b', { supersedes: 'a' })], {
+        triggerEventId: 'drift-2',
+      }),
+    );
+    const link = reg.supersedesMap('p1').get('a');
+    expect(link?.revision).toBe(1);
+    expect(link?.triggerEventId).toBe('drift-1');
+  });
+
+  it('dropped ids beyond the unpaired-new count get empty newTaskId (dangling)', () => {
+    // rev 0: [a, b]
+    // rev 1: []  (both dropped, nothing new) → heuristic emits dangling
+    //            edges for each dropped id with newTaskId=''.
+    reg.append(mkRecord('p1', 0, [mkTask('a'), mkTask('b')]));
+    reg.append(mkRecord('p1', 1, []));
+    const m = reg.supersedesMap('p1');
+    expect(m.size).toBe(2);
+    expect(m.get('a')?.newTaskId).toBe('');
+    expect(m.get('b')?.newTaskId).toBe('');
+  });
+
+  it('returns an empty map for an unknown planId', () => {
+    reg.append(mkRecord('p1', 0, [mkTask('a')]));
+    expect(reg.supersedesMap('p-unknown').size).toBe(0);
+  });
+});

--- a/frontend/src/components/TaskStages/RevisionHistoryBadge.css
+++ b/frontend/src/components/TaskStages/RevisionHistoryBadge.css
@@ -1,0 +1,152 @@
+/* RevisionHistoryBadge — compact supersedes-chain provenance pill.
+   Lives on each collapsed DAG node; expands inline to reveal the
+   predecessor trail. Reuses the severity / rev palette from views.css
+   (hg-traj__chip tokens) — do not introduce new colour tokens here. */
+
+.hg-rev-badge {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #c8ccd4;
+  line-height: 1.2;
+}
+
+.hg-rev-badge--singleton {
+  opacity: 0.7;
+}
+
+.hg-rev-badge__chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 10px;
+  border: 1px solid var(--md-sys-color-outline, #5a5e68);
+  background: transparent;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+
+.hg-rev-badge__chip--neutral {
+  color: #9ba0aa;
+  border-color: #3a3e46;
+}
+
+.hg-rev-badge__chip--chain {
+  color: #dbe3ff;
+  background: #2b3447;
+  border-color: #4b5770;
+}
+
+.hg-rev-badge__chip--history {
+  color: #c3c6cf;
+  background: transparent;
+  border-color: #3a3e46;
+}
+
+/* Toggle button — keeps pill + chevron + summary on one line. */
+.hg-rev-badge__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+
+.hg-rev-badge__toggle:focus-visible {
+  outline: 2px solid #9ab4ff;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.hg-rev-badge__chevron {
+  font-size: 9px;
+  opacity: 0.7;
+}
+
+.hg-rev-badge__chevron[data-open='true'] {
+  opacity: 1;
+}
+
+.hg-rev-badge__summary {
+  font-size: 10px;
+  opacity: 0.6;
+  margin-left: 2px;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+/* Expanded history list. Appears below the pill on its own line. */
+.hg-rev-badge__history {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+}
+
+.hg-rev-badge__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  /* Predecessors are superseded — dim them so the eye lands on the canonical. */
+  opacity: 0.65;
+}
+
+.hg-rev-badge__row--pinned {
+  opacity: 1;
+  background: rgba(91, 141, 239, 0.12);
+}
+
+.hg-rev-badge__row--clickable:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.hg-rev-badge__row-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  width: 100%;
+}
+
+.hg-rev-badge__row-btn:focus-visible {
+  outline: 2px solid #9ab4ff;
+  outline-offset: 1px;
+  border-radius: 4px;
+}
+
+.hg-rev-badge__title {
+  font-size: 11px;
+  color: #c8ccd4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 22ch;
+}
+
+.hg-rev-badge__pinned-tag {
+  font-size: 10px;
+  color: #9ab4ff;
+  font-style: italic;
+}

--- a/frontend/src/components/TaskStages/RevisionHistoryBadge.tsx
+++ b/frontend/src/components/TaskStages/RevisionHistoryBadge.tsx
@@ -1,0 +1,264 @@
+import {
+  useCallback,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactElement,
+} from 'react';
+import type { Task } from '../../gantt/types';
+// TODO(INT): LAY is landing the real `./collapsedLayout` module on a parallel
+// branch. Until it merges into this worktree we declare a minimal local shape
+// compatible with the one LAY is shipping. At integration time INT replaces
+// this block with `import type { TaskRevisionChain } from './collapsedLayout';`
+// and deletes the local interface.
+export interface TaskRevisionChain {
+  /** The representative task for the equivalence class — the one the DAG
+   *  actually renders as a node. */
+  canonical: Task;
+  /** All tasks in the equivalence class, ordered oldest → newest. The
+   *  last member MUST equal `canonical`. */
+  members: Task[];
+  /** Revision indices at which each `members[i]` was introduced. Same length
+   *  as `members`. */
+  revisions: number[];
+}
+import './RevisionHistoryBadge.css';
+
+export interface RevisionHistoryBadgeProps {
+  chain: TaskRevisionChain;
+  /** Pinned revision from the scrubber. null = "latest". Determines which
+   *  chain member appears "foregrounded" in the expanded view and how the
+   *  badge labels itself (e.g. "R0→R1→R2 (current R2)" vs
+   *  "R0→R1 (pinned R1, superseded by R2)"). */
+  currentRevision: number | null;
+  /** Controlled-expansion mode. If omitted, the component manages its own
+   *  open/close state internally. When provided, parent owns state. */
+  expanded?: boolean;
+  onToggleExpanded?: () => void;
+  /** Click handler for a specific chain member in the expanded trail.
+   *  Typical use: open a task-detail drawer for the predecessor. */
+  onClickMember?: (task: Task) => void;
+}
+
+const MAX_TITLE_LEN = 40;
+
+function truncate(s: string, n: number = MAX_TITLE_LEN): string {
+  if (s.length <= n) return s;
+  return `${s.slice(0, Math.max(0, n - 1))}…`;
+}
+
+function formatChainLabel(revisions: number[]): string {
+  return revisions.map((r) => `R${r}`).join('→');
+}
+
+/**
+ * Classify `currentRevision` against the chain. Returned `pinnedIndex` is the
+ * index in `members` / `revisions` that the scrubber is pointing at, or null
+ * when the pin is "latest" (>= canonical rev) or "not yet introduced"
+ * (< earliest rev). Exposed for test insight via the rendered DOM.
+ */
+function classifyPin(
+  revisions: number[],
+  currentRevision: number | null,
+): { mode: 'latest' | 'pinned' | 'not-yet'; pinnedIndex: number | null } {
+  if (currentRevision === null || revisions.length === 0) {
+    return { mode: 'latest', pinnedIndex: null };
+  }
+  const canonicalRev = revisions[revisions.length - 1];
+  const earliestRev = revisions[0];
+  if (currentRevision >= canonicalRev) {
+    return { mode: 'latest', pinnedIndex: null };
+  }
+  if (currentRevision < earliestRev) {
+    return { mode: 'not-yet', pinnedIndex: null };
+  }
+  // Find the latest member whose introduction rev is <= currentRevision.
+  // Scrubbing to an in-between rev (say R1 when the chain is R0→R2→R4) pins
+  // the most recent predecessor that was already live at that rev, not the
+  // one introduced strictly at that rev — matches how the scrubber filters
+  // tasks elsewhere.
+  let pinnedIndex = 0;
+  for (let i = 0; i < revisions.length; i++) {
+    if (revisions[i] <= currentRevision) pinnedIndex = i;
+  }
+  return { mode: 'pinned', pinnedIndex };
+}
+
+export function RevisionHistoryBadge(
+  props: RevisionHistoryBadgeProps,
+): ReactElement {
+  const { chain, currentRevision, expanded, onToggleExpanded, onClickMember } =
+    props;
+
+  const isControlled = expanded !== undefined;
+  const [internalExpanded, setInternalExpanded] = useState(false);
+  const isExpanded = isControlled ? Boolean(expanded) : internalExpanded;
+
+  const multiMember = chain.members.length >= 2;
+  const pin = classifyPin(chain.revisions, currentRevision);
+  const canonicalRev =
+    chain.revisions.length > 0
+      ? chain.revisions[chain.revisions.length - 1]
+      : 0;
+
+  const handleToggle = useCallback(() => {
+    if (!multiMember) return;
+    if (isControlled) {
+      onToggleExpanded?.();
+    } else {
+      setInternalExpanded((v) => !v);
+      onToggleExpanded?.();
+    }
+  }, [multiMember, isControlled, onToggleExpanded]);
+
+  const handleKey = useCallback(
+    (e: KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+        e.preventDefault();
+        handleToggle();
+      }
+    },
+    [handleToggle],
+  );
+
+  // Singleton chain: inert badge, no toggle. We still render it so DAG nodes
+  // get a consistent "R<n>" tag. Muted styling signals "no history to see".
+  if (!multiMember) {
+    const only = chain.revisions[0] ?? 0;
+    return (
+      <span
+        className="hg-rev-badge hg-rev-badge--singleton"
+        data-testid="hg-rev-badge"
+        aria-label={`Revision ${only}`}
+      >
+        <span className="hg-rev-badge__chip hg-rev-badge__chip--neutral">
+          R{only}
+        </span>
+      </span>
+    );
+  }
+
+  // Multi-member chain.
+  const chainLabel = formatChainLabel(chain.revisions);
+  const supersededRevs = chain.revisions
+    .slice(0, -1)
+    .map((r) => `R${r}`)
+    .join(', ');
+  const introducedRev = chain.revisions[0];
+  const ariaLabel =
+    `Revision history: introduced R${introducedRev}, superseded in ` +
+    `${supersededRevs.replace(/^R\d+, /, '') || `R${canonicalRev}`}`;
+
+  // Suffix summary attached to the pill text for quick glance. Kept brief so
+  // the pill doesn't blow up the node bounding box.
+  let summarySuffix = '';
+  if (pin.mode === 'pinned' && pin.pinnedIndex !== null) {
+    const pinnedRev = chain.revisions[pin.pinnedIndex];
+    summarySuffix = ` (pinned R${pinnedRev}, superseded by R${canonicalRev})`;
+  } else if (pin.mode === 'not-yet') {
+    summarySuffix = ' (not yet introduced)';
+  } else {
+    summarySuffix = ` (current R${canonicalRev})`;
+  }
+
+  // Predecessors, newest-first. Canonical is excluded — it's the node itself.
+  // `members[0 .. len-2]` are predecessors oldest→newest; reverse for display.
+  const predecessors = chain.members
+    .slice(0, -1)
+    .map((task, idx) => ({ task, rev: chain.revisions[idx], originalIndex: idx }))
+    .reverse();
+
+  const handleMemberClick = (task: Task) => (e: MouseEvent) => {
+    if (!onClickMember) return;
+    e.stopPropagation();
+    onClickMember(task);
+  };
+
+  return (
+    <span
+      className={`hg-rev-badge hg-rev-badge--multi${
+        isExpanded ? ' hg-rev-badge--expanded' : ''
+      }`}
+      data-testid="hg-rev-badge"
+      data-pin-mode={pin.mode}
+    >
+      <button
+        type="button"
+        className="hg-rev-badge__toggle"
+        aria-expanded={isExpanded}
+        aria-label={ariaLabel}
+        onClick={handleToggle}
+        onKeyDown={handleKey}
+      >
+        <span className="hg-rev-badge__chip hg-rev-badge__chip--chain">
+          {chainLabel}
+        </span>
+        <span
+          className="hg-rev-badge__chevron"
+          aria-hidden="true"
+          data-open={isExpanded}
+        >
+          {isExpanded ? '▾' : '▸'}
+        </span>
+        <span className="hg-rev-badge__summary">{summarySuffix.trim()}</span>
+      </button>
+      {isExpanded && (
+        <ul className="hg-rev-badge__history" role="list">
+          {predecessors.map(({ task, rev, originalIndex }) => {
+            const isPinned =
+              pin.mode === 'pinned' && pin.pinnedIndex === originalIndex;
+            const clickable = Boolean(onClickMember);
+            const rowClasses = [
+              'hg-rev-badge__row',
+              isPinned ? 'hg-rev-badge__row--pinned' : '',
+              clickable ? 'hg-rev-badge__row--clickable' : '',
+            ]
+              .filter(Boolean)
+              .join(' ');
+            const commonProps = {
+              className: rowClasses,
+              'data-task-id': task.id,
+              'data-rev': rev,
+              role: 'listitem',
+            } as const;
+            const inner = (
+              <>
+                <span
+                  className="hg-rev-badge__chip hg-rev-badge__chip--history"
+                  data-rev={rev}
+                >
+                  R{rev}
+                </span>
+                <span className="hg-rev-badge__title" title={task.title}>
+                  {truncate(task.title)}
+                </span>
+                {isPinned && (
+                  <span className="hg-rev-badge__pinned-tag">(pinned)</span>
+                )}
+              </>
+            );
+            if (clickable) {
+              return (
+                <li key={task.id} {...commonProps}>
+                  <button
+                    type="button"
+                    className="hg-rev-badge__row-btn"
+                    onClick={handleMemberClick(task)}
+                    aria-label={`Open predecessor R${rev}: ${task.title}`}
+                  >
+                    {inner}
+                  </button>
+                </li>
+              );
+            }
+            return (
+              <li key={task.id} {...commonProps}>
+                {inner}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/TaskStages/RevisionHistoryBadge.tsx
+++ b/frontend/src/components/TaskStages/RevisionHistoryBadge.tsx
@@ -6,22 +6,7 @@ import {
   type ReactElement,
 } from 'react';
 import type { Task } from '../../gantt/types';
-// TODO(INT): LAY is landing the real `./collapsedLayout` module on a parallel
-// branch. Until it merges into this worktree we declare a minimal local shape
-// compatible with the one LAY is shipping. At integration time INT replaces
-// this block with `import type { TaskRevisionChain } from './collapsedLayout';`
-// and deletes the local interface.
-export interface TaskRevisionChain {
-  /** The representative task for the equivalence class — the one the DAG
-   *  actually renders as a node. */
-  canonical: Task;
-  /** All tasks in the equivalence class, ordered oldest → newest. The
-   *  last member MUST equal `canonical`. */
-  members: Task[];
-  /** Revision indices at which each `members[i]` was introduced. Same length
-   *  as `members`. */
-  revisions: number[];
-}
+import type { TaskRevisionChain } from './collapsedLayout';
 import './RevisionHistoryBadge.css';
 
 export interface RevisionHistoryBadgeProps {

--- a/frontend/src/components/TaskStages/TaskStagesGraph.css
+++ b/frontend/src/components/TaskStages/TaskStagesGraph.css
@@ -1,4 +1,5 @@
 .hg-stages {
+  position: relative;
   width: 100%;
   min-height: 120px;
   max-height: 260px;

--- a/frontend/src/components/TaskStages/TaskStagesGraph.tsx
+++ b/frontend/src/components/TaskStages/TaskStagesGraph.tsx
@@ -1,30 +1,100 @@
 import { useMemo } from 'react';
 import type { Task, TaskEdge, TaskPlan } from '../../gantt/types';
 import { computeStages } from '../../gantt/stages';
-import type {
-  CumulativePlan,
-  SupersessionLink,
-  TaskRevisionMeta,
-} from '../../state/planHistory';
+import type { CumulativePlan as StoreCumulativePlan } from '../../state/planHistoryStore';
+import {
+  collapseCumulativePlan,
+  filterCollapsedAtRevision,
+  type CollapsedCumulativePlan,
+  type TaskRevisionChain,
+} from './collapsedLayout';
+import { RevisionHistoryBadge } from './RevisionHistoryBadge';
 import './TaskStagesGraph.css';
+
+/** Structural shape consumed by this component. Matches both
+ *  `state/planHistory.CumulativePlan` (legacy, uses `planId`) and
+ *  `state/planHistoryStore.CumulativePlan` (extends TaskPlan, uses
+ *  `id`). We accept either and normalise into the store shape before
+ *  handing off to `collapseCumulativePlan`. */
+export interface CumulativePlanInput {
+  /** Legacy id field (planHistory.ts). */
+  planId?: string;
+  /** TaskPlan-inherited id field (planHistoryStore.ts). */
+  id?: string;
+  tasks: Task[];
+  edges: TaskEdge[];
+  taskRevisionMeta: Map<
+    string,
+    { introducedInRevision: number; lastModifiedInRevision?: number; isSuperseded: boolean }
+  >;
+}
+
+/** Minimal SupersessionLink shape consumed by collapseCumulativePlan.
+ *  Both producers supply these; the extra fields the store/legacy
+ *  types carry (authoredBy, reason, kind) are unused by the collapse
+ *  pass and safely ignored. */
+export interface SupersessionLinkInput {
+  oldTaskId: string;
+  newTaskId: string;
+  revision: number;
+  kind: string;
+  reason: string;
+  triggerEventId: string;
+}
+
+/** Convert a `CumulativePlanInput` into the strict store shape the
+ *  collapse pass expects. Copies arrays/maps shallowly — the caller
+ *  retains ownership of the originals. */
+function adaptCumulative(input: CumulativePlanInput): StoreCumulativePlan {
+  const id = input.id ?? input.planId ?? '';
+  const meta = new Map<
+    string,
+    { introducedInRevision: number; lastModifiedInRevision: number; isSuperseded: boolean }
+  >();
+  for (const [k, v] of input.taskRevisionMeta) {
+    meta.set(k, {
+      introducedInRevision: v.introducedInRevision,
+      lastModifiedInRevision:
+        v.lastModifiedInRevision ?? v.introducedInRevision,
+      isSuperseded: v.isSuperseded,
+    });
+  }
+  return {
+    id,
+    invocationSpanId: '',
+    plannerAgentId: '',
+    createdAtMs: 0,
+    summary: '',
+    tasks: input.tasks,
+    edges: input.edges,
+    revisionReason: '',
+    taskRevisionMeta: meta,
+  };
+}
 
 interface TaskStagesGraphProps {
   // Legacy single-plan path — still used by "Latest only" mode and by
   // pre-existing tests. When `cumulative` is passed we ignore this.
   plan: TaskPlan;
   // Cumulative-DAG path (harmonograf plan-evolution). When present the
-  // renderer draws every task across every revision, grey-muting the
-  // ones whose `isSuperseded === true`, and paints dashed "supersedes"
-  // edges between old and new tasks.
-  cumulative?: CumulativePlan | null;
-  supersedesMap?: Map<string, SupersessionLink>;
+  // renderer collapses supersedes chains into single positional slots:
+  // one canonical card per chain, with a RevisionHistoryBadge surfacing
+  // the predecessor trail inline on the card.
+  cumulative?: CumulativePlanInput | null;
+  supersedesMap?: Map<string, SupersessionLinkInput>;
   // Revision scrubber: when set to a non-null integer, tasks whose
   // `introducedInRevision > revisionFilter` are muted (or hidden, see
   // `revisionFilterMode`). Passing null = "Latest" (no filter).
   revisionFilter?: number | null;
   revisionFilterMode?: 'mute' | 'hide';
   onTaskClick?: (task: Task) => void;
-  onSupersedesEdgeClick?: (link: SupersessionLink) => void;
+  // Retained for signature compatibility with TaskPlanPanel and legacy
+  // call sites. After the chain-collapse refactor the renderer no longer
+  // paints visible supersedes edges — the RevisionHistoryBadge's
+  // onClickMember surfaces predecessor detail instead. This prop is
+  // therefore unreachable from this view and will not fire; it's kept so
+  // existing callers don't need a simultaneous update.
+  onSupersedesEdgeClick?: (link: SupersessionLinkInput) => void;
   selectedTaskId?: string | null;
   agentColorFor?: (agentId: string) => string | null;
   agentNameFor?: (agentId: string) => string;
@@ -57,26 +127,6 @@ function generationColor(rev: number): { fill: string; text: string } {
   return GENERATION_PALETTE[Math.min(rev, GENERATION_PALETTE.length - 1)];
 }
 
-// Drift-kind → edge colour lookup. Autonomous goldfive kinds stay in a
-// warm hue; user-origin kinds sit in a cooler hue. Unknown kinds fall
-// back to a neutral outline.
-function edgeKindColor(kind: string): string {
-  const k = (kind || '').toLowerCase();
-  if (k.startsWith('user_')) return '#8bd17c';          // cool green (user)
-  if (k === 'off_topic' || k === 'off-topic') return '#f0a860';
-  if (k === 'missing_work' || k === 'missing-work') return '#e76c6c';
-  if (k === 'cascade_cancel') return '#c08cd6';
-  if (k) return '#d8a468';                              // other goldfive
-  return '#8d9199';                                      // unknown
-}
-
-function edgeAnnotation(link: SupersessionLink): string {
-  const kind = link.kind || '';
-  if (!kind) return 'superseded';
-  const author = link.authoredBy || (kind.toLowerCase().startsWith('user_') ? 'user' : 'goldfive');
-  return `${author}: ${kind.toLowerCase()}`;
-}
-
 const COLUMN_WIDTH = 140;
 const CARD_WIDTH = 120;
 const CARD_HEIGHT = 38;
@@ -88,6 +138,10 @@ const AGENT_STRIPE_W = 4;
 
 interface LaidOutCard {
   task: Task;
+  /** Chain this card represents. Always non-null. For non-cumulative
+   *  ("latest-only") mode or for singleton tasks, a synthetic 1-member
+   *  chain is created so downstream rendering is uniform. */
+  chain: TaskRevisionChain;
   x: number;
   y: number;
   stage: number;
@@ -95,19 +149,34 @@ interface LaidOutCard {
   muted: boolean;    // superseded OR scrubber-filtered (mute mode)
 }
 
-// Synthesize a TaskPlan shape from a CumulativePlan so we can reuse
+// Synthesize a TaskPlan shape from a task + edge list so we can reuse
 // computeStages() directly. The returned plan is purely for layout —
 // no other code reads it.
-function cumulativeAsPlan(cum: CumulativePlan): TaskPlan {
+function asLayoutPlan(
+  id: string,
+  tasks: readonly Task[],
+  edges: readonly TaskEdge[],
+): TaskPlan {
   return {
-    id: cum.planId,
+    id,
     invocationSpanId: '',
     plannerAgentId: '',
     createdAtMs: 0,
     summary: '',
-    tasks: cum.tasks,
-    edges: cum.edges,
+    tasks: [...tasks],
+    edges: [...edges],
     revisionReason: '',
+  };
+}
+
+/** Wrap a legacy per-task plan (non-cumulative) into synthetic singleton
+ *  chains so downstream rendering can use the same `LaidOutCard.chain`
+ *  structure. Revision is 0 for every task; no predecessors. */
+function singletonChainFor(task: Task): TaskRevisionChain {
+  return {
+    canonical: task,
+    members: [task],
+    revisions: [0],
   };
 }
 
@@ -116,21 +185,74 @@ export function TaskStagesGraph({
   cumulative,
   supersedesMap,
   revisionFilter = null,
-  revisionFilterMode = 'mute',
+  // Prop retained for backward compatibility; the collapsed layout's
+  // filter has a single "hide + mute" contract (see layout useMemo).
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  revisionFilterMode: _revisionFilterMode = 'mute',
   onTaskClick,
-  onSupersedesEdgeClick,
+  // `onSupersedesEdgeClick` kept in the prop signature for backward
+  // compatibility; never fires from this renderer (see prop docstring).
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onSupersedesEdgeClick: _onSupersedesEdgeClick,
   selectedTaskId = null,
   agentColorFor,
   agentNameFor,
 }: TaskStagesGraphProps) {
   const layout = useMemo(() => {
-    const sourcePlan: TaskPlan = cumulative ? cumulativeAsPlan(cumulative) : plan;
+    // Build the source task/edge list the layout works on.
+    //
+    // Cumulative mode with a supersedesMap → collapse the plan into one
+    // canonical task per chain, rewrite edges to anchor on canonicals,
+    // and carry each card's chain so the RevisionHistoryBadge can
+    // surface the predecessor trail.
+    //
+    // Non-cumulative (legacy) mode → one card per task, synthetic
+    // singleton chains so the badge path is a uniform no-op.
+    let sourceTasks: readonly Task[];
+    let sourceEdges: readonly TaskEdge[];
+    let chainForTaskId: Map<string, TaskRevisionChain>;
+    let collapsed: CollapsedCumulativePlan | null = null;
+    let hiddenChainIds: ReadonlySet<string> = new Set();
+    let mutedChainIds: ReadonlySet<string> = new Set();
+
+    if (cumulative && supersedesMap) {
+      const storeShape = adaptCumulative(cumulative);
+      // `supersedesMap` from the legacy producer carries an extra
+      // `authoredBy` field the store shape doesn't — the collapse pass
+      // ignores it, so a structural cast is safe here.
+      collapsed = collapseCumulativePlan(
+        storeShape,
+        supersedesMap as unknown as Map<
+          string,
+          import('../../state/planHistoryStore').SupersessionLink
+        >,
+      );
+      const filtered = filterCollapsedAtRevision(collapsed, revisionFilter);
+      hiddenChainIds = filtered.hiddenChainIds;
+      mutedChainIds = filtered.mutedChainIds;
+      sourceTasks = collapsed.chains.map((c) => c.canonical);
+      sourceEdges = collapsed.edges;
+      chainForTaskId = new Map();
+      for (const c of collapsed.chains) {
+        chainForTaskId.set(c.canonical.id, c);
+      }
+    } else {
+      sourceTasks = plan.tasks;
+      sourceEdges = plan.edges;
+      chainForTaskId = new Map();
+      for (const t of plan.tasks) {
+        chainForTaskId.set(t.id, singletonChainFor(t));
+      }
+    }
+
+    // `cumulative` may be the legacy shape (`planId`) or the store
+    // shape (`id`); fall back to the incoming plan id.
+    const sourcePlanId = cumulative?.id ?? cumulative?.planId ?? plan.id;
+    const sourcePlan = asLayoutPlan(sourcePlanId, sourceTasks, sourceEdges);
     const stages = computeStages(sourcePlan);
     if (stages.length === 0) return null;
 
-    const revMeta: Map<string, TaskRevisionMeta> | null = cumulative
-      ? cumulative.taskRevisionMeta
-      : null;
+    const revMeta = cumulative?.taskRevisionMeta ?? null;
 
     const cards = new Map<string, LaidOutCard>();
     let maxRows = 0;
@@ -139,17 +261,19 @@ export function TaskStagesGraph({
       stageTasks.forEach((task, rowIdx) => {
         const x = SIDE_PADDING + stageIdx * COLUMN_WIDTH + COL_PADDING;
         const y = TOP_PADDING + rowIdx * (CARD_HEIGHT + CARD_GAP);
-        const meta = revMeta?.get(task.id);
-        let hidden = false;
-        let muted = Boolean(meta?.isSuperseded);
-        if (revisionFilter !== null && meta) {
-          const introduced = meta.introducedInRevision;
-          if (introduced > revisionFilter) {
-            if (revisionFilterMode === 'hide') hidden = true;
-            else muted = true;
-          }
-        }
-        cards.set(task.id, { task, x, y, stage: stageIdx, hidden, muted });
+        const chain =
+          chainForTaskId.get(task.id) ?? singletonChainFor(task);
+        const hidden = hiddenChainIds.has(task.id);
+        const muted = mutedChainIds.has(task.id);
+        cards.set(task.id, {
+          task,
+          chain,
+          x,
+          y,
+          stage: stageIdx,
+          hidden,
+          muted,
+        });
       });
     });
 
@@ -160,8 +284,7 @@ export function TaskStagesGraph({
 
     // Plan-DAG edges (solid). Only keep forward edges — same rule as before.
     const planEdges: Array<{ from: LaidOutCard; to: LaidOutCard }> = [];
-    const edgeSource: ReadonlyArray<TaskEdge> = sourcePlan.edges;
-    for (const e of edgeSource) {
+    for (const e of sourceEdges) {
       const from = cards.get(e.fromTaskId);
       const to = cards.get(e.toTaskId);
       if (!from || !to) continue;
@@ -170,28 +293,28 @@ export function TaskStagesGraph({
       planEdges.push({ from, to });
     }
 
-    // Supersedes edges (dashed, one per supersession link).
-    const supersedesEdges: Array<{
-      from: LaidOutCard;
-      to: LaidOutCard;
-      link: SupersessionLink;
-    }> = [];
-    if (supersedesMap) {
-      for (const link of supersedesMap.values()) {
-        const from = cards.get(link.oldTaskId);
-        const to = link.newTaskId ? cards.get(link.newTaskId) : undefined;
-        if (!from || !to) continue;
-        if (from.hidden || to.hidden) continue;
-        supersedesEdges.push({ from, to, link });
-      }
-    }
-
-    return { stages, cards, width, height, planEdges, supersedesEdges };
-  }, [plan, cumulative, supersedesMap, revisionFilter, revisionFilterMode]);
+    return {
+      stages,
+      cards,
+      width,
+      height,
+      planEdges,
+      revMeta,
+      collapsed,
+    };
+    // `revisionFilterMode` is accepted in the prop signature for
+    // backward compatibility but is no longer consulted: the new
+    // collapsed-layout path uses `filterCollapsedAtRevision`, which has
+    // a single "hide when not yet born, mute when canonical post-pin"
+    // contract. Intentionally omitted from the dep list.
+  }, [plan, cumulative, supersedesMap, revisionFilter]);
 
   if (!layout) return null;
-  const { stages, cards, width, height, planEdges, supersedesEdges } = layout;
-  const revMeta = cumulative?.taskRevisionMeta;
+  const { stages, cards, width, height, planEdges, revMeta } = layout;
+
+  const handleBadgeMemberClick = (member: Task) => {
+    onTaskClick?.(member);
+  };
 
   return (
     <div className="hg-stages" data-testid="task-stages-graph">
@@ -213,17 +336,6 @@ export function TaskStagesGraph({
           >
             <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--md-sys-color-outline, #8d9199)" />
           </marker>
-          <marker
-            id="hg-stages-supersedes-arrow"
-            viewBox="0 0 10 10"
-            refX={9}
-            refY={5}
-            markerWidth={6}
-            markerHeight={6}
-            orient="auto-start-reverse"
-          >
-            <path d="M 0 0 L 10 5 L 0 10 z" fill="#d8a468" />
-          </marker>
         </defs>
 
         {stages.map((_, stageIdx) => {
@@ -244,7 +356,10 @@ export function TaskStagesGraph({
         {stages.map((stageTasks, stageIdx) => {
           const x = SIDE_PADDING + stageIdx * COLUMN_WIDTH + COLUMN_WIDTH / 2;
           // Progress badge counts only NON-superseded tasks so the N/M
-          // reflects the live plan, not historical noise.
+          // reflects the live plan, not historical noise. After chain
+          // collapse, each stage task IS the canonical (non-superseded
+          // by definition) — keep the read so the legacy non-cumulative
+          // path still filters properly.
           const visible = stageTasks.filter((t) => {
             const m = revMeta?.get(t.id);
             return !m || !m.isSuperseded;
@@ -309,52 +424,13 @@ export function TaskStagesGraph({
           );
         })}
 
-        {supersedesEdges.map(({ from, to, link }, i) => {
-          const x1 = from.x + CARD_WIDTH;
-          const y1 = from.y + CARD_HEIGHT / 2;
-          const x2 = to.x;
-          const y2 = to.y + CARD_HEIGHT / 2;
-          const dx = Math.max(30, (x2 - x1) * 0.5);
-          const d = `M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}`;
-          const color = edgeKindColor(link.kind);
-          const label = edgeAnnotation(link);
-          // Label anchors near the midpoint of the edge. Offset by -6 so
-          // the annotation text sits above the curve.
-          const mx = (x1 + x2) / 2;
-          const my = (y1 + y2) / 2 - 6;
-          return (
-            <g
-              key={`sedge-${link.oldTaskId}-${link.newTaskId}-${i}`}
-              className="hg-stages__supersedes"
-              data-testid="supersedes-edge"
-              data-kind={link.kind || ''}
-              onClick={(e) => {
-                e.stopPropagation();
-                onSupersedesEdgeClick?.(link);
-              }}
-              style={{ cursor: onSupersedesEdgeClick ? 'pointer' : 'default' }}
-            >
-              <title>{link.reason || link.kind || 'superseded'}</title>
-              <path
-                className="hg-stages__supersedes-path"
-                d={d}
-                stroke={color}
-                markerEnd="url(#hg-stages-supersedes-arrow)"
-              />
-              <text
-                className="hg-stages__supersedes-label"
-                x={mx}
-                y={my}
-                textAnchor="middle"
-                fill={color}
-              >
-                {label}
-              </text>
-            </g>
-          );
-        })}
+        {/* NOTE: visible "supersedes" edges (dashed old→new lines) have
+            been retired; the RevisionHistoryBadge rendered below surfaces
+            the same information inline on each canonical card. See
+            onSupersedesEdgeClick prop docstring for the compatibility
+            shim. */}
 
-        {Array.from(cards.values()).map(({ task, x, y, muted, hidden }) => {
+        {Array.from(cards.values()).map(({ task, chain, x, y, muted, hidden }) => {
           if (hidden) return null;
           const dotColor = STATUS_DOT[task.status];
           const title = task.title || '(untitled)';
@@ -392,6 +468,7 @@ export function TaskStagesGraph({
               transform={`translate(${x}, ${y})`}
               onClick={() => onTaskClick?.(task)}
               data-superseded={meta?.isSuperseded ? 'true' : 'false'}
+              data-chain-size={chain.members.length}
             >
               <title>{tooltipText}</title>
               <rect
@@ -457,6 +534,49 @@ export function TaskStagesGraph({
           );
         })}
       </svg>
+
+      {/* RevisionHistoryBadge overlay: absolutely positioned HTML atop the
+          SVG so the pill can open/close and render its predecessor trail
+          without breaking the SVG layout or existing card testids. One
+          overlay per multi-member chain card. */}
+      <div
+        className="hg-stages__badge-overlay"
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width,
+          height,
+          pointerEvents: 'none',
+        }}
+        data-testid="task-stages-badge-overlay"
+      >
+        {Array.from(cards.values())
+          .filter((c) => !c.hidden && c.chain.members.length > 1)
+          .map(({ task, chain, x, y }) => (
+            <div
+              key={`badge-${task.id}`}
+              className="hg-stages__badge-slot"
+              style={{
+                position: 'absolute',
+                // Anchor near the card's top-right corner. x + CARD_WIDTH
+                // places the right edge; we let the pill overflow a touch
+                // so it visually sits atop the status dot without
+                // colliding with the generation badge.
+                left: x + CARD_WIDTH - 60,
+                top: y - 10,
+                pointerEvents: 'auto',
+              }}
+              data-testid={`chain-badge-for-${task.id}`}
+            >
+              <RevisionHistoryBadge
+                chain={chain}
+                currentRevision={revisionFilter}
+                onClickMember={handleBadgeMemberClick}
+              />
+            </div>
+          ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/TaskStages/collapsedLayout.ts
+++ b/frontend/src/components/TaskStages/collapsedLayout.ts
@@ -1,0 +1,252 @@
+// Supersedes-aware DAG collapse for the cumulative-plan renderer.
+//
+// The cumulative plan (planHistoryStore.cumulativePlan) unions every task id
+// ever seen across every revision of a plan. Goldfive's refine workflow mints
+// a fresh task id per replacement, so a plan that has been revised 5 times
+// accumulates 5 "Research solar panel" tasks at stage 0, 5 "Create solar
+// panel pr" tasks at stage 1, etc. When rendered as distinct positional
+// nodes the result is a vertical stack of near-duplicate cards that obscure
+// the actual plan shape.
+//
+// This module collapses supersedes chains (a → b → c) into a single
+// positional slot represented by a `TaskRevisionChain`. The chain's latest
+// member is the canonical representative that the layout positions; the
+// superseded predecessors become per-slot metadata that the chrome can
+// surface as a revision history badge.
+//
+// Pure data transform — no React, no layout math. Consumed by
+// TaskStagesGraph (via the BAG integration change) to build the collapsed
+// node set + edge list before running existing topological positioning.
+
+import type { Task, TaskEdge } from '../../gantt/types';
+import type {
+  CumulativePlan,
+  SupersessionLink,
+} from '../../state/planHistoryStore';
+
+export interface TaskRevisionChain {
+  /** The chain's canonical representative: the latest non-superseded
+   *  member. The node that the layout positions and the UI foregrounds. */
+  canonical: Task;
+  /** All chain members ordered oldest → newest. Always non-empty;
+   *  canonical is always `members[members.length - 1]`. Length 1 when
+   *  the task has no supersedes relationships. */
+  members: Task[];
+  /** Revision in which each member was introduced (index-aligned with
+   *  `members`). Length equals members.length. */
+  revisions: number[];
+}
+
+export interface CollapsedCumulativePlan {
+  planId: string;
+  /** One chain per logical task slot. */
+  chains: TaskRevisionChain[];
+  /** Edges rewritten so every endpoint is a chain CANONICAL id. Edges
+   *  whose original endpoint was a non-canonical (superseded) member
+   *  are redirected to that chain's canonical. Self-edges (a chain's
+   *  members reaching into themselves via an intermediate non-canonical
+   *  hop) are dropped. Duplicate (from, to) pairs are dedup'd. */
+  edges: TaskEdge[];
+  /** Lookup: any member id → its chain. */
+  chainByTaskId: Map<string, TaskRevisionChain>;
+}
+
+/** Collapse a cumulative plan's tasks + edges into supersedes-equivalence
+ *  classes keyed by canonical representative.
+ *
+ *  Uses `supersedesMap` (keyed by oldTaskId → { newTaskId }) as the
+ *  authoritative source of chain membership. A task with no entry in
+ *  the map is its own singleton chain. Chains form transitively:
+ *  a→b, b→c produces one chain {a, b, c}. Orphan chains (link
+ *  references a task not present in the cumulative tasks) resolve
+ *  as if the missing link didn't exist.
+ *
+ *  Assumptions about `CumulativePlan.taskRevisionMeta`: every task id
+ *  has a `introducedInRevision` value; canonicals are chosen as the
+ *  task with the highest introducedInRevision within a chain that is
+ *  NOT an oldTaskId in the supersedes map.
+ */
+export function collapseCumulativePlan(
+  cumulative: CumulativePlan,
+  supersedesMap: Map<string, SupersessionLink>,
+): CollapsedCumulativePlan {
+  // Tasks present in this cumulative plan, indexed by id for O(1) lookup
+  // while walking supersedes links.
+  const tasksById = new Map<string, Task>();
+  for (const t of cumulative.tasks) tasksById.set(t.id, t);
+
+  // Forward edges of the supersedes relation: oldTaskId -> newTaskId.
+  // Drop entries with an empty newTaskId (dangling drop without a
+  // replacement — the old task becomes its own singleton chain) and
+  // orphan links whose endpoints are not in the cumulative task set.
+  const successor = new Map<string, string>();
+  for (const [oldId, link] of supersedesMap) {
+    const newId = link.newTaskId;
+    if (!newId) continue;
+    if (!tasksById.has(oldId) || !tasksById.has(newId)) continue;
+    successor.set(oldId, newId);
+  }
+
+  // Inverse edges so we can rewind to a chain's root.
+  const predecessor = new Map<string, string>();
+  for (const [oldId, newId] of successor) {
+    // Guard against a (malformed) fork where two old tasks point to the
+    // same new task — keep the first predecessor and ignore subsequent
+    // ones so the walk stays deterministic.
+    if (!predecessor.has(newId)) predecessor.set(newId, oldId);
+  }
+
+  const chains: TaskRevisionChain[] = [];
+  const chainByTaskId = new Map<string, TaskRevisionChain>();
+
+  // Walk tasks in the order they appear in `cumulative.tasks` to keep
+  // chain discovery deterministic. Cache chain membership so forward +
+  // backward walks from different members of the same chain don't redo
+  // work.
+  for (const task of cumulative.tasks) {
+    if (chainByTaskId.has(task.id)) continue;
+
+    // Rewind to the chain's oldest member (no predecessor). Follow
+    // `predecessor` backwards, guarding against cycles (shouldn't occur
+    // given append-only supersedes semantics, but defensive).
+    const seenInRewind = new Set<string>();
+    let rootId = task.id;
+    while (predecessor.has(rootId)) {
+      if (seenInRewind.has(rootId)) break; // cycle guard
+      seenInRewind.add(rootId);
+      rootId = predecessor.get(rootId)!;
+    }
+
+    // Walk forward from the root collecting chain members.
+    const members: Task[] = [];
+    const revisions: number[] = [];
+    const seenInWalk = new Set<string>();
+    let cursor: string | undefined = rootId;
+    while (cursor !== undefined) {
+      if (seenInWalk.has(cursor)) break; // cycle guard
+      seenInWalk.add(cursor);
+      const memberTask = tasksById.get(cursor);
+      if (!memberTask) break; // orphan — stop walk gracefully
+      members.push(memberTask);
+      const meta = cumulative.taskRevisionMeta.get(cursor);
+      revisions.push(meta ? meta.introducedInRevision : 0);
+      cursor = successor.get(cursor);
+    }
+
+    // Defensive: `task` might not itself be reachable from `rootId` if
+    // the supersedes graph is malformed (task sits on a disconnected
+    // branch that shares an id with something we rewound into). In that
+    // case fall back to a singleton chain so we still render the task.
+    if (members.length === 0 || !seenInWalk.has(task.id)) {
+      const meta = cumulative.taskRevisionMeta.get(task.id);
+      const chain: TaskRevisionChain = {
+        canonical: task,
+        members: [task],
+        revisions: [meta ? meta.introducedInRevision : 0],
+      };
+      chains.push(chain);
+      chainByTaskId.set(task.id, chain);
+      continue;
+    }
+
+    const chain: TaskRevisionChain = {
+      canonical: members[members.length - 1],
+      members,
+      revisions,
+    };
+    chains.push(chain);
+    for (const m of members) chainByTaskId.set(m.id, chain);
+  }
+
+  // Rewrite edges to anchor on canonicals; drop self-edges and
+  // duplicates. Edges whose endpoint is unknown to any chain (foreign
+  // id leaked into the edge list) are dropped — the renderer has no
+  // positional slot to attach them to.
+  const edgeKeys = new Set<string>();
+  const edges: TaskEdge[] = [];
+  for (const edge of cumulative.edges) {
+    const fromChain = chainByTaskId.get(edge.fromTaskId);
+    const toChain = chainByTaskId.get(edge.toTaskId);
+    if (!fromChain || !toChain) continue;
+    const canonicalFrom = fromChain.canonical.id;
+    const canonicalTo = toChain.canonical.id;
+    if (canonicalFrom === canonicalTo) continue; // self-edge dropped
+    const key = `${canonicalFrom}→${canonicalTo}`;
+    if (edgeKeys.has(key)) continue;
+    edgeKeys.add(key);
+    edges.push({ fromTaskId: canonicalFrom, toTaskId: canonicalTo });
+  }
+
+  return {
+    planId: cumulative.id,
+    chains,
+    edges,
+    chainByTaskId,
+  };
+}
+
+/** Apply a "pinned at revision" filter to a collapsed plan.
+ *
+ *  - revision === null: no filter; all chains visible, no muting.
+ *  - revision === N: chains whose canonical was introduced in a
+ *    revision ≤ N render normally. Chains whose canonical was
+ *    introduced in revision > N are returned in `hiddenChainIds`
+ *    (so the caller can omit them from layout) and/or
+ *    `mutedChainIds` (so the caller can dim them).
+ *
+ *  Trade-off (first-pass): if a chain's root was introduced on/before
+ *  N but a later member (still on/before N) is the canonical, we
+ *  render it normally. If the chain's root was introduced on/before N
+ *  but the canonical is later than N, we MUTE but still render the
+ *  full chain with its latest-ever canonical — the caller dims it so
+ *  the operator can see "this slot exists but the displayed face is
+ *  from a future revision". A later pass may replace the canonical
+ *  with the newest member ≤ N so the displayed face is period-
+ *  accurate; that requires constructing a new TaskRevisionChain which
+ *  changes the return contract, so INT will land that refinement.
+ */
+export function filterCollapsedAtRevision(
+  collapsed: CollapsedCumulativePlan,
+  revision: number | null,
+): {
+  chains: readonly TaskRevisionChain[];
+  edges: readonly TaskEdge[];
+  hiddenChainIds: ReadonlySet<string>;
+  mutedChainIds: ReadonlySet<string>;
+} {
+  if (revision === null) {
+    return {
+      chains: collapsed.chains,
+      edges: collapsed.edges,
+      hiddenChainIds: new Set(),
+      mutedChainIds: new Set(),
+    };
+  }
+
+  const hiddenChainIds = new Set<string>();
+  const mutedChainIds = new Set<string>();
+  for (const chain of collapsed.chains) {
+    let firstRev = Number.POSITIVE_INFINITY;
+    let latestRev = Number.NEGATIVE_INFINITY;
+    for (const r of chain.revisions) {
+      if (r < firstRev) firstRev = r;
+      if (r > latestRev) latestRev = r;
+    }
+    if (firstRev > revision) {
+      // Chain not yet born at this rev.
+      hiddenChainIds.add(chain.canonical.id);
+    } else if (latestRev > revision) {
+      // Root existed, but the displayed canonical is from a future rev.
+      // Render muted so the operator can tell this slot's face is newer
+      // than the pinned revision.
+      mutedChainIds.add(chain.canonical.id);
+    }
+  }
+
+  return {
+    chains: collapsed.chains,
+    edges: collapsed.edges,
+    hiddenChainIds,
+    mutedChainIds,
+  };
+}

--- a/frontend/src/gantt/types.ts
+++ b/frontend/src/gantt/types.ts
@@ -121,6 +121,12 @@ export interface Task {
   // the TaskStagesGraph tooltip, the Drawer Task Overview section, and
   // the TrajectoryView task-delta list.
   cancelReason?: string;
+  /** goldfive proto field (goldfive#237): id of the task this one
+   *  supersedes, empty if none. Populated by the refine LLM on
+   *  replacement tasks. Used by PlanHistoryRegistry.supersedesMap as the
+   *  authoritative chain; the positional heuristic is the fallback only
+   *  for revisions that pre-date the field or where the LLM omitted it. */
+  supersedes: string;
 }
 
 export interface TaskEdge {

--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -314,6 +314,9 @@ export function convertGoldfiveTask(t: GoldfiveTask): Task {
     predictedStartMs: Number(t.predictedStartMs),
     predictedDurationMs: Number(t.predictedDurationMs),
     boundSpanId: t.boundSpanId ?? '',
+    // goldfive#237: authoritative supersession link set by the refine LLM
+    // on replacement tasks. Defaults to '' on original / legacy plans.
+    supersedes: t.supersedes ?? '',
   };
 }
 

--- a/frontend/src/state/planHistoryStore.ts
+++ b/frontend/src/state/planHistoryStore.ts
@@ -202,10 +202,75 @@ export class PlanHistoryRegistry {
     };
   }
 
+  /**
+   * Build the per-plan supersession map, keyed by the OLD task id.
+   *
+   * Two-pass:
+   *
+   *   Pass 1 (authoritative): walk every revision. For each task `t`
+   *   whose `t.supersedes` is non-empty, emit a SupersessionLink from
+   *   `t.supersedes` → `t.id`, stamped with the kind/reason/trigger of
+   *   the revision in which `t` first appears. This is the goldfive
+   *   refine LLM's explicit signal (goldfive#237) and always wins over
+   *   the heuristic.
+   *
+   *   Pass 2 (fallback): for each revision transition prev → next,
+   *   compute dropped = prev \ next and trulyNew = next ids never seen
+   *   before. Any dropped id that Pass 1 DID NOT pair gets a
+   *   positional-heuristic pairing against the first unpaired trulyNew
+   *   id, in original list order. Dropped ids beyond the unpaired-new
+   *   count get an empty newTaskId so renderers can still draw a
+   *   dangling "retired" edge.
+   *
+   * The heuristic is brittle when a revision's drop count ≠ add count
+   * and mispairs across unrelated tasks — it remains only to cover
+   * legacy plans / tasks where the LLM did not set `supersedes`.
+   */
   supersedesMap(planId: string): Map<string, SupersessionLink> {
     const out = new Map<string, SupersessionLink>();
     const arr = this.revisions.get(planId);
-    if (!arr || arr.length < 2) return out;
+    if (!arr || arr.length === 0) return out;
+
+    // Pass 1 — authoritative. Track when each task id first appears so we
+    // can stamp the SupersessionLink with the revision that introduced
+    // the replacement (not subsequent carry-through revisions).
+    const firstSeenIn = new Map<string, number>(); // task id → arr index
+    for (let i = 0; i < arr.length; i++) {
+      for (const t of arr[i].plan.tasks) {
+        if (!firstSeenIn.has(t.id)) firstSeenIn.set(t.id, i);
+      }
+    }
+    const pairedOldIds = new Set<string>();
+    const pairedNewIds = new Set<string>();
+    for (let i = 0; i < arr.length; i++) {
+      const rec = arr[i];
+      for (const t of rec.plan.tasks) {
+        if (!t.supersedes) continue;
+        // Only emit once, at the revision the replacement first appears.
+        if (firstSeenIn.get(t.id) !== i) continue;
+        // Guard against a task claiming to supersede itself.
+        if (t.supersedes === t.id) continue;
+        // Don't overwrite if a later revision restates the link — first
+        // authoritative pairing wins. (Shouldn't happen in practice.)
+        if (out.has(t.supersedes)) continue;
+        out.set(t.supersedes, {
+          oldTaskId: t.supersedes,
+          newTaskId: t.id,
+          revision: rec.revision,
+          kind: rec.kind,
+          reason: rec.reason,
+          triggerEventId: rec.triggerEventId,
+        });
+        pairedOldIds.add(t.supersedes);
+        pairedNewIds.add(t.id);
+      }
+    }
+
+    if (arr.length < 2) return out;
+
+    // Pass 2 — positional heuristic fallback for any dropped ids that
+    // Pass 1 didn't pair. Walk transitions prev → next in order so that
+    // earlier revisions get their dedicated pool of unpaired-new ids.
     const everSeen = new Set<string>();
     for (const t of arr[0].plan.tasks) everSeen.add(t.id);
     for (let i = 1; i < arr.length; i++) {
@@ -214,15 +279,23 @@ export class PlanHistoryRegistry {
       const nextIds = new Set(next.tasks.map((t) => t.id));
       const dropped: string[] = [];
       for (const t of prev.tasks) {
-        if (!nextIds.has(t.id)) dropped.push(t.id);
+        if (!nextIds.has(t.id) && !pairedOldIds.has(t.id)) {
+          dropped.push(t.id);
+        }
       }
       const trulyNew: string[] = [];
       for (const t of next.tasks) {
-        if (!everSeen.has(t.id)) trulyNew.push(t.id);
+        if (everSeen.has(t.id)) continue;
+        if (pairedNewIds.has(t.id)) continue;
+        trulyNew.push(t.id);
       }
       const pairs = Math.min(dropped.length, trulyNew.length);
       const rec = arr[i];
       for (let k = 0; k < dropped.length; k++) {
+        // Skip any old id that Pass 1 paired since the last pass (e.g.
+        // if a replacement's `supersedes` targeted something dropped in
+        // this same transition and Pass 1 picked it up above).
+        if (pairedOldIds.has(dropped[k])) continue;
         out.set(dropped[k], {
           oldTaskId: dropped[k],
           newTaskId: k < pairs ? trulyNew[k] : '',


### PR DESCRIPTION
## Summary

Fixes the Trajectory DAG becoming unreadable as revisions accumulate: goldfive's refine creates a new task id per replacement, so a 5-revision plan produced 5 stacked \"Research solar panel\" nodes at stage 0, 5 stacked \"Create\" nodes at stage 1, etc. The cumulative-plan renderer treated each as a distinct positional node.

Now supersedes chains collapse into single slots: one canonical card per logical slot, with a `RevisionHistoryBadge` surfacing the predecessor trail inline on the card.

## What shipped (4 streams, 3 parallel + 1 integration)

- **SUPE** — authoritative `Task.supersedes` read from proto; `PlanHistoryRegistry.supersedesMap` rewritten as two-pass (proto-field first, positional heuristic as fallback for legacy data).
- **LAY** — new `collapsedLayout.ts` with `collapseCumulativePlan()` + `filterCollapsedAtRevision()`.
- **BAG** — new `RevisionHistoryBadge.tsx`: compact pill + expandable predecessor trail.
- **INT** (this PR) — wires SUPE + LAY + BAG into `TaskStagesGraph.tsx`; visual supersedes-edges retired in favor of the badge; 5-revision end-to-end test as the acceptance criterion.

## Compatibility with goldfive refinement strategy

Verified: goldfive's refine stamps `Task.supersedes` per `planner.py:411/421`. SUPE now reads that authoritative link; the old positional heuristic runs only for dropped ids the authoritative pass didn't pair (covers edge cases + any legacy sessions).

## Scope note — DagPane (TrajectoryView's own SVG renderer)

This integration lands the collapse in `TaskStagesGraph` (consumed by `TaskPlanPanel`). `TrajectoryView`'s `DagPane` is a separate custom SVG DAG renderer that does NOT route through `TaskStagesGraph`; its layout still renders one node per task id. A follow-up can extend `collapseCumulativePlan` into `DagPane` to carry the same fix through that view. The acceptance test below exercises the `TaskStagesGraph` path, which is where the SUPE+LAY+BAG integration actually lands.

## Test plan

- [x] pnpm tsc -b clean
- [x] pnpm lint clean (pre-existing GanttView warning only)
- [x] pnpm test --run — 583 passing (+5 from the acceptance test; +34 from the team's parallel work already counted in baselines)
- [x] 5-revision fixture: exactly one card per slot, badge on multi-member chains, A-chain predecessor click routes onTaskClick('A0')