### PR TITLE
fix(ui): trajectory header "rev N of M" reads plan-history indices

### DIFF
--- a/frontend/src/__tests__/components/TrajectoryView.headerMath.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.headerMath.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Regression test for the Trajectory view header's "rev N of M" math.
+ *
+ * Bug: the header read `rev <arrayIdx> of <length-1>` instead of using
+ * the actual `revisionIndex` field on each TaskPlan. For a session with
+ * a gap in revision numbering (e.g. R0 + R2 with R1 missing because the
+ * planner minted a fresh plan_id mid-stream), the header rendered
+ * "rev 1 of 1" while the scrubber correctly labeled the notch "REV 2".
+ * The two counts disagreed on what "revision" meant.
+ *
+ * Fix: header math now reads `currentRev.revisionIndex` for the
+ * numerator and the highest `revisionIndex` across `vm.revs` for the
+ * denominator. Empty plan history renders the placeholder
+ * "no plan yet" instead of a cryptic "rev 0 of 0".
+ */
+
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionStore } from '../../gantt/index';
+import type { Task, TaskPlan } from '../../gantt/types';
+
+vi.mock('../../components/shell/views/views.css', () => ({}));
+
+let mockStore = new SessionStore();
+const mockSessionId: string = 'sess-header-math';
+
+vi.mock('../../rpc/hooks', () => ({
+  useSessionWatch: () => ({
+    store: mockStore,
+    connected: true,
+    initialBurstComplete: true,
+    error: null,
+    sessionStatus: 'LIVE' as const,
+    lastEventAtMs: Date.now(),
+  }),
+  getSessionStore: () => mockStore,
+}));
+
+const uiStoreState = {
+  currentSessionId: mockSessionId as string | null,
+  selectSpan: vi.fn(),
+  trajectoryLegacyExpanded: false,
+  toggleTrajectoryLegacyExpanded: (): void => {
+    uiStoreState.trajectoryLegacyExpanded = !uiStoreState.trajectoryLegacyExpanded;
+  },
+  selectedRevision: null as number | null,
+  setSelectedRevision: (rev: number | null): void => {
+    uiStoreState.selectedRevision = rev;
+  },
+};
+vi.mock('../../state/uiStore', () => ({
+  useUiStore: <T,>(selector: (s: typeof uiStoreState) => T) =>
+    selector(uiStoreState),
+}));
+
+vi.mock('../../state/annotationStore', () => ({
+  useAnnotationStore: Object.assign(() => ({ list: () => [] }), {
+    getState: () => ({ list: () => [] }),
+    subscribe: () => () => {},
+  }),
+}));
+
+import { TrajectoryView } from '../../components/shell/views/TrajectoryView';
+
+function mkTask(id: string, assignee = 'agent-a'): Task {
+  return {
+    id,
+    title: id,
+    description: '',
+    assigneeAgentId: assignee,
+    status: 'PENDING',
+    predictedStartMs: 0,
+    predictedDurationMs: 0,
+    boundSpanId: '',
+    cancelReason: '',
+    supersedes: '',
+  };
+}
+
+function mkPlan(
+  id: string,
+  tasks: Task[],
+  revisionIndex = 0,
+  revisionReason = '',
+  revisionKind = '',
+): TaskPlan {
+  return {
+    id,
+    invocationSpanId: `inv-${id}-${revisionIndex}`,
+    plannerAgentId: 'planner-agent',
+    // createdAtMs sorts revs in buildViewModel; match revisionIndex order.
+    createdAtMs: revisionIndex,
+    summary: `plan ${id}`,
+    tasks,
+    edges: [],
+    revisionReason,
+    revisionKind,
+    revisionSeverity: 'warning',
+    revisionIndex,
+    triggerEventId: '',
+  };
+}
+
+function headerHint(): string {
+  return (
+    document.querySelector('.hg-traj__header .hg-panel__hint')?.textContent ?? ''
+  );
+}
+
+beforeEach(() => {
+  mockStore = new SessionStore();
+  uiStoreState.currentSessionId = mockSessionId;
+  uiStoreState.trajectoryLegacyExpanded = false;
+  uiStoreState.selectedRevision = null;
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('<TrajectoryView /> header "rev N of M" math', () => {
+  it('renders "no plan yet" when the plan history is empty', () => {
+    render(<TrajectoryView />);
+    expect(headerHint()).toBe('no plan yet');
+    // Defensive: never the cryptic "rev 0 of 0" for an empty session.
+    expect(headerHint()).not.toContain('rev 0 of 0');
+  });
+
+  it('uses revisionIndex (not array position) for the single-rev case', () => {
+    // Lone explicit revision with revisionIndex = 0 (the implicit initial).
+    mockStore.tasks.upsertPlan(mkPlan('p1', [mkTask('t1')], 0));
+    render(<TrajectoryView />);
+    // One rev → "rev 0 of 0". The denominator is the highest revisionIndex.
+    expect(headerHint()).toBe('rev 0 of 0');
+  });
+
+  it('reads the highest revisionIndex for the denominator across a contiguous chain', () => {
+    mockStore.tasks.upsertPlan(mkPlan('p1', [mkTask('t1')], 0));
+    mockStore.tasks.upsertPlan(
+      mkPlan('p1', [mkTask('t1'), mkTask('t2')], 1, 'add followup', 'user_steer'),
+    );
+    mockStore.tasks.upsertPlan(
+      mkPlan('p1', [mkTask('t1'), mkTask('t2'), mkTask('t3')], 2, 'next', 'goldfive'),
+    );
+    render(<TrajectoryView />);
+    // Latest live → numerator pinned to highest revisionIndex.
+    expect(headerHint()).toBe('rev 2 of 2');
+  });
+
+  it('uses revisionIndex (not length-1) when the rev numbering has a gap (R0 + R2, no R1)', () => {
+    // Goldfive planners can mint a fresh plan_id mid-stream, leaving the
+    // rev sequence non-contiguous when the trajectory merges both plans.
+    // The header denominator must reflect the highest revisionIndex
+    // observed, not `vm.revs.length - 1`.
+    mockStore.tasks.upsertPlan(mkPlan('p1', [mkTask('t1')], 0));
+    mockStore.tasks.upsertPlan(
+      mkPlan('p2', [mkTask('t1'), mkTask('t2')], 2, 'user steer', 'user_steer'),
+    );
+    render(<TrajectoryView />);
+    // vm.revs.length === 2, but max revisionIndex === 2 → "rev 2 of 2",
+    // not the buggy "rev 1 of 1".
+    expect(headerHint()).toBe('rev 2 of 2');
+  });
+
+  it('switches between "no plan yet" and a "rev N of M" hint as plans land', () => {
+    // Sanity: an empty session shows the placeholder; appending a plan
+    // flips the hint to the indices-based form. The heading itself is
+    // unaffected by either state.
+    const { rerender } = render(<TrajectoryView />);
+    expect(headerHint()).toBe('no plan yet');
+    mockStore.tasks.upsertPlan(mkPlan('p1', [mkTask('t1')], 0));
+    rerender(<TrajectoryView />);
+    expect(headerHint()).toMatch(/^rev \d+ of \d+$/);
+    expect(
+      screen.getByRole('heading', { name: 'Trajectory' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -465,6 +465,18 @@ export function TrajectoryView() {
     compareRevIdx !== null && compareRevIdx !== revIdx
       ? vm.revs[Math.min(compareRevIdx, latestIdx)] ?? null
       : null;
+  // Header math reconciles with the scrubber: revision INDICES from the
+  // plan history, not array positions. A session with R0 + R2 (R1 missing,
+  // e.g. because a refine produced a new plan_id and the prior was kept)
+  // should read "rev 2 of 2", not "rev 1 of 1". Falls back to the array
+  // index when revisionIndex is missing on a TaskPlan.
+  const highestRevisionIndex = vm.revs.reduce(
+    (max, p, i) => Math.max(max, p.revisionIndex ?? i),
+    0,
+  );
+  const currentRevisionIndex = currentRev?.revisionIndex ?? revIdx;
+  const compareRevisionIndex =
+    compareRev?.revisionIndex ?? compareRevIdx ?? null;
   // Only produce diff marks when the user has explicitly pinned a compare
   // rev — otherwise every task would be flagged "added" against a null prev.
   const marks =
@@ -561,7 +573,7 @@ export function TrajectoryView() {
         <span className="hg-panel__hint">
           {vm.revs.length === 0
             ? 'no plan yet'
-            : `rev ${revIdx} of ${latestIdx}${compareRev ? ` · comparing to rev ${compareRevIdx}` : ''}`}
+            : `rev ${currentRevisionIndex} of ${highestRevisionIndex}${compareRev ? ` · comparing to rev ${compareRevisionIndex}` : ''}`}
         </span>
       </header>
       <div className="hg-panel__body hg-traj__body">


### PR DESCRIPTION
## Summary

The Trajectory view's header read `rev 0 of 0` while the ribbon stats span correctly read `1 revision · 3 interventions` — the two counts disagreed on what "revision" meant. The header was indexing into `vm.revs` by array position; the ribbon was reading the authoritative `revisionIndex` field.

Fix:

- Header now reads `currentRev.revisionIndex` (numerator) and the highest `revisionIndex` across `vm.revs` (denominator) — falling back to array indices only when `revisionIndex` is absent on a `TaskPlan`.
- For a session with R0 + R2 (R1 missing — e.g. when a refine mints a new `plan_id` and the prior plan is kept in the trajectory), the header now reads `rev 2 of 2`, not the buggy `rev 1 of 1`.
- Empty plan history still renders the existing `no plan yet` placeholder rather than a cryptic `rev 0 of 0`.

Surveyed sibling surfaces — `RevisionScrubber` already reads `rec.revision`; `TaskPlanPanel`'s `Showing REV <n>` hint already reads the shared `selectedRevision` slice (a revision number, not an array index). No other `rev X of Y` user-facing strings exist outside this header, so the fix is self-contained.

## Test plan

- [x] `pnpm tsc -b` clean
- [x] `pnpm lint` (only the pre-existing GanttView warning)
- [x] `pnpm test --run` — 609 tests pass (604 before, +5 new)
- [x] New `TrajectoryView.headerMath.test.tsx` covers:
  - empty plan history → `no plan yet` (never `rev 0 of 0`)
  - single-rev (R0) → `rev 0 of 0`
  - contiguous chain (R0..R2) → `rev 2 of 2`
  - non-contiguous chain (R0 + R2, no R1) → `rev 2 of 2` (regression assertion: not `rev 1 of 1`)
  - state transition empty → populated flips the hint