### PR TITLE
feat(harmonograf): ingest + render TaskTransitioned events from goldfive #267

### DIFF
--- a/client/tests/test_harmonograf_sink.py
+++ b/client/tests/test_harmonograf_sink.py
@@ -102,6 +102,28 @@ def _make_drift_detected(sequence: int = 3) -> ge.Event:
     return evt
 
 
+def _make_task_transitioned(sequence: int = 4) -> ge.Event:
+    """Build a goldfive#267 / #251 R4 ``TaskTransitioned`` envelope.
+
+    Used to verify the sink's proto passthrough handles the new oneof
+    variant the same way it handles every other typed
+    ``goldfive.v1.Event`` payload — no special-casing on the sink side
+    because the variant rides the same buffer / transport pipeline.
+    """
+    evt = ge.Event()
+    evt.event_id = "e-transition"
+    evt.run_id = "run-1"
+    evt.sequence = sequence
+    evt.task_transitioned.task_id = "t-7"
+    evt.task_transitioned.from_status = "RUNNING"
+    evt.task_transitioned.to_status = "COMPLETED"
+    evt.task_transitioned.source = "llm_report"
+    evt.task_transitioned.revision_stamp = 0
+    evt.task_transitioned.agent_name = "researcher_agent"
+    evt.task_transitioned.invocation_id = "inv-7"
+    return evt
+
+
 class TestEmit:
     @pytest.mark.asyncio
     async def test_emit_run_started_pushes_envelope(
@@ -160,6 +182,10 @@ class TestEmit:
             (_make_plan_submitted, "plan_submitted"),
             (_make_task_started, "task_started"),
             (_make_drift_detected, "drift_detected"),
+            # goldfive#267 / #251 R4: TaskTransitioned rides the same
+            # proto-passthrough path; no sink-side translation needed
+            # (the new variant is forwarded as-is to the wire).
+            (_make_task_transitioned, "task_transitioned"),
         ],
     )
     async def test_emit_covers_each_payload_kind(
@@ -173,6 +199,32 @@ class TestEmit:
         envs = _drain(client)
         assert len(envs) == 1
         assert envs[0].payload.WhichOneof("payload") == expected_kind
+
+    @pytest.mark.asyncio
+    async def test_emit_task_transitioned_payload_round_trips(
+        self, sink: HarmonografSink, client: Client
+    ):
+        """The TaskTransitioned payload survives the sink with every
+        field intact — no canonicalization rewrite (the sink's
+        ``_canonicalize_agent_ids`` does not currently rewrite
+        ``TaskTransitioned.agent_name``; the field is bare and the
+        frontend tolerates either form). This test pins the current
+        passthrough contract so a future bare→compound rewrite is a
+        deliberate change, not an accident.
+        """
+        evt = _make_task_transitioned()
+        await sink.emit(evt)
+        envs = _drain(client)
+        assert len(envs) == 1
+        payload = envs[0].payload
+        assert payload.WhichOneof("payload") == "task_transitioned"
+        t = payload.task_transitioned
+        assert t.task_id == "t-7"
+        assert t.from_status == "RUNNING"
+        assert t.to_status == "COMPLETED"
+        assert t.source == "llm_report"
+        assert t.agent_name == "researcher_agent"
+        assert t.invocation_id == "inv-7"
 
 
 class TestClose:

--- a/frontend/src/__tests__/lib/taskTransitionDetail.test.ts
+++ b/frontend/src/__tests__/lib/taskTransitionDetail.test.ts
@@ -1,0 +1,68 @@
+// resolveTaskTransitionDetail — goldfive#267 / #251 R4.
+//
+// Verifies the InterventionDetail composition for TaskTransitioned
+// selections. The resolver maps the transition record onto the same
+// three-section shape as resolveDriftDetail so the existing detail
+// panel can render transitions without a new component.
+
+import { describe, expect, it } from 'vitest';
+import type { TaskTransitionRecord } from '../../gantt/index';
+import { resolveTaskTransitionDetail } from '../../lib/interventionDetail';
+
+function mkRecord(over: Partial<TaskTransitionRecord> = {}): TaskTransitionRecord {
+  return {
+    seq: 0,
+    runId: 'run-1',
+    taskId: 't-7',
+    fromStatus: 'RUNNING',
+    toStatus: 'COMPLETED',
+    source: 'llm_report',
+    revisionStamp: 0,
+    agentName: 'presentation-orchestrated-abc:researcher_agent',
+    invocationId: 'inv-7',
+    recordedAtMs: 100,
+    recordedAtAbsoluteMs: 100,
+    ...over,
+  };
+}
+
+describe('resolveTaskTransitionDetail', () => {
+  it('composes the steering section as "FROM → TO via SOURCE"', () => {
+    const detail = resolveTaskTransitionDetail(mkRecord());
+    expect(detail.steering).toContain('RUNNING → COMPLETED');
+    expect(detail.steering).toContain('source: llm_report');
+    expect(detail.targetAgentId).toBe(
+      'presentation-orchestrated-abc:researcher_agent',
+    );
+    expect(detail.targetTaskId).toBe('t-7');
+    expect(detail.trigger).toBe('');
+  });
+
+  it('omits the plan-rev line when revisionStamp is zero', () => {
+    const detail = resolveTaskTransitionDetail(mkRecord({ revisionStamp: 0 }));
+    expect(detail.steering).not.toContain('plan rev:');
+  });
+
+  it('includes the plan-rev line when revisionStamp is non-zero', () => {
+    const detail = resolveTaskTransitionDetail(mkRecord({ revisionStamp: 4 }));
+    expect(detail.steering).toContain('plan rev: 4');
+  });
+
+  it('includes the invocation id when present', () => {
+    const detail = resolveTaskTransitionDetail(mkRecord({ invocationId: 'inv-99' }));
+    expect(detail.steering).toContain('invocation: inv-99');
+  });
+
+  it('omits the invocation line when invocationId is empty', () => {
+    const detail = resolveTaskTransitionDetail(mkRecord({ invocationId: '' }));
+    expect(detail.steering).not.toContain('invocation:');
+  });
+
+  it('handles missing fromStatus gracefully', () => {
+    const detail = resolveTaskTransitionDetail(
+      mkRecord({ fromStatus: '', toStatus: 'CANCELLED' }),
+    );
+    expect(detail.steering).toContain('CANCELLED');
+    expect(detail.steering).not.toContain('→');
+  });
+});

--- a/frontend/src/__tests__/rpc/taskTransitioned.test.ts
+++ b/frontend/src/__tests__/rpc/taskTransitioned.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { TimestampSchema } from '@bufbuild/protobuf/wkt';
+import { SessionStore } from '../../gantt/index';
+import {
+  applyGoldfiveEvent,
+  applyTaskTransitioned,
+} from '../../rpc/goldfiveEvent';
+import {
+  EventSchema,
+  TaskTransitionedSchema,
+} from '../../pb/goldfive/v1/events_pb';
+import { deriveInterventionsFromStore } from '../../lib/interventions';
+
+// Tests the WatchSession dispatch for the typed
+// ``goldfive.v1.TaskTransitioned`` payload variant on the goldfive
+// Event envelope (goldfive#267 / #251 R4). Covers:
+//   * record ingestion onto the session store,
+//   * session-relative-ms derivation from ``Event.emitted_at``,
+//   * intervention-row filter (only terminal to_status + meaningful
+//     source surface; RUNNING transitions and noisy sources skipped),
+//   * the dispatcher routes ``payload.case === 'taskTransitioned'`` to
+//     the same helper as the direct call.
+
+function mkTransitionEvent(over: Partial<{
+  runId: string;
+  sequence: bigint;
+  sessionId: string;
+  taskId: string;
+  fromStatus: string;
+  toStatus: string;
+  source: string;
+  revisionStamp: number;
+  agentName: string;
+  invocationId: string;
+  emittedAtSecs: number;
+  emittedAtNanos: number;
+}> = {}) {
+  const emittedAt =
+    over.emittedAtSecs != null
+      ? create(TimestampSchema, {
+          seconds: BigInt(over.emittedAtSecs),
+          nanos: over.emittedAtNanos ?? 0,
+        })
+      : undefined;
+  const payload = create(TaskTransitionedSchema, {
+    taskId: over.taskId ?? 't-7',
+    fromStatus: over.fromStatus ?? 'RUNNING',
+    toStatus: over.toStatus ?? 'COMPLETED',
+    source: over.source ?? 'llm_report',
+    revisionStamp: over.revisionStamp ?? 0,
+    agentName:
+      over.agentName ?? 'presentation-orchestrated-abc:researcher_agent',
+    invocationId: over.invocationId ?? 'inv-7',
+  });
+  return create(EventSchema, {
+    runId: over.runId ?? 'run-1',
+    sequence: over.sequence ?? 9n,
+    sessionId: over.sessionId ?? 'sess-t',
+    emittedAt,
+    payload: {
+      case: 'taskTransitioned',
+      value: payload,
+    },
+  });
+}
+
+describe('applyTaskTransitioned', () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    store = new SessionStore();
+  });
+
+  it('appends a TaskTransitionRecord to the store', () => {
+    const ev = mkTransitionEvent({ emittedAtSecs: 1000, emittedAtNanos: 0 });
+    const payload = ev.payload;
+    if (payload.case !== 'taskTransitioned') throw new Error('bad fixture');
+    applyTaskTransitioned(payload.value, ev, store, 0);
+    const list = store.taskTransitions.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].taskId).toBe('t-7');
+    expect(list[0].fromStatus).toBe('RUNNING');
+    expect(list[0].toStatus).toBe('COMPLETED');
+    expect(list[0].source).toBe('llm_report');
+    expect(list[0].agentName).toBe(
+      'presentation-orchestrated-abc:researcher_agent',
+    );
+    expect(list[0].invocationId).toBe('inv-7');
+    expect(list[0].seq).toBe(0);
+  });
+
+  it('derives session-relative ms from Event.emitted_at', () => {
+    const ev = mkTransitionEvent({ emittedAtSecs: 1100, emittedAtNanos: 0 });
+    const payload = ev.payload;
+    if (payload.case !== 'taskTransitioned') throw new Error('bad fixture');
+    // sessionStartMs = 1_000_000 (i.e. epoch ms 1_000_000); event at
+    // epoch ms 1_100_000 → relative 100_000ms.
+    applyTaskTransitioned(payload.value, ev, store, 1_000_000);
+    const list = store.taskTransitions.list();
+    expect(list[0].recordedAtMs).toBe(100_000);
+    expect(list[0].recordedAtAbsoluteMs).toBe(1_100_000);
+  });
+
+  it('rebases on session-start-late delivery', () => {
+    // Live-path race: TaskTransitioned arrives before the 'session'
+    // SessionUpdate has set wallClockStartMs. Initial relative ms is
+    // wall-clock-scale; rebase corrects it once the start lands.
+    const ev = mkTransitionEvent({ emittedAtSecs: 2000 });
+    const payload = ev.payload;
+    if (payload.case !== 'taskTransitioned') throw new Error('bad fixture');
+    applyTaskTransitioned(payload.value, ev, store, 0);
+    const before = store.taskTransitions.list()[0].recordedAtMs;
+    expect(before).toBe(2_000_000);
+    store.taskTransitions.rebase(1_999_500);
+    const after = store.taskTransitions.list()[0].recordedAtMs;
+    expect(after).toBe(500);
+  });
+
+  it('routes via applyGoldfiveEvent when payload.case is taskTransitioned', () => {
+    const ev = mkTransitionEvent({ emittedAtSecs: 1000 });
+    applyGoldfiveEvent(ev, store, 0, 'sess-t');
+    const list = store.taskTransitions.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].source).toBe('llm_report');
+  });
+
+  it('coerces lowercase status strings to uppercase', () => {
+    // Defense-in-depth: spec says bare uppercase, but we tolerate
+    // lowercase emitters by upcasing on ingest.
+    const ev = mkTransitionEvent({
+      fromStatus: 'pending',
+      toStatus: 'completed',
+    });
+    const payload = ev.payload;
+    if (payload.case !== 'taskTransitioned') throw new Error('bad fixture');
+    applyTaskTransitioned(payload.value, ev, store, 0);
+    const list = store.taskTransitions.list();
+    expect(list[0].fromStatus).toBe('PENDING');
+    expect(list[0].toStatus).toBe('COMPLETED');
+  });
+});
+
+describe('TaskTransitioned → InterventionRow filter', () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    store = new SessionStore();
+  });
+
+  function ingest(over: Parameters<typeof mkTransitionEvent>[0]) {
+    const ev = mkTransitionEvent({ emittedAtSecs: 1000, ...over });
+    applyGoldfiveEvent(ev, store, 0, 'sess-t');
+  }
+
+  it('surfaces a row for llm_report → COMPLETED', () => {
+    ingest({ source: 'llm_report', toStatus: 'COMPLETED', taskId: 't1' });
+    const rows = deriveInterventionsFromStore(store, []).filter(
+      (r) => r.source === 'transition',
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('TASK_COMPLETED');
+    expect(rows[0].severity).toBe('info');
+    expect(rows[0].transitionToStatus).toBe('COMPLETED');
+    expect(rows[0].transitionSource).toBe('llm_report');
+    expect(rows[0].transitionTaskId).toBe('t1');
+    expect(rows[0].bodyOrReason).toContain('Task t1 COMPLETED via llm_report');
+  });
+
+  it('marks FAILED transitions as warning severity', () => {
+    ingest({ source: 'llm_report', toStatus: 'FAILED', taskId: 't2' });
+    const rows = deriveInterventionsFromStore(store, []).filter(
+      (r) => r.source === 'transition',
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('TASK_FAILED');
+    expect(rows[0].severity).toBe('warning');
+  });
+
+  it('marks CANCELLED transitions as warning severity', () => {
+    ingest({ source: 'plan_revision', toStatus: 'CANCELLED', taskId: 't3' });
+    const rows = deriveInterventionsFromStore(store, []).filter(
+      (r) => r.source === 'transition',
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('TASK_CANCELLED');
+    expect(rows[0].severity).toBe('warning');
+    expect(rows[0].transitionSource).toBe('plan_revision');
+  });
+
+  it('skips RUNNING transitions (intermediate, not terminal)', () => {
+    ingest({ source: 'llm_report', toStatus: 'RUNNING', taskId: 't4' });
+    const rows = deriveInterventionsFromStore(store, []).filter(
+      (r) => r.source === 'transition',
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('skips PENDING transitions', () => {
+    ingest({ source: 'llm_report', toStatus: 'PENDING', taskId: 't5' });
+    const rows = deriveInterventionsFromStore(store, []).filter(
+      (r) => r.source === 'transition',
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('skips handler_default-source transitions (too noisy)', () => {
+    ingest({
+      source: 'handler_default',
+      toStatus: 'COMPLETED',
+      taskId: 't6',
+    });
+    const rows = deriveInterventionsFromStore(store, []).filter(
+      (r) => r.source === 'transition',
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('skips other-source transitions (forward-compat catch-all)', () => {
+    ingest({ source: 'other', toStatus: 'COMPLETED', taskId: 't7' });
+    const rows = deriveInterventionsFromStore(store, []).filter(
+      (r) => r.source === 'transition',
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('skips unknown-source transitions', () => {
+    // Forward-compat: the schema permits new source strings without a
+    // proto bump. The deriver suppresses them by default — adding a new
+    // user-meaningful source is an explicit follow-up, not implicit.
+    ingest({
+      source: 'executor_dispatch',
+      toStatus: 'COMPLETED',
+      taskId: 't8',
+    });
+    const rows = deriveInterventionsFromStore(store, []).filter(
+      (r) => r.source === 'transition',
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('surfaces supersedes_reroute → COMPLETED', () => {
+    ingest({
+      source: 'supersedes_reroute',
+      toStatus: 'COMPLETED',
+      taskId: 't9',
+    });
+    const rows = deriveInterventionsFromStore(store, []).filter(
+      (r) => r.source === 'transition',
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].transitionSource).toBe('supersedes_reroute');
+  });
+
+  it('surfaces cancellation → CANCELLED', () => {
+    ingest({
+      source: 'cancellation',
+      toStatus: 'CANCELLED',
+      taskId: 't10',
+    });
+    const rows = deriveInterventionsFromStore(store, []).filter(
+      (r) => r.source === 'transition',
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('TASK_CANCELLED');
+    expect(rows[0].transitionSource).toBe('cancellation');
+  });
+
+  it('does not collapse transition rows into trigger_event_id merge groups', () => {
+    // Transition rows have empty triggerEventId by design — they're a
+    // parallel observability stream, not a refine consequence. The
+    // merger's pass-through guard keeps them visible alongside the
+    // drift / annotation rows.
+    ingest({ source: 'llm_report', toStatus: 'COMPLETED', taskId: 'tA' });
+    ingest({ source: 'llm_report', toStatus: 'FAILED', taskId: 'tB' });
+    const rows = deriveInterventionsFromStore(store, []).filter(
+      (r) => r.source === 'transition',
+    );
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.transitionTaskId))).toEqual(
+      new Set(['tA', 'tB']),
+    );
+  });
+});

--- a/frontend/src/gantt/index.ts
+++ b/frontend/src/gantt/index.ts
@@ -798,6 +798,115 @@ export interface RefineFailureRecord {
   recordedAtAbsoluteMs: number;
 }
 
+// A captured goldfive TaskTransitioned event (goldfive#267 / #251 R4).
+// Sink-only operator-observability marker — every plan-state transition
+// emits one with source attribution so operators can answer "who moved
+// this task and why". The frontend filters by ``source`` and
+// ``toStatus`` before surfacing as an intervention row (most
+// transitions are too granular for the user-facing list).
+//
+// Source vocabulary (goldfive#267 events.proto):
+//   * ``llm_report``        — LLM ``report_task_*`` tool call with explicit task_id
+//   * ``handler_default``   — same, but task_id resolved from adapter pin
+//   * ``supersedes_reroute`` — pin classifier rerouted to REPLACE successor
+//   * ``plan_revision``     — refine stamped status (FAILED / CANCELLED)
+//   * ``cancellation``      — cooperative cancel cascade
+//   * ``other``              — anything else (forward-compat catch-all)
+//
+// Readers MUST tolerate unknown source strings.
+export interface TaskTransitionRecord {
+  seq: number;              // monotonic per session, assigned on arrival
+  runId: string;
+  taskId: string;           // SUCCESSOR id after supersedes-reroute
+  fromStatus: string;       // bare uppercase ('PENDING'/'RUNNING'/...)
+  toStatus: string;
+  source: string;           // attribution string; unknown values pass through
+  revisionStamp: number;    // Plan.revision_index at transition time
+  agentName: string;        // canonicalized <client>:<bare> when present
+  invocationId: string;     // ADK invocation id, empty when not bound
+  recordedAtMs: number;
+  recordedAtAbsoluteMs: number;
+}
+
+// Registry of per-session task-transition records. Same append-on-ingest
+// + rebase-on-session-start pattern as InvocationCancelRegistry. Dedup
+// is keyed on (taskId, sequence) when sequence is non-zero, else
+// (taskId, fromStatus, toStatus, recordedAtAbsoluteMs) — goldfive emits
+// one TaskTransitioned per real transition, but reconnect replay can
+// re-deliver the same row through both the persisted-event burst and
+// the live tail.
+export class TaskTransitionRegistry {
+  private transitions: TaskTransitionRecord[] = [];
+  private listeners = new Set<() => void>();
+  private nextSeq = 0;
+  private seen = new Set<string>();
+
+  list(): readonly TaskTransitionRecord[] {
+    return this.transitions;
+  }
+
+  append(
+    t: Omit<TaskTransitionRecord, 'seq' | 'recordedAtAbsoluteMs'> & {
+      sequence?: number;
+    } & Partial<Pick<TaskTransitionRecord, 'recordedAtAbsoluteMs'>>,
+  ): void {
+    const recordedAtAbsoluteMs = t.recordedAtAbsoluteMs ?? t.recordedAtMs;
+    const seqKey = t.sequence ? `seq:${t.taskId}|${t.sequence}` : '';
+    const fbKey = `fb:${t.taskId}|${t.fromStatus}|${t.toStatus}|${
+      recordedAtAbsoluteMs || t.recordedAtMs
+    }`;
+    const key = seqKey || fbKey;
+    if (this.seen.has(key)) return;
+    this.seen.add(key);
+    const record: TaskTransitionRecord = {
+      runId: t.runId,
+      taskId: t.taskId,
+      fromStatus: t.fromStatus,
+      toStatus: t.toStatus,
+      source: t.source,
+      revisionStamp: t.revisionStamp,
+      agentName: t.agentName,
+      invocationId: t.invocationId,
+      recordedAtMs: t.recordedAtMs,
+      recordedAtAbsoluteMs,
+      seq: this.nextSeq++,
+    };
+    this.transitions.push(record);
+    this.emit();
+  }
+
+  rebase(sessionStartMs: number): void {
+    if (this.transitions.length === 0) return;
+    let changed = false;
+    for (const t of this.transitions) {
+      if (!t.recordedAtAbsoluteMs) continue;
+      const next = t.recordedAtAbsoluteMs - sessionStartMs;
+      if (t.recordedAtMs !== next) {
+        t.recordedAtMs = next;
+        changed = true;
+      }
+    }
+    if (changed) this.emit();
+  }
+
+  clear(): void {
+    if (this.transitions.length === 0) return;
+    this.transitions = [];
+    this.nextSeq = 0;
+    this.seen.clear();
+    this.emit();
+  }
+
+  subscribe(fn: () => void): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+
+  private emit(): void {
+    for (const fn of this.listeners) fn();
+  }
+}
+
 // Registry of per-session refine-attempt records (the start side).
 // Same append-on-ingest + rebase-on-session-start pattern as
 // DriftRegistry / InvocationCancelRegistry. Bounded only by session
@@ -1123,6 +1232,11 @@ export class SessionStore {
   // failure by ``attemptId`` in O(1) without filtering a tagged union.
   readonly refineAttempts = new RefineAttemptRegistry();
   readonly refineFailures = new RefineFailureRegistry();
+  // goldfive#267 / #251 R4: every plan-state transition emits a
+  // TaskTransitioned record with source attribution. Frontend filters
+  // the high-volume stream down to user-meaningful rows (terminal
+  // statuses + meaningful source) before surfacing as interventions.
+  readonly taskTransitions = new TaskTransitionRegistry();
   readonly delegations = new DelegationRegistry();
   readonly contextSeries = new ContextSeriesRegistry();
   // Accumulator for every revision of every plan observed in this
@@ -1273,6 +1387,7 @@ export class SessionStore {
     this.invocationCancels.rebase(sessionStartMs);
     this.refineAttempts.rebase(sessionStartMs);
     this.refineFailures.rebase(sessionStartMs);
+    this.taskTransitions.rebase(sessionStartMs);
     this.delegations.rebase(sessionStartMs);
   }
 

--- a/frontend/src/lib/interventionDetail.ts
+++ b/frontend/src/lib/interventionDetail.ts
@@ -24,7 +24,11 @@
 //   there is nothing to wire. Post-merge the ingest layer fills the span
 //   attributes and this resolver surfaces them.
 
-import type { DriftRecord, SessionStore } from '../gantt/index';
+import type {
+  DriftRecord,
+  SessionStore,
+  TaskTransitionRecord,
+} from '../gantt/index';
 import type { Span, TaskPlan, Task } from '../gantt/types';
 
 export interface InterventionDetail {
@@ -405,6 +409,52 @@ export function isJudgeSpan(span: Span | null | undefined): boolean {
   // matching so older sessions replayed from the server don't lose the
   // routing.
   return span.agentId === '__goldfive__' && span.name.startsWith('judge:');
+}
+
+// Resolve detail for a TaskTransitioned selection (goldfive#267 / #251 R4).
+// Reuses the same three-section shape as :func:`resolveDriftDetail` so the
+// existing :class:`InterventionDetailSections` view can render transitions
+// without a new component.
+//
+// Mapping:
+//   * trigger  — empty (TaskTransitioned has no observation snippet; the
+//                from→to status is rendered in the panel header instead).
+//   * steering — "{from_status} → {to_status} via {source}" plus the
+//                revision_stamp when non-zero (mirrors how plan-revision
+//                detail composes "input/output" lines).
+//   * target   — the agent the transition was attributed to (compound id
+//                when the sink rewrote it; bare otherwise).
+//
+// The detail panel reuses the drift-shape; no new component is added —
+// keeps the surface area minimal for a fine-grained marker that lives
+// only on the intervention list (no Gantt / Graph glyph).
+export function resolveTaskTransitionDetail(
+  transition: TaskTransitionRecord,
+): InterventionDetail {
+  const fromS = (transition.fromStatus || '').toUpperCase();
+  const toS = (transition.toStatus || '').toUpperCase();
+  const src = (transition.source || '').toLowerCase();
+  const steeringParts: string[] = [];
+  if (fromS && toS) {
+    steeringParts.push(`${fromS} → ${toS}`);
+  } else if (toS) {
+    steeringParts.push(toS);
+  }
+  if (src) {
+    steeringParts.push(`source: ${src}`);
+  }
+  if (transition.revisionStamp && transition.revisionStamp > 0) {
+    steeringParts.push(`plan rev: ${transition.revisionStamp}`);
+  }
+  if (transition.invocationId) {
+    steeringParts.push(`invocation: ${transition.invocationId}`);
+  }
+  return {
+    trigger: '',
+    steering: steeringParts.join('\n'),
+    targetAgentId: transition.agentName || '',
+    targetTaskId: transition.taskId || '',
+  };
 }
 
 // Resolve detail for a task cancellation (terminal status + cancelReason).

--- a/frontend/src/lib/interventions.ts
+++ b/frontend/src/lib/interventions.ts
@@ -36,6 +36,7 @@ import type {
   RefineAttemptRecord,
   RefineFailureRecord,
   SessionStore,
+  TaskTransitionRecord,
 } from '../gantt/index';
 import type { TaskPlan } from '../gantt/types';
 
@@ -56,7 +57,21 @@ import type { TaskPlan } from '../gantt/types';
 // from ``goldfive`` (which is reserved for autonomous orchestrator
 // kinds like cascade_cancel) so the UI can pick a refine-specific
 // glyph + palette swatch.
-export type InterventionSource = 'user' | 'drift' | 'goldfive' | 'cancel' | 'refine';
+// ``transition`` is the source tag for TaskTransitioned rows
+// (goldfive#267 / #251 R4). One row per filtered transition (terminal
+// to_status + meaningful source); see :func:`deriveInterventions` for
+// the filter ladder. Distinct from ``cancel`` (which fires on
+// invocation cancellation, not task status flip) and from ``goldfive``
+// (which is reserved for autonomous orchestrator kinds at the plan
+// revision level) so the UI can pick a transition-specific glyph and
+// palette swatch.
+export type InterventionSource =
+  | 'user'
+  | 'drift'
+  | 'goldfive'
+  | 'cancel'
+  | 'refine'
+  | 'transition';
 
 export interface InterventionRow {
   // Stable key for React lists — composed from source + (annotation id /
@@ -104,11 +119,52 @@ export interface InterventionRow {
   // failed-refine glyph variant (warning chevron) without re-deriving
   // the outcome from ``outcome``.
   failureKind: string;
+  // For ``transition`` rows: the bare uppercase ``to_status`` of the
+  // TaskTransitioned event (e.g. ``COMPLETED``, ``FAILED``,
+  // ``CANCELLED``). Absent on every other source. Surfaced on the row
+  // so the click-through detail panel and renderer can branch on the
+  // transition outcome without re-parsing ``outcome``. Optional (rather
+  // than required + ``''`` default) so existing test fixtures and any
+  // future synthetic-row builders don't have to know about the field.
+  transitionToStatus?: string;
+  // For ``transition`` rows: the source attribution string that goldfive
+  // stamped on the event (``llm_report`` / ``supersedes_reroute`` /
+  // ``plan_revision`` / ``cancellation`` / ``other``). Absent on every
+  // other source. Operators read it directly in the detail pane.
+  transitionSource?: string;
+  // For ``transition`` rows: the goldfive task id that transitioned
+  // (after supersedes-reroute this is the SUCCESSOR id). Absent on
+  // every other source.
+  transitionTaskId?: string;
 }
 
 // Drift kinds emitted by goldfive when the user pulled the trigger. Mirrors
 // _USER_DRIFT_KINDS on the server side.
 const USER_DRIFT_KINDS = new Set(['user_steer', 'user_cancel']);
+
+// TaskTransitioned filter ladder (goldfive#267).
+//
+// Only terminal ``to_status`` values surface as intervention rows.
+// RUNNING transitions are too granular for the operator-facing list —
+// the gantt + task panel already convey the running state. Statuses
+// the renderer doesn't recognize fall through to "skip" so unknown
+// future statuses don't crash the view.
+const TASK_TRANSITION_TERMINAL_STATUSES = new Set([
+  'COMPLETED',
+  'FAILED',
+  'CANCELLED',
+]);
+
+// Source-attribution values the operator cares about. Anything else
+// (``handler_default``, ``other``, future unknowns) is suppressed —
+// those are framework / adapter-driven transitions that flood the
+// wire without representing an operator-meaningful intervention.
+const TASK_TRANSITION_MEANINGFUL_SOURCES = new Set([
+  'llm_report',
+  'supersedes_reroute',
+  'plan_revision',
+  'cancellation',
+]);
 
 // Revision kinds minted by goldfive's own escalation ladder (not drift
 // kinds). Mirrors _GOLDFIVE_REVISION_KINDS on the server.
@@ -152,6 +208,13 @@ export interface DeriveInput {
   // the historical four sources.
   refineAttempts?: readonly RefineAttemptRecord[];
   refineFailures?: readonly RefineFailureRecord[];
+  // goldfive#267 / #251 R4: every plan-state transition. The deriver
+  // filters by ``to_status`` and ``source`` (see
+  // ``TASK_TRANSITION_TERMINAL_STATUSES`` and
+  // ``TASK_TRANSITION_MEANINGFUL_SOURCES``) before surfacing as a
+  // row. Optional so callers without a SessionStore stay backward-
+  // compatible.
+  transitions?: readonly TaskTransitionRecord[];
   // Opt-in Tier-2 legacy time-window fallback for plan-revision
   // attribution (pre-#99 behaviour). Default 0 / undefined disables.
   // Provided by the caller (app runtime context) — never read from
@@ -420,6 +483,70 @@ export function deriveInterventions(input: DeriveInput): InterventionRow[] {
     }
   }
 
+  // TaskTransitioned — goldfive#267 / #251 R4. Every plan-state
+  // transition emits one with source attribution; the deriver below
+  // filters to the user-meaningful subset.
+  //
+  //   * Skip when ``to_status`` is not terminal (RUNNING transitions
+  //     are too granular for the intervention list — Gantt + task
+  //     panel already surface the running state).
+  //   * Skip when ``source`` is ``handler_default`` /
+  //     ``executor_dispatch`` / ``other`` / unknown — these are the
+  //     framework / adapter-driven transitions that flood the wire
+  //     and don't represent an operator-meaningful intervention.
+  //   * Surface only ``llm_report`` / ``supersedes_reroute`` /
+  //     ``plan_revision`` / ``cancellation`` sources as rows.
+  //
+  // Severity ladder mirrors the cancel / refine pattern:
+  //   * COMPLETED     ⇒ info     (success outcome, informational)
+  //   * FAILED        ⇒ warning  (operator attention)
+  //   * CANCELLED     ⇒ warning  (operator attention)
+  //
+  // The intervention row carries the source attribution as a separate
+  // field (``transitionSource``) so the renderer / detail panel can
+  // surface the "why" alongside the "what" without re-parsing kind.
+  for (const tr of input.transitions ?? []) {
+    const to = (tr.toStatus || '').toUpperCase();
+    const src = (tr.source || '').toLowerCase();
+    if (!TASK_TRANSITION_TERMINAL_STATUSES.has(to)) continue;
+    if (!TASK_TRANSITION_MEANINGFUL_SOURCES.has(src)) continue;
+    let severity: string;
+    if (to === 'COMPLETED') severity = 'info';
+    else severity = 'warning'; // FAILED / CANCELLED
+    const taskLabel = tr.taskId || '?';
+    const kind = `TASK_${to}`;
+    const body = `Task ${taskLabel} ${to} via ${src}`;
+    rows.push({
+      key: `transition:${tr.seq}`,
+      atMs: tr.recordedAtMs,
+      source: 'transition',
+      kind,
+      bodyOrReason: body,
+      author: '',
+      // Carry the from→to + source as the outcome string so existing
+      // chrome that reads ``outcome`` (the compact list line, the
+      // outcome formatter) renders something meaningful without a
+      // schema bump. Detail panel reads the dedicated transition*
+      // fields directly.
+      outcome: `transition:${(tr.fromStatus || '?').toLowerCase()}->${to.toLowerCase()}`,
+      planRevisionIndex: tr.revisionStamp || 0,
+      severity,
+      annotationId: '',
+      driftKind: '',
+      // Transitions don't participate in the trigger_event_id strict-id
+      // merge groups (they're a parallel observability stream — see
+      // ``mergeByTriggerEventId``).
+      triggerEventId: '',
+      targetAgentId: tr.agentName || '',
+      driftId: '',
+      attemptId: '',
+      failureKind: '',
+      transitionToStatus: to,
+      transitionSource: src,
+      transitionTaskId: tr.taskId || '',
+    });
+  }
+
   rows.sort((a, b) => a.atMs - b.atMs);
 
   // Outcome attribution (pre-merge). Strict-id only by default; the
@@ -552,7 +679,12 @@ function mergeByTriggerEventId(rows: InterventionRow[]): InterventionRow[] {
     // them here keeps the merged row from collapsing into its source
     // drift / plan revision, which would discard the attempt-specific
     // failure_kind + bodyOrReason styling. See goldfive#264 / Option A.
-    if (row.source === 'refine') {
+    //
+    // Transition rows are similarly self-contained — they carry no
+    // ``triggerEventId`` (the merger short-circuits empty-string
+    // entries below anyway, but we route them through ``passthrough``
+    // explicitly so the intent is recorded near the refine guard).
+    if (row.source === 'refine' || row.source === 'transition') {
       passthrough.push(row);
       continue;
     }
@@ -685,6 +817,7 @@ export function deriveInterventionsFromStore(
     cancels: store.invocationCancels.list(),
     refineAttempts: store.refineAttempts.list(),
     refineFailures: store.refineFailures.list(),
+    transitions: store.taskTransitions.list(),
     legacyPlanAttributionWindowMs: opts.legacyPlanAttributionWindowMs,
   });
 }
@@ -700,46 +833,56 @@ export const SEVERITY_WEIGHT: Record<string, number> = {
 };
 
 export function markerRadiusFor(row: InterventionRow): number {
-  // drift / cancel / refine rows scale by severity so high-severity
-  // markers read as heavier on the strip (the most consequential
-  // markers). Annotation + plan-only rows render at the "info" weight
-  // (they don't carry a meaningful severity for the sizing axis).
+  // drift / cancel / refine / transition rows scale by severity so
+  // high-severity markers read as heavier on the strip (the most
+  // consequential markers). Annotation + plan-only rows render at the
+  // "info" weight (they don't carry a meaningful severity for the
+  // sizing axis).
   if (
     row.source !== 'drift' &&
     row.source !== 'cancel' &&
-    row.source !== 'refine'
+    row.source !== 'refine' &&
+    row.source !== 'transition'
   )
     return SEVERITY_WEIGHT.info;
   return SEVERITY_WEIGHT[row.severity] ?? SEVERITY_WEIGHT.info;
 }
 
 // Palette keyed by source — aligns with the palette note in issue #69:
-//   user-blue, drift-amber, goldfive-grey, cancel-red, refine-teal.
+//   user-blue, drift-amber, goldfive-grey, cancel-red, refine-teal,
+//   transition-violet.
 // Centralized so the planning and trajectory views render uniformly.
 // Cancel rows use a distinct red so the stop-glyph reads at a glance as
 // a terminal, operator-only marker (critical cancels intensify in the
 // renderer via the severity weight, not via the palette swatch). Refine
 // rows use a teal so they read as "orchestrator self-correction" without
-// pulling visual weight from cancels (red) or drifts (amber).
+// pulling visual weight from cancels (red) or drifts (amber). Transition
+// rows use a violet so terminal task-status events read as a distinct
+// "task moved" surface alongside the drift/refine lanes without
+// competing with cancel red.
 export const SOURCE_COLOR: Record<InterventionSource, string> = {
   user: '#5b8def',
   drift: '#f59e0b',
   goldfive: '#8d9199',
   cancel: '#e05e4a',
   refine: '#3a9b8a',
+  transition: '#9b6dd6',
 };
 
 // Glyph character keyed by source — so the compact list renders a
 // source-discriminating leading symbol even before the row's text kicks
 // in. Cancel is the stop / cancel symbol (U+2298 CIRCLED DIVISION SLASH),
 // mirroring the lane markers on the Gantt and Graph views. Refine uses
-// the cycle / refresh symbol (U+21BB CLOCKWISE OPEN CIRCLE ARROW). Other
-// sources default to a small middle dot so the column aligns across
-// rows.
+// the cycle / refresh symbol (U+21BB CLOCKWISE OPEN CIRCLE ARROW).
+// Transition uses the rightwards-arrow (U+2192 RIGHTWARDS ARROW) so the
+// "from→to" intent is legible at a glance without inspecting body
+// text. Other sources default to a small middle dot so the column
+// aligns across rows.
 export const SOURCE_GLYPH: Record<InterventionSource, string> = {
   user: '·',
   drift: '·',
   goldfive: '·',
   cancel: '⊘',
   refine: '↻',
+  transition: '→',
 };

--- a/frontend/src/pb/goldfive/v1/events_pb.ts
+++ b/frontend/src/pb/goldfive/v1/events_pb.ts
@@ -26,7 +26,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file goldfive/v1/events.proto.
  */
 export const file_goldfive_v1_events: GenFile = /*@__PURE__*/
-  fileDesc("Chhnb2xkZml2ZS92MS9ldmVudHMucHJvdG8SC2dvbGRmaXZlLnYxIr0MCgVFdmVudBIQCghldmVudF9pZBgBIAEoCRIOCgZydW5faWQYAiABKAkSEAoIc2VxdWVuY2UYAyABKAQSLgoKZW1pdHRlZF9hdBgEIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASEgoKc2Vzc2lvbl9pZBgFIAEoCRIuCgtydW5fc3RhcnRlZBgKIAEoCzIXLmdvbGRmaXZlLnYxLlJ1blN0YXJ0ZWRIABIwCgxnb2FsX2Rlcml2ZWQYCyABKAsyGC5nb2xkZml2ZS52MS5Hb2FsRGVyaXZlZEgAEjQKDnBsYW5fc3VibWl0dGVkGAwgASgLMhouZ29sZGZpdmUudjEuUGxhblN1Ym1pdHRlZEgAEjAKDHBsYW5fcmV2aXNlZBgNIAEoCzIYLmdvbGRmaXZlLnYxLlBsYW5SZXZpc2VkSAASMAoMdGFza19zdGFydGVkGA4gASgLMhguZ29sZGZpdmUudjEuVGFza1N0YXJ0ZWRIABIyCg10YXNrX3Byb2dyZXNzGA8gASgLMhkuZ29sZGZpdmUudjEuVGFza1Byb2dyZXNzSAASNAoOdGFza19jb21wbGV0ZWQYECABKAsyGi5nb2xkZml2ZS52MS5UYXNrQ29tcGxldGVkSAASLgoLdGFza19mYWlsZWQYESABKAsyFy5nb2xkZml2ZS52MS5UYXNrRmFpbGVkSAASMAoMdGFza19ibG9ja2VkGBIgASgLMhguZ29sZGZpdmUudjEuVGFza0Jsb2NrZWRIABI0Cg50YXNrX2NhbmNlbGxlZBgTIAEoCzIaLmdvbGRmaXZlLnYxLlRhc2tDYW5jZWxsZWRIABI0Cg5kcmlmdF9kZXRlY3RlZBgUIAEoCzIaLmdvbGRmaXZlLnYxLkRyaWZ0RGV0ZWN0ZWRIABIyCg1ydW5fY29tcGxldGVkGBUgASgLMhkuZ29sZGZpdmUudjEuUnVuQ29tcGxldGVkSAASLgoLcnVuX2Fib3J0ZWQYFiABKAsyFy5nb2xkZml2ZS52MS5SdW5BYm9ydGVkSAASQAoUY29udmVyc2F0aW9uX3N0YXJ0ZWQYFyABKAsyIC5nb2xkZml2ZS52MS5Db252ZXJzYXRpb25TdGFydGVkSAASPAoSY29udmVyc2F0aW9uX2VuZGVkGBggASgLMh4uZ29sZGZpdmUudjEuQ29udmVyc2F0aW9uRW5kZWRIABI8ChJhcHByb3ZhbF9yZXF1ZXN0ZWQYGSABKAsyHi5nb2xkZml2ZS52MS5BcHByb3ZhbFJlcXVlc3RlZEgAEjgKEGFwcHJvdmFsX2dyYW50ZWQYGiABKAsyHC5nb2xkZml2ZS52MS5BcHByb3ZhbEdyYW50ZWRIABI6ChFhcHByb3ZhbF9yZWplY3RlZBgbIAEoCzIdLmdvbGRmaXZlLnYxLkFwcHJvdmFsUmVqZWN0ZWRIABJHChhhZ2VudF9pbnZvY2F0aW9uX3N0YXJ0ZWQYHCABKAsyIy5nb2xkZml2ZS52MS5BZ2VudEludm9jYXRpb25TdGFydGVkSAASSwoaYWdlbnRfaW52b2NhdGlvbl9jb21wbGV0ZWQYHSABKAsyJS5nb2xkZml2ZS52MS5BZ2VudEludm9jYXRpb25Db21wbGV0ZWRIABI+ChNkZWxlZ2F0aW9uX29ic2VydmVkGB4gASgLMh8uZ29sZGZpdmUudjEuRGVsZWdhdGlvbk9ic2VydmVkSAASRQoXcmVhc29uaW5nX2p1ZGdlX2ludm9rZWQYHyABKAsyIi5nb2xkZml2ZS52MS5SZWFzb25pbmdKdWRnZUludm9rZWRIABJEChdnb2xkZml2ZV9sbG1fY2FsbF9zdGFydBggIAEoCzIhLmdvbGRmaXZlLnYxLkdvbGRmaXZlTExNQ2FsbFN0YXJ0SAASQAoVZ29sZGZpdmVfbGxtX2NhbGxfZW5kGCEgASgLMh8uZ29sZGZpdmUudjEuR29sZGZpdmVMTE1DYWxsRW5kSAASQAoUaW52b2NhdGlvbl9jYW5jZWxsZWQYIiABKAsyIC5nb2xkZml2ZS52MS5JbnZvY2F0aW9uQ2FuY2VsbGVkSABCCQoHcGF5bG9hZCJiCgpSdW5TdGFydGVkEg4KBnJ1bl9pZBgBIAEoCRIUCgxnb2FsX3N1bW1hcnkYAiABKAkSLgoKc3RhcnRlZF9hdBgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAiLwoLR29hbERlcml2ZWQSIAoFZ29hbHMYASADKAsyES5nb2xkZml2ZS52MS5Hb2FsIjAKDVBsYW5TdWJtaXR0ZWQSHwoEcGxhbhgBIAEoCzIRLmdvbGRmaXZlLnYxLlBsYW4iuQEKEFBsYW5SZXZpc2lvbkRpZmYSFgoOYWRkZWRfdGFza19pZHMYASADKAkSGAoQcmVtb3ZlZF90YXNrX2lkcxgCIAMoCRIZChFtb2RpZmllZF90YXNrX2lkcxgDIAMoCRIqCgthZGRlZF9lZGdlcxgEIAMoCzIVLmdvbGRmaXZlLnYxLlRhc2tFZGdlEiwKDXJlbW92ZWRfZWRnZXMYBSADKAsyFS5nb2xkZml2ZS52MS5UYXNrRWRnZSLNAgoLUGxhblJldmlzZWQSHwoEcGxhbhgBIAEoCzIRLmdvbGRmaXZlLnYxLlBsYW4SKgoKZHJpZnRfa2luZBgCIAEoDjIWLmdvbGRmaXZlLnYxLkRyaWZ0S2luZBIsCghzZXZlcml0eRgDIAEoDjIaLmdvbGRmaXZlLnYxLkRyaWZ0U2V2ZXJpdHkSDgoGcmVhc29uGAQgASgJEhYKDnJldmlzaW9uX2luZGV4GAUgASgNEisKBGRpZmYYBiABKAsyHS5nb2xkZml2ZS52MS5QbGFuUmV2aXNpb25EaWZmEhgKEHRyaWdnZXJfZXZlbnRfaWQYByABKAkSHAoUcmVmaW5lX2lucHV0X3N1bW1hcnkYCCABKAkSHQoVcmVmaW5lX291dHB1dF9zdW1tYXJ5GAkgASgJEhcKD3RhcmdldF9hZ2VudF9pZBgKIAEoCSIuCgtUYXNrU3RhcnRlZBIPCgd0YXNrX2lkGAEgASgJEg4KBmRldGFpbBgCIAEoCSJBCgxUYXNrUHJvZ3Jlc3MSDwoHdGFza19pZBgBIAEoCRIQCghmcmFjdGlvbhgCIAEoAhIOCgZkZXRhaWwYAyABKAkioQEKDVRhc2tDb21wbGV0ZWQSDwoHdGFza19pZBgBIAEoCRIPCgdzdW1tYXJ5GAIgASgJEjwKCWFydGlmYWN0cxgDIAMoCzIpLmdvbGRmaXZlLnYxLlRhc2tDb21wbGV0ZWQuQXJ0aWZhY3RzRW50cnkaMAoOQXJ0aWZhY3RzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASJCCgpUYXNrRmFpbGVkEg8KB3Rhc2tfaWQYASABKAkSDgoGcmVhc29uGAIgASgJEhMKC3JlY292ZXJhYmxlGAMgASgIIj8KC1Rhc2tCbG9ja2VkEg8KB3Rhc2tfaWQYASABKAkSDwoHYmxvY2tlchgCIAEoCRIOCgZuZWVkZWQYAyABKAkiMAoNVGFza0NhbmNlbGxlZBIPCgd0YXNrX2lkGAEgASgJEg4KBnJlYXNvbhgCIAEoCSKXAgoNRHJpZnREZXRlY3RlZBIkCgRraW5kGAEgASgOMhYuZ29sZGZpdmUudjEuRHJpZnRLaW5kEiwKCHNldmVyaXR5GAIgASgOMhouZ29sZGZpdmUudjEuRHJpZnRTZXZlcml0eRIOCgZkZXRhaWwYAyABKAkSFwoPY3VycmVudF90YXNrX2lkGAQgASgJEhgKEGN1cnJlbnRfYWdlbnRfaWQYBSABKAkSFQoNYW5ub3RhdGlvbl9pZBgGIAEoCRIKCgJpZBgHIAEoCRIVCg10cmlnZ2VyX2lucHV0GAggASgJEhMKC2F1dGhvcmVkX2J5GAkgASgJEiAKGHN1cHByZXNzZWRfYnlfdXNlcl9zdGVlchgKIAEoCCInCgxSdW5Db21wbGV0ZWQSFwoPb3V0Y29tZV9zdW1tYXJ5GAEgASgJIhwKClJ1bkFib3J0ZWQSDgoGcmVhc29uGAEgASgJIl4KE0NvbnZlcnNhdGlvblN0YXJ0ZWQSFwoPY29udmVyc2F0aW9uX2lkGAEgASgJEi4KCnN0YXJ0ZWRfYXQYAiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIlAKEUNvbnZlcnNhdGlvbkVuZGVkEhcKD2NvbnZlcnNhdGlvbl9pZBgBIAEoCRISCgp0dXJuX2NvdW50GAIgASgNEg4KBnJlYXNvbhgDIAEoCSLGAQoRQXBwcm92YWxSZXF1ZXN0ZWQSEQoJdGFyZ2V0X2lkGAEgASgJEgwKBGtpbmQYAiABKAkSDgoGcHJvbXB0GAMgASgJEg8KB3Rhc2tfaWQYBCABKAkSPgoIbWV0YWRhdGEYBSADKAsyLC5nb2xkZml2ZS52MS5BcHByb3ZhbFJlcXVlc3RlZC5NZXRhZGF0YUVudHJ5Gi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASI0Cg9BcHByb3ZhbEdyYW50ZWQSEQoJdGFyZ2V0X2lkGAEgASgJEg4KBmRldGFpbBgCIAEoCSI1ChBBcHByb3ZhbFJlamVjdGVkEhEKCXRhcmdldF9pZBgBIAEoCRIOCgZkZXRhaWwYAiABKAkiogEKFkFnZW50SW52b2NhdGlvblN0YXJ0ZWQSEgoKYWdlbnRfbmFtZRgBIAEoCRIPCgd0YXNrX2lkGAIgASgJEhUKDWludm9jYXRpb25faWQYAyABKAkSHAoUcGFyZW50X2ludm9jYXRpb25faWQYBCABKAkSLgoKc3RhcnRlZF9hdBgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAimQEKGEFnZW50SW52b2NhdGlvbkNvbXBsZXRlZBISCgphZ2VudF9uYW1lGAEgASgJEg8KB3Rhc2tfaWQYAiABKAkSFQoNaW52b2NhdGlvbl9pZBgDIAEoCRIPCgdzdW1tYXJ5GAQgASgJEjAKDGNvbXBsZXRlZF9hdBgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAikwEKEkRlbGVnYXRpb25PYnNlcnZlZBISCgpmcm9tX2FnZW50GAEgASgJEhAKCHRvX2FnZW50GAIgASgJEg8KB3Rhc2tfaWQYAyABKAkSFQoNaW52b2NhdGlvbl9pZBgEIAEoCRIvCgtvYnNlcnZlZF9hdBgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAi1wEKFVJlYXNvbmluZ0p1ZGdlSW52b2tlZBIOCgZydW5faWQYASABKAkSDwoHdGFza19pZBgCIAEoCRIYChBzdWJqZWN0X2FnZW50X2lkGAMgASgJEg0KBW1vZGVsGAQgASgJEhIKCmVsYXBzZWRfbXMYBSABKAMSFwoPcmVhc29uaW5nX2lucHV0GAYgASgJEhQKDHJhd19yZXNwb25zZRgHIAEoCRIPCgdvbl90YXNrGAggASgIEhAKCHNldmVyaXR5GAkgASgJEg4KBnJlYXNvbhgKIAEoCSK0AQoUR29sZGZpdmVMTE1DYWxsU3RhcnQSDwoHc3Bhbl9pZBgBIAEoCRIMCgRuYW1lGAIgASgJEg0KBW1vZGVsGAMgASgJEg8KB3Rhc2tfaWQYBCABKAkSFQoNc3RhcnRfdGltZV9ucxgFIAEoAxIVCg1pbnB1dF9wcmV2aWV3GAYgASgJEhcKD3RhcmdldF9hZ2VudF9pZBgHIAEoCRIWCg50YXJnZXRfdGFza19pZBgIIAEoCSLhAQoSR29sZGZpdmVMTE1DYWxsRW5kEg8KB3NwYW5faWQYASABKAkSDAoEbmFtZRgCIAEoCRITCgtlbmRfdGltZV9ucxgDIAEoAxIOCgZzdGF0dXMYBCABKAkSDQoFZXJyb3IYBSABKAkSFQoNaW5wdXRfcHJldmlldxgGIAEoCRIWCg5vdXRwdXRfcHJldmlldxgHIAEoCRIXCg90YXJnZXRfYWdlbnRfaWQYCCABKAkSFgoOdGFyZ2V0X3Rhc2tfaWQYCSABKAkSGAoQZGVjaXNpb25fc3VtbWFyeRgKIAEoCSKrAQoTSW52b2NhdGlvbkNhbmNlbGxlZBIVCg1pbnZvY2F0aW9uX2lkGAEgASgJEhIKCmFnZW50X25hbWUYAiABKAkSDgoGcmVhc29uGAMgASgJEhAKCHNldmVyaXR5GAQgASgJEhAKCGRyaWZ0X2lkGAUgASgJEhIKCmRyaWZ0X2tpbmQYBiABKAkSDgoGZGV0YWlsGAcgASgJEhEKCXRvb2xfbmFtZRgIIAEoCUI5WjdnaXRodWIuY29tL3BlZGFwdWRpL2dvbGRmaXZlL2dlbi9nb2xkZml2ZS92MTtnb2xkZml2ZXYxYgZwcm90bzM", [file_google_protobuf_timestamp, file_goldfive_v1_types]);
+  fileDesc("Chhnb2xkZml2ZS92MS9ldmVudHMucHJvdG8SC2dvbGRmaXZlLnYxIvkMCgVFdmVudBIQCghldmVudF9pZBgBIAEoCRIOCgZydW5faWQYAiABKAkSEAoIc2VxdWVuY2UYAyABKAQSLgoKZW1pdHRlZF9hdBgEIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASEgoKc2Vzc2lvbl9pZBgFIAEoCRIuCgtydW5fc3RhcnRlZBgKIAEoCzIXLmdvbGRmaXZlLnYxLlJ1blN0YXJ0ZWRIABIwCgxnb2FsX2Rlcml2ZWQYCyABKAsyGC5nb2xkZml2ZS52MS5Hb2FsRGVyaXZlZEgAEjQKDnBsYW5fc3VibWl0dGVkGAwgASgLMhouZ29sZGZpdmUudjEuUGxhblN1Ym1pdHRlZEgAEjAKDHBsYW5fcmV2aXNlZBgNIAEoCzIYLmdvbGRmaXZlLnYxLlBsYW5SZXZpc2VkSAASMAoMdGFza19zdGFydGVkGA4gASgLMhguZ29sZGZpdmUudjEuVGFza1N0YXJ0ZWRIABIyCg10YXNrX3Byb2dyZXNzGA8gASgLMhkuZ29sZGZpdmUudjEuVGFza1Byb2dyZXNzSAASNAoOdGFza19jb21wbGV0ZWQYECABKAsyGi5nb2xkZml2ZS52MS5UYXNrQ29tcGxldGVkSAASLgoLdGFza19mYWlsZWQYESABKAsyFy5nb2xkZml2ZS52MS5UYXNrRmFpbGVkSAASMAoMdGFza19ibG9ja2VkGBIgASgLMhguZ29sZGZpdmUudjEuVGFza0Jsb2NrZWRIABI0Cg50YXNrX2NhbmNlbGxlZBgTIAEoCzIaLmdvbGRmaXZlLnYxLlRhc2tDYW5jZWxsZWRIABI0Cg5kcmlmdF9kZXRlY3RlZBgUIAEoCzIaLmdvbGRmaXZlLnYxLkRyaWZ0RGV0ZWN0ZWRIABIyCg1ydW5fY29tcGxldGVkGBUgASgLMhkuZ29sZGZpdmUudjEuUnVuQ29tcGxldGVkSAASLgoLcnVuX2Fib3J0ZWQYFiABKAsyFy5nb2xkZml2ZS52MS5SdW5BYm9ydGVkSAASQAoUY29udmVyc2F0aW9uX3N0YXJ0ZWQYFyABKAsyIC5nb2xkZml2ZS52MS5Db252ZXJzYXRpb25TdGFydGVkSAASPAoSY29udmVyc2F0aW9uX2VuZGVkGBggASgLMh4uZ29sZGZpdmUudjEuQ29udmVyc2F0aW9uRW5kZWRIABI8ChJhcHByb3ZhbF9yZXF1ZXN0ZWQYGSABKAsyHi5nb2xkZml2ZS52MS5BcHByb3ZhbFJlcXVlc3RlZEgAEjgKEGFwcHJvdmFsX2dyYW50ZWQYGiABKAsyHC5nb2xkZml2ZS52MS5BcHByb3ZhbEdyYW50ZWRIABI6ChFhcHByb3ZhbF9yZWplY3RlZBgbIAEoCzIdLmdvbGRmaXZlLnYxLkFwcHJvdmFsUmVqZWN0ZWRIABJHChhhZ2VudF9pbnZvY2F0aW9uX3N0YXJ0ZWQYHCABKAsyIy5nb2xkZml2ZS52MS5BZ2VudEludm9jYXRpb25TdGFydGVkSAASSwoaYWdlbnRfaW52b2NhdGlvbl9jb21wbGV0ZWQYHSABKAsyJS5nb2xkZml2ZS52MS5BZ2VudEludm9jYXRpb25Db21wbGV0ZWRIABI+ChNkZWxlZ2F0aW9uX29ic2VydmVkGB4gASgLMh8uZ29sZGZpdmUudjEuRGVsZWdhdGlvbk9ic2VydmVkSAASRQoXcmVhc29uaW5nX2p1ZGdlX2ludm9rZWQYHyABKAsyIi5nb2xkZml2ZS52MS5SZWFzb25pbmdKdWRnZUludm9rZWRIABJEChdnb2xkZml2ZV9sbG1fY2FsbF9zdGFydBggIAEoCzIhLmdvbGRmaXZlLnYxLkdvbGRmaXZlTExNQ2FsbFN0YXJ0SAASQAoVZ29sZGZpdmVfbGxtX2NhbGxfZW5kGCEgASgLMh8uZ29sZGZpdmUudjEuR29sZGZpdmVMTE1DYWxsRW5kSAASQAoUaW52b2NhdGlvbl9jYW5jZWxsZWQYIiABKAsyIC5nb2xkZml2ZS52MS5JbnZvY2F0aW9uQ2FuY2VsbGVkSAASOgoRdGFza190cmFuc2l0aW9uZWQYIyABKAsyHS5nb2xkZml2ZS52MS5UYXNrVHJhbnNpdGlvbmVkSABCCQoHcGF5bG9hZCJiCgpSdW5TdGFydGVkEg4KBnJ1bl9pZBgBIAEoCRIUCgxnb2FsX3N1bW1hcnkYAiABKAkSLgoKc3RhcnRlZF9hdBgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAiLwoLR29hbERlcml2ZWQSIAoFZ29hbHMYASADKAsyES5nb2xkZml2ZS52MS5Hb2FsIjAKDVBsYW5TdWJtaXR0ZWQSHwoEcGxhbhgBIAEoCzIRLmdvbGRmaXZlLnYxLlBsYW4iuQEKEFBsYW5SZXZpc2lvbkRpZmYSFgoOYWRkZWRfdGFza19pZHMYASADKAkSGAoQcmVtb3ZlZF90YXNrX2lkcxgCIAMoCRIZChFtb2RpZmllZF90YXNrX2lkcxgDIAMoCRIqCgthZGRlZF9lZGdlcxgEIAMoCzIVLmdvbGRmaXZlLnYxLlRhc2tFZGdlEiwKDXJlbW92ZWRfZWRnZXMYBSADKAsyFS5nb2xkZml2ZS52MS5UYXNrRWRnZSLNAgoLUGxhblJldmlzZWQSHwoEcGxhbhgBIAEoCzIRLmdvbGRmaXZlLnYxLlBsYW4SKgoKZHJpZnRfa2luZBgCIAEoDjIWLmdvbGRmaXZlLnYxLkRyaWZ0S2luZBIsCghzZXZlcml0eRgDIAEoDjIaLmdvbGRmaXZlLnYxLkRyaWZ0U2V2ZXJpdHkSDgoGcmVhc29uGAQgASgJEhYKDnJldmlzaW9uX2luZGV4GAUgASgNEisKBGRpZmYYBiABKAsyHS5nb2xkZml2ZS52MS5QbGFuUmV2aXNpb25EaWZmEhgKEHRyaWdnZXJfZXZlbnRfaWQYByABKAkSHAoUcmVmaW5lX2lucHV0X3N1bW1hcnkYCCABKAkSHQoVcmVmaW5lX291dHB1dF9zdW1tYXJ5GAkgASgJEhcKD3RhcmdldF9hZ2VudF9pZBgKIAEoCSIuCgtUYXNrU3RhcnRlZBIPCgd0YXNrX2lkGAEgASgJEg4KBmRldGFpbBgCIAEoCSJBCgxUYXNrUHJvZ3Jlc3MSDwoHdGFza19pZBgBIAEoCRIQCghmcmFjdGlvbhgCIAEoAhIOCgZkZXRhaWwYAyABKAkioQEKDVRhc2tDb21wbGV0ZWQSDwoHdGFza19pZBgBIAEoCRIPCgdzdW1tYXJ5GAIgASgJEjwKCWFydGlmYWN0cxgDIAMoCzIpLmdvbGRmaXZlLnYxLlRhc2tDb21wbGV0ZWQuQXJ0aWZhY3RzRW50cnkaMAoOQXJ0aWZhY3RzRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASJCCgpUYXNrRmFpbGVkEg8KB3Rhc2tfaWQYASABKAkSDgoGcmVhc29uGAIgASgJEhMKC3JlY292ZXJhYmxlGAMgASgIIj8KC1Rhc2tCbG9ja2VkEg8KB3Rhc2tfaWQYASABKAkSDwoHYmxvY2tlchgCIAEoCRIOCgZuZWVkZWQYAyABKAkiMAoNVGFza0NhbmNlbGxlZBIPCgd0YXNrX2lkGAEgASgJEg4KBnJlYXNvbhgCIAEoCSKXAgoNRHJpZnREZXRlY3RlZBIkCgRraW5kGAEgASgOMhYuZ29sZGZpdmUudjEuRHJpZnRLaW5kEiwKCHNldmVyaXR5GAIgASgOMhouZ29sZGZpdmUudjEuRHJpZnRTZXZlcml0eRIOCgZkZXRhaWwYAyABKAkSFwoPY3VycmVudF90YXNrX2lkGAQgASgJEhgKEGN1cnJlbnRfYWdlbnRfaWQYBSABKAkSFQoNYW5ub3RhdGlvbl9pZBgGIAEoCRIKCgJpZBgHIAEoCRIVCg10cmlnZ2VyX2lucHV0GAggASgJEhMKC2F1dGhvcmVkX2J5GAkgASgJEiAKGHN1cHByZXNzZWRfYnlfdXNlcl9zdGVlchgKIAEoCCInCgxSdW5Db21wbGV0ZWQSFwoPb3V0Y29tZV9zdW1tYXJ5GAEgASgJIhwKClJ1bkFib3J0ZWQSDgoGcmVhc29uGAEgASgJIl4KE0NvbnZlcnNhdGlvblN0YXJ0ZWQSFwoPY29udmVyc2F0aW9uX2lkGAEgASgJEi4KCnN0YXJ0ZWRfYXQYAiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wIlAKEUNvbnZlcnNhdGlvbkVuZGVkEhcKD2NvbnZlcnNhdGlvbl9pZBgBIAEoCRISCgp0dXJuX2NvdW50GAIgASgNEg4KBnJlYXNvbhgDIAEoCSLGAQoRQXBwcm92YWxSZXF1ZXN0ZWQSEQoJdGFyZ2V0X2lkGAEgASgJEgwKBGtpbmQYAiABKAkSDgoGcHJvbXB0GAMgASgJEg8KB3Rhc2tfaWQYBCABKAkSPgoIbWV0YWRhdGEYBSADKAsyLC5nb2xkZml2ZS52MS5BcHByb3ZhbFJlcXVlc3RlZC5NZXRhZGF0YUVudHJ5Gi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJEg0KBXZhbHVlGAIgASgJOgI4ASI0Cg9BcHByb3ZhbEdyYW50ZWQSEQoJdGFyZ2V0X2lkGAEgASgJEg4KBmRldGFpbBgCIAEoCSI1ChBBcHByb3ZhbFJlamVjdGVkEhEKCXRhcmdldF9pZBgBIAEoCRIOCgZkZXRhaWwYAiABKAkiogEKFkFnZW50SW52b2NhdGlvblN0YXJ0ZWQSEgoKYWdlbnRfbmFtZRgBIAEoCRIPCgd0YXNrX2lkGAIgASgJEhUKDWludm9jYXRpb25faWQYAyABKAkSHAoUcGFyZW50X2ludm9jYXRpb25faWQYBCABKAkSLgoKc3RhcnRlZF9hdBgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAimQEKGEFnZW50SW52b2NhdGlvbkNvbXBsZXRlZBISCgphZ2VudF9uYW1lGAEgASgJEg8KB3Rhc2tfaWQYAiABKAkSFQoNaW52b2NhdGlvbl9pZBgDIAEoCRIPCgdzdW1tYXJ5GAQgASgJEjAKDGNvbXBsZXRlZF9hdBgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAikwEKEkRlbGVnYXRpb25PYnNlcnZlZBISCgpmcm9tX2FnZW50GAEgASgJEhAKCHRvX2FnZW50GAIgASgJEg8KB3Rhc2tfaWQYAyABKAkSFQoNaW52b2NhdGlvbl9pZBgEIAEoCRIvCgtvYnNlcnZlZF9hdBgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAi1wEKFVJlYXNvbmluZ0p1ZGdlSW52b2tlZBIOCgZydW5faWQYASABKAkSDwoHdGFza19pZBgCIAEoCRIYChBzdWJqZWN0X2FnZW50X2lkGAMgASgJEg0KBW1vZGVsGAQgASgJEhIKCmVsYXBzZWRfbXMYBSABKAMSFwoPcmVhc29uaW5nX2lucHV0GAYgASgJEhQKDHJhd19yZXNwb25zZRgHIAEoCRIPCgdvbl90YXNrGAggASgIEhAKCHNldmVyaXR5GAkgASgJEg4KBnJlYXNvbhgKIAEoCSK0AQoUR29sZGZpdmVMTE1DYWxsU3RhcnQSDwoHc3Bhbl9pZBgBIAEoCRIMCgRuYW1lGAIgASgJEg0KBW1vZGVsGAMgASgJEg8KB3Rhc2tfaWQYBCABKAkSFQoNc3RhcnRfdGltZV9ucxgFIAEoAxIVCg1pbnB1dF9wcmV2aWV3GAYgASgJEhcKD3RhcmdldF9hZ2VudF9pZBgHIAEoCRIWCg50YXJnZXRfdGFza19pZBgIIAEoCSLhAQoSR29sZGZpdmVMTE1DYWxsRW5kEg8KB3NwYW5faWQYASABKAkSDAoEbmFtZRgCIAEoCRITCgtlbmRfdGltZV9ucxgDIAEoAxIOCgZzdGF0dXMYBCABKAkSDQoFZXJyb3IYBSABKAkSFQoNaW5wdXRfcHJldmlldxgGIAEoCRIWCg5vdXRwdXRfcHJldmlldxgHIAEoCRIXCg90YXJnZXRfYWdlbnRfaWQYCCABKAkSFgoOdGFyZ2V0X3Rhc2tfaWQYCSABKAkSGAoQZGVjaXNpb25fc3VtbWFyeRgKIAEoCSKrAQoTSW52b2NhdGlvbkNhbmNlbGxlZBIVCg1pbnZvY2F0aW9uX2lkGAEgASgJEhIKCmFnZW50X25hbWUYAiABKAkSDgoGcmVhc29uGAMgASgJEhAKCHNldmVyaXR5GAQgASgJEhAKCGRyaWZ0X2lkGAUgASgJEhIKCmRyaWZ0X2tpbmQYBiABKAkSDgoGZGV0YWlsGAcgASgJEhEKCXRvb2xfbmFtZRgIIAEoCSKeAQoQVGFza1RyYW5zaXRpb25lZBIPCgd0YXNrX2lkGAEgASgJEhMKC2Zyb21fc3RhdHVzGAIgASgJEhEKCXRvX3N0YXR1cxgDIAEoCRIOCgZzb3VyY2UYBCABKAkSFgoOcmV2aXNpb25fc3RhbXAYBSABKAUSEgoKYWdlbnRfbmFtZRgGIAEoCRIVCg1pbnZvY2F0aW9uX2lkGAcgASgJQjlaN2dpdGh1Yi5jb20vcGVkYXB1ZGkvZ29sZGZpdmUvZ2VuL2dvbGRmaXZlL3YxO2dvbGRmaXZldjFiBnByb3RvMw", [file_google_protobuf_timestamp, file_goldfive_v1_types]);
 
 /**
  * Event is the uniform envelope wrapping every goldfive event. Sinks
@@ -233,6 +233,12 @@ export type Event = Message<"goldfive.v1.Event"> & {
      */
     value: InvocationCancelled;
     case: "invocationCancelled";
+  } | {
+    /**
+     * @generated from field: goldfive.v1.TaskTransitioned task_transitioned = 35;
+     */
+    value: TaskTransitioned;
+    case: "taskTransitioned";
   } | { case: undefined; value?: undefined };
 };
 
@@ -1527,4 +1533,123 @@ export type InvocationCancelled = Message<"goldfive.v1.InvocationCancelled"> & {
  */
 export const InvocationCancelledSchema: GenMessage<InvocationCancelled> = /*@__PURE__*/
   messageDesc(file_goldfive_v1_events, 26);
+
+/**
+ * Emitted on EVERY successful task status transition with source
+ * attribution so operators can answer "who moved this task and why".
+ * Sink-only — the LLM's ``report_task_*`` surface still returns
+ * ``{"acknowledged": True}``; this event is operator observability
+ * (audit trail + Gantt rendering).
+ *
+ * Pairs with the ``task_transition_refused`` dict event from the
+ * pin-versioning audit (#266): refused attempts emit the dict refusal
+ * payload and DO NOT emit ``TaskTransitioned`` (no transition
+ * happened). Successful transitions emit this typed proto envelope.
+ *
+ * ``source`` is a short symbolic vocabulary; readers MUST tolerate
+ * unknown values (forward-compat) and SHOULD render them as-is when
+ * surfacing to operators. Defined values:
+ *
+ *   * ``"llm_report"``        — driven by an LLM ``report_task_*``
+ *                                tool call with an explicit ``task_id``
+ *                                arg.
+ *   * ``"handler_default"``    — driven by an LLM ``report_task_*``
+ *                                tool call where ``task_id`` was
+ *                                resolved from the adapter-stamped
+ *                                pin (``goldfive.current_task_id``)
+ *                                rather than an explicit arg.
+ *   * ``"supersedes_reroute"`` — driven by an LLM report on a
+ *                                superseded task that the report-time
+ *                                pin classifier (#266) routed to the
+ *                                REPLACE-kind successor.
+ *   * ``"plan_revision"``      — refine changed the task's status (e.g.
+ *                                stamped FAILED on a looping task,
+ *                                CANCELLED on a supersede).
+ *   * ``"cancellation"``       — cooperative cancellation (#251 Stream
+ *                                C) transitioned a running task as a
+ *                                consequence (cascade-cancel from a
+ *                                CRITICAL drift).
+ *   * ``"other"``              — any transition that doesn't match a
+ *                                more specific source (e.g. framework
+ *                                auto-start, control-message rewinds).
+ *                                Operators can still surface the row;
+ *                                a follow-up may refine the vocabulary.
+ *
+ * @generated from message goldfive.v1.TaskTransitioned
+ */
+export type TaskTransitioned = Message<"goldfive.v1.TaskTransitioned"> & {
+  /**
+   * The task that transitioned. After supersedes-reroute this is the
+   * SUCCESSOR task id (the one whose status actually changed), not the
+   * pin the LLM quoted.
+   *
+   * @generated from field: string task_id = 1;
+   */
+  taskId: string;
+
+  /**
+   * ``TaskStatus`` enum value as the bare lowercase string (e.g.
+   * ``"PENDING"``, ``"RUNNING"``, ``"COMPLETED"``). Recorded as a
+   * string (not the enum) so consumers can render without a lookup
+   * and so unknown future statuses round-trip without proto-regen.
+   *
+   * @generated from field: string from_status = 2;
+   */
+  fromStatus: string;
+
+  /**
+   * @generated from field: string to_status = 3;
+   */
+  toStatus: string;
+
+  /**
+   * Source attribution — see the message comment for the defined
+   * vocabulary. Always non-empty on emitted events; readers MUST
+   * tolerate unknown strings.
+   *
+   * @generated from field: string source = 4;
+   */
+  source: string;
+
+  /**
+   * Plan revision in effect at transition time. Mirrors
+   * ``Plan.revision_index`` of ``session.plan`` at emit time so
+   * operators can correlate transitions with the revision that drove
+   * them (especially useful for supersedes-reroute and plan-revision
+   * sources). Recorded as ``int32`` rather than ``uint32`` for parity
+   * with the existing convention in this file (e.g. revision-driven
+   * counters elsewhere); negative values are not produced.
+   *
+   * @generated from field: int32 revision_stamp = 5;
+   */
+  revisionStamp: number;
+
+  /**
+   * Agent the transition was attributed to — usually
+   * ``Task.assignee_agent_id`` for the transitioning task. Empty when
+   * unbound (e.g. CANCELLED via cascade-from-upstream where the
+   * assignee field on the cascaded task was empty). Bare ADK name
+   * (harmonograf sink canonicalises to compound).
+   *
+   * @generated from field: string agent_name = 6;
+   */
+  agentName: string;
+
+  /**
+   * ADK ``invocation_id`` for the dispatch that drove this transition,
+   * when resolvable. Empty for transitions not tied to a specific
+   * in-flight invocation (e.g. plan-revision-driven CANCELLED) and on
+   * adapters that don't surface an invocation_id. Best-effort.
+   *
+   * @generated from field: string invocation_id = 7;
+   */
+  invocationId: string;
+};
+
+/**
+ * Describes the message goldfive.v1.TaskTransitioned.
+ * Use `create(TaskTransitionedSchema)` to create a new message.
+ */
+export const TaskTransitionedSchema: GenMessage<TaskTransitioned> = /*@__PURE__*/
+  messageDesc(file_goldfive_v1_events, 27);
 

--- a/frontend/src/rpc/goldfiveEvent.ts
+++ b/frontend/src/rpc/goldfiveEvent.ts
@@ -33,6 +33,7 @@ import {
 import type {
   Event as GoldfiveEvent,
   InvocationCancelled as InvocationCancelledPb,
+  TaskTransitioned as TaskTransitionedPb,
 } from '../pb/goldfive/v1/events_pb.js';
 import type {
   RefineAttempted as RefineAttemptedPb,
@@ -671,6 +672,18 @@ export function applyGoldfiveEvent(
       applyInvocationCancelled(payload.value, event, store, sessionStartMs, sessionId);
       return;
     }
+    case 'taskTransitioned': {
+      // Operator-observability marker (goldfive#267 / #251 R4). Every
+      // plan-state transition emits a TaskTransitioned record with
+      // source attribution; the deriver in ``lib/interventions.ts``
+      // filters down to the user-meaningful subset (terminal to_status
+      // + meaningful source) before surfacing as an intervention row.
+      // We do NOT synthesize a span on Gantt / Graph — these events are
+      // too fine-grained for those views; the intervention list is
+      // their only surface.
+      applyTaskTransitioned(payload.value, event, store, sessionStartMs);
+      return;
+    }
   }
 }
 
@@ -949,4 +962,49 @@ export function applyRefineFailed(
     recordedMs,
     goldfiveId,
   );
+}
+
+// Operator-observability: a ``TaskTransitioned`` payload landed on the
+// WatchSession stream as part of a ``goldfive.v1.Event`` envelope
+// (goldfive#267 / #251 R4). Append to the per-session
+// :class:`TaskTransitionRegistry` so the deriver in
+// ``lib/interventions.ts`` can pick the user-meaningful subset.
+//
+// We deliberately do NOT synthesize a span on any actor row. These
+// events are fine-grained (every plan-state transition emits one); the
+// intervention list is the only surface. Adding glyphs to Gantt /
+// Graph would be visual noise. If operators want them on Gantt later
+// that's a separate UX decision.
+//
+// We also do NOT mutate task status here — the existing TaskStarted /
+// TaskCompleted / TaskFailed / TaskCancelled handlers above are still
+// the authoritative path for the gantt task store. TaskTransitioned is
+// a *parallel* observability stream alongside those, not a replacement.
+export function applyTaskTransitioned(
+  payload: TaskTransitionedPb,
+  event: GoldfiveEvent,
+  store: SessionStore,
+  sessionStartMs: number,
+): void {
+  const recordedAbsMs = tsToMsAbs(event.emittedAt);
+  // When emitted_at is missing on a replay of legacy data, fall back to
+  // "now" so the record still has a usable timestamp to render.
+  const abs = recordedAbsMs || Date.now();
+  const recordedMs = abs - sessionStartMs;
+  store.taskTransitions.append({
+    runId: event.runId || '',
+    sequence: Number(event.sequence ?? 0n),
+    taskId: payload.taskId || '',
+    // ``from_status`` / ``to_status`` arrive as bare uppercase strings on
+    // the wire (per goldfive#267 events.proto comment). Coerce
+    // defensively in case a non-conforming emitter ships lowercase.
+    fromStatus: (payload.fromStatus || '').toUpperCase(),
+    toStatus: (payload.toStatus || '').toUpperCase(),
+    source: payload.source || '',
+    revisionStamp: payload.revisionStamp || 0,
+    agentName: payload.agentName || '',
+    invocationId: payload.invocationId || '',
+    recordedAtMs: recordedMs,
+    recordedAtAbsoluteMs: abs,
+  });
 }

--- a/server/harmonograf_server/bus.py
+++ b/server/harmonograf_server/bus.py
@@ -71,6 +71,14 @@ DELTA_INVOCATION_CANCELLED = "invocation_cancelled"
 # attempted+terminal into a single intervention row per attempt.
 DELTA_REFINE_ATTEMPTED = "refine_attempted"
 DELTA_REFINE_FAILED = "refine_failed"
+# Operator-observability: goldfive emitted a TaskTransitioned record at a
+# plan-state transition boundary (goldfive#267 / #251 R4). Carries the
+# from/to status, source attribution (llm_report, supersedes_reroute,
+# plan_revision, handler_default, cancellation, other), revision_stamp,
+# agent_name, and invocation_id. Frontend filters by source/to_status
+# before surfacing as an intervention row — the wire fans out every
+# transition; the deriver downstream picks the user-meaningful subset.
+DELTA_TASK_TRANSITIONED = "task_transitioned"
 
 
 @dataclass
@@ -528,6 +536,55 @@ class SessionBus:
                     "detail": detail,
                     "current_task_id": current_task_id,
                     "current_agent_id": current_agent_id,
+                    "recorded_at": recorded_at,
+                },
+            )
+        )
+
+    def publish_task_transitioned(
+        self,
+        session_id: str,
+        run_id: str,
+        *,
+        sequence: int = 0,
+        emitted_at: float | None = None,
+        task_id: str = "",
+        from_status: str = "",
+        to_status: str = "",
+        source: str = "",
+        revision_stamp: int = 0,
+        agent_name: str = "",
+        invocation_id: str = "",
+        recorded_at: float | None = None,
+    ) -> None:
+        """Publish a ``task_transitioned`` record onto the session bus.
+
+        Fields mirror the wire ``goldfive.v1.TaskTransitioned`` message
+        (goldfive#267): from/to status as bare lowercase strings (e.g.
+        ``"PENDING"``/``"RUNNING"``), source attribution as a free-form
+        symbolic string the frontend MUST tolerate unknown values for,
+        revision_stamp as the ``Plan.revision_index`` in effect at the
+        transition boundary, plus the ADK agent_name + invocation_id when
+        resolvable. ``recorded_at`` is the ingest-side wall clock;
+        ``emitted_at`` is the goldfive-side wall clock from the envelope.
+        Mirrors the DELTA_DRIFT / DELTA_INVOCATION_CANCELLED publish
+        pattern for emitted_at fall-through.
+        """
+        self.publish(
+            Delta(
+                session_id,
+                DELTA_TASK_TRANSITIONED,
+                {
+                    "run_id": run_id,
+                    "sequence": int(sequence or 0),
+                    "emitted_at": emitted_at,
+                    "task_id": task_id,
+                    "from_status": from_status,
+                    "to_status": to_status,
+                    "source": source,
+                    "revision_stamp": int(revision_stamp or 0),
+                    "agent_name": agent_name,
+                    "invocation_id": invocation_id,
                     "recorded_at": recorded_at,
                 },
             )

--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -906,6 +906,10 @@ class IngestPipeline:
             self._on_invocation_cancelled(
                 target_ctx, event.invocation_cancelled, run_id, event
             )
+        elif kind == "task_transitioned":
+            self._on_task_transitioned(
+                target_ctx, event.task_transitioned, run_id, event
+            )
         else:
             logger.debug(
                 "ignoring unknown goldfive event payload kind=%s on session_id=%s",
@@ -1317,6 +1321,61 @@ class IngestPipeline:
             drift_kind=payload.drift_kind or "",
             detail=payload.detail or "",
             tool_name=payload.tool_name or "",
+            recorded_at=self._now(),
+        )
+
+    def _on_task_transitioned(
+        self,
+        ctx: StreamContext,
+        payload: Any,
+        run_id: str,
+        event: Any,
+    ) -> None:
+        """Ingest a ``TaskTransitioned`` payload (goldfive#267 / #251 R4).
+
+        Plays the same "operator observability marker" role as
+        :meth:`_on_drift_detected` and :meth:`_on_invocation_cancelled`:
+        publish a ``DELTA_TASK_TRANSITIONED`` on the bus so live
+        WatchSession subscribers can render the transition immediately.
+        Persistence happens upstream in :meth:`_handle_goldfive_event`
+        via ``Store.append_goldfive_event`` — every TaskTransitioned
+        rides the same ``goldfive_events`` table so reconnect replay
+        pulls it back through the persisted-event read path with no
+        sibling table.
+
+        We deliberately do NOT add a sibling ``task_transitions`` table:
+        the ``goldfive_events`` row is sufficient for the frontend's
+        intervention-list workload (the deriver scans live events; it
+        does not query historical transitions by task_id). When a
+        clearly distinct query workload emerges (e.g. "show me every
+        ``llm_report``-sourced transition for task X across runs"),
+        promoting to a sibling table is a follow-up.
+
+        Sequence + emitted_at come off the parent ``Event`` envelope;
+        only payload-local fields (task_id, from_status, to_status,
+        source, revision_stamp, agent_name, invocation_id) are read off
+        ``payload``. ``agent_name`` arrives already canonicalised to
+        ``<client>:<bare>`` from the client sink (NOT YET — the sink's
+        ``_canonicalize_agent_ids`` does not currently rewrite this
+        field; the frontend tolerates either form. See the rewrite
+        dispatch table in ``client/harmonograf_client/sink.py``).
+        """
+        emitted_at_val: float | None = None
+        if event is not None and event.HasField("emitted_at"):
+            emitted_at_val = ts_to_float(event.emitted_at)
+        sequence_val = int(getattr(event, "sequence", 0) or 0)
+        self._bus.publish_task_transitioned(
+            ctx.session_id,
+            run_id,
+            sequence=sequence_val,
+            emitted_at=emitted_at_val,
+            task_id=payload.task_id or "",
+            from_status=payload.from_status or "",
+            to_status=payload.to_status or "",
+            source=payload.source or "",
+            revision_stamp=int(getattr(payload, "revision_stamp", 0) or 0),
+            agent_name=payload.agent_name or "",
+            invocation_id=payload.invocation_id or "",
             recorded_at=self._now(),
         )
 

--- a/server/harmonograf_server/rpc/frontend.py
+++ b/server/harmonograf_server/rpc/frontend.py
@@ -45,6 +45,7 @@ from harmonograf_server.bus import (
     DELTA_TASK_PROGRESS,
     DELTA_TASK_REPORT,
     DELTA_TASK_STATUS,
+    DELTA_TASK_TRANSITIONED,
     DELTA_CONTEXT_WINDOW_SAMPLE,
     Delta,
     SessionBus,
@@ -1458,6 +1459,35 @@ def _delta_to_session_update(delta: Delta) -> Optional[frontend_pb2.SessionUpdat
             if ts is not None:
                 fmsg.emitted_at.CopyFrom(ts)
         return frontend_pb2.SessionUpdate(refine_failed=fmsg)
+    if delta.kind == DELTA_TASK_TRANSITIONED:
+        p = delta.payload
+        # Wrap as a ``goldfive.v1.Event`` with the ``task_transitioned``
+        # payload oneof variant (goldfive#267 / #251 R4). Same envelope
+        # shape as DELTA_INVOCATION_CANCELLED / DELTA_DRIFT — frontend
+        # WatchSession dispatches on the goldfive-event payload case.
+        ev = goldfive_events_pb2.Event(
+            run_id=p.get("run_id", "") or "",
+            sequence=int(p.get("sequence", 0) or 0),
+            session_id=delta.session_id,
+        )
+        ev.task_transitioned.task_id = p.get("task_id", "") or ""
+        ev.task_transitioned.from_status = p.get("from_status", "") or ""
+        ev.task_transitioned.to_status = p.get("to_status", "") or ""
+        ev.task_transitioned.source = p.get("source", "") or ""
+        ev.task_transitioned.revision_stamp = int(p.get("revision_stamp", 0) or 0)
+        ev.task_transitioned.agent_name = p.get("agent_name", "") or ""
+        ev.task_transitioned.invocation_id = p.get("invocation_id", "") or ""
+        # Prefer the goldfive-side emitted_at; fall back to ingest-side
+        # recorded_at so the frontend always has a timestamp to render
+        # (mirrors the DELTA_DRIFT / DELTA_INVOCATION_CANCELLED pattern).
+        ts_val = p.get("emitted_at")
+        if not isinstance(ts_val, (int, float)):
+            ts_val = p.get("recorded_at")
+        if isinstance(ts_val, (int, float)):
+            ts = float_to_ts(float(ts_val))
+            if ts is not None:
+                ev.emitted_at.CopyFrom(ts)
+        return frontend_pb2.SessionUpdate(goldfive_event=ev)
     if delta.kind == DELTA_AGENT_INVOCATION_STARTED:
         p = delta.payload
         ev = goldfive_events_pb2.Event(run_id=p.get("run_id", ""))

--- a/server/tests/test_goldfive_ingest.py
+++ b/server/tests/test_goldfive_ingest.py
@@ -28,6 +28,7 @@ from harmonograf_server.bus import (
     DELTA_TASK_PLAN,
     DELTA_TASK_PROGRESS,
     DELTA_TASK_STATUS,
+    DELTA_TASK_TRANSITIONED,
     SessionBus,
 )
 from harmonograf_server.ingest import IngestPipeline, StreamContext
@@ -784,6 +785,87 @@ async def test_drift_detected_publishes_delta(pipeline):
     assert delta.payload["severity"] == "critical"
     assert delta.payload["detail"] == "backend flaky"
     assert delta.payload["current_task_id"] == "t1"
+
+
+# ---- task transitions (goldfive#267 / #251 R4) --------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_transitioned_publishes_delta(pipeline):
+    """``TaskTransitioned`` payloads fan out as ``DELTA_TASK_TRANSITIONED``
+    onto the session bus with envelope-derived sequence + emitted_at and
+    payload-local task_id / from_status / to_status / source / etc.
+    """
+    pipe, bus, _ = pipeline
+    sub = await bus.subscribe("sess_gf")
+    evt = _make_event(sequence=42)
+    evt.task_transitioned.task_id = "t-7"
+    evt.task_transitioned.from_status = "RUNNING"
+    evt.task_transitioned.to_status = "COMPLETED"
+    evt.task_transitioned.source = "llm_report"
+    evt.task_transitioned.revision_stamp = 3
+    evt.task_transitioned.agent_name = "researcher_agent"
+    evt.task_transitioned.invocation_id = "inv-7"
+    evt.emitted_at.seconds = 1_000
+    evt.emitted_at.nanos = 500_000_000
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_TASK_TRANSITIONED
+    assert delta.payload["task_id"] == "t-7"
+    assert delta.payload["from_status"] == "RUNNING"
+    assert delta.payload["to_status"] == "COMPLETED"
+    assert delta.payload["source"] == "llm_report"
+    assert delta.payload["revision_stamp"] == 3
+    assert delta.payload["agent_name"] == "researcher_agent"
+    assert delta.payload["invocation_id"] == "inv-7"
+    assert delta.payload["sequence"] == 42
+    assert delta.payload["emitted_at"] == pytest.approx(1_000.5, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_task_transitioned_persists_in_goldfive_events(pipeline, store):
+    """The TaskTransitioned event lands in the ``goldfive_events`` table
+    via the generic persist path (no sibling table — see the
+    ``_on_task_transitioned`` docstring). On reconnect, the events
+    replay through the same persisted-event path as other Event
+    variants.
+    """
+    pipe, _, _ = pipeline
+    evt = _make_event(sequence=7)
+    evt.task_transitioned.task_id = "t-99"
+    evt.task_transitioned.from_status = "PENDING"
+    evt.task_transitioned.to_status = "RUNNING"
+    evt.task_transitioned.source = "llm_report"
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    # The persisted-event path is the generic ``append_goldfive_event``
+    # in ``_handle_goldfive_event`` — verify a row landed by reading
+    # it back through the store API.
+    rows = await store.list_goldfive_events("sess_gf")
+    kinds = [r.kind for r in rows]
+    assert "task_transitioned" in kinds
+
+
+@pytest.mark.asyncio
+async def test_task_transitioned_tolerates_missing_emitted_at(pipeline):
+    """When the envelope's ``emitted_at`` is unset, the delta carries
+    ``emitted_at = None`` and the frontend falls back to ``recorded_at``
+    (the ingest-side wall clock). Mirrors the
+    ``test_invocation_cancelled_*`` pattern.
+    """
+    pipe, bus, _ = pipeline
+    sub = await bus.subscribe("sess_gf")
+    evt = _make_event(sequence=5)
+    evt.task_transitioned.task_id = "t-x"
+    evt.task_transitioned.from_status = "RUNNING"
+    evt.task_transitioned.to_status = "FAILED"
+    evt.task_transitioned.source = "plan_revision"
+    # No emitted_at set on the envelope.
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+    delta = sub.queue.get_nowait()
+    assert delta.kind == DELTA_TASK_TRANSITIONED
+    assert delta.payload["emitted_at"] is None
+    # recorded_at is stamped from the pipeline's now_fn.
+    assert delta.payload["recorded_at"] == 1_000_000.0
 
 
 # ---- dispatch sanity -----------------------------------------------------

--- a/server/tests/test_task_transitioned_rpc.py
+++ b/server/tests/test_task_transitioned_rpc.py
@@ -1,0 +1,137 @@
+"""Tests for the frontend RPC surfacing of TaskTransitioned events
+(goldfive#267 / #251 R4).
+
+Coverage
+--------
+* ``DELTA_TASK_TRANSITIONED`` translates to a ``SessionUpdate``
+  whose ``kind`` oneof case is ``goldfive_event``, and whose payload
+  oneof case is ``task_transitioned``.
+* All payload fields (task_id, from_status, to_status, source,
+  revision_stamp, agent_name, invocation_id) round-trip onto the typed
+  proto.
+* ``emitted_at`` is preferred over ``recorded_at``; absent both, the
+  Event's ``emitted_at`` stays unset.
+
+Mirrors :mod:`test_invocation_cancelled_rpc` byte-for-byte; the two
+events ride the same envelope shape and the translator follows the
+same pattern.
+"""
+
+from __future__ import annotations
+
+from harmonograf_server.bus import (
+    DELTA_TASK_TRANSITIONED,
+    Delta,
+)
+from harmonograf_server.pb import telemetry_pb2  # noqa: F401 — grafts goldfive.v1
+from harmonograf_server.rpc.frontend import _delta_to_session_update
+
+from goldfive.v1 import events_pb2 as goldfive_events_pb2  # noqa: E402
+
+
+def _transition_payload(
+    *,
+    run_id: str = "run-1",
+    sequence: int = 7,
+    task_id: str = "t-7",
+    from_status: str = "RUNNING",
+    to_status: str = "COMPLETED",
+    source: str = "llm_report",
+    revision_stamp: int = 3,
+    agent_name: str = "presentation-orchestrated-abc:researcher_agent",
+    invocation_id: str = "inv-7",
+    emitted_at: float | None = 1_700_000_000.456,
+    recorded_at: float | None = 1_000_000.0,
+) -> dict:
+    return {
+        "run_id": run_id,
+        "sequence": sequence,
+        "task_id": task_id,
+        "from_status": from_status,
+        "to_status": to_status,
+        "source": source,
+        "revision_stamp": revision_stamp,
+        "agent_name": agent_name,
+        "invocation_id": invocation_id,
+        "emitted_at": emitted_at,
+        "recorded_at": recorded_at,
+    }
+
+
+def _transition_event(update) -> goldfive_events_pb2.Event:
+    """Pull the goldfive Event out of a SessionUpdate produced by the
+    delta translator. Fails the test when the kind oneof is anything
+    other than ``goldfive_event``."""
+    assert update.WhichOneof("kind") == "goldfive_event"
+    return update.goldfive_event
+
+
+class TestDeltaToSessionUpdate:
+    def test_transition_delta_produces_goldfive_event(self):
+        delta = Delta("sess_t", DELTA_TASK_TRANSITIONED, _transition_payload())
+        update = _delta_to_session_update(delta)
+        assert update is not None
+        ev = _transition_event(update)
+        # The Event payload oneof case discriminates which goldfive
+        # variant we're carrying.
+        assert ev.WhichOneof("payload") == "task_transitioned"
+        # Envelope metadata reads off the parent Event.
+        assert ev.run_id == "run-1"
+        assert ev.sequence == 7
+        assert ev.session_id == "sess_t"
+        t = ev.task_transitioned
+        assert t.task_id == "t-7"
+        assert t.from_status == "RUNNING"
+        assert t.to_status == "COMPLETED"
+        assert t.source == "llm_report"
+        assert t.revision_stamp == 3
+        assert t.agent_name == "presentation-orchestrated-abc:researcher_agent"
+        assert t.invocation_id == "inv-7"
+
+    def test_transition_delta_emitted_at_stamped(self):
+        delta = Delta("sess_t", DELTA_TASK_TRANSITIONED, _transition_payload())
+        update = _delta_to_session_update(delta)
+        ev = _transition_event(update)
+        # emitted_at = 1_700_000_000.456 → seconds=1_700_000_000,
+        # nanos≈456_000_000.
+        assert ev.emitted_at.seconds == 1_700_000_000
+        assert abs(ev.emitted_at.nanos - 456_000_000) < 1000
+
+    def test_transition_delta_falls_back_to_recorded_at(self):
+        # No emitted_at — the translator falls back to recorded_at so
+        # the frontend always has a timestamp to render.
+        payload = _transition_payload(emitted_at=None, recorded_at=1_500_500.25)
+        delta = Delta("sess_t", DELTA_TASK_TRANSITIONED, payload)
+        update = _delta_to_session_update(delta)
+        ev = _transition_event(update)
+        assert ev.emitted_at.seconds == 1_500_500
+        assert abs(ev.emitted_at.nanos - 250_000_000) < 1000
+
+    def test_transition_delta_no_timestamp_leaves_emitted_at_unset(self):
+        payload = _transition_payload(emitted_at=None, recorded_at=None)
+        delta = Delta("sess_t", DELTA_TASK_TRANSITIONED, payload)
+        update = _delta_to_session_update(delta)
+        ev = _transition_event(update)
+        # Timestamp default-construct ⇒ both fields zero, "unset" on the wire.
+        assert ev.emitted_at.seconds == 0
+        assert ev.emitted_at.nanos == 0
+
+    def test_transition_delta_unknown_source_passes_through(self):
+        # Forward-compat: the goldfive proto comment says readers MUST
+        # tolerate unknown source strings. The server is just a
+        # passthrough; rendering filters live on the frontend.
+        payload = _transition_payload(source="some_future_source")
+        delta = Delta("sess_t", DELTA_TASK_TRANSITIONED, payload)
+        update = _delta_to_session_update(delta)
+        ev = _transition_event(update)
+        assert ev.task_transitioned.source == "some_future_source"
+
+    def test_transition_delta_zero_revision_stamp(self):
+        # Initial transitions (PENDING → RUNNING on a brand-new plan)
+        # carry revision_stamp=0. The translator must not coerce zero
+        # to truthy or skip the field.
+        payload = _transition_payload(revision_stamp=0)
+        delta = Delta("sess_t", DELTA_TASK_TRANSITIONED, payload)
+        update = _delta_to_session_update(delta)
+        ev = _transition_event(update)
+        assert ev.task_transitioned.revision_stamp == 0


### PR DESCRIPTION
## Summary

goldfive #267 ships ``TaskTransitioned`` proto events at every plan-state transition with source attribution. This PR wires harmonograf to consume them end-to-end:

- **Client sink** — rides the existing proto passthrough (no special-case branch). Forward-compat test pins the contract.
- **Server** — `_on_task_transitioned` handler persists via the generic `goldfive_events` path and fans out a new `DELTA_TASK_TRANSITIONED` to live WatchSession subscribers. `frontend.py` translator wraps the delta as a `goldfive.v1.Event` envelope (matches DELTA_DRIFT / DELTA_INVOCATION_CANCELLED). **No sibling table** -- the goldfive_events row is sufficient and there's no obvious distinct query workload.
- **Frontend** — `applyTaskTransitioned` in `goldfiveEvent.ts` appends to a new `TaskTransitionRegistry` on `SessionStore`. The deriver in `lib/interventions.ts` filters down to the user-meaningful subset before surfacing as intervention rows.
- **Filter ladder** — only terminal `to_status` (COMPLETED / FAILED / CANCELLED) with meaningful source (llm_report / supersedes_reroute / plan_revision / cancellation). RUNNING / PENDING intermediate states and noisy sources (handler_default / other / unknown) are suppressed.
- **Severity** — `info` for COMPLETED, `warning` for FAILED / CANCELLED.
- **Detail panel** — `resolveTaskTransitionDetail` reuses the existing `InterventionDetail` shape; the existing drift detail panel renders transitions via `InterventionDetailSections`. No new component.
- **Render scope** — intervention list only. No Gantt / Graph glyphs (too fine-grained for those views).

## Coordination

- F6 (submodule bump to 0db5e78) had not landed when this branch was authored; we updated the submodule pin in this PR. If F6 lands first the rebase is a no-op.
- F9 (refused-proto) may also touch `frontend/src/rpc/goldfiveEvent.ts`; conflicts limited to the switch block additions and easily resolved via PR ordering.

## Test plan

- [ ] Client sink: TaskTransitioned proto event flows through buffer/transport unchanged (`test_harmonograf_sink.py`).
- [ ] Server ingest: persists to `goldfive_events`, fans out `DELTA_TASK_TRANSITIONED` (`test_goldfive_ingest.py`).
- [ ] Server RPC: `DELTA_TASK_TRANSITIONED` translates to `SessionUpdate.goldfive_event(task_transitioned=...)` (`test_task_transitioned_rpc.py`).
- [ ] Frontend dispatch: `applyTaskTransitioned` appends a record, derives session-relative ms, and rebases on late `wallClockStartMs` (`taskTransitioned.test.ts`).
- [ ] Frontend filter: terminal+meaningful subset surfaces; RUNNING / PENDING / handler_default / other / unknown suppressed.
- [ ] Frontend detail: `resolveTaskTransitionDetail` composes the steering section.