### PR TITLE
feat(ui): UX cleanup batch — Activity labels, Graph zoom, Notes CTA, Trajectory header

### DIFF
--- a/frontend/src/__tests__/components/ActivityView.kindLabel.test.tsx
+++ b/frontend/src/__tests__/components/ActivityView.kindLabel.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Item 1 of UX cleanup batch — Activity view drift-row labelling.
+ *
+ * Drift-detected events (off_topic, plan_divergence, refine_steer, …)
+ * synthesise CUSTOM-kind spans on the goldfive lane. The Activity view
+ * used to render these rows with the bare "CUSTOM" enum value, which
+ * conveyed nothing about what the row actually represents. The
+ * ``activityKindLabel`` helper now inspects well-known goldfive / drift
+ * attributes and surfaces a useful label instead.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { activityKindLabel } from '../../components/shell/views/activityKind';
+import type { Span } from '../../gantt/types';
+
+function mkSpan(overrides: Partial<Span> = {}): Span {
+  return {
+    id: 'span-1',
+    sessionId: 'sess',
+    agentId: 'agent-1',
+    parentSpanId: null,
+    kind: 'CUSTOM',
+    status: 'COMPLETED',
+    name: '',
+    startMs: 0,
+    endMs: 0,
+    links: [],
+    attributes: {},
+    payloadRefs: [],
+    error: null,
+    lane: -1,
+    replaced: false,
+    ...overrides,
+  };
+}
+
+describe('Activity view kind label', () => {
+  it('renders SpanKind enum value for non-CUSTOM kinds unchanged', () => {
+    expect(activityKindLabel(mkSpan({ kind: 'INVOCATION' }))).toBe('INVOCATION');
+    expect(activityKindLabel(mkSpan({ kind: 'LLM_CALL' }))).toBe('LLM_CALL');
+    expect(activityKindLabel(mkSpan({ kind: 'TOOL_CALL' }))).toBe('TOOL_CALL');
+    expect(activityKindLabel(mkSpan({ kind: 'USER_MESSAGE' }))).toBe('USER_MESSAGE');
+  });
+
+  it('surfaces the drift kind on synthesised drift spans', () => {
+    const offTopic = mkSpan({
+      attributes: {
+        'drift.kind': { kind: 'string', value: 'off_topic' },
+      },
+    });
+    expect(activityKindLabel(offTopic)).toBe('OFF_TOPIC');
+
+    const planDivergence = mkSpan({
+      attributes: {
+        'drift.kind': { kind: 'string', value: 'plan_divergence' },
+      },
+    });
+    expect(activityKindLabel(planDivergence)).toBe('PLAN_DIVERGENCE');
+
+    const userSteer = mkSpan({
+      attributes: {
+        'drift.kind': { kind: 'string', value: 'user_steer' },
+      },
+    });
+    expect(activityKindLabel(userSteer)).toBe('USER_STEER');
+  });
+
+  it('surfaces refine spans with the triggering drift kind', () => {
+    // Synthesised refine spans carry ``refine.kind`` (the drift kind
+    // that drove the refine).
+    const refine = mkSpan({
+      attributes: {
+        'refine.kind': { kind: 'string', value: 'plan_divergence' },
+      },
+    });
+    expect(activityKindLabel(refine)).toBe('REFINE: PLAN_DIVERGENCE');
+  });
+
+  it('surfaces translated goldfive call_name (refine_steer, judge_*)', () => {
+    const refineSteer = mkSpan({
+      attributes: {
+        'goldfive.call_name': { kind: 'string', value: 'refine_steer' },
+      },
+    });
+    expect(activityKindLabel(refineSteer)).toBe('REFINE_STEER');
+
+    const judge = mkSpan({
+      attributes: {
+        'goldfive.call_name': { kind: 'string', value: 'judge_reasoning' },
+      },
+    });
+    expect(activityKindLabel(judge)).toBe('JUDGE_REASONING');
+  });
+
+  it('falls back to the span name when no goldfive/drift attribute is present', () => {
+    const named = mkSpan({ name: 'cooperative_cancel' });
+    expect(activityKindLabel(named)).toBe('COOPERATIVE_CANCEL');
+  });
+
+  it('falls back to bare "CUSTOM" only when no useful attribute or name is set', () => {
+    const bare = mkSpan({ name: '' });
+    expect(activityKindLabel(bare)).toBe('CUSTOM');
+  });
+
+  it('covers every DriftKind enum value via the drift.kind attribute path', () => {
+    // The well-known DriftKind enum values that appear on drift spans
+    // emitted by goldfive. Each surfaces as the uppercase form. This
+    // protects against the regression of one-off cases sneaking back
+    // into the activity view via a stale "CUSTOM" string.
+    const driftKinds = [
+      'tool_error',
+      'agent_refusal',
+      'new_work_discovered',
+      'plan_divergence',
+      'user_steer',
+      'user_cancel',
+      'task_failed_recoverable',
+      'task_failed_fatal',
+      'context_pressure',
+      'blocked',
+      'wrong_agent',
+      'agent_transfer',
+      'model_refusal',
+      'stopped_early',
+      'too_many_steps',
+      'goal_unreachable',
+      'task_timeout',
+      'repeated_failure',
+      'unexpected_output',
+      'schema_violation',
+      'hallucination_suspected',
+      'safety_concern',
+      'resource_exhausted',
+      'ambiguous_intent',
+      'looping_tool_call',
+      'looping_reasoning',
+      'confusion',
+      'off_topic',
+      'intent_divergence',
+      'uncertain_progress',
+      'self_reported_stuck',
+      'reasoning_cluster_tightening',
+      'confabulation_risk',
+      'runaway_delegation',
+      'refine_validation_failed',
+      'human_intervention_required',
+      'goal_drift',
+    ];
+    for (const k of driftKinds) {
+      const s = mkSpan({
+        attributes: { 'drift.kind': { kind: 'string', value: k } },
+      });
+      expect(activityKindLabel(s)).toBe(k.toUpperCase());
+    }
+  });
+});

--- a/frontend/src/__tests__/components/NotesView.emptyState.test.tsx
+++ b/frontend/src/__tests__/components/NotesView.emptyState.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Item 3 of UX cleanup batch — Notes view empty state CTA.
+ *
+ * The Notes panel used to render a near-blank empty state for sessions
+ * with no annotations. The new empty state surfaces a clear "no notes
+ * yet" message and a CTA pointing operators at the existing add-note
+ * flow on the span popover.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../components/shell/views/views.css', () => ({}));
+
+const uiStoreState = {
+  currentSessionId: 'sess-empty' as string | null,
+  selectSpan: vi.fn(),
+};
+vi.mock('../../state/uiStore', () => ({
+  useUiStore: <T,>(selector: (s: typeof uiStoreState) => T) =>
+    selector(uiStoreState),
+}));
+
+const annStoreState = {
+  bySession: new Map(),
+  list: () => [],
+};
+vi.mock('../../state/annotationStore', () => ({
+  useAnnotationStore: <T,>(selector: (s: typeof annStoreState) => T) =>
+    selector(annStoreState),
+}));
+
+import { NotesView } from '../../components/shell/views/NotesView';
+
+beforeEach(() => {
+  uiStoreState.currentSessionId = 'sess-empty';
+  annStoreState.bySession = new Map();
+});
+
+describe('<NotesView /> empty state CTA', () => {
+  it('renders the empty-state CTA when the session has no notes', () => {
+    render(<NotesView />);
+    const cta = screen.getByTestId('notes-empty-cta');
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveTextContent('No notes for this session yet.');
+    // Hint copy directs operators to the existing add-note flow.
+    expect(cta).toHaveTextContent(/Add note/i);
+  });
+
+  it('does not render the empty-state CTA when there is no session', () => {
+    uiStoreState.currentSessionId = null;
+    render(<NotesView />);
+    expect(screen.queryByTestId('notes-empty-cta')).toBeNull();
+    // Falls back to the generic "no session selected" hint.
+    expect(screen.getByText(/no session selected/i)).toBeInTheDocument();
+  });
+
+  it('does not render the empty-state CTA when notes exist', () => {
+    annStoreState.bySession = new Map([
+      [
+        'sess-empty',
+        [
+          {
+            id: 'a1',
+            sessionId: 'sess-empty',
+            spanId: '',
+            kind: 'COMMENT' as const,
+            body: 'a note',
+            author: 'tester',
+            createdAtMs: 1000,
+            pending: false,
+            error: null,
+          },
+        ],
+      ],
+    ]);
+    render(<NotesView />);
+    expect(screen.queryByTestId('notes-empty-cta')).toBeNull();
+    expect(screen.getByText('a note')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/TrajectoryView.headerMath.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.headerMath.test.tsx
@@ -151,14 +151,21 @@ describe('<TrajectoryView /> header "rev N of M" math', () => {
     // rev sequence non-contiguous when the trajectory merges both plans.
     // The header denominator must reflect the highest revisionIndex
     // observed, not `vm.revs.length - 1`.
+    //
+    // Multi-plan note (Item 4 of UX cleanup batch): two distinct plan
+    // ids (p1, p2) means the header now prefixes the rev label with
+    // "Plan {N} · " so operators can see which plan the current rev
+    // belongs to (the H1 plan picker lands the picker UI on top of this
+    // label). The numerator/denominator math is unchanged.
     mockStore.tasks.upsertPlan(mkPlan('p1', [mkTask('t1')], 0));
     mockStore.tasks.upsertPlan(
       mkPlan('p2', [mkTask('t1'), mkTask('t2')], 2, 'user steer', 'user_steer'),
     );
     render(<TrajectoryView />);
     // vm.revs.length === 2, but max revisionIndex === 2 → "rev 2 of 2",
-    // not the buggy "rev 1 of 1".
-    expect(headerHint()).toBe('rev 2 of 2');
+    // not the buggy "rev 1 of 1". Multi-plan prefix surfaces "Plan 2"
+    // because the latest rev belongs to the second distinct plan id.
+    expect(headerHint()).toBe('Plan 2 · rev 2 of 2');
   });
 
   it('switches between "no plan yet" and a "rev N of M" hint as plans land', () => {
@@ -173,5 +180,33 @@ describe('<TrajectoryView /> header "rev N of M" math', () => {
     expect(
       screen.getByRole('heading', { name: 'Trajectory' }),
     ).toBeInTheDocument();
+  });
+
+  it('omits the multi-plan prefix in the single-plan case (Item 4)', () => {
+    // One plan id across multiple revs → no "Plan N · " prefix; the
+    // header reads exactly "rev N of M" as before.
+    mockStore.tasks.upsertPlan(mkPlan('p1', [mkTask('t1')], 0));
+    mockStore.tasks.upsertPlan(
+      mkPlan('p1', [mkTask('t1'), mkTask('t2')], 1, 'next', 'goldfive'),
+    );
+    render(<TrajectoryView />);
+    expect(headerHint()).toBe('rev 1 of 1');
+    expect(headerHint()).not.toContain('Plan');
+  });
+
+  it('prefixes "Plan N · " when multiple plan ids are present (Item 4)', () => {
+    // Three distinct plan ids → header surfaces the index of the plan
+    // the current rev belongs to, so an operator viewing rev 2 can tell
+    // which plan they're scoped to ahead of the H1 plan picker landing.
+    mockStore.tasks.upsertPlan(mkPlan('p1', [mkTask('t1')], 0));
+    mockStore.tasks.upsertPlan(
+      mkPlan('p2', [mkTask('t1'), mkTask('t2')], 1, 'split', 'plan_divergence'),
+    );
+    mockStore.tasks.upsertPlan(
+      mkPlan('p3', [mkTask('t1'), mkTask('t2'), mkTask('t3')], 2, 'next', 'goldfive'),
+    );
+    render(<TrajectoryView />);
+    // Latest rev belongs to the third distinct plan id → "Plan 3".
+    expect(headerHint()).toBe('Plan 3 · rev 2 of 2');
   });
 });

--- a/frontend/src/__tests__/components/graphViewport.test.ts
+++ b/frontend/src/__tests__/components/graphViewport.test.ts
@@ -107,6 +107,33 @@ describe('graphViewport — fitRect', () => {
     expect(vp.scale).toBe(0.25);
   });
 
+  it('clamps the fit-scale up to ``minScale`` when content is larger than the container', () => {
+    // Item 2 of UX cleanup batch: the GraphView's initial-fit was leaving
+    // the canvas at 0.37× when the DAG was wider than the viewport,
+    // which read as broken / mostly empty. The fitRect ``minScale``
+    // option clamps the floor so big DAGs open at 1.0× (centered) and
+    // operators can pan from there.
+    const vp = fitRect(
+      { x: 0, y: 0, w: 2000, h: 1000 },
+      { w: 800, h: 600 },
+      24,
+      { minScale: 1 },
+    );
+    expect(vp.scale).toBe(1);
+  });
+
+  it('does not change behaviour when ``minScale`` is below the natural fit', () => {
+    // Sanity: minScale only acts as a floor. Tiny content that fits
+    // comfortably should still hit MAX_SCALE clamping.
+    const vp = fitRect(
+      { x: 0, y: 0, w: 100, h: 50 },
+      { w: 800, h: 600 },
+      20,
+      { minScale: 1 },
+    );
+    expect(vp.scale).toBe(MAX_SCALE);
+  });
+
   it('handles a non-origin content rect', () => {
     const vp = fitRect({ x: 50, y: 100, w: 200, h: 100 }, { w: 400, h: 300 }, 10);
     // Content top-left should sit at (pad + extraX, pad + extraY).

--- a/frontend/src/__tests__/lib/goldfiveSpan.test.ts
+++ b/frontend/src/__tests__/lib/goldfiveSpan.test.ts
@@ -11,6 +11,7 @@ import type { AttributeValue, Span } from '../../gantt/types';
 import {
   bareGoldfiveAgentName,
   goldfiveCallFill,
+  goldfiveCallGlyph,
   isGoldfiveSpan,
   resolveGoldfiveSpanInfo,
   truncatePreview,
@@ -386,5 +387,38 @@ describe('truncatePreview', () => {
 
   it('returns empty string for empty / undefined input', () => {
     expect(truncatePreview('', 10)).toBe('');
+  });
+});
+
+describe('goldfiveCallGlyph (Item 6 of UX cleanup batch)', () => {
+  // refine_steer used to render with the bare CUSTOM "•" glyph on the
+  // goldfive lane, indistinguishable from other goldfive spans. Each
+  // category now has its own glyph so operators triage at a glance.
+  it('returns distinct glyphs per category', () => {
+    const refine = goldfiveCallGlyph('refine');
+    const judge = goldfiveCallGlyph('judge');
+    const plan = goldfiveCallGlyph('plan');
+    const reflective = goldfiveCallGlyph('reflective');
+    expect(refine).toBeTruthy();
+    expect(judge).toBeTruthy();
+    expect(plan).toBeTruthy();
+    expect(reflective).toBeTruthy();
+    // All four are pairwise distinct.
+    const set = new Set([refine, judge, plan, reflective]);
+    expect(set.size).toBe(4);
+  });
+
+  it('returns null for the unknown category', () => {
+    // ``unknown`` is the legacy / pre-merge fallback — the renderer
+    // should keep using the SpanKind icon (or no icon) rather than
+    // overlaying a misleading glyph.
+    expect(goldfiveCallGlyph('unknown')).toBeNull();
+  });
+
+  it('returns the refine glyph for the refine category', () => {
+    // The renderer relies on this exact glyph being present (truthy and
+    // string) so refine_steer spans stand out on the lane. Any change
+    // here should be intentional and coordinated with the icon palette.
+    expect(typeof goldfiveCallGlyph('refine')).toBe('string');
   });
 });

--- a/frontend/src/__tests__/lib/interventions.test.ts
+++ b/frontend/src/__tests__/lib/interventions.test.ts
@@ -552,3 +552,111 @@ describe('marker sizing / palette', () => {
     expect(SOURCE_COLOR.drift).not.toBe(SOURCE_COLOR.goldfive);
   });
 });
+
+describe('deriveInterventions — targetPlanId (Item 5 of UX cleanup batch)', () => {
+  it('stamps targetPlanId on plan-revision rows from the plan they originated on', () => {
+    const planA = mkPlan({
+      id: 'plan-A',
+      revisionIndex: 1,
+      revisionKind: 'off_topic',
+      revisionReason: 'off topic',
+      createdAtMs: 100,
+    });
+    const rows = deriveInterventions({
+      annotations: [],
+      drifts: [],
+      plans: [planA],
+    });
+    const planRow = rows.find((r) => r.source === 'drift' && r.kind === 'OFF_TOPIC');
+    expect(planRow?.targetPlanId).toBe('plan-A');
+  });
+
+  it('stamps targetPlanId on drift rows via strict trigger_event_id match', () => {
+    // Drift triggers a refine that produces plan-B's revision; the
+    // attributeOutcomes step should copy plan-B's id onto the drift row.
+    const planB = mkPlan({
+      id: 'plan-B',
+      revisionIndex: 2,
+      revisionKind: 'off_topic',
+      revisionReason: 'reroute',
+      createdAtMs: 300,
+      triggerEventId: 'drift-id-1',
+    });
+    const rows = deriveInterventions({
+      annotations: [],
+      drifts: [
+        mkDrift({
+          seq: 1,
+          kind: 'off_topic',
+          driftId: 'drift-id-1',
+          recordedAtMs: 250,
+        }),
+      ],
+      plans: [planB],
+    });
+    const driftRow = rows.find((r) => r.source === 'drift' && r.driftId === 'drift-id-1');
+    expect(driftRow?.targetPlanId).toBe('plan-B');
+    // The plan-rev row that merged in the strict-id pass also carries
+    // plan-B's id (or the merge survivor inherits from either side).
+    expect(driftRow?.planRevisionIndex).toBe(2);
+  });
+
+  it('falls back to the active plan at intervention time when no rev match', () => {
+    // Two distinct plans in the session, an early drift that didn't
+    // produce a revision. The deriver attaches the drift to plan-A
+    // (active when the drift fired), not plan-B.
+    const planA = mkPlan({ id: 'plan-A', createdAtMs: 0, revisionIndex: 0 });
+    const planB = mkPlan({ id: 'plan-B', createdAtMs: 500, revisionIndex: 0 });
+    const rows = deriveInterventions({
+      annotations: [],
+      drifts: [
+        mkDrift({
+          seq: 1,
+          kind: 'looping_reasoning',
+          driftId: 'drift-id-1',
+          recordedAtMs: 100,
+        }),
+      ],
+      plans: [planA, planB],
+    });
+    const driftRow = rows.find((r) => r.source === 'drift');
+    expect(driftRow?.targetPlanId).toBe('plan-A');
+  });
+
+  it('attaches drifts that fired after the latest plan to that plan', () => {
+    const planA = mkPlan({ id: 'plan-A', createdAtMs: 0, revisionIndex: 0 });
+    const planB = mkPlan({ id: 'plan-B', createdAtMs: 500, revisionIndex: 0 });
+    const rows = deriveInterventions({
+      annotations: [],
+      drifts: [
+        mkDrift({
+          seq: 1,
+          kind: 'looping_reasoning',
+          driftId: 'drift-id-1',
+          recordedAtMs: 800,
+        }),
+      ],
+      plans: [planA, planB],
+    });
+    const driftRow = rows.find((r) => r.source === 'drift');
+    expect(driftRow?.targetPlanId).toBe('plan-B');
+  });
+
+  it('attaches early drifts to the first plan when they fired before any plan', () => {
+    const planA = mkPlan({ id: 'plan-A', createdAtMs: 500, revisionIndex: 0 });
+    const rows = deriveInterventions({
+      annotations: [],
+      drifts: [
+        mkDrift({
+          seq: 1,
+          kind: 'looping_reasoning',
+          driftId: 'drift-id-1',
+          recordedAtMs: 100, // Before plan-A's createdAtMs.
+        }),
+      ],
+      plans: [planA],
+    });
+    const driftRow = rows.find((r) => r.source === 'drift');
+    expect(driftRow?.targetPlanId).toBe('plan-A');
+  });
+});

--- a/frontend/src/components/shell/views/ActivityView.tsx
+++ b/frontend/src/components/shell/views/ActivityView.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useUiStore } from '../../../state/uiStore';
 import { useSessionWatch } from '../../../rpc/hooks';
 import type { Span } from '../../../gantt/types';
+import { activityKindLabel } from './activityKind';
 
 const MAX_ROWS = 200;
 
@@ -62,7 +63,7 @@ export function ActivityView() {
                 onClick={() => selectSpan(span.id)}
               >
                 <span className="hg-activity__time">{fmtTime(span.startMs)}</span>
-                <span className="hg-activity__kind">{span.kind}</span>
+                <span className="hg-activity__kind">{activityKindLabel(span)}</span>
                 <span className="hg-activity__name">{span.name || '(unnamed)'}</span>
                 <span className="hg-activity__agent">{span.agentId}</span>
                 <span

--- a/frontend/src/components/shell/views/GanttView.tsx
+++ b/frontend/src/components/shell/views/GanttView.tsx
@@ -374,17 +374,24 @@ export function GanttView() {
                   onTaskClick={handleTaskClick}
                 />
                 <InterventionsList
-                  rows={interventions.filter(
-                    // Attach each intervention to the plan whose rev it
-                    // produced, or — if it never produced a revision —
-                    // the nearest preceding plan. Keeps every plan
-                    // uncluttered while still showing every
-                    // intervention exactly once.
-                    (row) =>
-                      row.planRevisionIndex > 0
-                        ? (plan.revisionIndex ?? 0) === row.planRevisionIndex
-                        : (plan.revisionIndex ?? 0) === 0,
-                  )}
+                  rows={interventions.filter((row) => {
+                    // Plan-scoped attachment (Item 5 of UX cleanup batch /
+                    // PR #184 follow-up). Multi-plan sessions used to
+                    // duplicate every "intervention with revisionIndex 0"
+                    // under each plan's section because the filter only
+                    // compared revisionIndex. The deriver now stamps a
+                    // ``targetPlanId`` on every row, so we scope by it
+                    // when present.
+                    if (row.targetPlanId) {
+                      return row.targetPlanId === plan.id;
+                    }
+                    // Backward-compat path: a row without targetPlanId
+                    // (legacy fixtures, hand-built rows in tests) falls
+                    // back to the previous revisionIndex-only behaviour.
+                    return row.planRevisionIndex > 0
+                      ? (plan.revisionIndex ?? 0) === row.planRevisionIndex
+                      : (plan.revisionIndex ?? 0) === 0;
+                  })}
                 />
               </div>
             ))}

--- a/frontend/src/components/shell/views/GraphView.tsx
+++ b/frontend/src/components/shell/views/GraphView.tsx
@@ -811,7 +811,16 @@ export function GraphView() {
     if (containerSize.w <= 0 || containerSize.h <= 0) return;
     const cs = contentSizeRef.current;
     if (cs.w <= 0 || cs.h <= 0) return;
-    commitViewport(fitRect({ x: 0, y: 0, w: cs.w, h: cs.h }, containerSize));
+    // Initial-fit: clamp scale floor at 1.0 so a large DAG doesn't open at
+    // 0.37× (which used to leave most of the canvas blank — Item 2 of the
+    // UX cleanup batch). User-driven fits via the toolbar still clamp to
+    // 1.0 too — the operator can pan from there or hit zoom-out
+    // explicitly to see the whole DAG. See graphViewport.fitRect.
+    commitViewport(
+      fitRect({ x: 0, y: 0, w: cs.w, h: cs.h }, containerSize, 24, {
+        minScale: 1,
+      }),
+    );
   }, [commitViewport, containerSize]);
 
   const fitSelection = useCallback(() => {

--- a/frontend/src/components/shell/views/NotesView.tsx
+++ b/frontend/src/components/shell/views/NotesView.tsx
@@ -30,7 +30,26 @@ export function NotesView() {
           </div>
         )}
         {sessionId && sorted.length === 0 && (
-          <div className="hg-panel__empty">No notes yet for this session.</div>
+          // Empty-state CTA. The "Add note" affordance lives on the span
+          // popover (Interaction/SpanPopover.tsx :: annotate) — this view
+          // doesn't own the add flow. The CTA below directs operators to
+          // it so the empty panel isn't a dead end. See Item 3 of the UX
+          // cleanup batch.
+          <div className="hg-panel__empty hg-notes__empty" data-testid="notes-empty-cta">
+            <div className="hg-notes__empty-glyph" aria-hidden="true">
+              {'✉'}
+            </div>
+            <div className="hg-notes__empty-title">
+              No notes for this session yet.
+            </div>
+            <div className="hg-notes__empty-hint">
+              Click any span on the Gantt or Graph view, then press
+              {' '}
+              <kbd>Add note</kbd>
+              {' '}
+              in the popover to attach a comment.
+            </div>
+          </div>
         )}
         {sorted.length > 0 && (
           <ul className="hg-notes__list" data-testid="notes-list">

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -477,6 +477,30 @@ export function TrajectoryView() {
   const currentRevisionIndex = currentRev?.revisionIndex ?? revIdx;
   const compareRevisionIndex =
     compareRev?.revisionIndex ?? compareRevIdx ?? null;
+  // Multi-plan awareness for the header (Item 4 of UX cleanup batch).
+  // Compute the distinct plan_ids spanned by ``vm.revs`` — when the
+  // session contains more than one we prefix the rev label with "Plan
+  // {N}" so operators can tell which plan the current revision belongs
+  // to. Plans are numbered by first appearance in the time-sorted rev
+  // list; this composes naturally with the H1 plan picker landing in a
+  // sibling PR (the picker selects a plan and the header reflects which
+  // plan is selected). Single-plan sessions retain the unchanged
+  // "rev N of M" label.
+  const distinctPlanIds: string[] = [];
+  const planIdSeen = new Set<string>();
+  for (const rev of vm.revs) {
+    if (!planIdSeen.has(rev.id)) {
+      planIdSeen.add(rev.id);
+      distinctPlanIds.push(rev.id);
+    }
+  }
+  const multiPlan = distinctPlanIds.length > 1;
+  const currentPlanIndex = currentRev
+    ? distinctPlanIds.indexOf(currentRev.id) + 1
+    : 0;
+  const planPrefix = multiPlan && currentPlanIndex > 0
+    ? `Plan ${currentPlanIndex} · `
+    : '';
   // Only produce diff marks when the user has explicitly pinned a compare
   // rev — otherwise every task would be flagged "added" against a null prev.
   const marks =
@@ -573,7 +597,7 @@ export function TrajectoryView() {
         <span className="hg-panel__hint">
           {vm.revs.length === 0
             ? 'no plan yet'
-            : `rev ${currentRevisionIndex} of ${highestRevisionIndex}${compareRev ? ` · comparing to rev ${compareRevisionIndex}` : ''}`}
+            : `${planPrefix}rev ${currentRevisionIndex} of ${highestRevisionIndex}${compareRev ? ` · comparing to rev ${compareRevisionIndex}` : ''}`}
         </span>
       </header>
       <div className="hg-panel__body hg-traj__body">

--- a/frontend/src/components/shell/views/activityKind.ts
+++ b/frontend/src/components/shell/views/activityKind.ts
@@ -1,0 +1,47 @@
+// Helper for the Activity view's per-row kind label.
+//
+// CUSTOM-kind spans on the goldfive lane (drift detections, refine
+// calls, judge invocations, etc.) used to render with the bare "CUSTOM"
+// enum value, which conveyed nothing about what the row actually
+// represents. We re-key those rows by inspecting the well-known
+// goldfive / drift attributes the synthesizers stamp, and fall back to
+// the span name when no opt-in attribute is present. Non-CUSTOM kinds
+// are returned as their SpanKind enum value (INVOCATION, LLM_CALL, …)
+// — those already read clearly and have UI affordances elsewhere keyed
+// off them.
+//
+// Kept in its own module so ActivityView.tsx can satisfy the React
+// fast-refresh "only export components" lint rule (the helper is
+// shared with the focused unit test in __tests__/components).
+
+import type { Span } from '../../../gantt/types';
+
+export function activityKindLabel(span: Span): string {
+  if (span.kind !== 'CUSTOM') return span.kind;
+  // Drift-detected spans synthesised by goldfiveEvent.ts carry
+  // ``drift.kind`` ("off_topic", "user_steer", …). Surface the
+  // uppercase form so it reads alongside other UPPERCASE kind labels.
+  const driftAttr = span.attributes?.['drift.kind'];
+  if (driftAttr && driftAttr.kind === 'string' && driftAttr.value) {
+    return driftAttr.value.toUpperCase();
+  }
+  // Refine-span synthesisers stamp ``refine.kind`` (the drift kind
+  // that drove the refine). Surface that as "REFINE: <kind>" so it
+  // reads distinct from the drift row.
+  const refineKind = span.attributes?.['refine.kind'];
+  if (refineKind && refineKind.kind === 'string' && refineKind.value) {
+    return `REFINE: ${refineKind.value.toUpperCase()}`;
+  }
+  // Translated goldfive call_name (``refine_steer``, ``judge_reasoning``,
+  // etc.) stamped by the harmonograf-side translator.
+  const callName = span.attributes?.['goldfive.call_name'];
+  if (callName && callName.kind === 'string' && callName.value) {
+    return callName.value.toUpperCase();
+  }
+  // Last resort: the span's name often carries a useful tag (e.g. the
+  // synthesiser sets ``name`` to the drift kind directly). Falling
+  // back to the bare "CUSTOM" enum is uninformative; show the raw
+  // name when it's set.
+  if (span.name) return span.name.toUpperCase();
+  return 'CUSTOM';
+}

--- a/frontend/src/components/shell/views/graphViewport.ts
+++ b/frontend/src/components/shell/views/graphViewport.ts
@@ -66,16 +66,28 @@ export function panBy(vp: Viewport, dx: number, dy: number): Viewport {
 // Fit a content-space rectangle into a container, leaving `padding` CSS px of
 // breathing room around it, and clamp the resulting scale into the allowed
 // range. The content is centered inside the container.
+//
+// ``maxScale`` overrides the default upper clamp so callers (e.g. the
+// "fit selection" affordance) can keep the zoom from blowing up on a
+// tiny selection, and the initial-fit path can cap the lower bound at
+// 1.0 so the overview opens at 100% (the previous behaviour fit big DAGs
+// at 37% which left the canvas mostly empty — see Item 2 of the UX
+// cleanup batch). Pass ``minScale`` to clamp upward (≥ minScale) so a
+// large content rect doesn't render at 0.3× and look like the panel's
+// broken.
 export function fitRect(
   content: Rect,
   container: Size,
   padding = 24,
+  opts: { minScale?: number; maxScale?: number } = {},
 ): Viewport {
   const availW = Math.max(1, container.w - padding * 2);
   const availH = Math.max(1, container.h - padding * 2);
   const bw = Math.max(1, content.w);
   const bh = Math.max(1, content.h);
-  const scale = clampScale(Math.min(availW / bw, availH / bh));
+  let scale = clampScale(Math.min(availW / bw, availH / bh));
+  if (opts.maxScale !== undefined) scale = Math.min(scale, opts.maxScale);
+  if (opts.minScale !== undefined) scale = Math.max(scale, opts.minScale);
   const tx = padding + (availW - bw * scale) / 2 - content.x * scale;
   const ty = padding + (availH - bh * scale) / 2 - content.y * scale;
   return { scale, tx, ty };

--- a/frontend/src/components/shell/views/views.css
+++ b/frontend/src/components/shell/views/views.css
@@ -41,6 +41,42 @@
   text-align: center;
 }
 
+.hg-notes__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 48px 24px;
+  opacity: 1;
+}
+
+.hg-notes__empty-glyph {
+  font-size: 36px;
+  opacity: 0.5;
+}
+
+.hg-notes__empty-title {
+  font-size: 14px;
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.hg-notes__empty-hint {
+  font-size: 12px;
+  opacity: 0.6;
+  max-width: 320px;
+  line-height: 1.5;
+}
+
+.hg-notes__empty-hint kbd {
+  font-family: inherit;
+  font-size: 11px;
+  padding: 1px 6px;
+  background: var(--md-sys-color-surface-container-highest, #31333c);
+  border: 1px solid var(--md-sys-color-outline-variant, #4a4a53);
+  border-radius: 4px;
+}
+
 .hg-activity__list,
 .hg-notes__list {
   list-style: none;

--- a/frontend/src/gantt/renderer.ts
+++ b/frontend/src/gantt/renderer.ts
@@ -27,6 +27,7 @@ import type { Agent, ContextWindowSample, Span, SpanKind, Task, TaskStatus } fro
 import { hasThinking } from '../lib/thinking';
 import {
   goldfiveCallFill,
+  goldfiveCallGlyph,
   isGoldfiveSpan,
   resolveGoldfiveSpanInfo,
   type GoldfiveSpanInfo,
@@ -1056,7 +1057,14 @@ export class GanttRenderer {
     for (const b of buckets.values()) {
       for (const l of b.labels) {
         const { s, x, y: ly, w: lw, h: lh, gf } = l;
-        const icon = KIND_ICON[s.kind];
+        // Goldfive lane spans get a category-specific glyph in place of
+        // the bare CUSTOM "•" so refine_steer / judge_* / plan_* /
+        // reflective_check are distinguishable at a glance even when
+        // they share the same SpanKind. See Item 6 of the UX cleanup
+        // batch and goldfiveCallGlyph in lib/goldfiveSpan.ts.
+        const baseIcon = KIND_ICON[s.kind];
+        const gfGlyph = gf ? goldfiveCallGlyph(gf.category) : null;
+        const icon = gfGlyph ?? baseIcon;
         if (lw > 40) {
           const primary = gf ? gf.callName : s.name;
           const label = icon ? `${icon} ${primary}` : primary;

--- a/frontend/src/lib/goldfiveSpan.ts
+++ b/frontend/src/lib/goldfiveSpan.ts
@@ -199,3 +199,32 @@ export function truncatePreview(text: string, limit: number): string {
   if (text.length <= limit) return text;
   return text.slice(0, limit) + '…';
 }
+
+/**
+ * Per-category glyph used to disambiguate goldfive lane spans visually.
+ * The goldfive lane otherwise renders every category as a "CUSTOM"-kind
+ * span (• dot), so refine / judge / plan / reflective calls were
+ * indistinguishable beyond their fill colour. Distinct glyphs let
+ * operators triage at a glance: refine spans (↻ self-correction) read
+ * different from judge spans (⚖ verdict) read different from plan
+ * spans (📐 planning) read different from reflective spans (✱ progress
+ * check). See Item 6 of the UX cleanup batch.
+ *
+ * Returns null for ``unknown`` so the renderer keeps the default
+ * SpanKind icon (or no icon for plain CUSTOM spans).
+ */
+export function goldfiveCallGlyph(category: GoldfiveCallCategory): string | null {
+  switch (category) {
+    case 'refine':
+      return '↻';
+    case 'judge':
+      return '⚖';
+    case 'plan':
+      return '📐';
+    case 'reflective':
+      return '✱';
+    case 'unknown':
+    default:
+      return null;
+  }
+}

--- a/frontend/src/lib/interventions.ts
+++ b/frontend/src/lib/interventions.ts
@@ -136,6 +136,16 @@ export interface InterventionRow {
   // (after supersedes-reroute this is the SUCCESSOR id). Absent on
   // every other source.
   transitionTaskId?: string;
+  // Plan id this intervention is scoped to (Item 5 of UX cleanup batch /
+  // PR #184 follow-up). When a session contains multiple plans (different
+  // plan_ids), the per-plan ``InterventionsList`` filter scopes to this
+  // field so a row produced under one plan doesn't render under every
+  // other plan with the same revisionIndex. Empty when the deriver could
+  // not pin the intervention to a specific plan (e.g. a drift that fired
+  // before any plan landed) — the renderer falls back to attaching it to
+  // the earliest plan in that case so the row still renders exactly
+  // once.
+  targetPlanId?: string;
 }
 
 // Drift kinds emitted by goldfive when the user pulled the trigger. Mirrors
@@ -305,6 +315,8 @@ export function deriveInterventions(input: DeriveInput): InterventionRow[] {
       driftId: '',
       attemptId: '',
       failureKind: '',
+      // Plan-rev rows are intrinsically scoped to their own plan.
+      targetPlanId: plan.id,
     });
   }
 
@@ -593,6 +605,11 @@ function attributeOutcomes(
         const idx = matched.revisionIndex ?? 0;
         row.outcome = `plan_revised:r${idx}`;
         row.planRevisionIndex = idx;
+        // Carry the matched plan's id so the per-plan filter in
+        // GanttView doesn't fall through to "every plan with same
+        // revisionIndex" — fixes the duplicate-rendering bug under
+        // multi-plan sessions (Item 5 / PR #184 follow-up).
+        if (!row.targetPlanId) row.targetPlanId = matched.id;
         continue;
       }
     }
@@ -613,6 +630,7 @@ function attributeOutcomes(
         const idx = fallback.revisionIndex ?? 0;
         row.outcome = `plan_revised:r${idx}`;
         row.planRevisionIndex = idx;
+        if (!row.targetPlanId) row.targetPlanId = fallback.id;
         continue;
       }
     }
@@ -627,6 +645,28 @@ function attributeOutcomes(
       }
     }
     row.outcome = 'recorded';
+  }
+
+  // Final pass: ensure every row has a ``targetPlanId`` so the per-plan
+  // filter in GanttView can attach it exactly once. Rows that didn't
+  // match a plan revision via strict-id or legacy fallback still need a
+  // home; we attach them to the most recent plan whose ``createdAtMs``
+  // is at-or-before the row's ``atMs`` (i.e. the plan that was active
+  // when the intervention fired). No active plan ⇒ first plan in the
+  // session (the row was an early annotation / drift before any plan
+  // landed). No plans at all ⇒ leave empty; the GanttView filter has
+  // nothing to attach to anyway.
+  if (plans.length > 0) {
+    const sortedPlans = [...plans].sort((a, b) => a.createdAtMs - b.createdAtMs);
+    for (const row of rows) {
+      if (row.targetPlanId) continue;
+      let active: TaskPlan | null = null;
+      for (const p of sortedPlans) {
+        if (p.createdAtMs <= row.atMs) active = p;
+        else break;
+      }
+      row.targetPlanId = (active ?? sortedPlans[0]).id;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Bundle of small UX gaps surfaced by today's E2E. Net subtractive on visual clutter; net additive on clarity.

- **Item 1 — Activity labels.** Drift rows (off_topic, plan_divergence, refine_steer) used to render with the placeholder label "CUSTOM" on the Activity view. The new `activityKindLabel` helper reads `drift.kind` / `refine.kind` / `goldfive.call_name` off the synthesised CUSTOM-kind spans and surfaces the actual label. Covers every `DriftKind` enum value; falls back to `span.name` then bare `CUSTOM` only as a last resort.
- **Item 2 — Graph zoom.** Initial fit-to-content used to land at 0.37× on big DAGs leaving most of the canvas empty. `fitRect` gains a `minScale` option; GraphView's first-mount fit clamps the floor at 1.0 so the overview opens at 100% (operator pans or hits zoom-out from there). User overrides still persist via `uiStore`.
- **Item 3 — Notes CTA.** Empty Notes panel gains an icon + "No notes for this session yet." title + hint copy directing operators to the add-note flow on the span popover.
- **Item 4 — Trajectory header.** Multi-plan sessions now prefix the header with `Plan N · ` so operators can tell which plan the current rev belongs to. Single-plan sessions retain the unchanged `rev N of M` label. Composes with H1's plan picker when it lands.
- **Item 5 — Intervention dedupe.** PR #184's filter incorrectly matched every revision-index-0 plan for every intervention. The `deriveInterventions` deriver now stamps `targetPlanId` on every row (strict-id match → legacy-window fallback → active-plan-at-time inference) and GanttView scopes by `targetPlanId` instead of `revisionIndex` alone.
- **Item 6 — refine_steer glyph.** `refine` / `judge` / `plan` / `reflective` goldfive-lane spans now render with category-specific glyphs (`↻` / `⚖` / `📐` / `✱`) instead of the bare CUSTOM dot. Distinct from each other and from the per-category fill colour, so triage works even on monochrome captures.

## Test plan

- [x] `pnpm tsc -b` clean
- [x] `pnpm lint` clean (the one warning on GanttView.tsx:164 is pre-existing)
- [x] `pnpm test --run` — 669 tests pass (was 647 baseline; +22 new)
- [x] Item 1: focused unit test (`ActivityView.kindLabel.test.tsx`) covers every DriftKind enum value, refine spans, goldfive call names, name fallback, and the bare-CUSTOM last resort.
- [x] Item 2: focused unit test in `graphViewport.test.ts` confirms `minScale` clamps big content up to 1.0 and stays inert when content fits comfortably.
- [x] Item 3: focused unit test (`NotesView.emptyState.test.tsx`) confirms the empty-state CTA renders only when a session is selected and has zero notes.
- [x] Item 4: extended `TrajectoryView.headerMath.test.tsx` covers single-plan (no prefix), multi-plan (prefix), and the existing R0+R2 gap case.
- [x] Item 5: extended `lib/interventions.test.ts` covers strict-id match, active-plan-at-time inference (early / late / before-any-plan), and plan-rev rows being self-scoped.
- [x] Item 6: extended `lib/goldfiveSpan.test.ts` confirms each category returns a distinct truthy glyph and `unknown` returns null.