### PR TITLE
fix(server): silent plan-creation leak + convert round-trip drops supersedes fields

### DIFF
--- a/server/harmonograf_server/convert.py
+++ b/server/harmonograf_server/convert.py
@@ -373,6 +373,63 @@ def goldfive_pb_task_to_storage(pb: Any) -> Task:
         # envelope). Default to empty; the ingest pipeline stamps it on
         # the matching sqlite row when the cancel event arrives.
         cancel_reason="",
+        # goldfive#237 / goldfive#251: explicit supersession link. Both
+        # fields carry through verbatim from the wire; the storage layer
+        # uses the same goldfive Python dataclass that defines them, so
+        # the enum value lands on the dataclass directly. ``int(...)``
+        # is a defensive coerce — proto enums report as ``int`` but the
+        # accessor type can be the EnumTypeWrapper.
+        supersedes=getattr(pb, "supersedes", "") or "",
+        supersedes_kind=_supersession_kind_pb_to_storage(
+            int(getattr(pb, "supersedes_kind", 0) or 0)
+        ),
+    )
+
+
+def _supersession_kind_pb_to_storage(value: int) -> Any:
+    """Map a ``goldfive.v1.SupersessionKind`` enum int to the goldfive
+    Python dataclass enum (``goldfive.types.SupersessionKind``).
+
+    The storage ``Task`` dataclass is goldfive's own dataclass, so the
+    field is typed as the Python enum, not the proto int. Unknown /
+    UNSPECIFIED values map to ``UNSPECIFIED``.
+    """
+
+    from goldfive.types import SupersessionKind
+
+    pb_unspec = getattr(
+        goldfive_types_pb2, "SUPERSESSION_KIND_UNSPECIFIED", 0
+    )
+    pb_replace = getattr(
+        goldfive_types_pb2, "SUPERSESSION_KIND_REPLACE", 1
+    )
+    pb_correct = getattr(
+        goldfive_types_pb2, "SUPERSESSION_KIND_CORRECT", 2
+    )
+    if value == pb_replace:
+        return SupersessionKind.REPLACE
+    if value == pb_correct:
+        return SupersessionKind.CORRECT
+    if value == pb_unspec:
+        return SupersessionKind.UNSPECIFIED
+    return SupersessionKind.UNSPECIFIED
+
+
+def _supersession_kind_storage_to_pb(value: Any) -> int:
+    """Inverse of :func:`_supersession_kind_pb_to_storage`."""
+
+    from goldfive.types import SupersessionKind
+
+    if value == SupersessionKind.REPLACE:
+        return getattr(
+            goldfive_types_pb2, "SUPERSESSION_KIND_REPLACE", 1
+        )
+    if value == SupersessionKind.CORRECT:
+        return getattr(
+            goldfive_types_pb2, "SUPERSESSION_KIND_CORRECT", 2
+        )
+    return getattr(
+        goldfive_types_pb2, "SUPERSESSION_KIND_UNSPECIFIED", 0
     )
 
 
@@ -421,6 +478,11 @@ def goldfive_pb_plan_to_storage(
         # goldfive steerer's _apply_revision). Non-empty for every
         # revision; empty on the initial plan submission.
         trigger_event_id=getattr(pb, "revision_trigger_event_id", "") or "",
+        # goldfive#: ``Plan.run_id`` round-trip. The wire carries the
+        # producing run; harmonograf preserves it in storage so the
+        # storage→pb inverse can reconstitute the original Plan
+        # without a side channel.
+        run_id=getattr(pb, "run_id", "") or "",
     )
 
 
@@ -494,6 +556,18 @@ def storage_task_to_goldfive_pb(task: Task) -> Any:
     )
     if task.bound_span_id:
         pb.bound_span_id = task.bound_span_id
+    # goldfive#237 / goldfive#251: round-trip the supersedes link.
+    # Skip the assignment when both fields default — proto3 won't
+    # serialize empty defaults anyway, but explicit guarding keeps the
+    # round-trip byte-for-byte stable for legacy plans.
+    supersedes = getattr(task, "supersedes", "") or ""
+    if supersedes:
+        pb.supersedes = supersedes
+    supersedes_kind = getattr(task, "supersedes_kind", None)
+    if supersedes_kind is not None:
+        kind_pb = _supersession_kind_storage_to_pb(supersedes_kind)
+        if kind_pb:
+            pb.supersedes_kind = kind_pb
     return pb
 
 
@@ -507,6 +581,12 @@ def storage_plan_to_goldfive_pb(plan: TaskPlan) -> Any:
 
     pb = goldfive_types_pb2.Plan(
         id=plan.id,
+        # goldfive#: ``Plan.run_id`` round-trip. The storage layer
+        # retains the producing run id; preserve it on the pb side
+        # so downstream consumers (snapshot replay, frontend
+        # GetSessionPlanHistory) get the same value the wire
+        # originally carried.
+        run_id=getattr(plan, "run_id", "") or "",
         summary=plan.summary,
         revision_reason=plan.revision_reason,
         revision_kind=_drift_kind_string_to_pb(plan.revision_kind),

--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -832,40 +832,54 @@ class IngestPipeline:
             sequence,
             kind,
         )
-        # Persist the event envelope verbatim before dispatch. Writes
-        # are idempotent on (session_id, run_id, sequence); a reconnect
-        # replay or duplicate delivery is safe. The bus fan-out below
-        # still runs so live subscribers see the event immediately —
-        # persistence is additive. See harmonograf#113.
-        if kind is not None and run_id:
-            try:
-                raw_bytes = event.SerializeToString()
-            except Exception as exc:  # noqa: BLE001 — proto edge cases
-                logger.debug(
-                    "goldfive event serialize failed session_id=%s kind=%s: %s",
-                    target_ctx.session_id,
-                    kind,
-                    exc,
+        # Persist the event envelope verbatim before dispatch and gate
+        # the per-kind dispatch on the same condition. Writes are
+        # idempotent on (session_id, run_id, sequence); a reconnect
+        # replay or duplicate delivery is safe.
+        #
+        # harmonograf#: keep the audit log invariant — every row in a
+        # derived table (``task_plans``, ``tasks``, ``annotations``…)
+        # has a corresponding row in ``goldfive_events``. Gating ONLY
+        # the audit insert (and not the dispatch chain) lets plan /
+        # task events with empty ``run_id`` skip the audit row but
+        # still mutate ``task_plans`` and friends, leaving silent
+        # inconsistency (3 task_plans rows for 1 plan_submitted in
+        # ``goldfive_events`` was the symptom). An event without a
+        # ``run_id`` has no provenance — drop both the persist AND the
+        # dispatch so the DB stays consistent. Bus fan-out (live
+        # subscribers) lives inside the dispatch chain and is dropped
+        # too: there is no live state worth publishing for an event we
+        # cannot trace back to a run.
+        if kind is None or not run_id:
+            return
+        try:
+            raw_bytes = event.SerializeToString()
+        except Exception as exc:  # noqa: BLE001 — proto edge cases
+            logger.debug(
+                "goldfive event serialize failed session_id=%s kind=%s: %s",
+                target_ctx.session_id,
+                kind,
+                exc,
+            )
+            raw_bytes = b""
+        try:
+            await self._store.append_goldfive_event(
+                GoldfiveEventRecord(
+                    session_id=target_ctx.session_id,
+                    run_id=run_id,
+                    sequence=int(sequence),
+                    kind=kind,
+                    recorded_at=self._now(),
+                    payload_bytes=raw_bytes,
                 )
-                raw_bytes = b""
-            try:
-                await self._store.append_goldfive_event(
-                    GoldfiveEventRecord(
-                        session_id=target_ctx.session_id,
-                        run_id=run_id,
-                        sequence=int(sequence),
-                        kind=kind,
-                        recorded_at=self._now(),
-                        payload_bytes=raw_bytes,
-                    )
-                )
-            except Exception as exc:  # noqa: BLE001 — defensive: ingest must not raise
-                logger.debug(
-                    "goldfive event persist failed session_id=%s kind=%s: %s",
-                    target_ctx.session_id,
-                    kind,
-                    exc,
-                )
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive: ingest must not raise
+            logger.debug(
+                "goldfive event persist failed session_id=%s kind=%s: %s",
+                target_ctx.session_id,
+                kind,
+                exc,
+            )
         if kind == "run_started":
             await self._on_run_started(target_ctx, event.run_started, run_id)
         elif kind == "goal_derived":
@@ -1066,6 +1080,12 @@ class IngestPipeline:
             created_at=created_at,
             planner_agent_id=ctx.agent_id,
         )
+        # goldfive#: prefer the envelope-level ``run_id`` when the inline
+        # ``Plan.run_id`` is empty. The two are normally identical, but
+        # older clients populated only the envelope; this keeps the
+        # round-trip preserving the run pin in either case.
+        if not stored.run_id and run_id:
+            stored.run_id = run_id
         # Task ``assignee_agent_id`` fields arrive already-compound from the
         # client-side sink (harmonograf#125). The bare→compound resolve loop
         # that used to live here is no longer needed — wire is authoritative.

--- a/server/harmonograf_server/storage/base.py
+++ b/server/harmonograf_server/storage/base.py
@@ -203,6 +203,12 @@ class TaskPlan:
     # annotation_id, autonomous = DriftEvent.id). Empty on the initial
     # plan.
     trigger_event_id: str = ""
+    # goldfive#: the run that produced this plan. Mirrors
+    # ``goldfive.v1.Plan.run_id`` so the storage→pb round-trip preserves
+    # the run pin (otherwise the converter silently dropped the run_id
+    # and frontend plan-history could not be tied back to its run).
+    # Empty on legacy plans that pre-date the column.
+    run_id: str = ""
 
 
 # Sibling of TaskPlan — `task_plans` upserts on `id` alone, so every

--- a/server/harmonograf_server/storage/sqlite.py
+++ b/server/harmonograf_server/storage/sqlite.py
@@ -42,6 +42,43 @@ from harmonograf_server.storage.base import (
     ContextWindowSample,
     GoldfiveEventRecord,
 )
+from goldfive.types import SupersessionKind
+
+
+# goldfive#237 / goldfive#251: tasks.supersedes_kind storage encoding.
+# Persist as the same integer the proto enum uses (0 UNSPECIFIED /
+# 1 REPLACE / 2 CORRECT) so the column round-trips through the
+# converter without losing fidelity. The Python ``SupersessionKind``
+# is a ``StrEnum`` (string-valued); this mapping is what makes the
+# storage int authoritative.
+_SUPERSESSION_KIND_TO_INT: dict[Any, int] = {
+    SupersessionKind.UNSPECIFIED: 0,
+    SupersessionKind.REPLACE: 1,
+    SupersessionKind.CORRECT: 2,
+}
+_INT_TO_SUPERSESSION_KIND: dict[int, SupersessionKind] = {
+    0: SupersessionKind.UNSPECIFIED,
+    1: SupersessionKind.REPLACE,
+    2: SupersessionKind.CORRECT,
+}
+
+
+def _supersession_kind_to_int(value: Any) -> int:
+    """Map a Python ``SupersessionKind`` (or ``None``) to a storage int."""
+
+    if value is None:
+        return 0
+    return int(_SUPERSESSION_KIND_TO_INT.get(value, 0))
+
+
+def _supersession_kind_from_int(value: Any) -> SupersessionKind:
+    """Inverse of :func:`_supersession_kind_to_int`. Defaults to UNSPECIFIED."""
+
+    try:
+        i = int(value or 0)
+    except (TypeError, ValueError):
+        return SupersessionKind.UNSPECIFIED
+    return _INT_TO_SUPERSESSION_KIND.get(i, SupersessionKind.UNSPECIFIED)
 
 
 SCHEMA = """
@@ -135,7 +172,11 @@ CREATE TABLE IF NOT EXISTS task_plans (
     -- harmonograf#99 / goldfive#199: strict dedup key joining plan
     -- revisions to their originating annotation or drift. Non-empty on
     -- every revision (empty only on the initial plan).
-    trigger_event_id TEXT NOT NULL DEFAULT ''
+    trigger_event_id TEXT NOT NULL DEFAULT '',
+    -- goldfive#: the run that produced this plan. Mirrors
+    -- ``goldfive.v1.Plan.run_id`` on the wire. Empty on legacy rows
+    -- that pre-date the column.
+    run_id TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_task_plans_session ON task_plans(session_id);
 
@@ -189,6 +230,13 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- provenance id or human tail. Empty for PENDING / RUNNING /
     -- COMPLETED / BLOCKED rows.
     cancel_reason TEXT NOT NULL DEFAULT '',
+    -- goldfive#237 / goldfive#251: explicit supersession link. Non-empty
+    -- string on revision tasks that replace or correct an earlier task;
+    -- empty on initial plans and on tasks that are NOT replacements.
+    -- ``supersedes_kind`` carries the ``goldfive.v1.SupersessionKind``
+    -- enum int (0 UNSPECIFIED / 1 REPLACE / 2 CORRECT).
+    supersedes TEXT NOT NULL DEFAULT '',
+    supersedes_kind INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (plan_id, id),
     FOREIGN KEY (plan_id) REFERENCES task_plans(id) ON DELETE CASCADE
 );
@@ -308,6 +356,16 @@ class SqliteStore(Store):
             await self._db.execute(
                 "ALTER TABLE task_plans ADD COLUMN trigger_event_id TEXT NOT NULL DEFAULT ''"
             )
+        # goldfive#: ``Plan.run_id`` round-trip column. Pre-existing
+        # rows keep the default empty string; the value populates from
+        # the wire ``goldfive.v1.Plan.run_id`` on the next plan_submitted
+        # / plan_revised. Without this column, the storage→pb round-trip
+        # silently dropped the run_id and downstream consumers (frontend
+        # plan-history, intervention aggregator) lost the run pin.
+        if "run_id" not in tp_cols:
+            await self._db.execute(
+                "ALTER TABLE task_plans ADD COLUMN run_id TEXT NOT NULL DEFAULT ''"
+            )
         # harmonograf#110 / goldfive#205: cancel_reason on tasks table.
         # Additive, NOT NULL with empty-string default so existing rows
         # remain valid under the new schema. Pre-#205 sessions keep
@@ -318,6 +376,22 @@ class SqliteStore(Store):
         if "cancel_reason" not in task_cols:
             await self._db.execute(
                 "ALTER TABLE tasks ADD COLUMN cancel_reason TEXT NOT NULL DEFAULT ''"
+            )
+        # goldfive#237 / goldfive#251: ``Task.supersedes`` /
+        # ``supersedes_kind`` round-trip columns. Initial plans and
+        # legacy rows keep the empty default; revision tasks that
+        # replace / correct an earlier task carry the link. The
+        # frontend's chain-collapse renderer requires these to be
+        # preserved across the storage round-trip — without them,
+        # ``GetSessionPlanHistory`` returns plans with NULL supersedes
+        # and the chain rendering breaks.
+        if "supersedes" not in task_cols:
+            await self._db.execute(
+                "ALTER TABLE tasks ADD COLUMN supersedes TEXT NOT NULL DEFAULT ''"
+            )
+        if "supersedes_kind" not in task_cols:
+            await self._db.execute(
+                "ALTER TABLE tasks ADD COLUMN supersedes_kind INTEGER NOT NULL DEFAULT 0"
             )
         await self._db.commit()
 
@@ -982,8 +1056,8 @@ class SqliteStore(Store):
                                             planner_agent_id, created_at, summary, edges,
                                             revision_reason, revision_kind,
                                             revision_severity, revision_index,
-                                            trigger_event_id)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                            trigger_event_id, run_id)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(id) DO UPDATE SET
                         session_id=excluded.session_id,
                         invocation_span_id=excluded.invocation_span_id,
@@ -995,7 +1069,8 @@ class SqliteStore(Store):
                         revision_kind=excluded.revision_kind,
                         revision_severity=excluded.revision_severity,
                         revision_index=excluded.revision_index,
-                        trigger_event_id=excluded.trigger_event_id
+                        trigger_event_id=excluded.trigger_event_id,
+                        run_id=excluded.run_id
                     """,
                     (
                         plan.id,
@@ -1015,6 +1090,7 @@ class SqliteStore(Store):
                         plan.revision_severity or "",
                         int(plan.revision_index or 0),
                         plan.trigger_event_id or "",
+                        getattr(plan, "run_id", "") or "",
                     ),
                 )
                 # Replace tasks for this plan (simplest correct semantics for
@@ -1023,13 +1099,22 @@ class SqliteStore(Store):
                     "DELETE FROM tasks WHERE plan_id = ?", (plan.id,)
                 )
                 for t in plan.tasks:
+                    # goldfive#237 / goldfive#251: stash the supersedes
+                    # link alongside the rest of the task row. The
+                    # ``supersedes_kind`` field is the goldfive Python
+                    # enum (StrEnum). Persist as the matching int (0
+                    # UNSPECIFIED / 1 REPLACE / 2 CORRECT) — same wire
+                    # mapping the proto uses, no proto import needed.
+                    sup_kind = getattr(t, "supersedes_kind", None)
+                    sup_kind_int = _supersession_kind_to_int(sup_kind)
                     await self.db.execute(
                         """
                         INSERT INTO tasks (plan_id, id, title, description,
                                            assignee_agent_id, status,
                                            predicted_start_ms, predicted_duration_ms,
-                                           bound_span_id)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                           bound_span_id,
+                                           supersedes, supersedes_kind)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
                             plan.id,
@@ -1041,6 +1126,8 @@ class SqliteStore(Store):
                             t.predicted_start_ms,
                             t.predicted_duration_ms,
                             t.bound_span_id or None,
+                            getattr(t, "supersedes", "") or "",
+                            int(sup_kind_int or 0),
                         ),
                     )
                 await self.db.commit()
@@ -1066,6 +1153,7 @@ class SqliteStore(Store):
             "SELECT * FROM tasks WHERE plan_id = ? ORDER BY rowid", (plan_id,)
         ) as cur:
             for r in await cur.fetchall():
+                row_keys = r.keys()
                 tasks.append(
                     Task(
                         id=r["id"],
@@ -1077,8 +1165,16 @@ class SqliteStore(Store):
                         predicted_duration_ms=r["predicted_duration_ms"] or 0,
                         bound_span_id=r["bound_span_id"],
                         cancel_reason=(
-                            r["cancel_reason"] if "cancel_reason" in r.keys() else ""
+                            r["cancel_reason"] if "cancel_reason" in row_keys else ""
                         ) or "",
+                        supersedes=(
+                            r["supersedes"] if "supersedes" in row_keys else ""
+                        ) or "",
+                        supersedes_kind=_supersession_kind_from_int(
+                            r["supersedes_kind"]
+                            if "supersedes_kind" in row_keys
+                            else 0
+                        ),
                     )
                 )
         return TaskPlan(
@@ -1095,6 +1191,7 @@ class SqliteStore(Store):
             revision_severity=(row["revision_severity"] if "revision_severity" in row.keys() else "") or "",
             revision_index=int(row["revision_index"]) if "revision_index" in row.keys() and row["revision_index"] is not None else 0,
             trigger_event_id=(row["trigger_event_id"] if "trigger_event_id" in row.keys() else "") or "",
+            run_id=(row["run_id"] if "run_id" in row.keys() else "") or "",
         )
 
     async def get_task_plan(self, plan_id: str) -> Optional[TaskPlan]:

--- a/server/tests/test_convert_round_trip.py
+++ b/server/tests/test_convert_round_trip.py
@@ -1,0 +1,342 @@
+"""Round-trip coverage for ``convert.py`` plan / task converters.
+
+The converters between ``goldfive.v1.Plan`` (proto) and harmonograf's
+storage ``TaskPlan`` dataclass historically dropped fields on the
+trip in either direction. The fields involved in this regression:
+
+* ``Plan.run_id`` — the run that produced this plan
+* ``Task.supersedes`` — explicit supersession link (goldfive#237)
+* ``Task.supersedes_kind`` — REPLACE / CORRECT (goldfive#251)
+
+Pre-fix, ``goldfive_pb_plan_to_storage`` ignored ``pb.run_id``, the
+storage schema had no column for it, and ``storage_plan_to_goldfive_pb``
+wrote an empty ``run_id`` back. Same shape for the supersedes fields
+on ``Task``. The frontend's chain-collapse renderer (#183) requires
+``supersedes`` to reconstruct revision chains; null after round-trip
+broke the rendering.
+
+These tests pin both directions of the converter PLUS the storage
+write/read path, since the converter and the persistence layer must
+agree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from goldfive.pb.goldfive.v1 import types_pb2 as gt
+from goldfive.types import SupersessionKind
+
+from harmonograf_server.convert import (
+    goldfive_pb_plan_to_storage,
+    plan_from_snapshot_json,
+    plan_to_snapshot_json,
+    storage_plan_to_goldfive_pb,
+)
+from harmonograf_server.storage import make_store
+
+
+# ---- pure converter (no storage) ----------------------------------------
+
+
+def _build_plan_pb(
+    *,
+    plan_id: str = "p1",
+    run_id: str = "run-abc",
+    tasks: list[tuple[str, str, int]] | None = None,
+) -> gt.Plan:
+    """Construct a ``goldfive.v1.Plan`` with the supersedes-bearing fields set.
+
+    ``tasks`` is a list of ``(task_id, supersedes, supersedes_kind_int)``.
+    """
+
+    plan = gt.Plan()
+    plan.id = plan_id
+    plan.run_id = run_id
+    plan.summary = "round-trip test"
+    for tid, sup, sup_kind in tasks or []:
+        t = plan.tasks.add()
+        t.id = tid
+        t.title = f"task {tid}"
+        t.status = gt.TASK_STATUS_PENDING
+        if sup:
+            t.supersedes = sup
+        if sup_kind:
+            t.supersedes_kind = sup_kind
+    return plan
+
+
+def test_pb_to_storage_preserves_run_id_and_supersedes():
+    pb = _build_plan_pb(
+        plan_id="p1",
+        run_id="run-abc",
+        tasks=[
+            ("t_new", "t_old", gt.SUPERSESSION_KIND_CORRECT),
+            ("t_other", "", gt.SUPERSESSION_KIND_UNSPECIFIED),
+        ],
+    )
+    stored = goldfive_pb_plan_to_storage(
+        pb,
+        session_id="sess-1",
+        created_at=1.0,
+        invocation_span_id="span-1",
+        planner_agent_id="agent-1",
+    )
+    assert stored.run_id == "run-abc"
+
+    by_id = {t.id: t for t in stored.tasks}
+    assert by_id["t_new"].supersedes == "t_old"
+    assert by_id["t_new"].supersedes_kind == SupersessionKind.CORRECT
+    # Tasks without a supersedes link land with empty defaults.
+    assert by_id["t_other"].supersedes == ""
+    assert by_id["t_other"].supersedes_kind == SupersessionKind.UNSPECIFIED
+
+
+def test_storage_to_pb_preserves_run_id_and_supersedes():
+    """Inverse: storage → pb writes the new fields back to the proto."""
+
+    pb = _build_plan_pb(
+        plan_id="p1",
+        run_id="run-abc",
+        tasks=[
+            ("t_new", "t_old", gt.SUPERSESSION_KIND_REPLACE),
+            ("t_keep", "", 0),
+        ],
+    )
+    stored = goldfive_pb_plan_to_storage(
+        pb, session_id="sess-1", created_at=1.0
+    )
+    pb_out = storage_plan_to_goldfive_pb(stored)
+
+    assert pb_out.run_id == "run-abc"
+    by_id = {t.id: t for t in pb_out.tasks}
+    assert by_id["t_new"].supersedes == "t_old"
+    assert by_id["t_new"].supersedes_kind == gt.SUPERSESSION_KIND_REPLACE
+    # Empty defaults stay empty — the converter must NOT accidentally
+    # null something real or stamp UNSPECIFIED with stale state.
+    assert by_id["t_keep"].supersedes == ""
+    assert by_id["t_keep"].supersedes_kind == gt.SUPERSESSION_KIND_UNSPECIFIED
+
+
+def test_round_trip_idempotent_via_snapshot_json():
+    """The wire form used by ``task_plan_revisions`` is bit-stable across the round-trip."""
+
+    pb = _build_plan_pb(
+        plan_id="p1",
+        run_id="run-xyz",
+        tasks=[
+            ("a", "", 0),
+            ("b", "a", gt.SUPERSESSION_KIND_REPLACE),
+            ("c", "b", gt.SUPERSESSION_KIND_CORRECT),
+        ],
+    )
+    stored = goldfive_pb_plan_to_storage(
+        pb, session_id="sess-1", created_at=1.0
+    )
+
+    # Snapshot path goes through both directions of the converter
+    # (storage_plan_to_goldfive_pb on write, goldfive_pb_plan_to_storage
+    # on read). Two trips must reproduce the original storage state.
+    snapshot = plan_to_snapshot_json(stored)
+    rebuilt = plan_from_snapshot_json(snapshot)
+
+    assert rebuilt.run_id == stored.run_id == "run-xyz"
+    by_id = {t.id: t for t in rebuilt.tasks}
+    assert by_id["b"].supersedes == "a"
+    assert by_id["b"].supersedes_kind == SupersessionKind.REPLACE
+    assert by_id["c"].supersedes == "b"
+    assert by_id["c"].supersedes_kind == SupersessionKind.CORRECT
+    assert by_id["a"].supersedes == ""
+    assert by_id["a"].supersedes_kind == SupersessionKind.UNSPECIFIED
+
+
+def test_legacy_plan_without_supersedes_round_trips_with_empty_defaults():
+    """Plans without supersedes / run_id keep their empty defaults intact."""
+
+    pb = _build_plan_pb(
+        plan_id="p-legacy",
+        run_id="",  # legacy: no run_id on the wire
+        tasks=[("only", "", 0)],
+    )
+    stored = goldfive_pb_plan_to_storage(
+        pb, session_id="sess-1", created_at=1.0
+    )
+    pb_out = storage_plan_to_goldfive_pb(stored)
+    assert stored.run_id == ""
+    assert pb_out.run_id == ""
+    assert pb_out.tasks[0].supersedes == ""
+    assert pb_out.tasks[0].supersedes_kind == gt.SUPERSESSION_KIND_UNSPECIFIED
+
+
+# ---- storage layer round-trip (sqlite + memory) -------------------------
+
+
+@pytest_asyncio.fixture(params=["memory", "sqlite"])
+async def store(request, tmp_path: Path):
+    if request.param == "memory":
+        s = make_store("memory")
+    else:
+        db_path = tmp_path / "test.db"
+        s = make_store("sqlite", db_path=str(db_path))
+    await s.start()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+@pytest.mark.asyncio
+async def test_storage_round_trip_preserves_run_id_and_supersedes(store):
+    """Plan written → read round-trip preserves all three fields.
+
+    Exercises both the in-memory store (which stores the dataclass
+    verbatim) and the sqlite store (which goes through the schema +
+    migration path the brief specified).
+    """
+
+    pb = _build_plan_pb(
+        plan_id="p-store",
+        run_id="run-store-1",
+        tasks=[
+            ("t1", "", 0),
+            ("t2", "t1", gt.SUPERSESSION_KIND_REPLACE),
+            ("t3", "t2", gt.SUPERSESSION_KIND_CORRECT),
+        ],
+    )
+    stored = goldfive_pb_plan_to_storage(
+        pb,
+        session_id="sess-store",
+        created_at=42.0,
+        invocation_span_id="span-1",
+        planner_agent_id="agent-1",
+    )
+    written = await store.put_task_plan(stored)
+    assert written.run_id == "run-store-1"
+
+    fetched = await store.get_task_plan("p-store")
+    assert fetched is not None
+    assert fetched.run_id == "run-store-1"
+
+    by_id = {t.id: t for t in fetched.tasks}
+    assert by_id["t1"].supersedes == ""
+    assert by_id["t1"].supersedes_kind == SupersessionKind.UNSPECIFIED
+    assert by_id["t2"].supersedes == "t1"
+    assert by_id["t2"].supersedes_kind == SupersessionKind.REPLACE
+    assert by_id["t3"].supersedes == "t2"
+    assert by_id["t3"].supersedes_kind == SupersessionKind.CORRECT
+
+
+@pytest.mark.asyncio
+async def test_storage_round_trip_legacy_plan(store):
+    """Legacy plan (no supersedes, empty run_id) round-trips with empty defaults."""
+
+    pb = _build_plan_pb(
+        plan_id="p-legacy",
+        run_id="",
+        tasks=[("only", "", 0)],
+    )
+    stored = goldfive_pb_plan_to_storage(
+        pb, session_id="sess-store", created_at=1.0
+    )
+    await store.put_task_plan(stored)
+    fetched = await store.get_task_plan("p-legacy")
+    assert fetched is not None
+    assert fetched.run_id == ""
+    assert fetched.tasks[0].supersedes == ""
+    assert fetched.tasks[0].supersedes_kind == SupersessionKind.UNSPECIFIED
+
+
+# ---- migration: pre-existing DB without the new columns ----------------
+
+
+@pytest.mark.asyncio
+async def test_sqlite_migration_adds_columns_no_data_loss(tmp_path: Path):
+    """Existing DB with old schema gains the new columns cleanly.
+
+    Simulates an older DB created before this fix: ``task_plans`` has
+    no ``run_id`` column; ``tasks`` has no ``supersedes`` /
+    ``supersedes_kind`` columns. The store's ``start()`` should ALTER
+    TABLE to add them without dropping the legacy row.
+    """
+
+    import sqlite3
+
+    db_path = tmp_path / "legacy.db"
+    con = sqlite3.connect(db_path)
+    con.executescript(
+        """
+        CREATE TABLE task_plans (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            invocation_span_id TEXT,
+            planner_agent_id TEXT,
+            created_at REAL NOT NULL,
+            summary TEXT,
+            edges TEXT,
+            revision_reason TEXT NOT NULL DEFAULT '',
+            revision_kind TEXT NOT NULL DEFAULT '',
+            revision_severity TEXT NOT NULL DEFAULT '',
+            revision_index INTEGER NOT NULL DEFAULT 0,
+            trigger_event_id TEXT NOT NULL DEFAULT ''
+        );
+        INSERT INTO task_plans (
+            id, session_id, invocation_span_id, planner_agent_id,
+            created_at, summary, edges
+        ) VALUES (
+            'plan_legacy', 'sess_legacy', 'inv', 'planner', 1.0,
+            'legacy', '[]'
+        );
+        CREATE TABLE tasks (
+            plan_id TEXT NOT NULL,
+            id TEXT NOT NULL,
+            title TEXT,
+            description TEXT,
+            assignee_agent_id TEXT,
+            status TEXT NOT NULL,
+            predicted_start_ms INTEGER DEFAULT 0,
+            predicted_duration_ms INTEGER DEFAULT 0,
+            bound_span_id TEXT,
+            cancel_reason TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (plan_id, id)
+        );
+        INSERT INTO tasks (
+            plan_id, id, title, status
+        ) VALUES (
+            'plan_legacy', 't_legacy', 'old task', 'PENDING'
+        );
+        """
+    )
+    con.commit()
+    con.close()
+
+    store = make_store("sqlite", db_path=str(db_path))
+    await store.start()
+    try:
+        # Legacy row survives the migration with empty defaults.
+        got = await store.get_task_plan("plan_legacy")
+        assert got is not None
+        assert got.run_id == ""
+        assert len(got.tasks) == 1
+        assert got.tasks[0].id == "t_legacy"
+        assert got.tasks[0].supersedes == ""
+        assert got.tasks[0].supersedes_kind == SupersessionKind.UNSPECIFIED
+
+        # Fresh writes can use the new columns.
+        pb = _build_plan_pb(
+            plan_id="plan_new",
+            run_id="run-fresh",
+            tasks=[("t_new", "t_legacy", gt.SUPERSESSION_KIND_REPLACE)],
+        )
+        stored = goldfive_pb_plan_to_storage(
+            pb, session_id="sess_legacy", created_at=2.0
+        )
+        await store.put_task_plan(stored)
+        rebuilt = await store.get_task_plan("plan_new")
+        assert rebuilt is not None
+        assert rebuilt.run_id == "run-fresh"
+        assert rebuilt.tasks[0].supersedes == "t_legacy"
+        assert rebuilt.tasks[0].supersedes_kind == SupersessionKind.REPLACE
+    finally:
+        await store.close()

--- a/server/tests/test_goldfive_ingest.py
+++ b/server/tests/test_goldfive_ingest.py
@@ -1342,3 +1342,98 @@ async def test_delegation_observed_stored_verbatim(pipeline, store):
     assert delta.kind == DELTA_DELEGATION_OBSERVED
     assert delta.payload["from_agent"] == "client-abc:coordinator_agent"
     assert delta.payload["to_agent"] == "client-abc:research_agent"
+
+
+# ---- run_id-gated dispatch invariant (audit trail consistency) ----------
+#
+# An event without a ``run_id`` cannot be persisted to the audit log
+# (``goldfive_events`` is keyed on (session_id, run_id, sequence)).
+# Pre-fix, the ingest pipeline gated ONLY the audit insert; the
+# per-kind dispatch chain (which writes ``task_plans``, ``tasks``,
+# annotations, …) ran unconditionally. That left silent inconsistency:
+# 3 ``task_plans`` rows for a single ``plan_submitted`` row in
+# ``goldfive_events`` (the symptom that motivated this fix).
+#
+# Invariant: every row in a derived table has a corresponding row in
+# ``goldfive_events``. Achieved by gating the WHOLE dispatch chain on
+# ``kind is not None and run_id``, not just the audit insert.
+
+
+@pytest.mark.asyncio
+async def test_plan_with_empty_run_id_skips_both_writes(pipeline, store):
+    """A plan event with empty ``run_id`` writes neither audit nor derived rows."""
+
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+
+    evt = _make_event(run_id="")  # explicitly empty
+    evt.plan_submitted.plan.CopyFrom(_plan_pb(plan_id="p-empty", run_id=""))
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+
+    # Audit table: empty.
+    assert await store.list_goldfive_events("sess_gf") == []
+    # Derived ``task_plans``: nothing leaked through.
+    assert await store.list_task_plans_for_session("sess_gf") == []
+
+
+@pytest.mark.asyncio
+async def test_plan_with_non_empty_run_id_writes_both(pipeline, store):
+    """Sanity: the gate doesn't accidentally drop legitimate events."""
+
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+
+    evt = _make_event(run_id="run-1")
+    evt.plan_submitted.plan.CopyFrom(_plan_pb(plan_id="p-good", run_id="run-1"))
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+
+    audit = await store.list_goldfive_events("sess_gf", kind="plan_submitted")
+    assert len(audit) == 1
+    plans = await store.list_task_plans_for_session("sess_gf")
+    assert [p.id for p in plans] == ["p-good"]
+
+
+@pytest.mark.asyncio
+async def test_drift_detected_with_empty_run_id_skips_both_writes(pipeline, store):
+    """Other dispatch handlers (drift, etc.) honor the same gate."""
+
+    pipe, bus, _ = pipeline
+    await _ensure_session(store)
+    sub = await bus.subscribe("sess_gf")
+
+    evt = _make_event(run_id="")
+    evt.drift_detected.detail = "skipped"
+    await pipe.handle_message(_stream_ctx(), _wrap(evt))
+
+    assert await store.list_goldfive_events("sess_gf") == []
+    # Bus fan-out is part of the dispatch chain; gating drops it too.
+    assert sub.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_audit_invariant_no_orphan_task_plans(pipeline, store):
+    """Every row in ``task_plans`` has a matching ``goldfive_events`` row.
+
+    Mixes valid and gated events to exercise the invariant under load —
+    the symptom that motivated the fix was 3 ``task_plans`` for 1
+    audit row in a real session.
+    """
+
+    pipe, _bus, _ = pipeline
+    await _ensure_session(store)
+
+    # Three plan_submitted events; only the second carries a run_id.
+    for sequence, (run_id, plan_id) in enumerate(
+        [("", "p-leak-1"), ("run-keep", "p-keep"), ("", "p-leak-2")]
+    ):
+        evt = _make_event(event_id=f"e-{sequence}", sequence=sequence, run_id=run_id)
+        evt.plan_submitted.plan.CopyFrom(
+            _plan_pb(plan_id=plan_id, run_id=run_id)
+        )
+        await pipe.handle_message(_stream_ctx(), _wrap(evt))
+
+    audit = await store.list_goldfive_events("sess_gf", kind="plan_submitted")
+    plans = await store.list_task_plans_for_session("sess_gf")
+    assert {r.run_id for r in audit} == {"run-keep"}
+    assert [p.id for p in plans] == ["p-keep"]
+    assert len(plans) == len(audit) == 1


### PR DESCRIPTION
## Summary

Two regressions surfaced by goldfive #273 (G2 audit). Both real bugs, both surgical fixes.

### Bug 1 — Ingest gate causes silent task_plans leak

`server/harmonograf_server/ingest.py:840` (pre-fix line). The goldfive event handler gated the `goldfive_events` audit-log insert on `kind is not None and run_id`, but the per-kind dispatch chain (which writes `task_plans`, `tasks`, derived rows, …) ran unconditionally. A plan event with empty envelope `run_id` (the wire allows it) skipped the audit insert but still mutated derived tables — the symptom that motivated the fix was 3 `task_plans` rows for a single `plan_submitted` row in `goldfive_events` (session `de7320e7`).

**Choice (a) from the brief**: gate applies to BOTH writes. An event without `run_id` has no provenance, so dropping the dispatch (including bus fan-out) keeps the DB consistent: every row in a derived table has a corresponding row in `goldfive_events`. (Choice (b) — bucket events with empty `run_id` under an "unknown run" — was rejected as more surface for less invariant.)

### Bug 2 — Convert.py drops fields on storage round-trip

`server/harmonograf_server/convert.py::goldfive_pb_plan_to_storage` and `storage_plan_to_goldfive_pb` dropped:
- `Plan.run_id`
- `Task.supersedes`
- `Task.supersedes_kind`

Frontend chain-collapse (`#183`) reads the supersedes link to reconstruct revision chains; null after round-trip breaks the rendering.

**Fix**: schema columns added (`task_plans.run_id`, `tasks.supersedes`, `tasks.supersedes_kind`) with backfill migrations on the existing `start()` migration ladder. `TaskPlan` dataclass gains `run_id`. Converter reads/writes the new fields in both directions. `_upsert_plan` falls through to the envelope `run_id` when the inline `Plan.run_id` is empty (older clients populated only the envelope).

`supersedes_kind` is persisted as the proto enum int (0 UNSPECIFIED / 1 REPLACE / 2 CORRECT). Helpers `_supersession_kind_to_int` / `_supersession_kind_from_int` live in `storage/sqlite.py` so the storage layer doesn't import `convert`.

## Test plan

- [x] Server: `cd server && uv run pytest -x` — 401 passed (388 baseline + 13 new)
- [x] Client: `cd client && uv run pytest -x` — 325 pass (4 pre-existing `test_telemetry_plugin_dedup` failures unrelated to this PR; baseline reproduces them on `main`)
- [x] Frontend: `pnpm tsc -b && pnpm lint && pnpm test --run` — TS clean, lint 1 pre-existing warning, 669 tests pass
- [x] Bug 1 regression tests (`tests/test_goldfive_ingest.py`):
  - `test_plan_with_empty_run_id_skips_both_writes`
  - `test_plan_with_non_empty_run_id_writes_both`
  - `test_drift_detected_with_empty_run_id_skips_both_writes`
  - `test_audit_invariant_no_orphan_task_plans` — mixes valid + gated events, asserts row counts agree
- [x] Bug 2 regression tests (`tests/test_convert_round_trip.py`, parametrized on memory + sqlite stores):
  - `test_pb_to_storage_preserves_run_id_and_supersedes`
  - `test_storage_to_pb_preserves_run_id_and_supersedes`
  - `test_round_trip_idempotent_via_snapshot_json`
  - `test_legacy_plan_without_supersedes_round_trips_with_empty_defaults`
  - `test_storage_round_trip_preserves_run_id_and_supersedes`
  - `test_storage_round_trip_legacy_plan`
  - `test_sqlite_migration_adds_columns_no_data_loss` — pre-fix DB schema, asserts ALTER + data preservation