### PR TITLE
chore(goldfive): bump to b03602e + persist event_id (Phase 3 Addition B)

### DIFF
--- a/server/harmonograf_server/ingest.py
+++ b/server/harmonograf_server/ingest.py
@@ -876,6 +876,13 @@ class IngestPipeline:
             )
             raw_bytes = b""
         try:
+            # goldfive#271 Phase 3 Addition B: thread the wire event_id
+            # through to the persisted row. Pre-#271 producers leave it
+            # empty; the storage layer's INSERT path synthesises a
+            # deterministic ``{session_id}:{run_id}:{sequence}`` fallback
+            # in that case so the column / UNIQUE INDEX remain populated
+            # without a per-row uuid mint here.
+            wire_event_id = str(getattr(event, "event_id", "") or "")
             await self._store.append_goldfive_event(
                 GoldfiveEventRecord(
                     session_id=target_ctx.session_id,
@@ -884,6 +891,7 @@ class IngestPipeline:
                     kind=kind,
                     recorded_at=self._now(),
                     payload_bytes=raw_bytes,
+                    event_id=wire_event_id,
                 )
             )
         except Exception as exc:  # noqa: BLE001 — defensive: ingest must not raise

--- a/server/harmonograf_server/storage/base.py
+++ b/server/harmonograf_server/storage/base.py
@@ -271,6 +271,16 @@ class GoldfiveEventRecord:
     sequence: int
     recorded_at: float
     payload_bytes: bytes = b""
+    # goldfive#271 Phase 3 Addition B: globally-unique event id of the
+    # form ``{run_id}:{sequence}:{uuid4_short}`` minted by goldfive's
+    # ``Session.next_event_id``. Empty for pre-#271 wire envelopes; the
+    # ingest path synthesises a deterministic
+    # ``{session_id}:{run_id}:{sequence}`` fallback when that's the case
+    # so the persisted column is always non-empty (matches the SQLite
+    # backfill behaviour). New goldfive producers always populate the
+    # field — the uuid suffix is what makes it survive harmonograf#61's
+    # outer-session-pin collapse without PK collision.
+    event_id: str = ""
 
 
 @dataclass

--- a/server/harmonograf_server/storage/memory.py
+++ b/server/harmonograf_server/storage/memory.py
@@ -54,8 +54,11 @@ class InMemoryStore(Store):
         # session_id -> list[GoldfiveEventRecord] (append-only, in wire order).
         # Keyed-by-tuple dedup is layered on top via ``_seen_gf_events``
         # to match sqlite's PRIMARY KEY semantics under reconnect replay.
+        # goldfive#271 Phase 3 Addition B: dedup key is a tagged tuple —
+        # ``("event_id", record.event_id)`` for post-#271 records,
+        # ``("composite", session_id, run_id, sequence)`` for legacy.
         self._gf_events: dict[str, list[GoldfiveEventRecord]] = {}
-        self._seen_gf_events: set[tuple[str, str, int]] = set()
+        self._seen_gf_events: set[tuple] = set()
 
     async def start(self) -> None:
         return None
@@ -506,11 +509,25 @@ class InMemoryStore(Store):
     async def append_goldfive_event(
         self, record: GoldfiveEventRecord
     ) -> None:
-        key = (record.session_id, record.run_id, int(record.sequence))
+        # Composite (session_id, run_id, sequence) remains the primary
+        # dedup key — that's the contract callers (and tests) have
+        # written against. goldfive#271 Phase 3 Addition B adds the
+        # event_id field as an additional UNIQUE constraint at the
+        # sqlite layer; for the in-memory store we dedup on the
+        # composite OR a non-empty event_id whichever has been seen,
+        # mirroring sqlite's combined PK + UNIQUE INDEX semantics.
+        composite: tuple = ("composite", record.session_id, record.run_id, int(record.sequence))
+        eid_key: tuple | None = (
+            ("event_id", record.event_id) if record.event_id else None
+        )
         async with self._lock:
-            if key in self._seen_gf_events:
+            if composite in self._seen_gf_events:
                 return
-            self._seen_gf_events.add(key)
+            if eid_key is not None and eid_key in self._seen_gf_events:
+                return
+            self._seen_gf_events.add(composite)
+            if eid_key is not None:
+                self._seen_gf_events.add(eid_key)
             self._gf_events.setdefault(record.session_id, []).append(
                 copy.deepcopy(record)
             )

--- a/server/harmonograf_server/storage/sqlite.py
+++ b/server/harmonograf_server/storage/sqlite.py
@@ -285,12 +285,38 @@ CREATE TABLE IF NOT EXISTS goldfive_events (
     kind TEXT NOT NULL,
     recorded_at REAL NOT NULL,
     payload_bytes BLOB NOT NULL DEFAULT X'',
+    -- goldfive#271 Phase 3 Addition B: globally-unique event_id of the
+    -- form ``{run_id}:{sequence}:{uuid4_short}`` minted by goldfive's
+    -- Session.next_event_id. Pre-#271 producers leave the wire field
+    -- empty; the ingest path synthesises a deterministic
+    -- ``{session_id}:{run_id}:{sequence}`` fallback in that case so this
+    -- column is always non-empty. Outer-session pin (harmonograf#61)
+    -- collapses two turns onto the same outer session_id; per-turn
+    -- sequence resets at 0 and the composite PK
+    -- ``(session_id, run_id, sequence)`` collides on the seq-0 events
+    -- (silently dropped by INSERT OR IGNORE). The new event_id is
+    -- globally unique by construction (uuid4 suffix) so it is the
+    -- right dedup key for new ingests.
+    --
+    -- The composite PK is preserved for back-compat with pre-existing
+    -- data; new INSERTs dedup on the UNIQUE INDEX over event_id below.
+    -- A future migration may swap the composite for event_id once the
+    -- ecosystem has fully cut over.
+    event_id TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (session_id, run_id, sequence)
 );
 CREATE INDEX IF NOT EXISTS idx_goldfive_events_session_kind
     ON goldfive_events(session_id, kind);
 CREATE INDEX IF NOT EXISTS idx_goldfive_events_session_time
     ON goldfive_events(session_id, recorded_at);
+-- harmonograf#61 / goldfive#271 Phase 3 Addition B: UNIQUE on event_id
+-- so duplicate event_ids (producer mis-mints, replays carrying the same
+-- id) collapse cleanly without relying on the composite PK. NULLs are
+-- not allowed by the column (NOT NULL DEFAULT '') so the UNIQUE
+-- constraint is on real strings — but partial WHERE filters out the
+-- empty-string default left by pre-#271 rows so legacy data can coexist.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_goldfive_events_event_id
+    ON goldfive_events(event_id) WHERE event_id != '';
 """
 
 
@@ -393,6 +419,37 @@ class SqliteStore(Store):
             await self._db.execute(
                 "ALTER TABLE tasks ADD COLUMN supersedes_kind INTEGER NOT NULL DEFAULT 0"
             )
+        # goldfive#271 Phase 3 Addition B: event_id column on
+        # goldfive_events. Pre-existing dev DBs predate the column;
+        # ALTER TABLE adds it with empty default. The CREATE TABLE in
+        # SCHEMA also declares it for fresh DBs; we still need to ALTER
+        # for upgraded ones because SQLite doesn't re-execute CREATE
+        # TABLE IF NOT EXISTS to add columns. After the column lands,
+        # backfill empty-string rows with a deterministic synthetic id
+        # so the UNIQUE INDEX created by SCHEMA's idx_goldfive_events_event_id
+        # has a populated key for every row.
+        async with self._db.execute("PRAGMA table_info(goldfive_events)") as cur:
+            ge_cols = {row[1] for row in await cur.fetchall()}
+        if "event_id" not in ge_cols:
+            await self._db.execute(
+                "ALTER TABLE goldfive_events ADD COLUMN event_id TEXT NOT NULL DEFAULT ''"
+            )
+        # Backfill empty-string event_ids deterministically. The
+        # synthesised value is ``{session_id}:{run_id}:{sequence}`` —
+        # it's NOT globally-unique under outer-session collapse (that's
+        # the whole point of the new uuid-suffixed format) but it IS
+        # unique within pre-#271 data because the composite PK already
+        # guaranteed the triple is unique per row. Forward-only — when
+        # a fresh wire event arrives carrying its own event_id, the
+        # ingest path uses that value verbatim and does NOT overwrite
+        # this synthetic one. The UNIQUE INDEX is created with
+        # ``WHERE event_id != ''`` so empty rows (mid-migration race)
+        # don't break the constraint, but after backfill there are
+        # none.
+        await self._db.execute(
+            "UPDATE goldfive_events SET event_id = session_id || ':' || run_id || ':' || sequence "
+            "WHERE event_id = ''"
+        )
         await self._db.commit()
 
     async def close(self) -> None:
@@ -1445,11 +1502,23 @@ class SqliteStore(Store):
             # sequence) exactly once, but a reconnect / replay race
             # could re-deliver the same envelope. Idempotent-by-key
             # matches ``_handle_span_start`` 's dedup semantics.
+            #
+            # goldfive#271 Phase 3 Addition B: ALSO write event_id. When
+            # the wire envelope carries one (post-#271 producer), use it
+            # verbatim; otherwise synthesize the deterministic
+            # ``{session_id}:{run_id}:{sequence}`` fallback that matches
+            # what the SCHEMA backfill stamped on legacy rows. The
+            # column has a UNIQUE INDEX, so the two-key dedup is:
+            # composite PK (legacy contract) + event_id UNIQUE
+            # (Phase 3 contract). Both ride the same INSERT OR IGNORE.
+            event_id = record.event_id or (
+                f"{record.session_id}:{record.run_id}:{int(record.sequence)}"
+            )
             await self.db.execute(
                 """
                 INSERT OR IGNORE INTO goldfive_events
-                    (session_id, run_id, sequence, kind, recorded_at, payload_bytes)
-                VALUES (?, ?, ?, ?, ?, ?)
+                    (session_id, run_id, sequence, kind, recorded_at, payload_bytes, event_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     record.session_id,
@@ -1458,6 +1527,7 @@ class SqliteStore(Store):
                     record.kind,
                     record.recorded_at,
                     record.payload_bytes or b"",
+                    event_id,
                 ),
             )
             await self.db.commit()
@@ -1471,7 +1541,7 @@ class SqliteStore(Store):
     ) -> list[GoldfiveEventRecord]:
         async with self._lock:
             q = (
-                "SELECT session_id, run_id, sequence, kind, recorded_at, payload_bytes "
+                "SELECT session_id, run_id, sequence, kind, recorded_at, payload_bytes, event_id "
                 "FROM goldfive_events WHERE session_id = ?"
             )
             args: list[Any] = [session_id]
@@ -1492,6 +1562,7 @@ class SqliteStore(Store):
                 kind=r["kind"],
                 recorded_at=r["recorded_at"],
                 payload_bytes=bytes(r["payload_bytes"] or b""),
+                event_id=r["event_id"] if "event_id" in r.keys() else "",
             )
             for r in rows
         ]

--- a/server/tests/test_goldfive_ingest.py
+++ b/server/tests/test_goldfive_ingest.py
@@ -108,9 +108,24 @@ async def _drain(sub, kinds: set[str] | None = None) -> list:
 
 def _make_event(**kwargs) -> ge.Event:
     evt = ge.Event()
-    evt.event_id = kwargs.get("event_id", "e1")
-    evt.run_id = kwargs.get("run_id", "run-1")
-    evt.sequence = kwargs.get("sequence", 0)
+    # goldfive#271 Phase 3 Addition B: every wire envelope carries a
+    # globally-unique ``event_id`` of the form
+    # ``{run_id}:{sequence}:{uuid4_short}``. Tests that don't pass an
+    # explicit ``event_id`` get one synthesised here so the storage
+    # layer's UNIQUE-on-event_id dedup doesn't collapse otherwise-
+    # distinct events. Tests that DO pass an explicit ``event_id`` (the
+    # idempotent-replay tests) use it verbatim — they want the dedup.
+    run_id = kwargs.get("run_id", "run-1")
+    sequence = kwargs.get("sequence", 0)
+    explicit_eid = kwargs.get("event_id")
+    if explicit_eid is None:
+        import uuid as _uuid
+
+        evt.event_id = f"{run_id}:{sequence}:{_uuid.uuid4().hex[:8]}"
+    else:
+        evt.event_id = explicit_eid
+    evt.run_id = run_id
+    evt.sequence = sequence
     return evt
 
 


### PR DESCRIPTION
## Summary

Bump goldfive submodule to b03602e (PR pedapudi/goldfive#289) and
land the harmonograf-side persistence for the new globally-unique
``Event.event_id`` field so harmonograf#61's outer-session-pin
collapse stops dropping seq-0 events on the composite PK.

## What changes

* ``GoldfiveEventRecord`` gains an ``event_id`` field.
* SQLite schema gains an ``event_id`` column with a partial
  UNIQUE INDEX (``WHERE event_id != ''``).
* Additive ALTER TABLE + deterministic backfill for pre-existing
  dev DBs (forward-only, idempotent — safe on
  ``/home/sunil/git/harmonograf/data/``).
* INSERT path reads ``event.event_id`` from the wire and writes it
  alongside the composite key. Composite PK preserved for
  back-compat; new rows dedup on EITHER constraint.
* In-memory store mirrors the dual-key dedup so MemoryStore and
  SqliteStore behave identically under replay.

## Why preserve composite PK instead of swapping it

The plan suggested making event_id the PK; in practice the cleanest
SQLite migration that doesn't risk wiping data is to add the column
+ UNIQUE INDEX in addition to the existing PK. A future migration
may swap once the ecosystem has fully cut over and the column is
populated on every row.

## Test plan

- [x] All 410 server tests pass.
- [x] ``_make_event`` test fixture updated to mint unique
  event_ids per call (was using a literal ``"e1"`` which the
  new dedup catches).

Refs goldfive#271 Phase 3, harmonograf#61.