### PR TITLE
fix(telemetry): suppress AgentTool sub-Runner UserMessageReceived (#271)

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -1357,12 +1357,51 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         Idempotent: the duplicate-install guard short-circuits on
         secondary plugin instances. Empty / non-text messages are
         silently dropped — no point surfacing an empty marker.
+
+        AgentTool sub-Runners (harmonograf#271): callbacks fired by a
+        child Runner whose session.id differs from the cached
+        ``_root_session_id`` are dropped. AgentTool builds those
+        Runners with a fresh ``InMemorySessionService`` session and
+        feeds them the coordinator's tool-call args as a synthetic
+        ``Content(role='user', ...)``; without the guard those args
+        surface in the interventions panel as if the operator typed
+        them. The legitimate mid-turn HITL path stays on the parent's
+        session id and continues to emit.
         """
         if self._maybe_disable_as_duplicate(invocation_context):
             return
         text = _extract_user_message_text(user_message)
         if not text:
             return
+        # AgentTool sub-Runner suppression (harmonograf#271).
+        # ADK's ``AgentTool.run_async`` spawns a child Runner with
+        # ``new_message=Content(role='user', parts=[args['request']])``
+        # so the coordinator's tool-call argument flows through the
+        # same ``on_user_message_callback`` path as a real operator
+        # turn. The plugin instance is shared (``include_plugins=True``
+        # on the child Runner), so without a guard each AgentTool
+        # invocation emits a spurious ``UserMessageReceived`` carrying
+        # the model's tool-call args verbatim — these surface in the
+        # interventions panel as if the operator typed them.
+        #
+        # Discriminator: AgentTool builds the child Runner against a
+        # fresh ``InMemorySessionService`` session, so the sub-Runner
+        # ctx's ``session.id`` differs from the cached
+        # ``_root_session_id`` (set by the parent's first
+        # ``before_run_callback``). The legitimate mid-turn HITL path
+        # uses the SAME invocation_id (parent's), keeping its session
+        # id == _root_session_id, so it still emits.
+        sub_runner_session = ""
+        if self._root_session_id is not None:
+            sub_runner_session = _adk_session_id(invocation_context)
+            if sub_runner_session and sub_runner_session != self._root_session_id:
+                log.debug(
+                    "telemetry_plugin: suppressing UserMessageReceived from "
+                    "AgentTool sub-Runner (root_sid=%s, sub_sid=%s)",
+                    self._root_session_id,
+                    sub_runner_session,
+                )
+                return
         # Author hint: ADK's ``invocation_context.user_id`` is the
         # operator-side identifier; default to "user" when absent so
         # the frontend always has a non-empty author label.

--- a/client/tests/test_sink_user_messages.py
+++ b/client/tests/test_sink_user_messages.py
@@ -250,6 +250,123 @@ class TestUserMessageEmission:
         assert env.payload.content == "from dict"
 
 
+class TestAgentToolSubRunnerSuppression:
+    """harmonograf#271: AgentTool spawns a child Runner with the
+    coordinator's tool-call args wrapped as ``Content(role='user',
+    ...)``. Because the child Runner inherits the parent's plugin
+    instance (``include_plugins=True``), every AgentTool invocation
+    used to fire ``on_user_message_callback`` and emit a spurious
+    ``UserMessageReceived`` carrying the model's args verbatim —
+    those then surfaced in the interventions panel as if the operator
+    had typed them.
+
+    Discriminator: AgentTool builds the child Runner against a fresh
+    ``InMemorySessionService`` session, so the sub-Runner ctx's
+    ``session.id`` differs from the cached ``_root_session_id`` (set
+    by the parent's first ``before_run_callback``). The plugin must
+    suppress those, while still emitting for the legitimate mid-turn
+    HITL path which stays on the parent's session id."""
+
+    @pytest.mark.asyncio
+    async def test_sub_runner_user_message_suppressed(
+        self, plugin: HarmonografTelemetryPlugin, client: Client
+    ) -> None:
+        """The coordinator's tool-call args, replayed by AgentTool as
+        a synthetic user message on a fresh sub-Runner session, must
+        NOT be emitted as a UserMessageReceived envelope."""
+        # 1. Parent run opens — establishes _root_session_id.
+        parent_ctx = _InvocationContext("inv-parent", "sess-user-msg", [plugin])
+        await plugin.before_run_callback(invocation_context=parent_ctx)
+        # Drain the parent's INVOCATION span_start so the assertion
+        # below is unambiguous.
+        _drain(client)
+        # 2. The parent's first user turn arrives — emits as expected.
+        await plugin.on_user_message_callback(
+            invocation_context=parent_ctx,
+            user_message=_Content(
+                [_Part(text="Create a presentation about solar panels.")]
+            ),
+        )
+        envs = _drain(client)
+        user_envs = [e for e in envs if e.kind is EnvelopeKind.USER_MESSAGE]
+        assert len(user_envs) == 1
+        assert user_envs[0].payload.content == (
+            "Create a presentation about solar panels."
+        )
+        # 3. AgentTool spawns a child Runner with a fresh session id
+        # and feeds the coordinator's tool-call args as a synthetic
+        # ``Content(role='user', ...)``. This must be suppressed.
+        sub_ctx = _InvocationContext(
+            "inv-child-research",
+            # Distinct session id — matches AgentTool's
+            # ``InMemorySessionService.create_session`` behaviour.
+            "sess-agent-tool-child",
+            [plugin],
+        )
+        await plugin.on_user_message_callback(
+            invocation_context=sub_ctx,
+            user_message=_Content(
+                [
+                    _Part(
+                        text=(
+                            "Gather all relevant facts, types, benefits, "
+                            "installation considerations, and technical details."
+                        )
+                    )
+                ]
+            ),
+        )
+        envs = _drain(client)
+        user_envs = [e for e in envs if e.kind is EnvelopeKind.USER_MESSAGE]
+        assert user_envs == [], (
+            "AgentTool sub-Runner user message must not surface; got "
+            f"{[e.payload.content for e in user_envs]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mid_turn_hitl_still_emits_on_parent_session(
+        self, plugin: HarmonografTelemetryPlugin, client: Client
+    ) -> None:
+        """Regression guard for the legitimate mid-turn path: a
+        user message that lands while the parent invocation is open
+        and shares the parent's session id must still emit (the
+        existing ``mid_turn=True`` semantics). The sub-Runner guard
+        only fires when the session id differs."""
+        ctx = _InvocationContext("inv-hitl", "sess-user-msg", [plugin])
+        await plugin.before_run_callback(invocation_context=ctx)
+        _drain(client)
+        await plugin.on_user_message_callback(
+            invocation_context=ctx,
+            user_message=_Content([_Part(text="interject!")]),
+        )
+        envs = _drain(client)
+        user_envs = [e for e in envs if e.kind is EnvelopeKind.USER_MESSAGE]
+        assert len(user_envs) == 1
+        assert user_envs[0].payload.content == "interject!"
+        assert user_envs[0].payload.mid_turn is True
+
+    @pytest.mark.asyncio
+    async def test_pre_root_user_message_emits(
+        self, plugin: HarmonografTelemetryPlugin, client: Client
+    ) -> None:
+        """Before any ``before_run_callback`` fires the cache is
+        ``None``: the discriminator must NOT short-circuit and the
+        message must emit normally. ADK orders
+        ``on_user_message_callback`` strictly before
+        ``before_run_callback`` on the root invocation."""
+        ctx = _InvocationContext("inv-pre-root", "sess-user-msg", [plugin])
+        # Note: no before_run_callback first.
+        assert plugin._root_session_id is None
+        await plugin.on_user_message_callback(
+            invocation_context=ctx,
+            user_message=_Content([_Part(text="first turn")]),
+        )
+        envs = _drain(client)
+        user_envs = [e for e in envs if e.kind is EnvelopeKind.USER_MESSAGE]
+        assert len(user_envs) == 1
+        assert user_envs[0].payload.content == "first turn"
+
+
 class TestDuplicateInstall:
     @pytest.mark.asyncio
     async def test_duplicate_plugin_skips_callback(


### PR DESCRIPTION
## Summary

- Coordinator's tool-call args were surfacing in the harmonograf interventions panel as USER_MESSAGE entries, inflating the count and confusing operators about what the user actually typed.
- Root cause: ADK's ``AgentTool.run_async`` spawns a child Runner with ``new_message=Content(role='user', parts=[args['request']])``. Because ``include_plugins=True`` makes the child inherit the parent's ``HarmonografTelemetryPlugin`` instance, every AgentTool invocation fired ``on_user_message_callback`` and emitted a spurious ``UserMessageReceived`` carrying the model's tool-call args verbatim.
- Fix: suppress callbacks fired by a child Runner whose ``session.id`` differs from the cached ``_root_session_id`` (set by the parent's first ``before_run_callback``). AgentTool builds its child Runner against a fresh ``InMemorySessionService`` session, so the discriminator is exact. The legitimate mid-turn HITL path keeps the parent's session id and continues to emit.

## Test plan

- [x] New regression test ``test_sub_runner_user_message_suppressed`` fails on origin/main, passes with the fix.
- [x] ``test_mid_turn_hitl_still_emits_on_parent_session`` confirms the existing mid-turn HITL semantics are preserved.
- [x] ``test_pre_root_user_message_emits`` confirms the very first user turn (before any ``before_run``) is unaffected.
- [x] All 347 ``client/`` tests pass.