### PR TITLE
fix(gantt): scale agent lane height to fit concurrent spans (#271)

### DIFF
--- a/frontend/src/__tests__/gantt/laneScaling.test.ts
+++ b/frontend/src/__tests__/gantt/laneScaling.test.ts
@@ -1,0 +1,231 @@
+// Regression for harmonograf#271: an agent with multiple concurrent spans
+// must vertically scale its row so each span lands on a distinct sub-track,
+// instead of every span stacking on lane 0 and the rear ones disappearing
+// behind the front (the v15presmtx-1 goldfive lane symptom).
+//
+// We exercise three contracts:
+//   1. packLanes() returns the correct lane count and assigns concurrent
+//      spans to distinct lane indices (max-concurrency = N → uses N lanes).
+//   2. GanttRenderer.rowHeight scales above ROW_HEIGHT_PX once the agent's
+//      lane count exceeds the legacy 3-track budget.
+//   3. The rectangles for two concurrent spans on the same agent end up at
+//      different y offsets (no overlap on the canvas).
+
+import { describe, expect, it } from 'vitest';
+import { GanttRenderer } from '../../gantt/renderer';
+import { SessionStore } from '../../gantt/index';
+import { packLanes } from '../../gantt/layout';
+import {
+  ROW_HEIGHT_PX,
+  SUB_LANE_HEIGHT_PX,
+  TOP_MARGIN_PX,
+} from '../../gantt/viewport';
+import type { Span } from '../../gantt/types';
+
+function stubCtx(): CanvasRenderingContext2D {
+  const handler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'canvas') return { width: 1200, height: 400 };
+      if (prop === 'globalAlpha') return 1;
+      if (prop === 'measureText') return () => ({ width: 10 });
+      return () => undefined;
+    },
+    set() {
+      return true;
+    },
+  };
+  return new Proxy({}, handler) as CanvasRenderingContext2D;
+}
+
+function stubCanvas(): HTMLCanvasElement {
+  const el = document.createElement('canvas');
+  el.width = 1200;
+  el.height = 400;
+  (el as unknown as { getContext: () => CanvasRenderingContext2D }).getContext =
+    () => stubCtx();
+  return el;
+}
+
+function mkAgent(store: SessionStore, id: string): void {
+  store.agents.upsert({
+    id,
+    name: id,
+    framework: 'ADK',
+    status: 'CONNECTED',
+    capabilities: [],
+    connectedAtMs: 0,
+    currentActivity: '',
+    stuck: false,
+    taskReport: '',
+    taskReportAt: 0,
+    metadata: {},
+  });
+}
+
+function mkSpan(overrides: Partial<Span> & { id: string; agentId: string }): Span {
+  return {
+    sessionId: 'sess',
+    parentSpanId: null,
+    kind: 'CUSTOM',
+    name: 'span',
+    status: 'COMPLETED',
+    startMs: 0,
+    endMs: null,
+    lane: -1,
+    attributes: {},
+    payloadRefs: [],
+    links: [],
+    replaced: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe('packLanes() concurrency tracking (harmonograf#271)', () => {
+  it('assigns two concurrent spans to distinct lanes and reports laneCount=2', () => {
+    const spans: Span[] = [
+      mkSpan({ id: 'a', agentId: 'g', startMs: 0, endMs: 1000 }),
+      mkSpan({ id: 'b', agentId: 'g', startMs: 200, endMs: 800 }),
+    ];
+    const count = packLanes(spans);
+    expect(count).toBe(2);
+    const a = spans.find((s) => s.id === 'a')!;
+    const b = spans.find((s) => s.id === 'b')!;
+    expect(a.lane).not.toBe(b.lane);
+    expect(new Set([a.lane, b.lane])).toEqual(new Set([0, 1]));
+  });
+
+  it('reuses lane 0 once the prior span ends (no over-allocation)', () => {
+    const spans: Span[] = [
+      mkSpan({ id: 'a', agentId: 'g', startMs: 0, endMs: 100 }),
+      mkSpan({ id: 'b', agentId: 'g', startMs: 200, endMs: 300 }),
+    ];
+    const count = packLanes(spans);
+    expect(count).toBe(1);
+    expect(spans[0].lane).toBe(0);
+    expect(spans[1].lane).toBe(0);
+  });
+
+  it('handles 4-way concurrency (lane budget exceeds default 3-track row)', () => {
+    const spans: Span[] = [
+      mkSpan({ id: 'a', agentId: 'g', startMs: 0, endMs: 1000 }),
+      mkSpan({ id: 'b', agentId: 'g', startMs: 100, endMs: 900 }),
+      mkSpan({ id: 'c', agentId: 'g', startMs: 200, endMs: 800 }),
+      mkSpan({ id: 'd', agentId: 'g', startMs: 300, endMs: 700 }),
+    ];
+    const count = packLanes(spans);
+    expect(count).toBe(4);
+    const lanes = spans.map((s) => s.lane).sort();
+    expect(lanes).toEqual([0, 1, 2, 3]);
+  });
+});
+
+describe('GanttRenderer row-height scaling (harmonograf#271)', () => {
+  it('keeps the default row height for <=3 concurrent spans', () => {
+    const store = new SessionStore();
+    mkAgent(store, 'g');
+    store.spans.append(
+      mkSpan({ id: 'a', agentId: 'g', startMs: 0, endMs: 1000 }),
+    );
+    store.spans.append(
+      mkSpan({ id: 'b', agentId: 'g', startMs: 200, endMs: 800 }),
+    );
+    packLanes(
+      store.spans.queryAgent(
+        'g',
+        -Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+      ),
+    );
+
+    const r = new GanttRenderer(store);
+    r.attach(stubCanvas(), stubCanvas(), stubCanvas());
+    r.resize(1200, 200, 1);
+
+    const layout = r.getRowLayout();
+    expect(layout).toHaveLength(1);
+    expect(layout[0].height).toBe(ROW_HEIGHT_PX);
+    r.detach();
+  });
+
+  it('scales the row vertically when concurrency exceeds the 3-track budget', () => {
+    const store = new SessionStore();
+    mkAgent(store, 'g');
+    // Four mutually-overlapping spans → laneCount=4.
+    for (const id of ['a', 'b', 'c', 'd']) {
+      store.spans.append(
+        mkSpan({
+          id,
+          agentId: 'g',
+          startMs: 0 + ['a', 'b', 'c', 'd'].indexOf(id) * 50,
+          endMs: 10_000,
+        }),
+      );
+    }
+    packLanes(
+      store.spans.queryAgent(
+        'g',
+        -Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+      ),
+    );
+
+    const r = new GanttRenderer(store);
+    r.attach(stubCanvas(), stubCanvas(), stubCanvas());
+    r.resize(1200, 400, 1);
+
+    const layout = r.getRowLayout();
+    expect(layout).toHaveLength(1);
+    // The 3-lane base height was ROW_HEIGHT_PX = 56 → baseLaneH=18; for
+    // laneCount=4 the row must be at least 4*18 + 4 = 76px.
+    const baseLaneH = Math.max(SUB_LANE_HEIGHT_PX, Math.floor(ROW_HEIGHT_PX / 3));
+    expect(layout[0].height).toBeGreaterThan(ROW_HEIGHT_PX);
+    expect(layout[0].height).toBe(4 * baseLaneH + 4);
+    r.detach();
+  });
+
+  it('places two concurrent spans at distinct y offsets via rectFor()', () => {
+    const store = new SessionStore();
+    mkAgent(store, 'g');
+    store.spans.append(
+      mkSpan({ id: 'front', agentId: 'g', startMs: 0, endMs: 5_000 }),
+    );
+    store.spans.append(
+      mkSpan({ id: 'rear', agentId: 'g', startMs: 1_000, endMs: 4_000 }),
+    );
+    packLanes(
+      store.spans.queryAgent(
+        'g',
+        -Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+      ),
+    );
+
+    const r = new GanttRenderer(store);
+    r.attach(stubCanvas(), stubCanvas(), stubCanvas());
+    r.resize(1200, 200, 1);
+    r.setViewport({
+      endMs: 5_000,
+      windowMs: 5_000,
+      liveFollow: false,
+      replay: false,
+    });
+
+    const front = r.rectFor('front');
+    const rear = r.rectFor('rear');
+    expect(front).not.toBeNull();
+    expect(rear).not.toBeNull();
+    expect(front!.y).not.toBe(rear!.y);
+    // Both rects should fit inside the row's vertical extent.
+    const layout = r.getRowLayout();
+    const top = layout[0].top;
+    const bottom = top + layout[0].height;
+    expect(front!.y).toBeGreaterThanOrEqual(top);
+    expect(front!.y + front!.h).toBeLessThanOrEqual(bottom);
+    expect(rear!.y).toBeGreaterThanOrEqual(top);
+    expect(rear!.y + rear!.h).toBeLessThanOrEqual(bottom);
+    // Sanity: row above the agent is the time axis margin.
+    expect(top).toBe(TOP_MARGIN_PX);
+    r.detach();
+  });
+});

--- a/frontend/src/gantt/layout.ts
+++ b/frontend/src/gantt/layout.ts
@@ -7,6 +7,10 @@ import type { Span } from './types';
 //
 // This function mutates spans in place. It does NOT guarantee stable lanes
 // across rebuilds — if you need stability, rebuild only affected agents.
+//
+// Returns the number of lanes used (= max concurrency at any timestamp). The
+// renderer uses this count to vertically size the agent's row so concurrent
+// spans render on distinct sub-tracks instead of overlapping (harmonograf#271).
 
 export function packLanes(spans: Span[]): number {
   // Sort (stable): startMs, then endMs ascending, so nested spans get lane 1+

--- a/frontend/src/gantt/renderer.ts
+++ b/frontend/src/gantt/renderer.ts
@@ -128,17 +128,41 @@ interface FrameMetrics {
 // Shared row/lane → Y math. Used by drawBlocks, drawLinks, and drawDelegations
 // so a span's rendered Y center matches the arrow anchors exactly. Keep in
 // sync with the inline `laneTop = row.top + 2 + lane * laneH` formula used by
-// the block draw pass.
+// the block draw pass. `laneCount` lets the row scale vertically when an
+// agent has more than 3 concurrent spans so sub-tracks don't overlap or
+// bleed into the next agent's row (harmonograf#271).
 interface RowLayoutLite {
   top: number;
   height: number;
+  laneCount: number;
 }
-function laneCenterY(row: RowLayoutLite, lane: number): number {
+
+// Per-lane vertical pitch within a row. Divides the row into max(3, laneCount)
+// sub-tracks: with a 3-lane budget the math reduces to the legacy formula
+// (`floor(rowH/3)`) so existing visuals stay unchanged for the typical case;
+// with more lanes, rowHeight() has already scaled the row up so each lane
+// keeps the same visual height (~18px regular, ~40px focused).
+function laneHeightFor(rowH: number, laneCount: number): number {
+  const denom = Math.max(3, Math.max(1, laneCount));
+  return Math.max(SUB_LANE_HEIGHT_PX, Math.floor(rowH / denom));
+}
+
+function laneRect(
+  rowTop: number,
+  rowH: number,
+  laneCount: number,
+  lane: number,
+): { laneTop: number; rectH: number } {
   const laneIdx = lane >= 0 ? lane : 0;
-  const laneH = Math.max(SUB_LANE_HEIGHT_PX, Math.floor(row.height / 3));
-  const laneTop = row.top + 2 + laneIdx * laneH;
-  const laneBot = Math.min(row.top + row.height - 2, laneTop + laneH - 2);
+  const laneH = laneHeightFor(rowH, laneCount);
+  const laneTop = rowTop + 2 + laneIdx * laneH;
+  const laneBot = Math.min(rowTop + rowH - 2, laneTop + laneH - 2);
   const rectH = Math.max(6, laneBot - laneTop);
+  return { laneTop, rectH };
+}
+
+function laneCenterY(row: RowLayoutLite, lane: number): number {
+  const { laneTop, rectH } = laneRect(row.top, row.height, row.laneCount, lane);
   return laneTop + rectH / 2;
 }
 
@@ -918,6 +942,7 @@ export class GanttRenderer {
         y += rowH;
         continue;
       }
+      const laneCount = this.getLaneCount(agent.id);
       const rowDataX = GUTTER_WIDTH_PX + 10; // skip color strip
       const scratch: Span[] = [];
       spanIndex.queryAgent(agent.id, vs, ve, scratch);
@@ -930,10 +955,7 @@ export class GanttRenderer {
         );
         const x2 = msToPx(this.viewport, w, s.endMs ?? this.store.nowMs);
         const width = Math.max(MIN_BLOCK_WIDTH_PX, x2 - x1);
-        const laneH = Math.max(SUB_LANE_HEIGHT_PX, Math.floor(rowH / 3));
-        const laneTop = y + 2 + (s.lane >= 0 ? s.lane : 0) * laneH;
-        const laneBot = Math.min(y + rowH - 2, laneTop + laneH - 2);
-        const rectH = Math.max(6, laneBot - laneTop);
+        const { laneTop, rectH } = laneRect(y, rowH, laneCount, s.lane);
         if (width < MIN_BLOCK_WIDTH_PX * 2 && s.status !== 'AWAITING_HUMAN') {
           // Merge into a density stripe for this lane.
           const d = laneDensity.get(s.lane >= 0 ? s.lane : 0);
@@ -1169,12 +1191,13 @@ export class GanttRenderer {
     // Row layout lookup: top, height, center. We need top+height to resolve
     // per-span lane positions so link anchors land on the actual bar, not the
     // row's center line.
-    type RowLayout = { top: number; height: number; centerY: number };
+    type RowLayout = { top: number; height: number; centerY: number; laneCount: number };
     const rowLayout = new Map<string, RowLayout>();
     let y = TOP_MARGIN_PX;
     for (const agent of agents) {
       const rowH = this.rowHeight(agent.id);
-      rowLayout.set(agent.id, { top: y, height: rowH, centerY: y + rowH / 2 });
+      const laneCount = this.getLaneCount(agent.id);
+      rowLayout.set(agent.id, { top: y, height: rowH, centerY: y + rowH / 2, laneCount });
       y += rowH;
     }
     const spanCenterY = (s: Span, row: RowLayout): number =>
@@ -1276,12 +1299,13 @@ export class GanttRenderer {
     // NOT the row midline. On a 3-sub-lane row the INVOCATION bar sits at
     // ~row.top+10 while the midline is at row.top+28, so anchoring to
     // midline leaves the arrow floating below the bar (harmonograf#129).
-    type RowLayout = { top: number; height: number; centerY: number };
+    type RowLayout = { top: number; height: number; centerY: number; laneCount: number };
     const rowLayout = new Map<string, RowLayout>();
     let y = TOP_MARGIN_PX;
     for (const agent of agents) {
       const rowH = this.rowHeight(agent.id);
-      rowLayout.set(agent.id, { top: y, height: rowH, centerY: y + rowH / 2 });
+      const laneCount = this.getLaneCount(agent.id);
+      rowLayout.set(agent.id, { top: y, height: rowH, centerY: y + rowH / 2, laneCount });
       y += rowH;
     }
 
@@ -1775,7 +1799,7 @@ export class GanttRenderer {
 
       if (mode === 'ghost' || mode === 'hybrid') {
         // Ghost rect at predicted time, bottom lane of the row.
-        const laneH = Math.max(SUB_LANE_HEIGHT_PX, Math.floor(rowH / 3));
+        const laneH = laneHeightFor(rowH, this.getLaneCount(agent.id));
         const ghostH = Math.max(8, laneH - 4);
         const ghostY = y + rowH - ghostH - 3;
         for (const task of tasks) {
@@ -2220,6 +2244,7 @@ export class GanttRenderer {
     const scratch: Span[] = [];
     for (const agent of agents) {
       const rowH = this.rowHeight(agent.id);
+      const laneCount = this.getLaneCount(agent.id);
       scratch.length = 0;
       this.store.spans.queryAgent(agent.id, vs, ve, scratch);
       for (const s of scratch) {
@@ -2227,9 +2252,7 @@ export class GanttRenderer {
         const x1 = Math.max(GUTTER_WIDTH_PX + 10, msToPx(this.viewport, this.widthCss, s.startMs));
         const x2 = msToPx(this.viewport, this.widthCss, s.endMs ?? this.store.nowMs);
         const width = Math.max(MIN_BLOCK_WIDTH_PX, x2 - x1);
-        const laneH = Math.max(SUB_LANE_HEIGHT_PX, Math.floor(rowH / 3));
-        const laneTop = y + 2 + (s.lane >= 0 ? s.lane : 0) * laneH;
-        const rectH = Math.max(6, Math.min(y + rowH - 2, laneTop + laneH - 2) - laneTop);
+        const { laneTop, rectH } = laneRect(y, rowH, laneCount, s.lane);
         if (s.status === 'RUNNING') {
           ctx.globalAlpha = breathe * 0.35;
           ctx.fillStyle = cssVar('--md-sys-color-primary') || '#a8c8ff';
@@ -2261,6 +2284,7 @@ export class GanttRenderer {
       if (py >= y && py < y + rowH) {
         const vs = viewportStart(this.viewport);
         const ve = this.viewport.endMs;
+        const laneCount = this.getLaneCount(agent.id);
         scratch.length = 0;
         this.store.spans.queryAgent(agent.id, vs, ve, scratch);
         // Iterate back-to-front so topmost sublane wins.
@@ -2269,9 +2293,7 @@ export class GanttRenderer {
           const x1 = Math.max(GUTTER_WIDTH_PX + 10, msToPx(this.viewport, this.widthCss, s.startMs));
           const x2 = msToPx(this.viewport, this.widthCss, s.endMs ?? this.store.nowMs);
           const width = Math.max(MIN_BLOCK_WIDTH_PX, x2 - x1);
-          const laneH = Math.max(SUB_LANE_HEIGHT_PX, Math.floor(rowH / 3));
-          const laneTop = y + 2 + (s.lane >= 0 ? s.lane : 0) * laneH;
-          const rectH = Math.max(6, Math.min(y + rowH - 2, laneTop + laneH - 2) - laneTop);
+          const { laneTop, rectH } = laneRect(y, rowH, laneCount, s.lane);
           // Expand hit zone by 4px on each side so small blocks are easier to click.
           if (px >= x1 - 4 && px <= x1 + width + 4 && py >= laneTop && py <= laneTop + rectH) {
             return s.id;
@@ -2298,9 +2320,8 @@ export class GanttRenderer {
         );
         const x2 = msToPx(this.viewport, this.widthCss, s.endMs ?? this.store.nowMs);
         const width = Math.max(MIN_BLOCK_WIDTH_PX, x2 - x1);
-        const laneH = Math.max(SUB_LANE_HEIGHT_PX, Math.floor(rowH / 3));
-        const laneTop = y + 2 + (s.lane >= 0 ? s.lane : 0) * laneH;
-        const rectH = Math.max(6, Math.min(y + rowH - 2, laneTop + laneH - 2) - laneTop);
+        const laneCount = this.getLaneCount(agent.id);
+        const { laneTop, rectH } = laneRect(y, rowH, laneCount, s.lane);
         return { x: x1, y: laneTop, w: width, h: rectH };
       }
       y += rowH;
@@ -2310,7 +2331,35 @@ export class GanttRenderer {
 
   private rowHeight(agentId: string): number {
     if (this.hiddenAgentIds.has(agentId)) return ROW_HEIGHT_COLLAPSED_PX;
-    return agentId === this.focusedAgentId ? ROW_HEIGHT_FOCUSED_PX : ROW_HEIGHT_PX;
+    const base = agentId === this.focusedAgentId ? ROW_HEIGHT_FOCUSED_PX : ROW_HEIGHT_PX;
+    // harmonograf#271: when an agent has more than the default 3-lane budget
+    // of concurrent activity, expand the row vertically so each sub-track
+    // keeps its visual height (~18px regular, ~40px focused) instead of
+    // overlapping or bleeding into the next agent's row. baseLaneH is
+    // derived from the default 3-track budget so 1–3-lane rows render at
+    // exactly the legacy size.
+    const laneCount = this.getLaneCount(agentId);
+    if (laneCount <= 3) return base;
+    const baseLaneH = Math.max(SUB_LANE_HEIGHT_PX, Math.floor(base / 3));
+    return laneCount * baseLaneH + 4; // 2px top + 2px bottom padding
+  }
+
+  // Concurrency-derived lane count for a given agent: the highest lane index
+  // assigned by packLanes() across that agent's spans, plus one. Returns 0
+  // when the agent has no spans (in which case rowHeight() falls back to its
+  // default). Linear in the per-agent span count; cheap enough to call from
+  // every getRowLayout() / draw pass without caching.
+  private getLaneCount(agentId: string): number {
+    const spans = this.store.spans.queryAgent(
+      agentId,
+      -Number.MAX_SAFE_INTEGER,
+      Number.MAX_SAFE_INTEGER,
+    );
+    let max = -1;
+    for (const s of spans) {
+      if (s.lane > max) max = s.lane;
+    }
+    return max + 1;
   }
 
   // --- Perf ---------------------------------------------------------------

--- a/frontend/src/rpc/hooks.ts
+++ b/frontend/src/rpc/hooks.ts
@@ -31,6 +31,22 @@ import {
 } from './goldfiveEvent';
 import { loadPlanHistory } from '../state/planHistoryLoader';
 
+// Repack the lanes for a single agent so concurrent spans land on distinct
+// sub-tracks (harmonograf#271). Convert paths leave new spans at lane=-1; the
+// renderer treats that as lane 0, so without a per-event repack every
+// concurrent live span stacks on top of its peers. Called from the live
+// arms (newSpan / endedSpan / goldfiveEvent) — burstComplete still does its
+// own per-agent sweep over the full snapshot.
+function repackAgentLanes(store: SessionStore, agentId: string): void {
+  if (!agentId) return;
+  const spans = store.spans.queryAgent(
+    agentId,
+    -Number.MAX_SAFE_INTEGER,
+    Number.MAX_SAFE_INTEGER,
+  );
+  packLanes(spans);
+}
+
 // Translate the generated SessionStatus enum to the closed string set
 // consumers actually care about. Unknown numeric values fall through to
 // 'UNKNOWN' so a forward-compatible server can't blow the UI up.
@@ -389,6 +405,12 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
                 if (ui.agentId.endsWith(':goldfive')) {
                   store.mergeGoldfiveAlias();
                 }
+                // harmonograf#271: repack lanes for the affected agent so
+                // concurrent spans land on distinct sub-tracks. Without
+                // this, every live span keeps its convertSpan default of
+                // lane=-1 (rendered as lane 0) and overlapping spans
+                // stack on top of each other on the same agent row.
+                repackAgentLanes(store, ui.agentId);
               }
               break;
             }
@@ -418,6 +440,7 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
             case 'endedSpan': {
               const existing = store.spans.get(kind.value.spanId);
               if (existing) {
+                const wasOpen = existing.endMs === null;
                 if (kind.value.endTime && origin) {
                   existing.endMs =
                     Number(kind.value.endTime.seconds) * 1000 +
@@ -441,6 +464,13 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
                   existing.payloadRefs = kind.value.payloadRefs.map(convertPayloadRef);
                 }
                 store.spans.update(existing);
+                // harmonograf#271: a finalized end time can free up a lane
+                // a later span had been forced past — repack so the lane
+                // assignment shrinks back when concurrency drops. Cheap
+                // (per-agent sort) and bounded by typical lane counts.
+                if (wasOpen) {
+                  repackAgentLanes(store, existing.agentId);
+                }
                 // If an INVOCATION span just ended and the agent has no other
                 // running INVOCATION spans, clear any stale taskReport so the
                 // Graph view doesn't keep showing "Thinking: …" after the agent
@@ -528,6 +558,13 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
                 origin?.startMs ?? 0,
                 sessionId,
               );
+              // harmonograf#271: several goldfive event types synthesize
+              // spans on the canonical goldfive actor row (drift, refine,
+              // judge, …). Repack that row so concurrent synthetic spans
+              // (e.g. a long refine_steer overlapping a judge call) get
+              // distinct sub-tracks. Repacking by ID is cheap and
+              // idempotent for events that don't append spans.
+              repackAgentLanes(store, store.resolveGoldfiveActorId());
               break;
             }
             case 'refineAttempted': {
@@ -551,6 +588,9 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
                 origin?.startMs ?? 0,
                 sessionId,
               );
+              // Repack the goldfive row: applyRefineFailed synthesizes a
+              // CUSTOM span there (harmonograf#271).
+              repackAgentLanes(store, store.resolveGoldfiveActorId());
               break;
             }
             case 'userMessage': {
@@ -565,6 +605,9 @@ export function useSessionWatch(sessionId: string | null): WatchSessionState {
                 origin?.startMs ?? 0,
                 sessionId,
               );
+              // Repack the user actor row: applyUserMessage synthesizes a
+              // USER_MESSAGE span there (harmonograf#271).
+              repackAgentLanes(store, '__user__');
               break;
             }
             case 'taskReport': {


### PR DESCRIPTION
## Summary
- Live spans landed at convertSpan's default \`lane: -1\` (rendered as lane 0) on every \`newSpan\` event — concurrent spans on a single agent row stacked on top of each other. The burst path called \`packLanes\` but the live/goldfive-event paths did not. Goldfive's purple \`refine_steer\` overlapping a judge call disappeared visually.
- Repack per-agent lanes after each live \`newSpan\`, \`endedSpan\` (open → finalized), \`goldfiveEvent\`, \`refineFailed\`, and \`userMessage\` arrival.
- Scale each agent row vertically when its concurrency exceeds the default 3-track budget so lane 4+ no longer bleeds into the next agent's row. 1–3-lane rows render at their existing size.
- Centralize lane Y math in \`laneRect()\` / \`laneHeightFor()\` so drawBlocks, drawLinks, drawDelegations, drawAnimatedSpans, hitTest, and rectForSpan share one source of truth.

## Test plan
- [x] \`npm test -- laneScaling\` (6 new tests pass, covering packLanes concurrency tracking, rowHeight scaling above 3 lanes, distinct y offsets via rectFor() for two concurrent spans on the same agent)
- [x] Full \`npm test\` — all gantt + delegation tests still pass; only pre-existing TrajectoryView.headerMath failures remain (unrelated, also fail on \`main\`)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` (no new warnings)
- [x] Manual: visited \`v15presmtx-1\` on a running stack against this branch — goldfive lane renders \`refine_steer\` and \`goal_derive\` on distinct vertical sub-tracks within the same row.

Closes #271