### PR TITLE
fix(interventions): filter synthetic install plan-revisions from UI

### DIFF
--- a/frontend/src/__tests__/lib/interventions.test.ts
+++ b/frontend/src/__tests__/lib/interventions.test.ts
@@ -185,6 +185,96 @@ describe('deriveInterventions', () => {
     }
   });
 
+  // goldfive#271 follow-up: v17 UI regression. PR #302 set
+  // ``synthetic = true`` on Runner._install_revision's drift and PR
+  // #219 made the deriver filter synthetic drifts. But the matching
+  // PlanRevised carries the synthetic drift's id as triggerEventId
+  // with no synthetic flag of its own (the proto field doesn't exist
+  // on PlanRevised) — so once the drift was filtered, the
+  // plan-revision row fell through the strict-id merge alone and
+  // surfaced as a phantom ``STEER WARNING -> REV 1`` card at 0:22 on
+  // every fresh user turn (v17 session
+  // 845dcbe8-0861-452f-b7ba-e37703458785). This test pins the third
+  // leak path: a plan-revision row whose triggerEventId matches a
+  // synthetic drift's id MUST be filtered too.
+  it('filters synthetic install plan-revisions from the interventions panel', () => {
+    const rows = deriveInterventions({
+      annotations: [
+        // Real operator STEER drives revision 2.
+        mkAnnotation({
+          id: 'ann_real',
+          createdAtMs: 240,
+          author: 'alice',
+          body: 'operator-Alice: refocus on flares',
+        }),
+      ],
+      drifts: [
+        // Synthetic install drift — filtered by the existing PR #219
+        // loop. We're checking the plan-revision filter doesn't depend
+        // on the drift surviving.
+        mkDrift({
+          seq: 0,
+          kind: 'user_steer',
+          severity: 'warning',
+          recordedAtMs: 100,
+          driftId: 'drift_install_v17',
+          synthetic: true,
+        }),
+        // Real operator STEER — surfaces as the user row, with rev 2
+        // outcome merged via strict-id (annotation_id == triggerEventId).
+        mkDrift({
+          seq: 1,
+          kind: 'user_steer',
+          severity: 'warning',
+          recordedAtMs: 250,
+          driftId: 'drift_real_steer',
+          annotationId: 'ann_real',
+          synthetic: false,
+        }),
+      ],
+      plans: [
+        // The synthetic install plan revision — triggerEventId matches
+        // the synthetic drift. MUST be filtered (was leaking pre-fix).
+        mkPlan({
+          id: 'plan_install_1',
+          createdAtMs: 100,
+          revisionKind: 'user_steer',
+          revisionSeverity: 'warning',
+          revisionIndex: 1,
+          revisionReason: 'Create a presentation about solar panels',
+          triggerEventId: 'drift_install_v17',
+        }),
+        // The real STEER's plan revision (rev 2) — strict-id-merges
+        // onto the annotation row. MUST surface via the merged user
+        // row, NOT as a separate goldfive/user STEER card.
+        mkPlan({
+          id: 'plan_real_2',
+          createdAtMs: 260,
+          revisionKind: 'user_steer',
+          revisionSeverity: 'warning',
+          revisionIndex: 2,
+          revisionReason: 'Forget solar panels, tell me about solar flares',
+          triggerEventId: 'ann_real',
+        }),
+      ],
+    });
+
+    // Only the real operator STEER (annotation row, with rev 2 outcome
+    // absorbed) surfaces. No phantom rev 1 STEER card.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source).toBe('user');
+    expect(rows[0].kind).toBe('STEER');
+    expect(rows[0].annotationId).toBe('ann_real');
+    expect(rows[0].outcome).toBe('plan_revised:r2');
+    expect(rows[0].planRevisionIndex).toBe(2);
+    // Belt-and-braces: rev 1 (the synthetic install) MUST NOT appear
+    // anywhere in the surfaced rows.
+    for (const row of rows) {
+      expect(row.planRevisionIndex).not.toBe(1);
+      expect(row.triggerEventId).not.toBe('drift_install_v17');
+    }
+  });
+
   it('preserves annotation_id for deep-linking', () => {
     const rows = deriveInterventions({
       annotations: [mkAnnotation({ id: 'ann_steer_42' })],

--- a/frontend/src/lib/interventions.ts
+++ b/frontend/src/lib/interventions.ts
@@ -246,6 +246,21 @@ export interface DeriveInput {
 export function deriveInterventions(input: DeriveInput): InterventionRow[] {
   const rows: InterventionRow[] = [];
 
+  // goldfive#271 follow-up: collect every synthetic drift's id BEFORE
+  // the drift-projection loop filters them out. The matching plan
+  // revision (Runner._install_revision's PlanRevised) carries the same
+  // id as triggerEventId but no synthetic flag of its own — without
+  // this set the plan-revision row leaks into the panel as a phantom
+  // ``STEER WARNING -> REV 1`` card on every fresh user turn (v17 UI
+  // regression at 0:22). PRs #302 + #219 filter the synthetic drift +
+  // refine_attempted; this set closes the third leak path (the plan
+  // revision itself).
+  const syntheticTriggerIds = new Set<string>();
+  for (const dr of input.drifts) {
+    if (!dr.synthetic) continue;
+    if (dr.driftId) syntheticTriggerIds.add(dr.driftId);
+  }
+
   for (const ann of input.annotations) {
     const label = annotationKindLabel(ann.kind);
     if (!label) continue;
@@ -312,6 +327,15 @@ export function deriveInterventions(input: DeriveInput): InterventionRow[] {
     const revKind = (plan.revisionKind || '').toLowerCase();
     const revIdx = plan.revisionIndex ?? 0;
     if (!revKind || revIdx <= 0) continue;
+    // goldfive#271 follow-up: drop the plan revision minted by
+    // ``Runner._install_revision``. Identified by a ``triggerEventId``
+    // that matches a known synthetic drift (collected above before the
+    // drift-projection loop strips them out). Closes the v17 UI
+    // regression where the synthetic drift was filtered but its paired
+    // PlanRevised still surfaced as a phantom ``STEER WARNING -> REV 1``.
+    if (plan.triggerEventId && syntheticTriggerIds.has(plan.triggerEventId)) {
+      continue;
+    }
     let source: InterventionSource;
     if (GOLDFIVE_REVISION_KINDS.has(revKind)) source = 'goldfive';
     else if (USER_DRIFT_KINDS.has(revKind)) source = 'user';

--- a/server/harmonograf_server/interventions.py
+++ b/server/harmonograf_server/interventions.py
@@ -194,10 +194,27 @@ async def list_interventions(
         logger.debug("drifts_for_session failed: %s", exc)
         drifts = []
 
+    # goldfive#271 follow-up: collect every synthetic drift's id BEFORE
+    # ``_project_drifts`` filters them out. The matching ``PlanRevised``
+    # carries the same id as ``trigger_event_id`` but no synthetic flag
+    # of its own (the proto field doesn't exist), so without this set the
+    # plan-revision row leaks into the panel as a phantom
+    # ``STEER WARNING -> REV 1`` card on every fresh user turn (v17 UI
+    # regression: drift filtered but plan row survived). Drift rows pass
+    # through their own ``synthetic`` filter in ``_project_drifts``;
+    # plan rows are filtered against this set in ``_project_plans``.
+    synthetic_trigger_ids: set[str] = set()
+    for dr in drifts:
+        if not dr.get("synthetic"):
+            continue
+        drift_id = str(dr.get("id") or "")
+        if drift_id:
+            synthetic_trigger_ids.add(drift_id)
+
     records: list[InterventionRecord] = []
     records.extend(_project_annotations(annotations))
     records.extend(_project_drifts(drifts))
-    records.extend(_project_plans(plans))
+    records.extend(_project_plans(plans, synthetic_trigger_ids=synthetic_trigger_ids))
 
     records.sort(key=lambda r: r.at)
     _attribute_outcomes(records, plans, legacy_window_ms=window_ms)
@@ -383,7 +400,11 @@ def _project_drifts(drifts: Iterable[dict[str, Any]]) -> list[InterventionRecord
     return out
 
 
-def _project_plans(plans: Iterable[TaskPlan]) -> list[InterventionRecord]:
+def _project_plans(
+    plans: Iterable[TaskPlan],
+    *,
+    synthetic_trigger_ids: frozenset[str] | set[str] | None = None,
+) -> list[InterventionRecord]:
     """Project every plan revision (index > 0) to an InterventionRecord.
 
     Unlike the pre-#99 projector, this one does **not** try to suppress
@@ -394,14 +415,35 @@ def _project_plans(plans: Iterable[TaskPlan]) -> list[InterventionRecord]:
 
     ``trigger_event_id`` comes off the persisted plan row (stamped by
     ingest.py::_on_plan_revised from ``PlanRevised.trigger_event_id``).
+
+    ``synthetic_trigger_ids``: set of drift ids whose originating
+    ``DriftDetected`` carried ``synthetic = True``. Plan rows whose
+    ``trigger_event_id`` is in this set are skipped — they are the
+    PlanRevised that goldfive's ``Runner._install_revision`` plumbing
+    fabricates on every fresh user turn (paired with a synthetic
+    USER_STEER drift). PR #302+#219 filter the synthetic drift +
+    refine_attempted; this filter closes the third leak path (the plan
+    revision itself), v17 UI regression evidence: a phantom
+    ``STEER WARNING -> REV 1`` card surfaced at 0:22 because the drift
+    was filtered before the strict-id merge could fold the plan onto
+    it, leaving the plan row to surface alone.
     """
 
+    skip_ids = synthetic_trigger_ids or frozenset()
     out: list[InterventionRecord] = []
     for plan in plans:
         rev_kind = (plan.revision_kind or "").lower()
         rev_index = int(plan.revision_index or 0)
         if not rev_kind or rev_index <= 0:
             # Initial plan submission — not an intervention.
+            continue
+        # goldfive#271 follow-up: drop the plan revision minted by
+        # ``Runner._install_revision``. Identified by a ``trigger_event_id``
+        # that matches a known synthetic drift (collected in
+        # :func:`list_interventions` before ``_project_drifts`` strips
+        # them out).
+        trig = plan.trigger_event_id or ""
+        if trig and trig in skip_ids:
             continue
         if rev_kind in _GOLDFIVE_REVISION_KINDS:
             source = "goldfive"

--- a/server/tests/test_interventions.py
+++ b/server/tests/test_interventions.py
@@ -270,6 +270,132 @@ async def test_synthetic_user_steer_drift_is_filtered_from_intervention_list(sto
     assert records[0].annotation_id == "ann_real_x"
 
 
+# goldfive#271 follow-up: v17 UI regression. PR #302 set
+# ``synthetic = True`` on ``Runner._install_revision``'s drift and
+# PR #219 made the aggregator filter synthetic drifts. But the
+# matching ``PlanRevised`` carries the synthetic drift's id as
+# ``trigger_event_id`` with no synthetic flag of its own (the proto
+# field doesn't exist on PlanRevised) — so once the drift was filtered,
+# the plan-revision row fell through the strict-id merge alone and
+# surfaced as a phantom ``STEER WARNING -> REV 1`` card at 0:22 on
+# every fresh user turn (v17 session
+# 845dcbe8-0861-452f-b7ba-e37703458785). This test pins the third leak
+# path: the plan-revision row whose ``trigger_event_id`` matches a
+# synthetic drift's id MUST be filtered too.
+async def test_synthetic_install_plan_revision_is_filtered_from_intervention_list(store):
+    """A ``PlanRevised`` whose ``trigger_event_id`` matches a synthetic
+    drift's id MUST NOT surface as an intervention.
+
+    A real operator STEER drift + matching plan revision on the same
+    session MUST surface unchanged so this filter does not silently
+    swallow genuine interventions.
+    """
+
+    sid = "sess_synthetic_plan"
+    await _seed_session(store, sid)
+
+    synthetic_drift_id = "drift_install_xyz"
+    real_drift_id = "drift_real_steer_xyz"
+
+    # The PlanRevised that goldfive's _install_revision pipeline would
+    # mint on the first user turn — trigger_event_id matches the
+    # synthetic USER_STEER drift below.
+    await store.put_task_plan(
+        TaskPlan(
+            id="plan_install_1",
+            session_id=sid,
+            created_at=100.0,
+            summary="install rev 1",
+            tasks=[],
+            edges=[],
+            revision_reason="Create a presentation about solar panels",
+            revision_kind="user_steer",
+            revision_severity="warning",
+            revision_index=1,
+            trigger_event_id=synthetic_drift_id,
+        )
+    )
+    # A genuine user STEER followed by a real revision (rev 2). MUST
+    # surface so the regression test pins both the filter-out AND the
+    # don't-overfilter requirements.
+    await store.put_annotation(
+        Annotation(
+            id="ann_real",
+            session_id=sid,
+            target=AnnotationTarget(agent_id="a", time_start=240.0),
+            author="alice",
+            created_at=240.0,
+            kind=AnnotationKind.STEERING,
+            body="operator-Alice: refocus on flares",
+        )
+    )
+    await store.put_task_plan(
+        TaskPlan(
+            id="plan_real_2",
+            session_id=sid,
+            created_at=260.0,
+            summary="real rev 2",
+            tasks=[],
+            edges=[],
+            revision_reason="Forget solar panels, tell me about solar flares",
+            revision_kind="user_steer",
+            revision_severity="warning",
+            revision_index=2,
+            # Real operator STEER drift carries the source annotation_id
+            # as trigger_event_id (per goldfive#199 / harmonograf#99
+            # rescope), which strict-id-merges onto the annotation row.
+            trigger_event_id="ann_real",
+        )
+    )
+    drifts = _StubDrifts(
+        {
+            sid: [
+                {
+                    "run_id": "r1",
+                    "kind": "user_steer",
+                    "severity": "warning",
+                    "detail": "Create a presentation about solar panels",
+                    "recorded_at": 100.0,
+                    "synthetic": True,
+                    "id": synthetic_drift_id,
+                },
+                {
+                    "run_id": "r1",
+                    "kind": "user_steer",
+                    "severity": "warning",
+                    "detail": "Forget solar panels, tell me about solar flares",
+                    "recorded_at": 250.0,
+                    "synthetic": False,
+                    "id": real_drift_id,
+                    "annotation_id": "ann_real",
+                },
+            ]
+        }
+    )
+
+    records = await list_interventions(sid, store=store, drifts_provider=drifts)
+
+    # The synthetic drift, the synthetic install plan-revision row, AND
+    # any phantom STEER card built from them MUST all be filtered. Only
+    # the real operator STEER (annotation row, with rev 2 outcome
+    # absorbed via strict-id merge) surfaces.
+    surfaced = [(r.source, r.kind, r.outcome, r.body_or_reason) for r in records]
+    assert len(records) == 1, (
+        "expected synthetic install plan-revision to be filtered out; got "
+        f"records={surfaced!r}"
+    )
+    assert records[0].source == "user"
+    assert records[0].kind == "STEER"
+    assert records[0].annotation_id == "ann_real"
+    # Belt-and-braces: no record should reference the synthetic drift's
+    # id as its trigger_event_id (would re-introduce the phantom).
+    for r in records:
+        assert r.trigger_event_id != synthetic_drift_id
+        assert r.plan_revision_index != 1, (
+            "rev 1 was the synthetic install revision and must not surface"
+        )
+
+
 async def test_ordering_across_sources_is_by_timestamp(store):
     """Rows interleave strictly by timestamp, regardless of source."""
 


### PR DESCRIPTION
## Summary

- Closes the v17 UI regression where a phantom ``STEER WARNING -> REV 1`` intervention appeared at 0:22 on every fresh user turn despite PRs #302 (synthetic flag on drift) and #219 (UI filter for synthetic drifts).
- Plugs the third leak path: the ``PlanRevised`` paired with ``Runner._install_revision``'s synthetic drift carries the drift's id as ``trigger_event_id`` but no synthetic flag of its own (no proto field). Once #219 filtered the drift, the plan-revision row fell through the strict-id merge alone and surfaced as the phantom card.
- Pure client-side fix in both the server aggregator (``server/harmonograf_server/interventions.py``) and the frontend deriver (``frontend/src/lib/interventions.ts``) — no proto bump, no DB schema change.

## Empirical evidence

v17 session `845dcbe8-0861-452f-b7ba-e37703458785`:
- DriftDetected seq=5 has ``synthetic=True``, drift.id=`0eb3bf3feb7943c8...`
- PlanRevised seq=7 carries ``trigger_event_id=0eb3bf3feb7943c8...``, ``drift_kind=USER_STEER``, ``rev_idx=1`` — no synthetic flag, surfaced as the phantom card.

## Test plan

- [x] Server: ``server/tests/test_interventions.py::test_synthetic_install_plan_revision_is_filtered_from_intervention_list`` pins both filter-out (synthetic install rev) and don't-overfilter (real operator STEER + rev 2 still surfaces).
- [x] Frontend: ``frontend/src/__tests__/lib/interventions.test.ts`` — equivalent regression test in the deriver.
- [x] Full server suite: 412 passed, 1 skipped.
- [x] Full frontend suite: 688 passed (2 pre-existing failures in TrajectoryView.headerMath unrelated to this change — verified via stash).
- [ ] Manual UI verification on v17 session DB after merging + bumping submodule (next agent / next session).

## Note

Per `project_271_intent_validated` memory: this is the immediate bandaid. Once #202 (drift as stateful condition) lands and eliminates the per-event-row model, the synthetic-flag plumbing becomes moot.