### PR TITLE
fix(client): honor goldfive ReentryKind contract; suppress duplicate user_message emits

### DIFF
--- a/client/harmonograf_client/telemetry_plugin.py
+++ b/client/harmonograf_client/telemetry_plugin.py
@@ -1367,9 +1367,41 @@ class HarmonografTelemetryPlugin(BasePlugin):  # type: ignore[misc]
         surface in the interventions panel as if the operator typed
         them. The legitimate mid-turn HITL path stays on the parent's
         session id and continues to emit.
+
+        Goldfive re-entry contract (harmonograf#234, goldfive#325): when
+        running under a goldfive-wrapped agent tree, the inner ADK
+        Runner re-fires ``on_user_message_callback`` for goldfive's
+        re-feed of the operator's input (``OVERLAY_REPLAY``) and again
+        for goldfive-composed nudge / steer-restart bodies
+        (``NUDGE_REPLAY`` / ``STEER_REPLAY``). The outer adk-web Runner
+        already emitted the operator's user_message as a USER_TURN, so
+        every non-USER_TURN re-entry is a duplicate (or goldfive-authored
+        framing, not operator content) that we must NOT re-emit. Plain
+        ADK use is unaffected: the contextvar's default is USER_TURN
+        and the ``ImportError`` fallback keeps the plugin working when
+        goldfive is not installed.
         """
         if self._maybe_disable_as_duplicate(invocation_context):
             return
+        # Honor goldfive's re-entry contract (goldfive#325). Only
+        # USER_TURN represents new operator input; other kinds are
+        # framework replays whose content was already emitted by the
+        # outer runner, or is goldfive-composed (not operator-authored).
+        try:
+            from goldfive.adapters.adk_reentry import (  # type: ignore[import-not-found]
+                ReentryKind,
+                current_reentry_kind,
+            )
+        except ImportError:
+            pass  # plain ADK, no goldfive — proceed with current behaviour
+        else:
+            if current_reentry_kind.get() is not ReentryKind.USER_TURN:
+                log.debug(
+                    "telemetry_plugin: suppressing UserMessageReceived for "
+                    "goldfive re-entry kind=%s",
+                    current_reentry_kind.get().value,
+                )
+                return
         text = _extract_user_message_text(user_message)
         if not text:
             return

--- a/client/tests/test_sink_user_messages.py
+++ b/client/tests/test_sink_user_messages.py
@@ -422,3 +422,111 @@ class TestTransportMaterialization:
         )
         env = _drain(client)[0]
         assert _session_id_of_envelope(env) == "sess-user-msg"
+
+
+class TestGoldfiveReentryContract:
+    """harmonograf#234 / goldfive#325: when running under a
+    goldfive-wrapped agent tree, the inner ADK Runner re-fires
+    ``on_user_message_callback`` for goldfive's re-feed of the
+    operator's input (``OVERLAY_REPLAY``) and again for
+    goldfive-composed nudge / steer-restart bodies. The outer adk-web
+    Runner already emitted the operator's user_message as a USER_TURN,
+    so non-USER_TURN re-entry must NOT re-emit.
+
+    Plain ADK use is unaffected — the contextvar's default is
+    USER_TURN; if goldfive is not installed the ImportError fallback
+    keeps the plugin emitting as before.
+    """
+
+    @pytest.mark.asyncio
+    async def test_user_turn_emits(
+        self, plugin: HarmonografTelemetryPlugin, client: Client
+    ) -> None:
+        """The default contextvar value is USER_TURN — emission proceeds."""
+        pytest.importorskip("goldfive.adapters.adk_reentry")
+        from goldfive.adapters.adk_reentry import (  # type: ignore[import-not-found]
+            ReentryKind,
+            reentry,
+        )
+
+        ctx = _InvocationContext("inv-ut", "sess-user-msg", [plugin])
+        msg = _Content([_Part(text="operator typed this")])
+        with reentry(ReentryKind.USER_TURN):
+            await plugin.on_user_message_callback(
+                invocation_context=ctx, user_message=msg
+            )
+        envs = _drain(client)
+        user_envs = [e for e in envs if e.kind is EnvelopeKind.USER_MESSAGE]
+        assert len(user_envs) == 1
+        assert user_envs[0].payload.content == "operator typed this"
+
+    @pytest.mark.asyncio
+    async def test_overlay_replay_suppressed(
+        self, plugin: HarmonografTelemetryPlugin, client: Client
+    ) -> None:
+        """Goldfive re-feeding the operator's input via the inner
+        runner (OVERLAY_REPLAY) emits nothing."""
+        pytest.importorskip("goldfive.adapters.adk_reentry")
+        from goldfive.adapters.adk_reentry import (  # type: ignore[import-not-found]
+            ReentryKind,
+            reentry,
+        )
+
+        ctx = _InvocationContext("inv-or", "sess-user-msg", [plugin])
+        msg = _Content([_Part(text="operator typed this")])
+        with reentry(ReentryKind.OVERLAY_REPLAY):
+            await plugin.on_user_message_callback(
+                invocation_context=ctx, user_message=msg
+            )
+        envs = _drain(client)
+        user_envs = [e for e in envs if e.kind is EnvelopeKind.USER_MESSAGE]
+        assert user_envs == []
+
+    @pytest.mark.asyncio
+    async def test_nudge_replay_suppressed(
+        self, plugin: HarmonografTelemetryPlugin, client: Client
+    ) -> None:
+        """Goldfive-composed nudge replay (autonomous drift → refine
+        spawned a replacement task) is goldfive-authored framing, not
+        operator-typed; do not emit."""
+        pytest.importorskip("goldfive.adapters.adk_reentry")
+        from goldfive.adapters.adk_reentry import (  # type: ignore[import-not-found]
+            ReentryKind,
+            reentry,
+        )
+
+        ctx = _InvocationContext("inv-nr", "sess-user-msg", [plugin])
+        msg = _Content([_Part(text="please follow up on task X_v2")])
+        with reentry(ReentryKind.NUDGE_REPLAY):
+            await plugin.on_user_message_callback(
+                invocation_context=ctx, user_message=msg
+            )
+        envs = _drain(client)
+        user_envs = [e for e in envs if e.kind is EnvelopeKind.USER_MESSAGE]
+        assert user_envs == []
+
+    @pytest.mark.asyncio
+    async def test_steer_replay_suppressed(
+        self, plugin: HarmonografTelemetryPlugin, client: Client
+    ) -> None:
+        """Goldfive-composed steer-restart (operator STEER wrapped in
+        USER STEERING CONTROL framing) is goldfive-authored framing
+        around operator text; the operator's STEER turn was already
+        emitted by the outer runner."""
+        pytest.importorskip("goldfive.adapters.adk_reentry")
+        from goldfive.adapters.adk_reentry import (  # type: ignore[import-not-found]
+            ReentryKind,
+            reentry,
+        )
+
+        ctx = _InvocationContext("inv-sr", "sess-user-msg", [plugin])
+        msg = _Content(
+            [_Part(text="USER STEERING CONTROL — switch to topic Y")]
+        )
+        with reentry(ReentryKind.STEER_REPLAY):
+            await plugin.on_user_message_callback(
+                invocation_context=ctx, user_message=msg
+            )
+        envs = _drain(client)
+        user_envs = [e for e in envs if e.kind is EnvelopeKind.USER_MESSAGE]
+        assert user_envs == []


### PR DESCRIPTION
## Summary

- `on_user_message_callback` now consults `goldfive.adapters.adk_reentry.current_reentry_kind` after the existing duplicate-install guard. Non-`USER_TURN` kinds (`OVERLAY_REPLAY`, `NUDGE_REPLAY`, `STEER_REPLAY`) short-circuit emission — the outer adk-web Runner already emitted the operator's user_message; the inner re-entry is goldfive's re-feed (or goldfive-composed framing) and must not be re-emitted.
- Bumps `third_party/goldfive` to `afa0d19` to pull in the contract (goldfive#325).
- Adds `TestGoldfiveReentryContract` covering `USER_TURN` emits and `OVERLAY_REPLAY` / `NUDGE_REPLAY` / `STEER_REPLAY` each suppress.

## Why

gRPC ground truth on a 4-turn session showed 6 `UserMessageReceived` envelopes — turns that completed emitted twice, turns that aborted before reaching `invoke_passthrough` emitted once. The existing `_maybe_disable_as_duplicate` guard only catches multiple plugin *instances* on the same plugin manager. Here we have ONE plugin instance fired twice in two distinct invocation contexts (outer adk-web runner + inner goldfive-driven runner). The frontend-dedup workaround masks the symptom but the duplicate envelopes still flow over the wire.

Goldfive#325 introduces a ContextVar discriminator pinned at the boundary of every goldfive re-entry. This change reads it and short-circuits in the framework-replay cases. Plain ADK use is unaffected: the contextvar's default is `USER_TURN`, and the `ImportError` fallback keeps the plugin emitting as before when goldfive is not installed.

## Test plan

- [x] `make client-test` — 351 passed (was 347 + 4 skips before the submodule bump; the 4 new re-entry tests now run for real)
- [x] Tested suppression in all three non-`USER_TURN` kinds (`OVERLAY_REPLAY` / `NUDGE_REPLAY` / `STEER_REPLAY`) plus positive `USER_TURN` emit
- [x] Ruff clean on changed files
- [ ] Empirically verify 4 user turns → 4 envelopes on a goldfive overlay session (next step on a live run)

Closes #234.
Depends on goldfive#325.