### PR TITLE
chore: bump goldfive (presentation_agent recovery + edge_missing retry + flake fix) + frozen-Task storage fix

### DIFF
--- a/server/harmonograf_server/storage/memory.py
+++ b/server/harmonograf_server/storage/memory.py
@@ -13,6 +13,8 @@ from typing import Optional
 
 from intervaltree import Interval, IntervalTree
 
+from goldfive.types import replace_task
+
 from harmonograf_server.storage.base import (
     Agent,
     AgentStatus,
@@ -435,19 +437,24 @@ class InMemoryStore(Store):
             plan = self._task_plans.get(plan_id)
             if plan is None:
                 return None
-            for t in plan.tasks:
-                if t.id == task_id:
-                    t.status = status
-                    if bound_span_id is not None:
-                        t.bound_span_id = bound_span_id
-                    # harmonograf#110: same preserve-semantics as sqlite —
-                    # keep an existing cancel_reason when no fresh one is
-                    # supplied (e.g. BLOCKED transition after CANCELLED
-                    # must not blank the reason).
-                    if cancel_reason:
-                        t.cancel_reason = cancel_reason
-                    return copy.deepcopy(t)
-            return None
+            if not any(t.id == task_id for t in plan.tasks):
+                return None
+            # goldfive#247 made Task frozen — rebuild via the canonical
+            # ``replace_task`` helper instead of in-place assignment.
+            changes: dict = {"status": status}
+            if bound_span_id is not None:
+                changes["bound_span_id"] = bound_span_id
+            # harmonograf#110: same preserve-semantics as sqlite —
+            # keep an existing cancel_reason when no fresh one is
+            # supplied (e.g. BLOCKED transition after CANCELLED
+            # must not blank the reason).
+            if cancel_reason:
+                changes["cancel_reason"] = cancel_reason
+            new_plan = replace_task(plan, task_id, **changes)
+            self._task_plans[plan_id] = new_plan
+            return copy.deepcopy(
+                next(t for t in new_plan.tasks if t.id == task_id)
+            )
 
     # task plan revisions ------------------------------------------------
     async def put_task_plan_revision(


### PR DESCRIPTION
## Summary

Bumps `third_party/goldfive` `86f6c84..80a1f27`, picking up three goldfive PRs that resolve the live-e2e failure mode caught in session `692f1ef3` on 2026-05-08:

- **goldfive#372 (closes #205)** — presentation_agent example now has a `find_presentation_files` tool wired into `debugger_agent`, plus tightened prompts on web_developer / reviewer / coordinator / debugger. Recovers from the topic-string mismatch (developer writes `output/<topic>_presentation/`, reviewer reads `output/<topic>/`) instead of looping `read_presentation_files` until LOOPING_REASONING fires.

- **goldfive#373 (closes #250)** — `LLMPlanner._build_correction_prompt` now embeds copy-paste-ready JSON snippets when the validator rejects with `edge_missing` / `terminal_missing` / `terminal_regressed`. Naming the missing piece right next to the rejection text is what attempt 2 needs on Qwen 35B; the iter-11C same-class short-circuit stays in place as the actual give-up signal.

- **goldfive#374 (closes #251)** — Autouse conftest fixture clears `_ACTIVE_INVOCATION_TASKS` and `_CANCEL_REQUESTED_INVOCATIONS` between tests. These module-level dicts in `goldfive/orchestration_store.py` are keyed by `session.id` (a `@property` aliased to `run_id`); 83 test files share `run_id="r1"`, so cancel-touching tests leaked state into later tests' late-drift gate, manifesting as a CI-only flake of `test_judge_verdict_with_live_invocation_proceeds_normally`.

## Test plan

- [x] All three goldfive PRs CI green on rebased main.
- [ ] Re-run the live NAND prompt against the new build via `scripts/launch-stack.sh` and confirm the `files_not_found` → debugger → recovery flow lands instead of pausing for human intervention.
- [ ] Confirm `find_presentation_files` is visible on debugger_agent's tool list at runtime.