### PR TITLE
fix(sink): map goldfive cancelled wire-status to SPAN_STATUS_CANCELLED

### DIFF
--- a/client/harmonograf_client/sink.py
+++ b/client/harmonograf_client/sink.py
@@ -529,16 +529,52 @@ class HarmonografSink:
         )
 
     def _emit_llm_call_end(self, event_pb: Any) -> None:
-        """``GoldfiveLLMCallEnd`` → ``SpanEnd``."""
+        """``GoldfiveLLMCallEnd`` → ``SpanEnd``.
+
+        Status translation:
+
+        * ``"failed"``    → ``SPAN_STATUS_FAILED`` + ``ErrorInfo`` populated.
+        * ``"cancelled"`` → ``SPAN_STATUS_CANCELLED`` (goldfive#266). The
+          ``end.error`` carries a benign lifecycle reason
+          ("drained at run boundary") rather than a CancelledError stack;
+          we propagate it as the span's error message so operators can
+          read the reason inline but it does NOT render red. Distinct
+          from ``failed`` so the frontend's status filter renders
+          shutdown-initiated teardowns differently from genuine errors.
+        * anything else   → ``SPAN_STATUS_COMPLETED`` (success path).
+        """
         end = event_pb.goldfive_llm_call_end
         span_id = end.span_id or self._derive_span_id(event_pb)
         wire_status = (end.status or "").lower()
-        status = "FAILED" if wire_status == "failed" else "COMPLETED"
-        error = (
-            {"type": "goldfive_llm_call", "message": end.error}
-            if wire_status == "failed" and end.error
-            else None
-        )
+        if wire_status == "failed":
+            status: str = "FAILED"
+        elif wire_status == "cancelled":
+            # goldfive#266 — drain-initiated teardown of an in-flight
+            # judge / drift task at run boundary. Routine lifecycle,
+            # NOT an error. Map onto the dedicated CANCELLED SpanStatus
+            # so harmonograf's frontend can render it as a neutral
+            # cancel (gray / muted) rather than a red FAILED span.
+            status = "CANCELLED"
+        else:
+            status = "COMPLETED"
+        if wire_status == "failed" and end.error:
+            error: dict[str, Any] | None = {
+                "type": "goldfive_llm_call",
+                "message": end.error,
+            }
+        elif wire_status == "cancelled" and end.error:
+            # Surface the benign cancel-reason as the span's error
+            # message so operators can read it inline. Type is
+            # deliberately ``goldfive_llm_call_cancelled`` (not
+            # ``goldfive_llm_call``) so frontends that pattern-match
+            # error.type can render cancels distinctly from genuine
+            # errors even before they upgrade to the SpanStatus axis.
+            error = {
+                "type": "goldfive_llm_call_cancelled",
+                "message": end.error,
+            }
+        else:
+            error = None
         attributes: dict[str, Any] = {}
         if end.name:
             # Echo the call name on end so out-of-order End-before-Start

--- a/client/tests/test_sink_llm_span_translation.py
+++ b/client/tests/test_sink_llm_span_translation.py
@@ -201,6 +201,85 @@ class TestGoldfiveLLMCallEnd:
         assert se.error.type == "goldfive_llm_call"
         assert se.error.message == "timeout after 30s"
 
+    @pytest.mark.asyncio
+    async def test_cancelled_status_maps_to_span_status_cancelled(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """goldfive#266 — drain-initiated cancel surfaces as
+        ``SPAN_STATUS_CANCELLED``, not ``SPAN_STATUS_FAILED``.
+
+        Live session 4538863f-0dea-4fe8-97b4-5f660ee2cb7f surfaced
+        routine run-boundary teardowns of in-flight ``judge_reasoning``
+        calls as red FAILED spans with CancelledError stack traces.
+        goldfive now emits ``status="cancelled"`` (with a benign
+        ``error="drained at run boundary"``) for those cases; this sink
+        must map that distinct wire status onto the dedicated
+        ``SPAN_STATUS_CANCELLED`` enum so the frontend can render it
+        neutrally instead of as an error.
+        """
+
+        def setup(e: ge.Event) -> None:
+            end = e.goldfive_llm_call_end
+            end.span_id = "span-judge-drained"
+            end.name = "judge_reasoning"
+            end.end_time_ns = 1_700_000_000_500_000_000
+            end.status = "cancelled"
+            end.error = "drained at run boundary"
+
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert len(envs) == 1
+        se = envs[0].payload
+        types_pb2 = client._types_pb2
+        # Status: CANCELLED, NOT FAILED — the routine-lifecycle marker
+        # that lets harmonograf's frontend render the span neutrally.
+        assert se.status == types_pb2.SPAN_STATUS_CANCELLED
+        # The lifecycle reason rides through on error.message so
+        # operators can read "why was this cancelled?" inline, but the
+        # ``type`` is the distinct ``goldfive_llm_call_cancelled``
+        # variant so pattern-matchers on the old type don't flag it
+        # as an error.
+        assert se.error.type == "goldfive_llm_call_cancelled"
+        assert se.error.message == "drained at run boundary"
+        # Attributes echo the wire status verbatim for downstream
+        # filters (e.g. status='cancelled' lane).
+        assert (
+            se.attributes["goldfive.status"].string_value == "cancelled"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancelled_status_without_error_omits_error_info(
+        self, sink: HarmonografSink, client: Client
+    ) -> None:
+        """A cancelled span with no error text omits ErrorInfo entirely.
+
+        The goldfive helper always populates the reason today, but a
+        future code path or a custom span emitter might not. The sink
+        must not synthesize an ErrorInfo for the empty-reason case —
+        the SpanStatus enum carries the cancel signal on its own.
+        """
+
+        def setup(e: ge.Event) -> None:
+            end = e.goldfive_llm_call_end
+            end.span_id = "span-judge-no-reason"
+            end.name = "judge_reasoning"
+            end.end_time_ns = 1_700_000_000_500_000_000
+            end.status = "cancelled"
+            # No end.error.
+
+        evt = _event(setup)
+        await sink.emit(evt)
+
+        envs = _drain(client)
+        assert len(envs) == 1
+        se = envs[0].payload
+        types_pb2 = client._types_pb2
+        assert se.status == types_pb2.SPAN_STATUS_CANCELLED
+        assert se.error.message == ""
+        assert se.error.type == ""
+
 
 # ---------------------------------------------------------------------------
 # ReasoningJudgeInvoked → SpanStart + SpanEnd (pair)


### PR DESCRIPTION
## Summary

Companion to [goldfive#266 / PR#390](https://github.com/pedapudi/goldfive/pull/390).

goldfive's `_llm_span` helper now emits `status="cancelled"` (with a
benign `error="drained at run boundary"`) when an in-flight
`judge_reasoning` / `judge_goal_drift` call is torn down by the
steerer's run-boundary drain. Previously the harmonograf-client sink
only recognized `"failed"` vs everything-else, collapsing the new
cancelled case onto `SPAN_STATUS_COMPLETED` and losing the lifecycle
signal.

## Change

`_emit_llm_call_end` now branches three ways:

| wire status   | SpanStatus                | error.type                       |
|---------------|---------------------------|----------------------------------|
| `failed`      | `SPAN_STATUS_FAILED`      | `goldfive_llm_call`              |
| `cancelled`   | `SPAN_STATUS_CANCELLED`   | `goldfive_llm_call_cancelled`    |
| anything else | `SPAN_STATUS_COMPLETED`   | (none)                           |

The lifecycle reason rides through on `error.message` for the cancelled
case so operators can read "why was this cancelled?" inline, but the
distinct `error.type` lets pattern-matchers render the cancel
distinctly even before they upgrade to the SpanStatus axis.

## Test plan

- [x] `test_cancelled_status_maps_to_span_status_cancelled`
- [x] `test_cancelled_status_without_error_omits_error_info`
- [x] Full client test suite (353 tests) still passes.

## Coordination

Merge goldfive#390 first (it emits the new wire status); then merge
this; then bump the goldfive submodule in harmonograf so harmonograf
ships the new emitter alongside its translation.