### PR TITLE
fix(frontend/gantt): delegation-observed arrow tail anchors at source span end (closes #241)

### DIFF
--- a/frontend/src/__tests__/gantt/delegationAnchor.test.ts
+++ b/frontend/src/__tests__/gantt/delegationAnchor.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from 'vitest';
 import { GanttRenderer } from '../../gantt/renderer';
 import { SessionStore } from '../../gantt/index';
 import {
+  GUTTER_WIDTH_PX,
   ROW_HEIGHT_PX,
   SUB_LANE_HEIGHT_PX,
   TOP_MARGIN_PX,
@@ -299,5 +300,229 @@ describe('GanttRenderer delegation anchor (harmonograf#129)', () => {
     expect(e.tgtY).toBe(subBarY);
 
     r.detach();
+  });
+});
+
+// harmonograf#241: delegation arrow TAIL must anchor at the source span's
+// END time (where the hand-off actually happened on the coordinator's
+// bar), NOT at the observed-time of the delegation_observed event. The
+// previous behavior set both endpoints to observedAtMs which collapsed
+// the tail onto a single x — for delegations dispatched near session
+// start that put the tail right at the leftmost data position. The
+// arrowhead (target side) is unchanged.
+describe('GanttRenderer delegation tail anchoring (harmonograf#241)', () => {
+  function pxAt(ms: number, windowMs = 10_000, widthCss = 1200): number {
+    // Mirror msToPx(): viewport.startMs is endMs - windowMs.
+    const startMs = 10_000 - windowMs;
+    const dataW = widthCss - GUTTER_WIDTH_PX;
+    return GUTTER_WIDTH_PX + ((ms - startMs) / windowMs) * dataW;
+  }
+
+  it('tail anchors at the source INVOCATION end when the source has completed before observation', () => {
+    // Scenario: coordinator runs 0→500ms, completes; sub starts at 700ms.
+    // Delegation observed at 700ms (sub start). Tail x must land at the
+    // coordinator's endMs (500), NOT at observedAtMs (700) — though in
+    // this fixture observedAtMs===subStart so head/tail differ visibly.
+    const store = new SessionStore();
+    mkAgent(store, 'coord');
+    mkAgent(store, 'sub');
+
+    store.spans.append(
+      mkSpan({
+        id: 'inv-coord',
+        agentId: 'coord',
+        startMs: 0,
+        endMs: 500,
+        status: 'COMPLETED',
+      }),
+    );
+    store.spans.append(
+      mkSpan({
+        id: 'inv-sub',
+        agentId: 'sub',
+        startMs: 700,
+        endMs: 4_000,
+        status: 'COMPLETED',
+      }),
+    );
+
+    store.delegations.append({
+      fromAgentId: 'coord',
+      toAgentId: 'sub',
+      taskId: 't-1',
+      invocationId: 'inv-1',
+      observedAtMs: 700,
+    });
+
+    const r = new GanttRenderer(store);
+    r.attach(stubCanvas(), stubCanvas(), stubCanvas());
+    r.resize(1200, 200, 1);
+    r.setViewport({
+      endMs: 10_000,
+      windowMs: 10_000,
+      liveFollow: false,
+      replay: false,
+    });
+    drawBlocks(r);
+
+    const edges = r._delegationLayoutsForTesting();
+    expect(edges).toHaveLength(1);
+    const e = edges[0];
+
+    // Head (tgtX) lands at observedAtMs=700; tail (srcX) lands at coord
+    // endMs=500. The two must differ — that's the whole point of the fix.
+    expect(e.tgtX).toBeCloseTo(pxAt(700), 5);
+    expect(e.srcX).toBeCloseTo(pxAt(500), 5);
+    expect(e.srcX).toBeLessThan(e.tgtX);
+  });
+
+  it('tail uses observed time when source span endMs is AFTER observation (clock drift safeguard)', () => {
+    // Scenario: coordinator INVOCATION end stamp is past the
+    // delegation_observed event (an agent's own bar can outlive the
+    // hand-off when it spawns then continues to do other things). Tail
+    // must NOT precede head — fall back to observedAtMs.
+    const store = new SessionStore();
+    mkAgent(store, 'coord');
+    mkAgent(store, 'sub');
+
+    store.spans.append(
+      mkSpan({
+        id: 'inv-coord',
+        agentId: 'coord',
+        startMs: 0,
+        endMs: 5_000, // past the delegation
+        status: 'COMPLETED',
+      }),
+    );
+    store.spans.append(
+      mkSpan({
+        id: 'inv-sub',
+        agentId: 'sub',
+        startMs: 1_000,
+        endMs: 4_000,
+        status: 'COMPLETED',
+      }),
+    );
+
+    store.delegations.append({
+      fromAgentId: 'coord',
+      toAgentId: 'sub',
+      taskId: 't-1',
+      invocationId: 'inv-1',
+      observedAtMs: 1_000,
+    });
+
+    const r = new GanttRenderer(store);
+    r.attach(stubCanvas(), stubCanvas(), stubCanvas());
+    r.resize(1200, 200, 1);
+    r.setViewport({
+      endMs: 10_000,
+      windowMs: 10_000,
+      liveFollow: false,
+      replay: false,
+    });
+    drawBlocks(r);
+
+    const edges = r._delegationLayoutsForTesting();
+    expect(edges).toHaveLength(1);
+    const e = edges[0];
+
+    // Degenerate fallback: srcX === tgtX (both at observedAtMs).
+    expect(e.srcX).toBe(e.tgtX);
+    expect(e.tgtX).toBeCloseTo(pxAt(1_000), 5);
+  });
+
+  it('tail anchors at store.nowMs when the source span is still RUNNING', () => {
+    // Scenario: coordinator is still RUNNING when the delegation is
+    // observed. Tail tracks the session's "now" cursor so the live edge
+    // of the bar holds the arrow's tail — same visual contract as the
+    // bar itself, which the renderer paints out to nowMs while running.
+    const store = new SessionStore();
+    mkAgent(store, 'coord');
+    mkAgent(store, 'sub');
+
+    store.spans.append(
+      mkSpan({
+        id: 'inv-coord',
+        agentId: 'coord',
+        startMs: 0,
+        endMs: null,
+        status: 'RUNNING',
+      }),
+    );
+    store.spans.append(
+      mkSpan({
+        id: 'inv-sub',
+        agentId: 'sub',
+        startMs: 2_000,
+        endMs: null,
+        status: 'RUNNING',
+      }),
+    );
+
+    store.delegations.append({
+      fromAgentId: 'coord',
+      toAgentId: 'sub',
+      taskId: 't-1',
+      invocationId: 'inv-1',
+      observedAtMs: 2_000,
+    });
+    // Session has progressed past the delegation moment.
+    store.nowMs = 1_500;
+
+    const r = new GanttRenderer(store);
+    r.attach(stubCanvas(), stubCanvas(), stubCanvas());
+    r.resize(1200, 200, 1);
+    r.setViewport({
+      endMs: 10_000,
+      windowMs: 10_000,
+      liveFollow: false,
+      replay: false,
+    });
+    drawBlocks(r);
+
+    const edges = r._delegationLayoutsForTesting();
+    expect(edges).toHaveLength(1);
+    const e = edges[0];
+
+    // Tail at nowMs (1500), head at observedAtMs (2000).
+    expect(e.srcX).toBeCloseTo(pxAt(1_500), 5);
+    expect(e.tgtX).toBeCloseTo(pxAt(2_000), 5);
+    expect(e.srcX).toBeLessThan(e.tgtX);
+  });
+
+  it('falls back to observedAtMs when no source INVOCATION span has been reported yet', () => {
+    // Scenario: source row has no INVOCATION span yet (delegation
+    // ingested before the coordinator's span landed). Tail degenerates
+    // to observedAtMs so the arrow stays visible.
+    const store = new SessionStore();
+    mkAgent(store, 'coord');
+    mkAgent(store, 'sub');
+
+    store.delegations.append({
+      fromAgentId: 'coord',
+      toAgentId: 'sub',
+      taskId: 't-1',
+      invocationId: 'inv-1',
+      observedAtMs: 1_500,
+    });
+
+    const r = new GanttRenderer(store);
+    r.attach(stubCanvas(), stubCanvas(), stubCanvas());
+    r.resize(1200, 200, 1);
+    r.setViewport({
+      endMs: 10_000,
+      windowMs: 10_000,
+      liveFollow: false,
+      replay: false,
+    });
+    drawBlocks(r);
+
+    const edges = r._delegationLayoutsForTesting();
+    expect(edges).toHaveLength(1);
+    const e = edges[0];
+
+    expect(e.srcX).toBe(e.tgtX);
+    expect(e.tgtX).toBeCloseTo(pxAt(1_500), 5);
   });
 });

--- a/frontend/src/__tests__/gantt/delegationHitTest.test.ts
+++ b/frontend/src/__tests__/gantt/delegationHitTest.test.ts
@@ -9,14 +9,23 @@ import { GanttRenderer } from '../../gantt/renderer';
 // _seedDelegationLayoutsForTesting shim and assert the hit-test returns
 // the expected record for points-near-bezier and null for far points.
 //
-// Geometry under test — bezier P0..P3 matching drawDelegations():
-//   P0 = (x, srcY)
-//   P1 = (x + off, srcY)
-//   P2 = (x + off, tgtY)
-//   P3 = (x, tgtY)
-// For (x=500, srcY=100, tgtY=200, off=24), the midpoint of the curve
-// evaluates to roughly (518, 150). Points within ~6px of any sampled
-// segment should hit; points far from the curve should miss.
+// Geometry under test — bezier P0..P3 matching drawDelegations(). The
+// renderer now supports two shapes:
+//   * Degenerate (srcX === tgtX): right-bulging curve via curveOffset.
+//       P0 = (srcX, srcY)
+//       P1 = (srcX + off, srcY)
+//       P2 = (srcX + off, tgtY)
+//       P3 = (srcX, tgtY)
+//     For (srcX=500, srcY=100, tgtY=200, off=24), the t=0.5 sample
+//     evaluates to roughly (518, 150).
+//   * Slanted (srcX !== tgtX, harmonograf#241): horizontal-then-vertical
+//     bezier between the two endpoints.
+//       P0 = (srcX, srcY); P1 = (midX, srcY)
+//       P2 = (midX, tgtY); P3 = (tgtX, tgtY)
+//
+// Most legacy assertions here exercise the degenerate path because they
+// were written before #241 split srcX/tgtX. The fix(#241) describe block
+// at the bottom covers the slanted geometry explicitly.
 
 function mkRecord(
   seq: number,
@@ -48,7 +57,7 @@ describe('GanttRenderer.hitTestDelegation', () => {
     const r = mkRenderer();
     const rec = mkRecord(0);
     r._seedDelegationLayoutsForTesting([
-      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: rec.seq, record: rec, srcX: 500, tgtX: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
     ]);
     // Midpoint of the bezier is at (x + 3/4 * off, (srcY+tgtY)/2) = (518, 150).
     expect(r.hitTestDelegation(518, 150)).toBe(rec);
@@ -58,7 +67,7 @@ describe('GanttRenderer.hitTestDelegation', () => {
     const r = mkRenderer();
     const rec = mkRecord(0);
     r._seedDelegationLayoutsForTesting([
-      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: rec.seq, record: rec, srcX: 500, tgtX: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
     ]);
     // A tolerance of 6px means (501, 101) sits on the source-anchor region.
     expect(r.hitTestDelegation(501, 101)).toBe(rec);
@@ -69,7 +78,7 @@ describe('GanttRenderer.hitTestDelegation', () => {
     const r = mkRenderer();
     const rec = mkRecord(0);
     r._seedDelegationLayoutsForTesting([
-      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: rec.seq, record: rec, srcX: 500, tgtX: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
     ]);
     // Point well outside the bezier's bounding bump.
     expect(r.hitTestDelegation(100, 100)).toBeNull();
@@ -85,8 +94,8 @@ describe('GanttRenderer.hitTestDelegation', () => {
     // hitTestDelegation must return the `newer` one since it was appended
     // later in the Registry's array.
     r._seedDelegationLayoutsForTesting([
-      { seq: older.seq, record: older, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
-      { seq: newer.seq, record: newer, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: older.seq, record: older, srcX: 500, tgtX: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: newer.seq, record: newer, srcX: 500, tgtX: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
     ]);
     expect(r.hitTestDelegation(518, 150)).toBe(newer);
   });
@@ -95,7 +104,7 @@ describe('GanttRenderer.hitTestDelegation', () => {
     const r = mkRenderer();
     const rec = mkRecord(0);
     r._seedDelegationLayoutsForTesting([
-      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: rec.seq, record: rec, srcX: 500, tgtX: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
     ]);
     // x > x + off + tol (≈ 530): out of bbox.
     expect(r.hitTestDelegation(540, 150)).toBeNull();
@@ -108,8 +117,8 @@ describe('GanttRenderer.hitTestDelegation', () => {
     const a = mkRecord(0);
     const b = mkRecord(1);
     r._seedDelegationLayoutsForTesting([
-      { seq: a.seq, record: a, x: 200, srcY: 100, tgtY: 200, curveOffset: 24 },
-      { seq: b.seq, record: b, x: 400, srcY: 300, tgtY: 400, curveOffset: 24 },
+      { seq: a.seq, record: a, srcX: 200, tgtX: 200, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: b.seq, record: b, srcX: 400, tgtX: 400, srcY: 300, tgtY: 400, curveOffset: 24 },
     ]);
     expect(r.hitTestDelegation(218, 150)).toBe(a);
     expect(r.hitTestDelegation(418, 350)).toBe(b);
@@ -125,7 +134,7 @@ describe('GanttRenderer delegation hover/click callbacks', () => {
     const r = new GanttRenderer(store, { onDelegationClick });
     const rec = mkRecord(0);
     r._seedDelegationLayoutsForTesting([
-      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: rec.seq, record: rec, srcX: 500, tgtX: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
     ]);
     r.handleClick(518, 150);
     expect(onDelegationClick).toHaveBeenCalledTimes(1);
@@ -138,7 +147,7 @@ describe('GanttRenderer delegation hover/click callbacks', () => {
     const r = new GanttRenderer(store, { onDelegationHoverChange });
     const rec = mkRecord(0);
     r._seedDelegationLayoutsForTesting([
-      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: rec.seq, record: rec, srcX: 500, tgtX: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
     ]);
     r.handlePointerMove(518, 150);
     r.handlePointerMove(100, 100);
@@ -155,7 +164,7 @@ describe('GanttRenderer delegation hover/click callbacks', () => {
     const r = new GanttRenderer(store, { onDelegationClick });
     const rec = mkRecord(0);
     r._seedDelegationLayoutsForTesting([
-      { seq: rec.seq, record: rec, x: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
+      { seq: rec.seq, record: rec, srcX: 500, tgtX: 500, srcY: 100, tgtY: 200, curveOffset: 24 },
     ]);
     r.handleClick(100, 100);
     expect(onDelegationClick).not.toHaveBeenCalled();

--- a/frontend/src/gantt/renderer.ts
+++ b/frontend/src/gantt/renderer.ts
@@ -105,16 +105,76 @@ interface EdgeLayout {
 // redraw. Persisted so the hit-test pass and the overlay pulse highlight
 // share one source of truth with the primary draw call and the bezier is
 // never sampled against stale control points.
+//
+// harmonograf#241: the source (tail) and target (head) endpoints now sit at
+// distinct x positions — srcX anchors at the delegating agent's INVOCATION
+// end (the moment the hand-off happened on the coordinator's bar), tgtX
+// anchors at the delegation_observed timestamp (where the sub-agent's
+// INVOCATION will appear). When the source span is still running we anchor
+// srcX at session "now" so the tail tracks the live edge of the bar; when
+// no source span is found, or its end is past the observation, srcX falls
+// back to tgtX (recovers the legacy vertical curve so the edge stays
+// visible). `curveOffset` is now only consulted on that degenerate
+// srcX === tgtX path; for the common slanted case the bezier control
+// points run along the segment itself.
 interface DelegationEdgeLayout {
   seq: number;
   record: DelegationRecord;
-  // Both endpoints sit at the same x (delegation is instantaneous), so we
-  // only store one x value and the two y anchors + the horizontal curve
-  // offset — the bezier is fully determined by these.
-  x: number;
+  srcX: number;
+  tgtX: number;
   srcY: number;
   tgtY: number;
+  // Horizontal nudge for the degenerate (srcX === tgtX) curve so the
+  // bezier doesn't collapse into a zero-width vertical line. Unused when
+  // srcX !== tgtX.
   curveOffset: number;
+}
+
+// Shared bezier control points for a delegation curve. Centralizes the
+// degenerate-vs-slanted decision so drawDelegations, hitTestDelegation,
+// the midpoint glyph pass, and the overlay (hover + pulse) all sample the
+// same geometry. Returns P0..P3 of a cubic bezier.
+function delegationBezier(e: DelegationEdgeLayout): {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  x3: number;
+  y3: number;
+} {
+  const dx = e.tgtX - e.srcX;
+  if (dx === 0) {
+    // Degenerate fallback: both anchors share x. Bump control points to
+    // the right so the path doesn't collapse to a vertical line.
+    return {
+      x0: e.srcX,
+      y0: e.srcY,
+      x1: e.srcX + e.curveOffset,
+      y1: e.srcY,
+      x2: e.srcX + e.curveOffset,
+      y2: e.tgtY,
+      x3: e.srcX,
+      y3: e.tgtY,
+    };
+  }
+  // Slanted curve from (srcX, srcY) to (tgtX, tgtY). Control points sit
+  // at the horizontal midpoint of the segment but at each endpoint's y so
+  // the curve leaves the source bar horizontally before sloping toward
+  // the target — reads as a clear "hand-off then arrive" gesture rather
+  // than a diagonal line.
+  const midX = e.srcX + dx / 2;
+  return {
+    x0: e.srcX,
+    y0: e.srcY,
+    x1: midX,
+    y1: e.srcY,
+    x2: midX,
+    y2: e.tgtY,
+    x3: e.tgtX,
+    y3: e.tgtY,
+  };
 }
 
 interface FrameMetrics {
@@ -1309,13 +1369,18 @@ export class GanttRenderer {
       y += rowH;
     }
 
-    // Finds the INVOCATION span to anchor the arrow endpoint to on a
-    // given agent row at `atMs`. Prefers a span active at `atMs`; falls
-    // back to the most recent INVOCATION that ended before `atMs`, and
-    // finally to lane-0 math (same visual position the INVOCATION bar
-    // will occupy once it arrives) so the arrow stays stable on the live
-    // path even before the target row's INVOCATION span is reported.
-    const anchorY = (agentId: string, atMs: number): number | undefined => {
+    // Picks the INVOCATION span to anchor an endpoint to on a given agent
+    // row at `atMs`. Prefers a span active at `atMs`; falls back to the
+    // most recent INVOCATION that ended before `atMs`; finally lane-0
+    // math (same visual position the bar will occupy once it arrives) so
+    // the arrow stays stable on the live path even before the target
+    // row's INVOCATION span is reported. Returned `span` is undefined
+    // when no INVOCATION fits — callers fall back to the row's lane-0
+    // center via the returned `y`.
+    const pickAnchorSpan = (
+      agentId: string,
+      atMs: number,
+    ): { y: number; span: Span | undefined } | undefined => {
       const row = rowLayout.get(agentId);
       if (!row) return undefined;
       const pad = Math.max(this.viewport.windowMs * 0.5, 1);
@@ -1328,16 +1393,13 @@ export class GanttRenderer {
         if (s.startMs > atMs) continue;
         const end = s.endMs ?? Number.POSITIVE_INFINITY;
         if (end >= atMs) {
-          // Active at atMs — strongest match, prefer the latest-started
-          // one if multiple overlap (rare: invocation spans usually don't
-          // stack on a single row).
           if (!active || s.startMs > active.startMs) active = s;
         } else if (!mostRecentCompleted || s.startMs > mostRecentCompleted.startMs) {
           mostRecentCompleted = s;
         }
       }
       const chosen = active ?? mostRecentCompleted;
-      return laneCenterY(row, chosen ? chosen.lane : 0);
+      return { y: laneCenterY(row, chosen ? chosen.lane : 0), span: chosen };
     };
 
     const dataLeft = GUTTER_WIDTH_PX + 10;
@@ -1354,17 +1416,59 @@ export class GanttRenderer {
       if (d.observedAtMs < vs - margin || d.observedAtMs > ve + margin) {
         continue;
       }
-      const srcY = anchorY(d.fromAgentId, d.observedAtMs);
-      const tgtY = anchorY(d.toAgentId, d.observedAtMs);
-      if (srcY === undefined || tgtY === undefined) continue;
-      const x = msToPx(this.viewport, w, d.observedAtMs);
-      if (x < dataLeft || x > dataRight) continue;
+      const srcAnchor = pickAnchorSpan(d.fromAgentId, d.observedAtMs);
+      const tgtAnchor = pickAnchorSpan(d.toAgentId, d.observedAtMs);
+      if (!srcAnchor || !tgtAnchor) continue;
+
+      // Tail X — harmonograf#241. The tail should anchor at the END of
+      // the delegating agent's INVOCATION (the moment the hand-off
+      // actually happened on the coordinator's bar), NOT at the
+      // observed-time of the delegation_observed event. The previous
+      // behavior placed both endpoints at observedAtMs which, for
+      // delegations dispatched near session start, visually collapsed
+      // the tail onto the leftmost x position. Edge-case fallbacks:
+      //   * Source span still RUNNING (endMs null) → use store.nowMs so
+      //     the tail tracks the live edge of the bar.
+      //   * No source span found → degenerate to observedAtMs (tgtX);
+      //     delegationBezier() draws the legacy vertical curve so the
+      //     edge stays visible.
+      //   * Source span endMs is AFTER observedAtMs (rare clock drift) →
+      //     also degenerate to observedAtMs; a tail past the head would
+      //     read as the arrow going backwards in time.
+      const tgtMs = d.observedAtMs;
+      let srcMs: number;
+      const srcSpan = srcAnchor.span;
+      if (!srcSpan) {
+        srcMs = tgtMs;
+      } else if (srcSpan.endMs === null) {
+        const nowMs = this.store.nowMs;
+        srcMs = nowMs > srcSpan.startMs ? nowMs : tgtMs;
+      } else if (srcSpan.endMs > tgtMs) {
+        srcMs = tgtMs;
+      } else {
+        srcMs = srcSpan.endMs;
+      }
+      // Clamp the tail to not precede the source span's own start —
+      // protects against fixtures where the source span has an end past
+      // its start in negative direction (shouldn't happen but is cheap
+      // to defend against).
+      if (srcSpan && srcMs < srcSpan.startMs) srcMs = srcSpan.startMs;
+
+      const srcX = msToPx(this.viewport, w, srcMs);
+      const tgtX = msToPx(this.viewport, w, tgtMs);
+      // Viewport cull — drop only when BOTH endpoints sit off the same
+      // edge of the data area. A delegation whose tail starts before the
+      // visible window but lands inside it should still render.
+      if ((srcX < dataLeft && tgtX < dataLeft) || (srcX > dataRight && tgtX > dataRight)) {
+        continue;
+      }
       this.delegationEdges.push({
         seq: d.seq,
         record: d,
-        x,
-        srcY,
-        tgtY,
+        srcX,
+        tgtX,
+        srcY: srcAnchor.y,
+        tgtY: tgtAnchor.y,
         curveOffset,
       });
     }
@@ -1377,21 +1481,21 @@ export class GanttRenderer {
     ctx.setLineDash([4, 3]);
     ctx.strokeStyle = color;
     for (const e of this.delegationEdges) {
-      // Same-time, different-row edge: draw a shallow curve so the path
-      // doesn't collapse into a zero-width vertical line. Offset the
-      // control points horizontally by a fixed nudge.
+      const b = delegationBezier(e);
       ctx.beginPath();
-      ctx.moveTo(e.x, e.srcY);
-      ctx.bezierCurveTo(
-        e.x + e.curveOffset, e.srcY,
-        e.x + e.curveOffset, e.tgtY,
-        e.x, e.tgtY,
-      );
+      ctx.moveTo(b.x0, b.y0);
+      ctx.bezierCurveTo(b.x1, b.y1, b.x2, b.y2, b.x3, b.y3);
       ctx.stroke();
     }
 
     // Midpoint glyph pass — unsharp without lineDash so the symbol reads
-    // as a single solid mark instead of picking up the dash pattern.
+    // as a single solid mark instead of picking up the dash pattern. For
+    // the slanted geometry the bezier with horizontal-midpoint controls
+    // has its t=0.5 sample at ((srcX+tgtX)/2, (srcY+tgtY)/2); for the
+    // degenerate (srcX === tgtX) case the t=0.5 sample collapses to
+    // (srcX + 3/4 * curveOffset, (srcY+tgtY)/2). Both reduce to "midpoint
+    // of the curve's bounding box-ish region", which the glyph nudges +4
+    // to the right of.
     ctx.setLineDash([]);
     ctx.globalAlpha = 0.6;
     ctx.fillStyle = color;
@@ -1399,10 +1503,9 @@ export class GanttRenderer {
     ctx.textAlign = 'left';
     ctx.textBaseline = 'middle';
     for (const e of this.delegationEdges) {
-      // Midpoint of a bezier with equal-x endpoints and offset control
-      // points collapses to (x + 3/4 * offset, (srcY+tgtY)/2). Hand-fit
-      // so the glyph clears the curve's crest.
-      ctx.fillText('↪↪', e.x + 4, (e.srcY + e.tgtY) / 2);
+      const glyphX =
+        e.srcX === e.tgtX ? e.srcX + 4 : (e.srcX + e.tgtX) / 2;
+      ctx.fillText('↪↪', glyphX, (e.srcY + e.tgtY) / 2);
     }
     ctx.restore();
   }
@@ -1425,26 +1528,30 @@ export class GanttRenderer {
     // Walk back-to-front so the latest delegation wins when curves overlap.
     for (let i = edges.length - 1; i >= 0; i--) {
       const e = edges[i];
-      // Quick bbox reject. The curve hugs x..x+curveOffset in the x-axis;
-      // y is bounded by the two anchors, padded for rounding.
-      const minX = e.x - tol;
-      const maxX = e.x + e.curveOffset + tol;
+      // Quick bbox reject. For the slanted curve (srcX != tgtX) the
+      // bezier with horizontal-midpoint controls stays inside the
+      // x-rectangle [min(srcX,tgtX), max(srcX,tgtX)]; for the degenerate
+      // (srcX === tgtX) curve the right-bulging control points push the
+      // path out to srcX + curveOffset. Pick whichever envelope contains
+      // both shapes.
+      const xLo = Math.min(e.srcX, e.tgtX);
+      const xHi = Math.max(e.srcX, e.tgtX);
+      const minX = xLo - tol;
+      const maxX = (e.srcX === e.tgtX ? e.srcX + e.curveOffset : xHi) + tol;
       const minY = Math.min(e.srcY, e.tgtY) - tol;
       const maxY = Math.max(e.srcY, e.tgtY) + tol;
       if (px < minX || px > maxX || py < minY || py > maxY) continue;
-      // Bezier coefficients for the curve drawn in drawDelegations:
-      //   P0 = (x, srcY)
-      //   P1 = (x + off, srcY)
-      //   P2 = (x + off, tgtY)
-      //   P3 = (x, tgtY)
-      const x0 = e.x;
-      const y0 = e.srcY;
-      const x1 = e.x + e.curveOffset;
-      const y1 = e.srcY;
-      const x2 = e.x + e.curveOffset;
-      const y2 = e.tgtY;
-      const x3 = e.x;
-      const y3 = e.tgtY;
+      // Bezier coefficients shared with drawDelegations / overlay pulse /
+      // hover via delegationBezier() so all four sample the same geometry.
+      const b = delegationBezier(e);
+      const x0 = b.x0;
+      const y0 = b.y0;
+      const x1 = b.x1;
+      const y1 = b.y1;
+      const x2 = b.x2;
+      const y2 = b.y2;
+      const x3 = b.x3;
+      const y3 = b.y3;
       let prevX = x0;
       let prevY = y0;
       for (let j = 1; j <= samples; j++) {
@@ -2129,17 +2236,14 @@ export class GanttRenderer {
           (d) => d.seq === this.hoveredDelegationSeq,
         );
         if (e) {
+          const b = delegationBezier(e);
           ctx.strokeStyle = color;
           ctx.globalAlpha = 0.85;
           ctx.lineWidth = 2;
           ctx.setLineDash([4, 3]);
           ctx.beginPath();
-          ctx.moveTo(e.x, e.srcY);
-          ctx.bezierCurveTo(
-            e.x + e.curveOffset, e.srcY,
-            e.x + e.curveOffset, e.tgtY,
-            e.x, e.tgtY,
-          );
+          ctx.moveTo(b.x0, b.y0);
+          ctx.bezierCurveTo(b.x1, b.y1, b.x2, b.y2, b.x3, b.y3);
           ctx.stroke();
         }
       }
@@ -2148,6 +2252,7 @@ export class GanttRenderer {
           (d) => d.seq === this.pulsingDelegationSeq,
         );
         if (e) {
+          const b = delegationBezier(e);
           const remaining = Math.max(0, this.pulseUntilMs - nowMs);
           const fade = remaining / 500; // 1 → 0 across 500ms.
           ctx.strokeStyle = color;
@@ -2155,12 +2260,8 @@ export class GanttRenderer {
           ctx.lineWidth = 2.5 + 2 * fade;
           ctx.setLineDash([]);
           ctx.beginPath();
-          ctx.moveTo(e.x, e.srcY);
-          ctx.bezierCurveTo(
-            e.x + e.curveOffset, e.srcY,
-            e.x + e.curveOffset, e.tgtY,
-            e.x, e.tgtY,
-          );
+          ctx.moveTo(b.x0, b.y0);
+          ctx.bezierCurveTo(b.x1, b.y1, b.x2, b.y2, b.x3, b.y3);
           ctx.stroke();
         }
         // Keep asking for more frames until the deadline passes so the


### PR DESCRIPTION
## Summary

The dashed `↪↪` delegation arrow's TAIL now anchors at the **end of the delegating agent's INVOCATION span** (the moment the hand-off actually happened on the coordinator's bar). Previously both endpoints sat at the `delegation_observed` event's `observed_at` timestamp, which for delegations dispatched near session start collapsed the tail onto the leftmost data-area x position — reading as if the hand-off originated from session-start.

The arrowhead (target side) is unchanged — still anchored at the observed-at moment where the sub-agent's INVOCATION will land.

## Code

- `frontend/src/gantt/renderer.ts`
  - Split `DelegationEdgeLayout.x` into `srcX` + `tgtX`.
  - New `delegationBezier()` helper centralises the slanted-vs-degenerate geometry decision so `drawDelegations`, `hitTestDelegation`, the midpoint glyph pass, and the overlay (hover + pulse) all sample the same curve.
  - `drawDelegations` now picks the source-side x from the delegating agent's INVOCATION span end with three edge-case fallbacks (RUNNING source → `store.nowMs`; missing source span → degenerate to `tgtX`; source endMs > observed → degenerate to `tgtX`).

## Edge cases handled

| Case | Behaviour |
|---|---|
| Source span has `endMs` ≤ `observedAtMs` (normal) | Tail at `srcSpan.endMs`, head at `observedAtMs` — slanted curve. |
| Source span still RUNNING (`endMs === null`) | Tail at `store.nowMs` (when past `startMs`), otherwise degenerate to `tgtX`. |
| Source span not yet reported (ingest race) | Degenerate to `tgtX`; legacy vertical curve keeps the edge visible. |
| Source `endMs` > `observedAtMs` (rare clock drift) | Degenerate to `tgtX`; a tail past the head would read as time-travel. |

## Contract preserved

- Non-delegation arrows (LINK_INVOKED edges via `drawLinks`) — untouched.
- Arrowhead (target) positioning — unchanged.
- No DB schema change. No backend change.
- Existing `delegationAnchor` lane/Y assertions (harmonograf#129) still hold — the source-Y is unchanged; only source-X moved.

## Test plan

- [x] `npx vitest run src/__tests__/gantt/ src/__tests__/components/GraphView.delegation.test.tsx` — 140/140 pass.
- [x] `npx vitest run` — 707 pass (2 pre-existing TrajectoryView header failures on `main`, unrelated).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` clean (1 pre-existing warning unrelated).
- [x] Visual check on live stack (cherry-tree session `2d27ff4a`) — delegation arrows now slant from source-bar-end to target-bar-start instead of collapsing onto the data-area's left edge.

New unit tests in `delegationAnchor.test.ts` cover:
1. Tail at source endMs when source completed before observation.
2. Tail at `store.nowMs` when source is still RUNNING.
3. Tail falls back to `tgtX` on clock-drift (source endMs > observed).
4. Tail falls back to `tgtX` when no source INVOCATION exists yet.