### PR TITLE
Replay goldfive events.jsonl from disk: harmonograf-replay + zicato handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ materialise live in the harmonograf tab. Ctrl-C tears all three down.
 | [docs/overview.md](docs/overview.md) | Longer-form writeup: motivation, design principles, current features, non-goals, roadmap. |
 | [docs/goldfive-integration.md](docs/goldfive-integration.md) | How harmonograf consumes goldfive: `HarmonografTelemetryPlugin`, `HarmonografSink`, `observe()`, `goldfive_event` envelope, per-ADK-agent rows, session unification. |
 | [docs/standalone-observability.md](docs/standalone-observability.md) | Non-ADK flow: emit spans from any Python process with `harmonograf_client.Client`. |
+| [docs/zicato-handoff.md](docs/zicato-handoff.md) | Replaying a finished run's goldfive `events.jsonl` from disk with `harmonograf-replay`; deep-linking a zicato run into harmonograf as its execution view. |
 | [docs/operator-quickstart.md](docs/operator-quickstart.md) | Flags, retention, health probes, bearer-token auth, STEER from the UI — the ops-facing reference. |
 | [docs/reporting-tools.md](docs/reporting-tools.md) | Redirect to goldfive's reporting-tool reference (owned there post-migration). |
 | [docs/user-guide/](docs/user-guide/) | Navigating the UI: Gantt, graph, trajectory, inspector, transport bar, keyboard shortcuts. |

--- a/client/harmonograf_client/replay.py
+++ b/client/harmonograf_client/replay.py
@@ -196,7 +196,26 @@ async def _run(args: argparse.Namespace) -> int:
         # whole run before this process dies.
         client.shutdown(flush_timeout=args.flush_timeout)
 
-    session_id = client.session_id or "(unassigned)"
+    # Delivery accounting. Replay is fire-and-forget on the wire — events
+    # are pushed onto the transport buffer and a background send loop
+    # drains them. The CLI must still tell an operator (or a zicato hook
+    # shelling out to replay) whether the run actually *landed*, so a
+    # dropped run is not mistaken for an ingested one.
+    #
+    # The reliable "reached a server" signal is ``client.session_id``:
+    # the transport's ``assigned_session_id`` is set ONLY when the server
+    # answers the Hello with a Welcome. Buffer emptiness is NOT a sound
+    # signal — the send loop pops envelopes off the ring buffer into an
+    # in-flight gRPC call before that call can fail, so the ring can read
+    # empty even though nothing was acked.
+    #
+    # ``client.session_id`` is empty here only when no Welcome ever
+    # arrived (server down, wrong --server, auth rejected). It is
+    # non-empty — the run id from the file, or a server-minted id if the
+    # events carried no session_id — once the run has landed.
+    delivered_session_id = client.session_id
+    dropped = client._events.stats_snapshot().dropped_total
+    session_id = delivered_session_id or "(unassigned)"
     logger.info("replay complete: %s", stats)
     print(f"replayed {path}")
     print(f"  {stats}")
@@ -205,6 +224,28 @@ async def _run(args: argparse.Namespace) -> int:
     if stats.emitted == 0:
         logger.warning("no events emitted — is %s a goldfive events.jsonl?", path)
         return 1
+    if not delivered_session_id:
+        logger.error(
+            "the run did NOT reach %s — no session was assigned within the "
+            "%.1fs flush window (server down / wrong --server / auth "
+            "rejected); raise --flush-timeout for a slow link or fix the "
+            "address",
+            args.server,
+            args.flush_timeout,
+        )
+        return 3
+    if dropped > 0:
+        # The run reached the server, but the ring overflowed mid-replay
+        # and shed events before they could be sent — the session landed
+        # incomplete. Surface it: a partial session is misleading.
+        logger.error(
+            "%d event(s) dropped by buffer overflow during replay — "
+            "session %s is INCOMPLETE; the link could not keep up with "
+            "the file (raise the client buffer or slow the producer)",
+            dropped,
+            delivered_session_id,
+        )
+        return 3
     return 0
 
 

--- a/client/harmonograf_client/replay.py
+++ b/client/harmonograf_client/replay.py
@@ -1,0 +1,279 @@
+"""Replay a goldfive ``events.jsonl`` file into a harmonograf server.
+
+Harmonograf normally terminates a live goldfive event stream over gRPC
+(see :class:`HarmonografSink`). But a finished run is also a *file*:
+goldfive's recorder writes one ``goldfive.v1.Event`` per line to an
+``events.jsonl`` next to the run. Tools that produce those files — most
+notably zicato, which runs multi-agent systems under goldfive and keeps
+each run's events under ``.zicato/epochs/.../runs/<run>/events.jsonl`` —
+want to point an operator at the harmonograf timeline for one run
+*after* it has completed.
+
+This module is that bridge: it reads an ``events.jsonl`` from disk,
+parses each line, and feeds the events through the *exact same*
+:class:`HarmonografSink` the live path uses. No new wire surface, no new
+server endpoint — replay is just a non-live producer. The session id is
+preserved from the events themselves, so the run is addressable in the
+harmonograf UI at ``/session/<run-id>`` and a dashboard can deep-link to
+it (see ``docs/zicato-handoff.md``).
+
+Two on-disk event shapes are accepted, matching what
+:meth:`HarmonografSink.emit` already handles:
+
+* **proto-JSON** — the protobuf JSON mapping of ``goldfive.v1.Event``
+  (camelCase keys, payload oneof at top level). Parsed with
+  ``json_format.Parse(..., ignore_unknown_fields=True)`` so an
+  ``events.jsonl`` written by a *newer* goldfive than the harmonograf
+  submodule is pinned to still replays — unknown event kinds are
+  dropped, known ones render.
+* **dict envelope** — a JSON object with top-level ``kind`` + ``payload``
+  keys (snake_case). Goldfive emits a handful of operator-observability
+  events this way (``refine_attempted``, ``refine_failed``, ...).
+  Passed through to the sink verbatim; the sink owns the dict→proto
+  translation.
+
+Usage::
+
+    harmonograf-replay path/to/events.jsonl
+    harmonograf-replay --server 127.0.0.1:7531 --title "my run" run/events.jsonl
+
+Then open the harmonograf frontend and the replayed session appears in
+the picker, addressable by the run id the file carries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+from .client import Client
+from .sink import HarmonografSink
+
+logger = logging.getLogger(__name__)
+
+
+class ReplayStats:
+    """Tally of what a replay run did, for the operator-facing summary."""
+
+    def __init__(self) -> None:
+        self.proto_events = 0
+        self.dict_events = 0
+        self.skipped_unparseable = 0
+        self.skipped_empty_payload = 0
+
+    @property
+    def emitted(self) -> int:
+        return self.proto_events + self.dict_events
+
+    def __str__(self) -> str:
+        return (
+            f"emitted={self.emitted} "
+            f"(proto={self.proto_events}, dict={self.dict_events}) "
+            f"skipped={self.skipped_unparseable + self.skipped_empty_payload} "
+            f"(unparseable={self.skipped_unparseable}, "
+            f"empty_payload={self.skipped_empty_payload})"
+        )
+
+
+def _iter_jsonl(path: Path) -> Iterator[tuple[int, dict[str, Any]]]:
+    """Yield ``(line_number, parsed_object)`` for every non-blank line.
+
+    Blank lines are skipped silently (a trailing newline is common).
+    A line that is not valid JSON is logged at WARNING and skipped — a
+    single corrupt line must not abort the replay of a long run.
+    """
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                logger.warning("skipping line %d: invalid JSON (%s)", lineno, exc)
+                continue
+            if not isinstance(obj, dict):
+                logger.warning("skipping line %d: not a JSON object", lineno)
+                continue
+            yield lineno, obj
+
+
+def _is_dict_envelope(obj: dict[str, Any]) -> bool:
+    """True when ``obj`` is a goldfive dict envelope (``kind`` + ``payload``).
+
+    Distinct from the proto-JSON shape, where the payload oneof variant
+    is itself a top-level camelCase key and there is no literal ``kind``
+    field. :meth:`HarmonografSink.emit` routes the two shapes apart the
+    same way — this mirrors that test so replay classifies before the
+    sink does and can keep an accurate per-shape tally.
+    """
+    return (
+        "kind" in obj
+        and "payload" in obj
+        and isinstance(obj.get("payload"), dict)
+    )
+
+
+async def replay_events(
+    path: Path,
+    sink: HarmonografSink,
+    *,
+    stats: ReplayStats | None = None,
+) -> ReplayStats:
+    """Parse ``path`` and feed every event through ``sink``.
+
+    The events are emitted in file order — goldfive writes ``events.jsonl``
+    in ``sequence`` order, so file order is replay order. The sink reuses
+    the client's buffer + transport, so emission is non-blocking; the
+    caller drains the buffer via :meth:`Client.shutdown`.
+    """
+    from goldfive.pb.goldfive.v1 import events_pb2 as goldfive_events_pb2
+    from google.protobuf import json_format
+
+    stats = stats or ReplayStats()
+    for lineno, obj in _iter_jsonl(path):
+        if _is_dict_envelope(obj):
+            # Operator-observability dict envelope — the sink owns the
+            # dict→proto translation (refine_attempted, refine_failed).
+            await sink.emit(obj)
+            stats.dict_events += 1
+            continue
+
+        event = goldfive_events_pb2.Event()
+        try:
+            # ignore_unknown_fields keeps a file written by a newer
+            # goldfive than this submodule replayable: unknown event
+            # kinds parse to an Event with no payload oneof set and are
+            # dropped just below, known kinds still render.
+            json_format.Parse(json.dumps(obj), event, ignore_unknown_fields=True)
+        except json_format.ParseError as exc:
+            logger.warning("skipping line %d: not a goldfive Event (%s)", lineno, exc)
+            stats.skipped_unparseable += 1
+            continue
+
+        if event.WhichOneof("payload") is None:
+            # Either a genuinely empty envelope or an event whose only
+            # payload field was unknown to this goldfive submodule and
+            # got dropped by ignore_unknown_fields. Nothing to render.
+            stats.skipped_empty_payload += 1
+            continue
+
+        await sink.emit(event)
+        stats.proto_events += 1
+
+    return stats
+
+
+async def _run(args: argparse.Namespace) -> int:
+    path = Path(args.events_file).expanduser()
+    if not path.is_file():
+        logger.error("no such file: %s", path)
+        return 2
+
+    # Default the session title to the run directory name — for a zicato
+    # run that is the run slug (e.g. ``transformers_lay_audience``), which
+    # is far more useful in the session picker than the bare run id.
+    title = args.title or f"replay: {path.parent.name}"
+
+    client = Client(
+        name=args.agent_name,
+        framework="CUSTOM",
+        server_addr=args.server,
+        session_title=title,
+        token=args.token or None,
+    )
+    sink = HarmonografSink(client)
+    try:
+        stats = await replay_events(path, sink)
+    finally:
+        await sink.close()
+        # Drain the transport buffer before exit so the server has the
+        # whole run before this process dies.
+        client.shutdown(flush_timeout=args.flush_timeout)
+
+    session_id = client.session_id or "(unassigned)"
+    logger.info("replay complete: %s", stats)
+    print(f"replayed {path}")
+    print(f"  {stats}")
+    print(f"  session: {session_id}")
+    print(f"  open:    harmonograf frontend → /session/{session_id}")
+    if stats.emitted == 0:
+        logger.warning("no events emitted — is %s a goldfive events.jsonl?", path)
+        return 1
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="harmonograf-replay",
+        description=(
+            "Replay a goldfive events.jsonl file into a harmonograf server "
+            "so a finished run renders as a session in the harmonograf UI."
+        ),
+    )
+    p.add_argument(
+        "events_file",
+        help="path to a goldfive events.jsonl (one goldfive.v1.Event per line)",
+    )
+    p.add_argument(
+        "--server",
+        default="127.0.0.1:7531",
+        help="harmonograf server gRPC address (default: 127.0.0.1:7531)",
+    )
+    p.add_argument(
+        "--title",
+        default="",
+        help=(
+            "session title shown in the picker; defaults to "
+            "'replay: <run-dir-name>'"
+        ),
+    )
+    p.add_argument(
+        "--agent-name",
+        default="zicato-replay",
+        help=(
+            "display name for the replay client's own agent row "
+            "(default: zicato-replay)"
+        ),
+    )
+    p.add_argument(
+        "--token",
+        default="",
+        help="bearer token, if the target server was started with --auth-token",
+    )
+    p.add_argument(
+        "--flush-timeout",
+        type=float,
+        default=15.0,
+        help=(
+            "seconds to wait for the transport buffer to drain before exit; "
+            "raise for very large event files (default: 15.0)"
+        ),
+    )
+    p.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=("DEBUG", "INFO", "WARNING", "ERROR"),
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+    try:
+        return asyncio.run(_run(args))
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest>=8.0", "pytest-asyncio>=0.23"]
 
+[project.scripts]
+harmonograf-replay = "harmonograf_client.replay:main"
+
 [build-system]
 requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"

--- a/client/tests/test_replay.py
+++ b/client/tests/test_replay.py
@@ -1,0 +1,287 @@
+"""Tests for ``harmonograf_client.replay`` — goldfive events.jsonl replay.
+
+The replay path turns a finished run's ``events.jsonl`` (one
+``goldfive.v1.Event`` per line, as written by goldfive's recorder /
+zicato) into a harmonograf session by feeding every event through the
+same :class:`HarmonografSink` the live gRPC path uses.
+
+These tests drive :func:`replay_events` directly against a
+:class:`Client` backed by a :class:`FakeTransport`, so no server is
+needed. They pin three invariants:
+
+* both on-disk shapes — proto-JSON and dict envelope — are accepted;
+* an event kind unknown to the pinned goldfive submodule is skipped,
+  not fatal (forward-compat via ``ignore_unknown_fields``);
+* a corrupt JSON line is skipped, not fatal.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from harmonograf_client.buffer import EnvelopeKind
+from harmonograf_client.client import Client
+from harmonograf_client.replay import ReplayStats, _is_dict_envelope, replay_events
+from harmonograf_client.sink import HarmonografSink
+
+from tests._fixtures import FakeTransport, make_factory
+
+
+CLIENT_AGENT_ID = "zicato-replay-abc123"
+
+
+@pytest.fixture
+def made() -> list[FakeTransport]:
+    return []
+
+
+@pytest.fixture
+def client(made: list[FakeTransport]) -> Client:
+    return Client(
+        name="zicato-replay",
+        agent_id=CLIENT_AGENT_ID,
+        session_id="run-xyz",
+        framework="CUSTOM",
+        buffer_size=256,
+        _transport_factory=make_factory(made),
+    )
+
+
+@pytest.fixture
+def sink(client: Client) -> HarmonografSink:
+    return HarmonografSink(client)
+
+
+def _drain(client: Client) -> list:
+    return list(client._events.drain())
+
+
+def _write_jsonl(tmp_path: Path, lines: list[str]) -> Path:
+    path = tmp_path / "events.jsonl"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+# ---- shape classification --------------------------------------------------
+
+
+class TestIsDictEnvelope:
+    def test_dict_envelope_recognised(self) -> None:
+        assert _is_dict_envelope({"kind": "refine_attempted", "payload": {}})
+
+    def test_proto_json_not_a_dict_envelope(self) -> None:
+        # proto-JSON puts the payload oneof variant at the top level and
+        # has no literal ``kind`` key.
+        assert not _is_dict_envelope(
+            {"runId": "r", "runStarted": {"runId": "r"}}
+        )
+
+    def test_kind_without_dict_payload_not_envelope(self) -> None:
+        assert not _is_dict_envelope({"kind": "x", "payload": "not-a-dict"})
+
+
+# ---- proto-JSON events -----------------------------------------------------
+
+
+class TestProtoJsonReplay:
+    @pytest.mark.asyncio
+    async def test_run_started_proto_json_emitted(
+        self, tmp_path: Path, sink: HarmonografSink, client: Client
+    ) -> None:
+        path = _write_jsonl(
+            tmp_path,
+            [
+                json.dumps(
+                    {
+                        "eventId": "e0",
+                        "runId": "run-xyz",
+                        "sequence": "1",
+                        "sessionId": "run-xyz",
+                        "runStarted": {
+                            "runId": "run-xyz",
+                            "goalSummary": "do a thing",
+                        },
+                    }
+                )
+            ],
+        )
+        stats = await replay_events(path, sink)
+        assert stats.proto_events == 1
+        assert stats.dict_events == 0
+        assert stats.emitted == 1
+
+        env = _drain(client)[0]
+        assert env.kind is EnvelopeKind.GOLDFIVE_EVENT
+        assert env.payload.WhichOneof("payload") == "run_started"
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_kind_skipped_not_fatal(
+        self, tmp_path: Path, sink: HarmonografSink, client: Client
+    ) -> None:
+        """A line whose only payload field is unknown to the pinned
+        goldfive submodule parses to an Event with no payload oneof and
+        is counted as skipped — the replay continues."""
+        path = _write_jsonl(
+            tmp_path,
+            [
+                json.dumps(
+                    {
+                        "eventId": "e1",
+                        "runId": "run-xyz",
+                        "sequence": "2",
+                        # A made-up future event kind. ignore_unknown_fields
+                        # drops it; WhichOneof('payload') is then None.
+                        "someFutureEventKind": {"foo": "bar"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "eventId": "e2",
+                        "runId": "run-xyz",
+                        "sequence": "3",
+                        "runCompleted": {"runId": "run-xyz"},
+                    }
+                ),
+            ],
+        )
+        stats = await replay_events(path, sink)
+        assert stats.skipped_empty_payload == 1
+        assert stats.proto_events == 1  # run_completed still emitted
+
+        env = _drain(client)[0]
+        assert env.payload.WhichOneof("payload") == "run_completed"
+
+
+# ---- dict-envelope events --------------------------------------------------
+
+
+class TestDictEnvelopeReplay:
+    @pytest.mark.asyncio
+    async def test_refine_attempted_dict_envelope_emitted(
+        self, tmp_path: Path, sink: HarmonografSink, client: Client
+    ) -> None:
+        path = _write_jsonl(
+            tmp_path,
+            [
+                json.dumps(
+                    {
+                        "kind": "refine_attempted",
+                        "run_id": "run-xyz",
+                        "sequence": 7,
+                        "session_id": "run-xyz",
+                        "emitted_at": {"seconds": 1778889023, "nanos": 0},
+                        "payload": {
+                            "attempt_id": "att-1",
+                            "drift_id": "drift-1",
+                            "trigger_kind": "capability_mismatch",
+                            "trigger_severity": "critical",
+                            "current_task_id": "t-draft",
+                            "current_agent_id": "reviewer_agent",
+                        },
+                    }
+                )
+            ],
+        )
+        stats = await replay_events(path, sink)
+        assert stats.dict_events == 1
+        assert stats.proto_events == 0
+
+        env = _drain(client)[0]
+        # The sink translates the dict envelope to a RefineAttempted proto.
+        assert env.kind is EnvelopeKind.REFINE_ATTEMPTED
+        assert env.payload.attempt_id == "att-1"
+        # Agent id is canonicalized bare -> compound by the sink.
+        assert env.payload.current_agent_id == f"{CLIENT_AGENT_ID}:reviewer_agent"
+
+
+# ---- mixed + resilience ----------------------------------------------------
+
+
+class TestMixedAndResilience:
+    @pytest.mark.asyncio
+    async def test_blank_and_corrupt_lines_skipped(
+        self, tmp_path: Path, sink: HarmonografSink, client: Client
+    ) -> None:
+        path = tmp_path / "events.jsonl"
+        path.write_text(
+            "\n".join(
+                [
+                    "",  # blank
+                    "{not json",  # corrupt
+                    "[1, 2, 3]",  # JSON but not an object
+                    json.dumps(
+                        {
+                            "eventId": "e0",
+                            "runId": "run-xyz",
+                            "sequence": "1",
+                            "runStarted": {"runId": "run-xyz"},
+                        }
+                    ),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        stats = await replay_events(path, sink)
+        # Corrupt + non-object lines are skipped silently; only the valid
+        # event is emitted.
+        assert stats.proto_events == 1
+        assert stats.emitted == 1
+
+    @pytest.mark.asyncio
+    async def test_mixed_proto_and_dict_in_one_file(
+        self, tmp_path: Path, sink: HarmonografSink, client: Client
+    ) -> None:
+        path = _write_jsonl(
+            tmp_path,
+            [
+                json.dumps(
+                    {
+                        "eventId": "e0",
+                        "runId": "run-xyz",
+                        "sequence": "1",
+                        "runStarted": {"runId": "run-xyz"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "kind": "refine_attempted",
+                        "run_id": "run-xyz",
+                        "sequence": 2,
+                        "session_id": "run-xyz",
+                        "payload": {"attempt_id": "att-1"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "eventId": "e2",
+                        "runId": "run-xyz",
+                        "sequence": "3",
+                        "runCompleted": {"runId": "run-xyz"},
+                    }
+                ),
+            ],
+        )
+        stats = await replay_events(path, sink)
+        assert stats.proto_events == 2
+        assert stats.dict_events == 1
+        assert stats.emitted == 3
+
+
+# ---- ReplayStats -----------------------------------------------------------
+
+
+def test_replay_stats_str_is_operator_readable() -> None:
+    stats = ReplayStats()
+    stats.proto_events = 107
+    stats.dict_events = 9
+    stats.skipped_unparseable = 0
+    stats.skipped_empty_payload = 13
+    text = str(stats)
+    assert "emitted=116" in text
+    assert "proto=107" in text
+    assert "dict=9" in text
+    assert "empty_payload=13" in text

--- a/client/tests/test_replay.py
+++ b/client/tests/test_replay.py
@@ -24,7 +24,13 @@ import pytest
 
 from harmonograf_client.buffer import EnvelopeKind
 from harmonograf_client.client import Client
-from harmonograf_client.replay import ReplayStats, _is_dict_envelope, replay_events
+from harmonograf_client.replay import (
+    ReplayStats,
+    _is_dict_envelope,
+    _run,
+    build_parser,
+    replay_events,
+)
 from harmonograf_client.sink import HarmonografSink
 
 from tests._fixtures import FakeTransport, make_factory
@@ -232,6 +238,47 @@ class TestMixedAndResilience:
         assert stats.emitted == 1
 
     @pytest.mark.asyncio
+    async def test_json_object_that_is_not_a_goldfive_event_skipped(
+        self, tmp_path: Path, sink: HarmonografSink, client: Client
+    ) -> None:
+        """A line that is a valid JSON object but not a parseable
+        ``goldfive.v1.Event`` (a type mismatch ``ignore_unknown_fields``
+        cannot paper over) raises ``json_format.ParseError`` — it must be
+        counted as ``skipped_unparseable`` and the replay must continue.
+
+        This is a distinct path from the corrupt-JSON skip (which never
+        reaches the proto parser) and was previously untested."""
+        path = _write_jsonl(
+            tmp_path,
+            [
+                # ``sequence`` is a scalar field on Event; handing it a
+                # nested object is a type error proto-JSON cannot parse.
+                json.dumps(
+                    {
+                        "eventId": "e0",
+                        "sequence": {"not": "a scalar"},
+                        "runStarted": {"runId": "run-xyz"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "eventId": "e1",
+                        "runId": "run-xyz",
+                        "sequence": "2",
+                        "runCompleted": {"runId": "run-xyz"},
+                    }
+                ),
+            ],
+        )
+        stats = await replay_events(path, sink)
+        assert stats.skipped_unparseable == 1
+        assert stats.proto_events == 1  # the well-formed event still lands
+        assert stats.emitted == 1
+
+        env = _drain(client)[0]
+        assert env.payload.WhichOneof("payload") == "run_completed"
+
+    @pytest.mark.asyncio
     async def test_mixed_proto_and_dict_in_one_file(
         self, tmp_path: Path, sink: HarmonografSink, client: Client
     ) -> None:
@@ -269,6 +316,75 @@ class TestMixedAndResilience:
         assert stats.proto_events == 2
         assert stats.dict_events == 1
         assert stats.emitted == 3
+
+
+# ---- _run exit codes -------------------------------------------------------
+
+
+class TestRunExitCodes:
+    """``_run`` is the CLI body; its exit codes are the contract a zicato
+    hook (or an operator) keys on. These drive ``_run`` directly with a
+    parsed args namespace. The error cases below never reach the network
+    (missing / empty file) or point at a guaranteed-dead port, so no
+    harmonograf server is needed."""
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_2(self, tmp_path: Path) -> None:
+        args = build_parser().parse_args(
+            [str(tmp_path / "does-not-exist.jsonl")]
+        )
+        assert await _run(args) == 2
+
+    @pytest.mark.asyncio
+    async def test_directory_argument_returns_2(self, tmp_path: Path) -> None:
+        # A directory is not a file — ``path.is_file()`` is False, so the
+        # CLI rejects it cleanly instead of raising IsADirectoryError on
+        # open().
+        args = build_parser().parse_args([str(tmp_path)])
+        assert await _run(args) == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_file_returns_1(self, tmp_path: Path) -> None:
+        # Nothing is emitted, so nothing can be buffered/undelivered —
+        # ``_run`` reaches the ``emitted == 0`` branch and returns 1
+        # regardless of whether a server is reachable.
+        path = tmp_path / "events.jsonl"
+        path.write_text("", encoding="utf-8")
+        args = build_parser().parse_args([str(path)])
+        assert await _run(args) == 1
+
+    @pytest.mark.asyncio
+    async def test_blank_only_file_returns_1(self, tmp_path: Path) -> None:
+        path = tmp_path / "events.jsonl"
+        path.write_text("\n\n   \n\n", encoding="utf-8")
+        args = build_parser().parse_args([str(path)])
+        assert await _run(args) == 1
+
+    @pytest.mark.asyncio
+    async def test_undelivered_run_returns_3(self, tmp_path: Path) -> None:
+        """Events that parse but never reach the server (here: a dead
+        port) must exit 3, not 0 — a green exit on a dropped run would
+        let a caller treat it as ingested."""
+        path = _write_jsonl(
+            tmp_path,
+            [
+                json.dumps(
+                    {
+                        "eventId": "e0",
+                        "runId": "run-xyz",
+                        "sequence": "1",
+                        "sessionId": "run-xyz",
+                        "runStarted": {"runId": "run-xyz"},
+                    }
+                )
+            ],
+        )
+        # Port 1 is privileged and never has a harmonograf server; the
+        # short flush timeout keeps the test fast.
+        args = build_parser().parse_args(
+            [str(path), "--server", "127.0.0.1:1", "--flush-timeout", "0.5"]
+        )
+        assert await _run(args) == 3
 
 
 # ---- ReplayStats -----------------------------------------------------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ to observe and steer them.
 | [overview.md](overview.md) | Longer-form motivation and design principles; what ships today and what's deliberately out of scope. |
 | [goldfive-integration.md](goldfive-integration.md) | The `goldfive.wrap` + `observe()` contract: per-ADK-agent rows, session unification, intervention emission. |
 | [standalone-observability.md](standalone-observability.md) | The non-ADK path: emit spans from any Python process with `harmonograf_client.Client`. |
+| [zicato-handoff.md](zicato-handoff.md) | Replay a finished run's goldfive `events.jsonl` from disk with `harmonograf-replay`; deep-link a zicato run into harmonograf as its execution view. |
 | [reporting-tools.md](reporting-tools.md) | Redirect to the goldfive reporting-tool reference (the tools live in goldfive post-migration). |
 | [user-guide/index.md](user-guide/index.md) | UI reference hub — overview of regions of the shell and the contents list below. |
 | [user-guide/sessions.md](user-guide/sessions.md) | Session picker, filters, attention badges. |

--- a/docs/zicato-handoff.md
+++ b/docs/zicato-handoff.md
@@ -1,0 +1,221 @@
+# Zicato → Harmonograf handoff
+
+[zicato](https://github.com/pedapudi/zicato) runs multi-agent systems
+under goldfive as a competition: many runs, scored against each other,
+surfaced on zicato's own bracket dashboard. Each run is one goldfive
+execution and writes a goldfive `events.jsonl` — the
+`goldfive.v1.Event` envelope, one JSON line per event — alongside the
+run on disk:
+
+```
+.zicato/epochs/<epoch>/generations/<gen>/runs/<run-slug>/events.jsonl
+```
+
+Harmonograf is the **execution view** of a single one of those runs:
+the Gantt timeline, the plan/task/drift story, the intervention
+history. This document is the contract for deep-linking the two:
+zicato's dashboard shows the *bracket* across runs; clicking one run
+opens *that run's temporal trace* in harmonograf.
+
+> **Conceptual split.** Harmonograf renders **one run over time** —
+> spans, tasks, drift, refine attempts on a timeline. Zicato's own
+> dashboard renders **many runs against each other** — the
+> competition/bracket view. They are complementary, not redundant:
+> zicato never grows a Gantt, harmonograf never grows a bracket.
+
+---
+
+## How harmonograf ingests goldfive events
+
+Harmonograf has one ingest contract and three producers feeding it:
+
+1. **Live gRPC stream** — an agent runs under `goldfive.wrap(...)` with a
+   `HarmonografSink`; the sink ships every `goldfive.v1.Event` over the
+   `StreamTelemetry` bidi RPC as it happens. This is the `make demo`
+   path. See [`goldfive-integration.md`](goldfive-integration.md).
+2. **Standalone spans** — any Python process emits spans directly via
+   `harmonograf_client.Client`. No orchestration. See
+   [`standalone-observability.md`](standalone-observability.md).
+3. **File replay** — a *finished* run's `events.jsonl` replayed from
+   disk. This is the zicato handoff path, described below.
+
+All three converge on the same server-side `IngestPipeline` and the
+same storage, so a replayed run is indistinguishable from a live one
+once it lands: same Gantt, same task strip, same Trajectory view.
+
+The translation logic that turns a `goldfive.v1.Event` into harmonograf
+spans + deltas lives entirely in `HarmonografSink` (LLM-call events →
+spans, agent-id canonicalization, dict-envelope handling). Replay
+**reuses that sink unchanged** — it is just a non-live producer.
+
+---
+
+## Replaying a run: `harmonograf-replay`
+
+`harmonograf-replay` is a console script (installed with
+`harmonograf-client`) that reads a goldfive `events.jsonl` and feeds
+every event through `HarmonografSink` into a running harmonograf
+server.
+
+```bash
+# 1. Start a harmonograf server (sqlite store keeps the run after exit)
+harmonograf-server --store sqlite --data-dir ~/.harmonograf/data
+
+# 2. Replay a zicato run's events.jsonl into it
+harmonograf-replay \
+  .zicato/epochs/2026-05-15_e0/generations/v0/runs/transformers_lay_audience/events.jsonl
+
+# 3. Open the harmonograf frontend; the run is now a session in the picker.
+```
+
+Output:
+
+```
+replayed .../transformers_lay_audience/events.jsonl
+  emitted=116 (proto=107, dict=9) skipped=13 (unparseable=0, empty_payload=13)
+  session: 5fa857509c8849bcb51288a0bd3e5338
+  open:    harmonograf frontend → /session/5fa857509c8849bcb51288a0bd3e5338
+```
+
+Flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--server` | `127.0.0.1:7531` | harmonograf server gRPC address |
+| `--title` | `replay: <run-dir-name>` | session title in the picker |
+| `--agent-name` | `zicato-replay` | display name for the replay client's row |
+| `--token` | _(none)_ | bearer token if the server has `--auth-token` |
+| `--flush-timeout` | `15.0` | seconds to drain the buffer before exit |
+
+### What replay accepts
+
+The two on-disk event shapes goldfive writes are both handled — the same
+two shapes `HarmonografSink.emit` already routes apart:
+
+- **proto-JSON** — the protobuf JSON mapping of `goldfive.v1.Event`
+  (camelCase keys, payload oneof at top level). Parsed with
+  `ignore_unknown_fields=True`, so an `events.jsonl` written by a
+  **newer goldfive than the harmonograf submodule pin** still replays:
+  unknown event kinds are dropped, known ones render. (Concretely, the
+  real zicato runs carry a `steeringDecisionMade` event kind newer than
+  the pinned goldfive; replay skips it cleanly and renders the other
+  ~116 events per run.)
+- **dict envelope** — a JSON object with top-level `kind` + `payload`
+  keys (`refine_attempted`, `refine_failed`, …). Passed to the sink
+  verbatim; the sink owns the dict→proto translation.
+
+Corrupt JSON lines and blank lines are skipped, never fatal — a single
+bad line must not abort a long run's replay.
+
+### Session identity
+
+The replayed session id is the **run id carried in the events
+themselves** (`Event.session_id`). For a zicato run that is the goldfive
+run id, e.g. `5fa857509c8849bcb51288a0bd3e5338`. This is deliberate:
+
+- The session is **stable and addressable** — replay the same file
+  twice and it lands on the same session (ingest is idempotent on
+  `(session_id, run_id, sequence)`).
+- Zicato already knows the run id, so it can construct the harmonograf
+  link **without** a round-trip — it does not need to replay first and
+  read back an assigned id.
+
+---
+
+## The deep-link contract
+
+For zicato's dashboard to deep-link a run into harmonograf, two things
+must line up: the run's events must be **ingested** into a harmonograf
+server, and the dashboard must point at the **session whose id is the
+run id**.
+
+### URL shape
+
+Harmonograf's frontend is served at a single origin (the Vite dev
+server at `http://127.0.0.1:5173` in `make demo`; a static deploy
+otherwise). The session-scoped deep link is:
+
+```
+<harmonograf-frontend-origin>/#/session/<run-id>
+```
+
+e.g. `http://127.0.0.1:5173/#/session/5fa857509c8849bcb51288a0bd3e5338`
+
+The `<run-id>` segment is exactly the goldfive run id zicato already
+has. Zicato builds the link by string concatenation; no harmonograf API
+call is needed.
+
+> **Current state — honest note.** The harmonograf frontend uses a hash
+> router that today recognises `#/` (the Shell) and `#/stress` (the dev
+> stress harness). Session selection is in-app zustand state
+> (`uiStore.currentSessionId`), set by the session picker — it is **not
+> yet** parsed from the URL hash. So today the deep link lands the
+> operator on the Shell and they pick the run (titled
+> `replay: <run-slug>`) from the session picker. Wiring `#/session/<id>`
+> to call `setCurrentSession(id)` on load is a small, isolated frontend
+> change tracked as a follow-up; the `/#/session/<run-id>` shape above
+> is the agreed target so zicato can emit the final URL now and have it
+> resolve once that lands. Until then the run id is the **session id**
+> the operator selects.
+
+### What zicato must emit for the link to resolve
+
+For a deep link to land on a real session, the run's events must have
+been ingested. Zicato has two integration options:
+
+1. **Replay on demand.** Zicato's dashboard shells out to
+   `harmonograf-replay <run>/events.jsonl --server <addr>` (or calls
+   `harmonograf_client.replay.replay_events` in-process) the first time
+   a run is opened, then redirects to `/#/session/<run-id>`. Simplest;
+   no harmonograf changes.
+2. **Replay ahead of time.** A zicato post-run hook replays each run's
+   `events.jsonl` into a long-lived harmonograf server (`--store
+   sqlite`) as soon as the run finishes. The dashboard link then
+   resolves immediately with no shell-out.
+
+Either way, the only hard requirement on zicato is:
+
+- **Emit a real goldfive `events.jsonl`** per run — the
+  `goldfive.v1.Event` envelope, one JSON line per event, in `sequence`
+  order. Zicato already does this; it is goldfive's recorder output.
+- **Stamp `Event.session_id`** (goldfive does this since goldfive#155).
+  This is what makes the replayed session addressable by run id.
+- **Know the harmonograf frontend origin** to build the link.
+
+Nothing in the event payloads is zicato-specific — harmonograf renders
+a zicato run exactly as it renders a `make demo` run.
+
+---
+
+## Programmatic replay
+
+`harmonograf-replay` is a thin CLI over `harmonograf_client.replay`. To
+replay in-process (e.g. from a zicato hook):
+
+```python
+import asyncio
+from pathlib import Path
+from harmonograf_client import Client, HarmonografSink
+from harmonograf_client.replay import replay_events
+
+async def push_run(events_path: str, server: str) -> str:
+    client = Client(name="zicato-replay", server_addr=server)
+    sink = HarmonografSink(client)
+    try:
+        stats = await replay_events(Path(events_path), sink)
+    finally:
+        await sink.close()
+        client.shutdown(flush_timeout=15.0)
+    return client.session_id  # == the run id; use it to build the deep link
+```
+
+---
+
+## Related docs
+
+- [`goldfive-integration.md`](goldfive-integration.md) — the live
+  `goldfive.wrap` + `HarmonografSink` path.
+- [`standalone-observability.md`](standalone-observability.md) — the
+  non-goldfive span-only path.
+- [`operator-quickstart.md`](operator-quickstart.md) — server flags,
+  retention, auth.


### PR DESCRIPTION
## Summary

Smooths the zicato to harmonograf handoff. A zicato run produces a goldfive `events.jsonl` (one `goldfive.v1.Event` per line); zicato's dashboard wants to deep-link each run into harmonograf as that run's *execution view*. Harmonograf could terminate a live event stream but had no way to ingest one of those files after the fact.

- **`harmonograf-replay`** -- a new console script (over `harmonograf_client.replay`) that reads a goldfive `events.jsonl` from disk and feeds every event through the existing `HarmonografSink`, so a finished run renders as a harmonograf session. No new wire surface, no new server endpoint -- replay is just a non-live producer that reuses the live path's LLM-call-to-span translation, agent-id canonicalization, and dict-envelope handling unchanged.
- **`docs/zicato-handoff.md`** -- the handoff contract: the deep-link URL shape, what zicato must emit, and the conceptual split (harmonograf = one run over time; zicato's dashboard = the competition across runs).

## What it handles

Both on-disk event shapes goldfive writes:
- **proto-JSON** -- parsed with `ignore_unknown_fields=True`, so a file written by a *newer goldfive than the pinned submodule* still replays (unknown event kinds drop, known ones render).
- **dict envelope** (`kind` + `payload`) -- passed to the sink verbatim; the sink owns dict-to-proto translation.

Corrupt and blank lines are skipped, never fatal. The session id is preserved from `Event.session_id`, so a replayed run is stable and addressable by its run id (ingest is idempotent on `(session_id, run_id, sequence)`).

## Verification

Verified end-to-end against a real zicato run's `events.jsonl` and a live `harmonograf-server`: 116 events emitted per run (107 proto + 9 dict, 13 `steeringDecisionMade` events newer than the pinned goldfive skipped cleanly), landing as a session with 2 agent rows, 24 spans, 21 goldfive events, and 3 refine attempts -- exactly what the frontend Gantt/Trajectory consume.

## Deep-link shape

`<harmonograf-frontend-origin>/#/session/<run-id>` where `<run-id>` is the goldfive run id zicato already has. The doc includes an honest note: the frontend hash router does not yet parse a session id from the URL (today it routes `#/` and `#/stress`; session selection is in-app state). Wiring `#/session/<id>` to `setCurrentSession` on load is a small isolated follow-up; the URL shape is the agreed target so zicato can emit the final URL now.

## Test plan

- [x] `make client-test` -- 362 passed (9 new in `test_replay.py`)
- [x] `ruff check` clean on new files
- [x] `harmonograf-replay <real zicato events.jsonl>` against a live server -- session renders with spans, goldfive events, refine attempts
- [ ] Frontend `#/session/<id>` hash route (follow-up, out of scope here)