### PR TITLE
feat(server): serve the console UI from harmonograf-server (portable, runtime-configured)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ tests/reference_agents/presentation_agent/output/
 
 # Python build artifacts
 client/build/
+# Console SPA staged into the server wheel by `make console` (built output;
+# the canonical source lives in frontend/, see server/pyproject.toml).
+server/harmonograf_server/_console/
 
 # Demo output tarballs
 waffle.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CLIENT_PB := $(ROOT)/client/harmonograf_client/pb
 FRONTEND_PB := $(ROOT)/frontend/src/pb
 
 .PHONY: help proto proto-python proto-ts \
-        server-install client-install frontend-install install \
+        server-install client-install frontend-install install console \
         server-run frontend-dev demo demo-presentation demo-presentation-orchestrated demo-standalone .demo-agents-stage \
         test server-test client-test frontend-test e2e \
         lint format clean stats
@@ -24,6 +24,7 @@ help:
 	@echo "  proto-python     Regenerate Python stubs under server/ and client/"
 	@echo "  proto-ts         Regenerate TypeScript stubs under frontend/"
 	@echo "  install          Install all components"
+	@echo "  console          Build the frontend and stage it into the server wheel"
 	@echo "  server-run       Run the server in dev mode"
 	@echo "  frontend-dev     Run the Vite dev server"
 	@echo "  demo             Boot server + frontend + adk web (shows both presentation_agent variants)"
@@ -106,6 +107,26 @@ client-install:
 
 frontend-install:
 	@cd $(ROOT)/frontend && pnpm install --frozen-lockfile
+
+# ---------------------------------------------------------------------------
+# Console bundle (ship the built SPA inside the server wheel)
+# ---------------------------------------------------------------------------
+
+# Where the wheel expects the bundled console (see server/pyproject.toml
+# force-include + static_site.py importlib.resources lookup).
+CONSOLE_DIR := $(ROOT)/server/harmonograf_server/_console
+
+# Build the frontend and stage it into the server package so the wheel ships
+# the UI. Run this before packaging the server (`uv build server`, etc.).
+# The server's static_site.py also auto-locates ../frontend/dist in a repo
+# checkout, so `make console` is only required for producing a distributable
+# wheel — local `make server-run` works without it.
+console:
+	@cd $(ROOT)/frontend && pnpm install --frozen-lockfile && pnpm build
+	@rm -rf $(CONSOLE_DIR)
+	@mkdir -p $(CONSOLE_DIR)
+	@cp -R $(ROOT)/frontend/dist/. $(CONSOLE_DIR)/
+	@echo "Console staged into $(CONSOLE_DIR) (shipped in the server wheel)."
 
 # ---------------------------------------------------------------------------
 # Run
@@ -322,4 +343,5 @@ clean:
 	@find $(ROOT) -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
 	@find $(ROOT) -type d -name .pytest_cache -prune -exec rm -rf {} + 2>/dev/null || true
 	@rm -rf $(ROOT)/frontend/dist
+	@rm -rf $(CONSOLE_DIR)
 	@echo "Clean done. Run 'make proto' to regenerate stubs."

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Shell } from './components/shell/Shell';
 import { StressPage } from './gantt/StressPage';
 import { useUiStore } from './state/uiStore';
-import { useSessionsStore } from './state/sessionsStore';
 import { sessionIdFromHash } from './lib/sessionRoute';
 
 // Minimal hash router. The stress harness is dev-only and intentionally not
@@ -18,28 +17,28 @@ function useHashRoute(): string {
 }
 
 // Reads a `#/session/<id>` deep link and selects that session in the UI store.
-// Runs on the initial hash and on every hashchange. Because the deep-linked id
-// may not have arrived from ListSessions yet (sessions still loading), it
-// records the desired id and (re)applies the selection whenever the sessions
-// list changes — selecting the session as soon as it appears. Setting
-// currentSessionId here also pre-empts SessionsSyncer's newest-session
-// auto-select, so a deep link opens straight into its trace.
+// Applies each distinct deep-link target exactly once — on the initial hash and
+// again whenever the hash changes to a new session. The selection is eager: the
+// id need not have arrived from ListSessions yet (WatchSession/ListSessions will
+// populate it), and setting currentSessionId here also pre-empts SessionsSyncer's
+// newest-first auto-select, so a deep link opens straight into its trace.
+//
+// Crucially this does NOT re-fire on every sessions poll: doing so would yank the
+// user back to the deep-linked session ~every 5s after they navigate away via the
+// picker (which updates the store, not the hash), trapping them on that session.
 function useSessionDeepLink(hash: string): void {
   const setCurrentSession = useUiStore((s) => s.setCurrentSession);
-  const sessions = useSessionsStore((s) => s.sessions);
-
   const wantedId = sessionIdFromHash(hash);
+  const appliedId = useRef<string | null>(null);
 
   useEffect(() => {
     if (!wantedId) return;
-    // Already selected — nothing to do.
-    const current = useUiStore.getState().currentSessionId;
-    if (current === wantedId) return;
-    // If the session is known, select it now. If not, select it eagerly
-    // anyway: WatchSession/ListSessions will populate it, and this still
-    // blocks SessionsSyncer's newest-first auto-select from racing ahead.
+    // Apply this target once; let a later manual selection (picker) stick.
+    if (appliedId.current === wantedId) return;
+    appliedId.current = wantedId;
+    if (useUiStore.getState().currentSessionId === wantedId) return;
     setCurrentSession(wantedId);
-  }, [wantedId, sessions, setCurrentSession]);
+  }, [wantedId, setCurrentSession]);
 }
 
 export default function App() {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Shell } from './components/shell/Shell';
 import { StressPage } from './gantt/StressPage';
+import { useUiStore } from './state/uiStore';
+import { useSessionsStore } from './state/sessionsStore';
+import { sessionIdFromHash } from './lib/sessionRoute';
 
 // Minimal hash router. The stress harness is dev-only and intentionally not
 // linked anywhere user-facing. Visit /#/stress to open it.
@@ -14,8 +17,34 @@ function useHashRoute(): string {
   return hash;
 }
 
+// Reads a `#/session/<id>` deep link and selects that session in the UI store.
+// Runs on the initial hash and on every hashchange. Because the deep-linked id
+// may not have arrived from ListSessions yet (sessions still loading), it
+// records the desired id and (re)applies the selection whenever the sessions
+// list changes — selecting the session as soon as it appears. Setting
+// currentSessionId here also pre-empts SessionsSyncer's newest-session
+// auto-select, so a deep link opens straight into its trace.
+function useSessionDeepLink(hash: string): void {
+  const setCurrentSession = useUiStore((s) => s.setCurrentSession);
+  const sessions = useSessionsStore((s) => s.sessions);
+
+  const wantedId = sessionIdFromHash(hash);
+
+  useEffect(() => {
+    if (!wantedId) return;
+    // Already selected — nothing to do.
+    const current = useUiStore.getState().currentSessionId;
+    if (current === wantedId) return;
+    // If the session is known, select it now. If not, select it eagerly
+    // anyway: WatchSession/ListSessions will populate it, and this still
+    // blocks SessionsSyncer's newest-first auto-select from racing ahead.
+    setCurrentSession(wantedId);
+  }, [wantedId, sessions, setCurrentSession]);
+}
+
 export default function App() {
   const hash = useHashRoute();
+  useSessionDeepLink(hash);
   if (hash.startsWith('#/stress')) return <StressPage />;
   return <Shell />;
 }

--- a/frontend/src/__tests__/rpc/sessionDeepLink.test.tsx
+++ b/frontend/src/__tests__/rpc/sessionDeepLink.test.tsx
@@ -79,6 +79,33 @@ describe('App #/session/<id> deep link', () => {
     expect(useUiStore.getState().currentSessionId).toBe('sess-late');
   });
 
+  it('does not bounce back to the deep link after a manual selection', () => {
+    // Regression: the effect must apply the deep link once, not re-fire on
+    // every ListSessions poll. Otherwise a user who deep-links to sess-a and
+    // then picks sess-b (which updates the store, not the hash) gets dragged
+    // back to sess-a on the next poll.
+    setHash('#/session/sess-a');
+    const { rerender } = render(<App />);
+    expect(useUiStore.getState().currentSessionId).toBe('sess-a');
+
+    // User picks another session via the picker.
+    act(() => {
+      useUiStore.getState().setCurrentSession('sess-b');
+    });
+
+    // A ListSessions poll lands (new sessions array) and App re-renders.
+    act(() => {
+      useSessionsStore.setState({
+        sessions: [{ id: 'sess-a' } as RpcSession, { id: 'sess-b' } as RpcSession],
+        loading: false,
+        error: null,
+      });
+    });
+    rerender(<App />);
+
+    expect(useUiStore.getState().currentSessionId).toBe('sess-b');
+  });
+
   it('does not select anything for the default route', () => {
     setHash('#/');
     render(<App />);

--- a/frontend/src/__tests__/rpc/sessionDeepLink.test.tsx
+++ b/frontend/src/__tests__/rpc/sessionDeepLink.test.tsx
@@ -1,0 +1,87 @@
+// Coverage for the `#/session/<id>` deep-link routing added to App.tsx:
+//   * sessionIdFromHash parses the hash form (and rejects others),
+//   * mounting App with a `#/session/<id>` hash selects that session in the
+//     UI store — even before the session has arrived from ListSessions, and
+//     re-applies once the sessions list updates.
+//
+// Shell + StressPage are mocked to inert markers so the test exercises only
+// the routing/selection logic without pulling in the whole UI tree.
+
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sessionIdFromHash } from '../../lib/sessionRoute';
+import { useUiStore } from '../../state/uiStore';
+import { useSessionsStore } from '../../state/sessionsStore';
+import type { RpcSession } from '../../state/sessionsStore';
+
+// Inert stand-ins — App's routing only needs to mount *something*.
+vi.mock('../../components/shell/Shell', () => ({
+  Shell: () => <div data-testid="shell" />,
+}));
+vi.mock('../../gantt/StressPage', () => ({
+  StressPage: () => <div data-testid="stress" />,
+}));
+
+import App from '../../App';
+
+function setHash(hash: string): void {
+  window.location.hash = hash;
+}
+
+beforeEach(() => {
+  useUiStore.setState({ currentSessionId: null });
+  useSessionsStore.setState({ sessions: [], loading: false, error: null });
+});
+
+afterEach(() => {
+  setHash('');
+});
+
+describe('sessionIdFromHash', () => {
+  it('parses #/session/<id>', () => {
+    expect(sessionIdFromHash('#/session/abc-123')).toBe('abc-123');
+    expect(sessionIdFromHash('#/session/abc-123/')).toBe('abc-123');
+  });
+
+  it('url-decodes the id', () => {
+    expect(sessionIdFromHash('#/session/run%2F42')).toBe('run/42');
+  });
+
+  it('returns null for non-session hashes', () => {
+    expect(sessionIdFromHash('#/')).toBeNull();
+    expect(sessionIdFromHash('#/stress')).toBeNull();
+    expect(sessionIdFromHash('#/session/')).toBeNull();
+    expect(sessionIdFromHash('')).toBeNull();
+  });
+});
+
+describe('App #/session/<id> deep link', () => {
+  it('selects the deep-linked session on mount, even before it loads', () => {
+    setHash('#/session/sess-xyz');
+    render(<App />);
+    // Selected eagerly so SessionsSyncer's newest-first auto-select can't race.
+    expect(useUiStore.getState().currentSessionId).toBe('sess-xyz');
+  });
+
+  it('keeps the deep-linked selection once the session appears in the list', () => {
+    setHash('#/session/sess-late');
+    render(<App />);
+    expect(useUiStore.getState().currentSessionId).toBe('sess-late');
+
+    act(() => {
+      useSessionsStore.setState({
+        sessions: [{ id: 'sess-late' } as RpcSession],
+        loading: false,
+        error: null,
+      });
+    });
+    expect(useUiStore.getState().currentSessionId).toBe('sess-late');
+  });
+
+  it('does not select anything for the default route', () => {
+    setHash('#/');
+    render(<App />);
+    expect(useUiStore.getState().currentSessionId).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/rpc/transport.test.ts
+++ b/frontend/src/__tests__/rpc/transport.test.ts
@@ -1,0 +1,33 @@
+// Coverage for transport.apiBaseUrl()'s resolution precedence:
+//   1. window.__HARMONOGRAF_API__ (runtime, injected by the serving server)
+//   2. VITE_HARMONOGRAF_API (build-time env var)
+//   3. the compiled-in default.
+//
+// The runtime global is the new path that lets a single built bundle work
+// behind any host/port without a rebuild (see static_site.py).
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { apiBaseUrl } from '../../rpc/transport';
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:7532';
+
+afterEach(() => {
+  delete window.__HARMONOGRAF_API__;
+});
+
+describe('apiBaseUrl', () => {
+  it('prefers the runtime window.__HARMONOGRAF_API__ global', () => {
+    window.__HARMONOGRAF_API__ = 'http://example.test:9000';
+    expect(apiBaseUrl()).toBe('http://example.test:9000');
+  });
+
+  it('ignores an empty runtime global and falls through', () => {
+    window.__HARMONOGRAF_API__ = '';
+    // No VITE env set in the test runner, so this lands on the default.
+    expect(apiBaseUrl()).toBe(DEFAULT_BASE_URL);
+  });
+
+  it('falls back to the compiled-in default when nothing is configured', () => {
+    expect(apiBaseUrl()).toBe(DEFAULT_BASE_URL);
+  });
+});

--- a/frontend/src/lib/sessionRoute.ts
+++ b/frontend/src/lib/sessionRoute.ts
@@ -1,0 +1,17 @@
+// Hash-route parsing for the `#/session/<id>` deep link consumed by App.tsx.
+// Kept in its own module so App.tsx only exports its component (react-refresh).
+
+// Parse a `#/session/<id>` deep link, returning the (decoded) session id or
+// null. Tolerates a trailing slash and an empty id. Accepts both
+// `#/session/<id>` and a bare `/session/<id>` defensively.
+export function sessionIdFromHash(hash: string): string | null {
+  const m = /^#?\/session\/([^/]+)\/?$/.exec(hash);
+  if (!m) return null;
+  const raw = m[1];
+  if (!raw) return null;
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/frontend/src/rpc/transport.ts
+++ b/frontend/src/rpc/transport.ts
@@ -1,10 +1,17 @@
 // Connect-Web transport. We speak gRPC-Web so Connect-Web's createGrpcWebTransport
 // is the right wire format for the Python harmonograf_server (sonora grpcASGI,
-// served by hypercorn — no Envoy/grpcwebproxy needed). The base URL is taken
-// from the Vite env var VITE_HARMONOGRAF_API, falling back to the server's
-// default --web-port (7532) on loopback. To point at a non-default server,
-// set the env var before running `pnpm dev`, e.g.:
-//     VITE_HARMONOGRAF_API=http://127.0.0.1:17532 pnpm dev
+// served by hypercorn — no Envoy/grpcwebproxy needed). The base URL is resolved
+// in three steps, most-specific first:
+//
+//   1. window.__HARMONOGRAF_API__ — a runtime global the server injects into
+//      the index.html it serves itself (see server/harmonograf_server/
+//      static_site.py). This lets a single built bundle work behind any
+//      host/port without a rebuild, because the server fills in the URL the
+//      browser actually used to reach it.
+//   2. VITE_HARMONOGRAF_API — a build-time env var, useful for `pnpm dev`
+//      against a non-default server:
+//          VITE_HARMONOGRAF_API=http://127.0.0.1:17532 pnpm dev
+//   3. the compiled-in default --web-port (7532) on loopback.
 
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import type { Transport } from '@connectrpc/connect';
@@ -12,11 +19,26 @@ import type { Transport } from '@connectrpc/connect';
 // Must track server/harmonograf_server/cli.py --web-port default.
 const DEFAULT_BASE_URL = 'http://127.0.0.1:7532';
 
+// The runtime global the server injects when it serves the bundle itself.
+declare global {
+  interface Window {
+    __HARMONOGRAF_API__?: string;
+  }
+}
+
 export function apiBaseUrl(): string {
-  // Vite injects env vars prefixed with VITE_.
+  // 1. Runtime global injected by the serving harmonograf_server.
+  if (typeof window !== 'undefined') {
+    const fromRuntime = window.__HARMONOGRAF_API__;
+    if (typeof fromRuntime === 'string' && fromRuntime.length > 0) {
+      return fromRuntime;
+    }
+  }
+  // 2. Build-time env var (Vite injects env vars prefixed with VITE_).
   const fromEnv =
     typeof import.meta !== 'undefined' &&
     (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_HARMONOGRAF_API;
+  // 3. Compiled-in default.
   return fromEnv || DEFAULT_BASE_URL;
 }
 

--- a/server/README.md
+++ b/server/README.md
@@ -17,8 +17,12 @@ browser the whole console — no separate static host or frontend dev server.
 
 - `GET /` and `GET /index.html` → the SPA's `index.html`.
 - `GET /assets/*` and any other real file in the web root → served directly.
-- Any other non-API path that isn't a real file → falls back to `index.html`,
-  so client-side hash routes such as `#/session/<id>` load when deep-linked.
+  Content-hashed `/assets/*` are sent `Cache-Control: immutable`; `index.html`
+  is sent `no-cache` so a redeploy is picked up.
+- Any other **extension-less** non-API path → falls back to `index.html`, so
+  client-side hash routes such as `#/session/<id>` load when deep-linked. A
+  missing *file-like* path (`*.js`, `*.svg`, …) returns `404` rather than HTML,
+  to avoid handing the browser a MIME-mismatched `index.html`.
 - gRPC-Web requests (`application/grpc-web*`), gRPC service-method paths
   (`/<pkg>.<Service>/<Method>`), and the health routes are never intercepted —
   they always reach the gRPC-Web / health app.

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,72 @@
+# harmonograf-server
+
+gRPC fan-in for multi-agent telemetry and control, plus the self-served
+console UI.
+
+## Ports
+
+- `--port` (default `7531`) — native gRPC, for agents/SDKs.
+- `--web-port` (default `7532`) — gRPC-Web (for browsers) **and** the console
+  SPA + health endpoints, all on one ASGI app.
+
+## Self-served console UI
+
+The web port serves the built console single-page app alongside gRPC-Web and
+the `/healthz` / `/readyz` probes. One `harmonograf-server` process hands a
+browser the whole console — no separate static host or frontend dev server.
+
+- `GET /` and `GET /index.html` → the SPA's `index.html`.
+- `GET /assets/*` and any other real file in the web root → served directly.
+- Any other non-API path that isn't a real file → falls back to `index.html`,
+  so client-side hash routes such as `#/session/<id>` load when deep-linked.
+- gRPC-Web requests (`application/grpc-web*`), gRPC service-method paths
+  (`/<pkg>.<Service>/<Method>`), and the health routes are never intercepted —
+  they always reach the gRPC-Web / health app.
+
+### Runtime endpoint config (one bundle, any host/port)
+
+When serving `index.html`, the server injects a `window.__HARMONOGRAF_API__`
+global with the gRPC-Web base URL the browser should use to reach this server.
+The frontend's `transport.ts` reads the endpoint in this precedence:
+
+1. `window.__HARMONOGRAF_API__` (runtime — injected by this server),
+2. `VITE_HARMONOGRAF_API` (build-time env var, for `pnpm dev`),
+3. the compiled-in default (`http://127.0.0.1:7532`).
+
+So a single built bundle works behind any host/port with no rebuild. The
+injected URL is derived per-request from the `Host` / `X-Forwarded-*` headers,
+or set explicitly with `--public-base-url` when behind a reverse proxy.
+
+### Locating the bundle
+
+In precedence order:
+
+1. `--web-root <dir>` (explicit override),
+2. the packaged console shipped in the wheel
+   (`harmonograf_server/_console/`, located via `importlib.resources`),
+3. a dev fallback to `../frontend/dist` in a repo checkout.
+
+If no bundle is found the server logs a warning and keeps serving gRPC-Web +
+health (graceful degradation).
+
+## Packaging: shipping the console in the wheel
+
+`pip/uv install harmonograf-server` carries the console so consumers don't need
+to build the frontend. The build flow:
+
+1. `make console` builds the frontend (`pnpm build`) and stages the output
+   into `server/harmonograf_server/_console/`.
+2. `uv build` (hatchling) collects that directory into the wheel via the
+   `tool.hatch.build.targets.wheel.artifacts` glob in `pyproject.toml`
+   (`artifacts` overrides the repo `.gitignore`, which ignores build output).
+3. At runtime `static_site.py` locates the packaged `_console/` directory via
+   `importlib.resources`.
+
+`make console` is only required when producing a distributable wheel —
+`make server-run` in a repo checkout works without it (it falls back to
+`../frontend/dist`). The `_console/` directory is build output and is
+git-ignored.
+
+**Release note:** a release/publish workflow must run `make console` before
+`uv build` so the wheel includes the UI. CI currently runs tests only (no
+wheel build); the server test suite is independent of a built bundle.

--- a/server/harmonograf_server/cli.py
+++ b/server/harmonograf_server/cli.py
@@ -90,6 +90,29 @@ def build_parser() -> argparse.ArgumentParser:
             "disables auth. /healthz and /readyz are always unauthenticated."
         ),
     )
+    # ---- console UI serving (static_site.py) ------------------------
+    p.add_argument(
+        "--web-root",
+        default="",
+        help=(
+            "directory to serve the built console SPA from on the web port "
+            "(alongside gRPC-Web + health); empty auto-locates the packaged "
+            "console, then ../frontend/dist. If no bundle is found the server "
+            "logs a warning and serves gRPC-Web + health only."
+        ),
+    )
+    p.add_argument(
+        "--public-base-url",
+        default="",
+        help=(
+            "public gRPC-Web base URL the browser should use to reach this "
+            "server; injected into the served index.html as "
+            "window.__HARMONOGRAF_API__. Empty derives it per-request from the "
+            "Host / X-Forwarded-* headers, so one bundle works behind any "
+            "host/port (set this only behind a reverse proxy that rewrites the "
+            "path or terminates on a different public URL)."
+        ),
+    )
     p.add_argument(
         "--legacy-plan-attribution-window-ms",
         type=float,
@@ -159,6 +182,8 @@ def config_from_args(argv: list[str] | None = None) -> ServerConfig:
         log_format=args.log_format,
         metrics_interval_seconds=args.metrics_interval_seconds,
         auth_token=args.auth_token,
+        web_root=args.web_root,
+        public_base_url=args.public_base_url,
         legacy_plan_attribution_window_ms=args.legacy_plan_attribution_window_ms,
         heartbeat_timeout_seconds=args.heartbeat_timeout_seconds,
         payload_max_bytes=args.payload_max_bytes,

--- a/server/harmonograf_server/config.py
+++ b/server/harmonograf_server/config.py
@@ -24,6 +24,18 @@ class ServerConfig:
     metrics_interval_seconds: float = 30.0  # 0 disables periodic metrics
     auth_token: str = ""  # empty string disables shared-secret auth
 
+    # ---- console UI serving (static_site.py) -------------------------
+    # The web port serves the built console SPA alongside gRPC-Web +
+    # health. ``web_root`` overrides where the bundle is read from; empty
+    # auto-locates (packaged _console dir, then ../frontend/dist). When no
+    # bundle is found the server logs a warning and serves gRPC-Web +
+    # health only. ``public_base_url`` (if set) is injected verbatim into
+    # the served index.html as the SPA's gRPC-Web endpoint
+    # (window.__HARMONOGRAF_API__); empty derives it per-request from the
+    # Host / X-Forwarded-* headers so one bundle works behind any host/port.
+    web_root: str = ""
+    public_base_url: str = ""
+
     # Opt-in legacy time-window fallback for plan-revision attribution
     # (pre-strict-id-dedup behaviour from before harmonograf#99). Default
     # 0 disables the fallback — plan revisions without a trigger_event_id

--- a/server/harmonograf_server/main.py
+++ b/server/harmonograf_server/main.py
@@ -39,6 +39,7 @@ from harmonograf_server.pb import service_pb2_grpc
 from harmonograf_server.metrics import metrics_loop
 from harmonograf_server.retention import retention_loop
 from harmonograf_server.rpc.telemetry import TelemetryServicer, heartbeat_sweeper
+from harmonograf_server.static_site import build_static_router
 from harmonograf_server.storage import make_store
 
 
@@ -177,7 +178,17 @@ class Harmonograf:
         # CORS middleware sits outside auth so preflights succeed even
         # before the browser attaches the bearer token.
         grpc_web_app = asgi_cors(grpc_web_app)
-        self._web_app = build_health_router(self.store, grpc_web_app)
+        # Health router answers /healthz + /readyz and forwards everything
+        # else to gRPC-Web. The static layer wraps that: it serves the
+        # built console SPA (with runtime endpoint injection + SPA fallback)
+        # for browser GET/HEAD paths and forwards gRPC-Web + health through.
+        health_app = build_health_router(self.store, grpc_web_app)
+        self._web_app = build_static_router(
+            health_app,
+            web_root=self.cfg.web_root,
+            web_port=self.cfg.web_port,
+            public_base_url=self.cfg.public_base_url,
+        )
         self._web_shutdown = asyncio.Event()
         hc = HypercornConfig()
         hc.bind = [f"{self.cfg.host}:{self.cfg.web_port}"]

--- a/server/harmonograf_server/static_site.py
+++ b/server/harmonograf_server/static_site.py
@@ -8,9 +8,10 @@ layer that:
   * serves ``index.html`` at ``/`` (and as the SPA fallback),
   * serves hashed asset files under ``/assets/*`` and any other real file
     in the web root (favicon, etc.),
-  * falls back to ``index.html`` for any *other* GET/HEAD path that is not
-    a real file — so client-side hash routes like ``/#/session/<id>`` load
-    the SPA when deep-linked, and
+  * falls back to ``index.html`` for any *other* extension-less GET/HEAD
+    path that is not a real file — so client-side hash routes like
+    ``/#/session/<id>`` load the SPA when deep-linked, while a missing
+    file-like path (``*.js``/``*.svg`` …) returns 404 rather than HTML, and
   * never touches gRPC-Web requests (content-type ``application/grpc-web*``)
     or the health routes — those flow straight through to ``inner``.
 
@@ -33,6 +34,8 @@ gRPC-Web + health, just without the bundled UI.
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 import os
 import re
@@ -121,6 +124,17 @@ def _content_type(path: str) -> str:
     return _CONTENT_TYPES.get(ext.lower(), "application/octet-stream")
 
 
+def _looks_like_file(path: str) -> bool:
+    """True when the last path segment has a file extension (e.g. ``.js``,
+    ``.svg``). Such a request is for a concrete asset, so when it isn't found
+    we return 404 rather than the SPA fallback — handing back ``index.html``
+    (text/html) for a missing ``.js``/``.css`` only yields confusing MIME
+    errors in the browser. Navigation/hash routes have no extension and still
+    fall through to the SPA."""
+
+    return "." in os.path.basename(path)
+
+
 def _is_grpc_web(scope: dict) -> bool:
     for k, v in scope.get("headers") or ():
         if k.lower() == b"content-type" and v.lower().startswith(b"application/grpc-web"):
@@ -147,14 +161,13 @@ def _inject_runtime_config(html: str, api_base_url: str) -> str:
     gRPC-Web endpoint at runtime. Injected just before the first module
     script so it runs before the app boots."""
 
-    # JS string-literal escaping for the URL (it is operator-controlled but
-    # be defensive about quotes / closing tags anyway).
-    safe = (
-        api_base_url.replace("\\", "\\\\")
-        .replace('"', '\\"')
-        .replace("</", "<\\/")
-    )
-    snippet = f'<script>window.__HARMONOGRAF_API__ = "{safe}";</script>'
+    # Emit a valid JS string literal. ``json.dumps`` handles all string
+    # escaping (quotes, backslashes, control chars, U+2028/U+2029); the URL is
+    # largely operator-controlled but can be host/X-Forwarded-Host-derived, so
+    # we additionally neutralise ``</`` (which JSON leaves intact) to keep a
+    # crafted value from closing the <script> element early.
+    literal = json.dumps(api_base_url).replace("</", "<\\/")
+    snippet = f"<script>window.__HARMONOGRAF_API__ = {literal};</script>"
     needle = "<script type=\"module\""
     idx = html.find(needle)
     if idx != -1:
@@ -207,13 +220,31 @@ def build_static_router(
 ) -> ASGIApp:
     """Wrap ``inner`` (gRPC-Web + health) with static SPA serving.
 
-    ``web_root`` is an explicit override; when ``None`` the bundle is
-    auto-located. ``public_base_url`` (if non-empty) is injected verbatim as
-    the SPA's gRPC-Web endpoint; otherwise it is derived per-request from the
-    Host / forwarding headers.
+    ``web_root`` is an explicit override; when falsy (``None``/``""``) the
+    bundle is auto-located. ``public_base_url`` (if non-empty) is injected
+    verbatim as the SPA's gRPC-Web endpoint; otherwise it is derived
+    per-request from the Host / forwarding headers.
     """
 
     root = locate_web_root(web_root)
+    # Read index.html once at startup: it is an immutable build artifact, so
+    # re-reading it per request would only add blocking disk I/O to the shared
+    # event loop (which also serves gRPC-Web streaming). Only the per-request
+    # endpoint injection varies, and that is done in memory below. A read
+    # failure here degrades to "no bundle" (gRPC-Web + health only).
+    index_template: Optional[str] = None
+    if root is not None:
+        index_path = os.path.join(root, "index.html")
+        try:
+            with open(index_path, "r", encoding="utf-8") as f:
+                index_template = f.read()
+        except OSError:
+            logger.exception(
+                "failed to read index.html at %s; serving gRPC-Web + health only",
+                index_path,
+            )
+            root = None
+
     if root is None:
         logger.warning(
             "console UI bundle not found (looked for index.html via "
@@ -224,9 +255,17 @@ def build_static_router(
     else:
         logger.info("serving console UI from %s", root)
 
-    index_path = os.path.join(root, "index.html") if root else None
-
-    async def _send_bytes(send, status: int, body: bytes, content_type: str, *, extra_headers=None) -> None:
+    async def _send_bytes(
+        send,
+        status: int,
+        body: bytes,
+        content_type: str,
+        *,
+        extra_headers=None,
+        head: bool = False,
+    ) -> None:
+        # Content-Length always reflects the GET body; a HEAD response carries
+        # the headers but no body (RFC 9110 §9.3.2).
         headers = [
             (b"content-type", content_type.encode("latin-1")),
             (b"content-length", str(len(body)).encode("latin-1")),
@@ -234,24 +273,18 @@ def build_static_router(
         if extra_headers:
             headers.extend(extra_headers)
         await send({"type": "http.response.start", "status": status, "headers": headers})
-        await send({"type": "http.response.body", "body": body})
+        await send({"type": "http.response.body", "body": b"" if head else body})
 
-    async def _serve_index(scope, send, *, status: int = 200) -> None:
-        try:
-            with open(index_path, "r", encoding="utf-8") as f:
-                html = f.read()
-        except OSError:
-            logger.exception("failed to read index.html at %s", index_path)
-            await _send_bytes(send, 500, b"internal error\n", "text/plain; charset=utf-8")
-            return
+    async def _serve_index(scope, send, *, status: int = 200, head: bool = False) -> None:
         api_base = _resolve_api_base_url(scope, public_base_url, web_port)
-        html = _inject_runtime_config(html, api_base)
+        html = _inject_runtime_config(index_template, api_base)
         await _send_bytes(
             send,
             status,
             html.encode("utf-8"),
             "text/html; charset=utf-8",
             extra_headers=[(b"cache-control", b"no-cache")],
+            head=head,
         )
 
     async def app(scope, receive, send):
@@ -276,26 +309,52 @@ def build_static_router(
             await inner(scope, receive, send)
             return
 
+        head = method == "HEAD"
+
         # Root + explicit index → serve the (config-injected) index.html.
         if path in ("/", "/index.html"):
-            await _serve_index(scope, send)
+            await _serve_index(scope, send, head=head)
             return
 
         # Try to serve a real file from the web root.
         fs_path = _safe_join(root, path)
         if fs_path and os.path.isfile(fs_path):
             try:
-                with open(fs_path, "rb") as f:
-                    body = f.read()
+                # Off-load the (potentially large) read so a big bundle can't
+                # block the event loop shared with gRPC-Web streaming.
+                body = await asyncio.to_thread(_read_file, fs_path)
             except OSError:
                 logger.exception("failed to read static file %s", fs_path)
-                await _send_bytes(send, 500, b"internal error\n", "text/plain; charset=utf-8")
+                await _send_bytes(
+                    send, 500, b"internal error\n", "text/plain; charset=utf-8", head=head
+                )
                 return
-            await _send_bytes(send, 200, body, _content_type(fs_path))
+            # Vite content-hashes everything under /assets/, so it is safe to
+            # cache immutably; other real files (favicon, etc.) stay uncached.
+            extra = None
+            if path.startswith("/assets/"):
+                extra = [(b"cache-control", b"public, max-age=31536000, immutable")]
+            await _send_bytes(
+                send, 200, body, _content_type(fs_path), extra_headers=extra, head=head
+            )
             return
 
-        # SPA fallback: any unknown non-API path serves index.html so the
-        # client-side hash router can take over (e.g. /#/session/<id>).
-        await _serve_index(scope, send)
+        # A request for a concrete asset that doesn't exist → 404, not the SPA
+        # fallback (returning index.html for a missing .js/.svg only produces
+        # MIME errors). Extension-less paths are navigation/hash routes.
+        if _looks_like_file(path):
+            await _send_bytes(
+                send, 404, b"not found\n", "text/plain; charset=utf-8", head=head
+            )
+            return
+
+        # SPA fallback: any unknown non-API, non-file path serves index.html so
+        # the client-side hash router can take over (e.g. /#/session/<id>).
+        await _serve_index(scope, send, head=head)
 
     return app
+
+
+def _read_file(path: str) -> bytes:
+    with open(path, "rb") as f:
+        return f.read()

--- a/server/harmonograf_server/static_site.py
+++ b/server/harmonograf_server/static_site.py
@@ -1,0 +1,301 @@
+"""Serve the built console SPA on the web port, beside gRPC-Web + health.
+
+A single ``harmonograf-server`` process should be able to hand a browser
+the whole console without a separate static host or a frontend dev
+server. This module wraps the gRPC-Web/health ASGI app with a thin static
+layer that:
+
+  * serves ``index.html`` at ``/`` (and as the SPA fallback),
+  * serves hashed asset files under ``/assets/*`` and any other real file
+    in the web root (favicon, etc.),
+  * falls back to ``index.html`` for any *other* GET/HEAD path that is not
+    a real file — so client-side hash routes like ``/#/session/<id>`` load
+    the SPA when deep-linked, and
+  * never touches gRPC-Web requests (content-type ``application/grpc-web*``)
+    or the health routes — those flow straight through to ``inner``.
+
+The served ``index.html`` is rewritten on the fly to inject the server's
+own gRPC-Web base URL as ``window.__HARMONOGRAF_API__`` so one built
+bundle works behind any host/port without a rebuild (see ``transport.ts``).
+
+Locating the bundle (in precedence order):
+
+  1. an explicit ``web_root`` (the ``--web-root`` CLI flag),
+  2. the packaged console shipped inside the wheel
+     (``harmonograf_server/_console``), located via ``importlib.resources``,
+  3. a dev fallback to ``../../frontend/dist`` relative to this file
+     (the repo checkout).
+
+If none of those contains an ``index.html`` the layer logs a warning once
+and forwards every request to ``inner`` — the server keeps serving
+gRPC-Web + health, just without the bundled UI.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from importlib import resources
+from typing import Awaitable, Callable, Optional
+
+logger = logging.getLogger("harmonograf_server.static_site")
+
+
+ASGIApp = Callable[..., Awaitable[None]]
+
+# Minimal extension → content-type map. Covers everything Vite emits plus
+# the static assets we ship; anything unknown falls back to
+# application/octet-stream.
+_CONTENT_TYPES = {
+    ".html": "text/html; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".mjs": "text/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".map": "application/json; charset=utf-8",
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".ico": "image/x-icon",
+    ".webp": "image/webp",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".txt": "text/plain; charset=utf-8",
+    ".wasm": "application/wasm",
+}
+
+# Paths that must always reach the inner gRPC-Web/health app, never the
+# static layer. gRPC-Web is additionally identified by content-type below.
+_HEALTH_PATHS = frozenset({"/healthz", "/readyz"})
+
+# gRPC service-method routes look like ``/<pkg>.<Service>/<Method>`` (e.g.
+# ``/harmonograf.v1.Harmonograf/GetStats``). Real gRPC-Web traffic is POST
+# with an ``application/grpc-web*`` content-type and is already excluded, but
+# we additionally never hijack a gRPC-shaped path as an SPA route regardless
+# of method — so the inner auth/gRPC-Web app always owns it (no SPA fallback
+# masking a 401, no surprises for non-binary gRPC-Web). A leading segment
+# containing a dot is the tell; the SPA never serves such paths.
+_GRPC_PATH_RE = re.compile(r"^/[A-Za-z_][\w.]*\.[A-Za-z_]\w*/[A-Za-z_]\w*/?$")
+
+
+def locate_web_root(web_root: Optional[str] = None) -> Optional[str]:
+    """Return an absolute path to a directory containing ``index.html``,
+    or ``None`` if no console bundle can be found.
+
+    Precedence: explicit ``web_root`` → packaged ``_console`` → repo
+    ``frontend/dist`` dev fallback.
+    """
+
+    candidates: list[str] = []
+    if web_root:
+        candidates.append(os.path.abspath(os.path.expanduser(web_root)))
+
+    # Packaged console inside the installed wheel.
+    try:
+        pkg_console = resources.files("harmonograf_server") / "_console"
+        # ``files()`` returns a Traversable; for a normal filesystem install
+        # str() yields a usable path. Guard against zipped installs by
+        # checking existence below.
+        candidates.append(str(pkg_console))
+    except (ModuleNotFoundError, AttributeError):  # pragma: no cover - defensive
+        pass
+
+    # Dev fallback: repo checkout's frontend/dist (../../frontend/dist).
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates.append(
+        os.path.abspath(os.path.join(here, "..", "..", "frontend", "dist"))
+    )
+
+    for cand in candidates:
+        if cand and os.path.isfile(os.path.join(cand, "index.html")):
+            return cand
+    return None
+
+
+def _content_type(path: str) -> str:
+    _, ext = os.path.splitext(path)
+    return _CONTENT_TYPES.get(ext.lower(), "application/octet-stream")
+
+
+def _is_grpc_web(scope: dict) -> bool:
+    for k, v in scope.get("headers") or ():
+        if k.lower() == b"content-type" and v.lower().startswith(b"application/grpc-web"):
+            return True
+    return False
+
+
+def _safe_join(root: str, url_path: str) -> Optional[str]:
+    """Resolve ``url_path`` against ``root``, refusing any traversal that
+    escapes ``root``. Returns the absolute filesystem path or ``None``."""
+
+    rel = url_path.lstrip("/")
+    # Normalize and reject anything that climbs out of root.
+    candidate = os.path.normpath(os.path.join(root, rel))
+    root_abs = os.path.abspath(root)
+    candidate_abs = os.path.abspath(candidate)
+    if candidate_abs != root_abs and not candidate_abs.startswith(root_abs + os.sep):
+        return None
+    return candidate_abs
+
+
+def _inject_runtime_config(html: str, api_base_url: str) -> str:
+    """Insert ``window.__HARMONOGRAF_API__`` so the bundle learns its
+    gRPC-Web endpoint at runtime. Injected just before the first module
+    script so it runs before the app boots."""
+
+    # JS string-literal escaping for the URL (it is operator-controlled but
+    # be defensive about quotes / closing tags anyway).
+    safe = (
+        api_base_url.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("</", "<\\/")
+    )
+    snippet = f'<script>window.__HARMONOGRAF_API__ = "{safe}";</script>'
+    needle = "<script type=\"module\""
+    idx = html.find(needle)
+    if idx != -1:
+        return html[:idx] + snippet + "\n    " + html[idx:]
+    # Fall back to injecting at end of <head>, then start of <body>.
+    for anchor in ("</head>", "<body>"):
+        idx = html.find(anchor)
+        if idx != -1:
+            if anchor == "</head>":
+                return html[:idx] + snippet + "\n  " + html[idx:]
+            return html[: idx + len(anchor)] + "\n    " + snippet + html[idx + len(anchor):]
+    # Last resort: prepend.
+    return snippet + html
+
+
+def _resolve_api_base_url(scope: dict, configured_public_base: str, web_port: int) -> str:
+    """Derive the gRPC-Web base URL the *browser* should use to reach this
+    server. Prefers an operator-configured public base; otherwise derives
+    scheme+host from the request (so it follows whatever host:port the user
+    actually typed, including reverse proxies that set forwarded headers)."""
+
+    if configured_public_base:
+        return configured_public_base.rstrip("/")
+
+    headers = {k.lower(): v for k, v in (scope.get("headers") or ())}
+
+    # Honor common reverse-proxy forwarding headers when present.
+    fwd_proto = headers.get(b"x-forwarded-proto")
+    fwd_host = headers.get(b"x-forwarded-host")
+    if fwd_host:
+        scheme = (fwd_proto or b"http").split(b",")[0].strip().decode("latin-1")
+        host = fwd_host.split(b",")[0].strip().decode("latin-1")
+        return f"{scheme}://{host}"
+
+    host = headers.get(b"host")
+    if host:
+        scheme = scope.get("scheme") or "http"
+        return f"{scheme}://{host.decode('latin-1')}"
+
+    # No Host header (rare): fall back to the bind port on loopback.
+    return f"http://127.0.0.1:{web_port}"
+
+
+def build_static_router(
+    inner: ASGIApp,
+    *,
+    web_root: Optional[str],
+    web_port: int,
+    public_base_url: str = "",
+) -> ASGIApp:
+    """Wrap ``inner`` (gRPC-Web + health) with static SPA serving.
+
+    ``web_root`` is an explicit override; when ``None`` the bundle is
+    auto-located. ``public_base_url`` (if non-empty) is injected verbatim as
+    the SPA's gRPC-Web endpoint; otherwise it is derived per-request from the
+    Host / forwarding headers.
+    """
+
+    root = locate_web_root(web_root)
+    if root is None:
+        logger.warning(
+            "console UI bundle not found (looked for index.html via "
+            "--web-root, the packaged _console dir, and ../frontend/dist); "
+            "serving gRPC-Web + health only. Build the frontend "
+            "(cd frontend && pnpm build) or pass --web-root to enable the UI."
+        )
+    else:
+        logger.info("serving console UI from %s", root)
+
+    index_path = os.path.join(root, "index.html") if root else None
+
+    async def _send_bytes(send, status: int, body: bytes, content_type: str, *, extra_headers=None) -> None:
+        headers = [
+            (b"content-type", content_type.encode("latin-1")),
+            (b"content-length", str(len(body)).encode("latin-1")),
+        ]
+        if extra_headers:
+            headers.extend(extra_headers)
+        await send({"type": "http.response.start", "status": status, "headers": headers})
+        await send({"type": "http.response.body", "body": body})
+
+    async def _serve_index(scope, send, *, status: int = 200) -> None:
+        try:
+            with open(index_path, "r", encoding="utf-8") as f:
+                html = f.read()
+        except OSError:
+            logger.exception("failed to read index.html at %s", index_path)
+            await _send_bytes(send, 500, b"internal error\n", "text/plain; charset=utf-8")
+            return
+        api_base = _resolve_api_base_url(scope, public_base_url, web_port)
+        html = _inject_runtime_config(html, api_base)
+        await _send_bytes(
+            send,
+            status,
+            html.encode("utf-8"),
+            "text/html; charset=utf-8",
+            extra_headers=[(b"cache-control", b"no-cache")],
+        )
+
+    async def app(scope, receive, send):
+        # Non-HTTP (lifespan/websocket) and the "no bundle" case go straight
+        # through to the inner app.
+        if scope.get("type") != "http" or root is None:
+            await inner(scope, receive, send)
+            return
+
+        path = scope.get("path", "") or "/"
+        method = (scope.get("method") or "GET").upper()
+
+        # Health + gRPC-Web (by content-type) + gRPC-shaped service paths
+        # always belong to the inner app — never the SPA layer.
+        if path in _HEALTH_PATHS or _is_grpc_web(scope) or _GRPC_PATH_RE.match(path):
+            await inner(scope, receive, send)
+            return
+
+        # Anything that isn't a static-servable verb (POST gRPC-Web, etc.)
+        # also belongs to the inner app — the SPA only needs GET/HEAD.
+        if method not in ("GET", "HEAD"):
+            await inner(scope, receive, send)
+            return
+
+        # Root + explicit index → serve the (config-injected) index.html.
+        if path in ("/", "/index.html"):
+            await _serve_index(scope, send)
+            return
+
+        # Try to serve a real file from the web root.
+        fs_path = _safe_join(root, path)
+        if fs_path and os.path.isfile(fs_path):
+            try:
+                with open(fs_path, "rb") as f:
+                    body = f.read()
+            except OSError:
+                logger.exception("failed to read static file %s", fs_path)
+                await _send_bytes(send, 500, b"internal error\n", "text/plain; charset=utf-8")
+                return
+            await _send_bytes(send, 200, body, _content_type(fs_path))
+            return
+
+        # SPA fallback: any unknown non-API path serves index.html so the
+        # client-side hash router can take over (e.g. /#/session/<id>).
+        await _serve_index(scope, send)
+
+    return app

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -30,6 +30,16 @@ harmonograf-server = "harmonograf_server.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["harmonograf_server"]
+# Ship the built console SPA inside the wheel so `pip/uv install
+# harmonograf-server` carries the UI with no separate frontend build on the
+# consumer's side. The bundle is staged into harmonograf_server/_console/ by
+# `make console` (frontend pnpm build → copy into the package) before
+# packaging; static_site.py locates it at runtime via importlib.resources.
+# `artifacts` overrides the repo .gitignore so the staged, uncommitted bundle
+# is collected. It is permissive: when _console/ is absent (a plain dev
+# checkout / editable install) the wheel simply omits it and the server falls
+# back to ../frontend/dist or serves gRPC-Web + health only.
+artifacts = ["harmonograf_server/_console/**"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/server/tests/test_static_site.py
+++ b/server/tests/test_static_site.py
@@ -1,0 +1,317 @@
+"""Tests for serving the built console SPA on the web port.
+
+Covers both the pure ASGI wrapper (``build_static_router``) with a temporary
+web root and an end-to-end run through ``Harmonograf`` confirming:
+
+  * ``GET /`` serves index.html with the injected ``window.__HARMONOGRAF_API__``,
+  * a real static asset under ``/assets/`` is served with the right type,
+  * an unknown non-API path falls back to index.html (SPA hash routing),
+  * ``/healthz`` + ``/readyz`` still work, and
+  * gRPC-shaped service paths are never hijacked by the SPA layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+
+import pytest
+
+from harmonograf_server.config import ServerConfig
+from harmonograf_server.main import Harmonograf
+from harmonograf_server.static_site import (
+    build_static_router,
+    locate_web_root,
+)
+
+
+INDEX_HTML = (
+    "<!doctype html>\n<html><head><title>Harmonograf</title>\n"
+    '<script type="module" crossorigin src="/assets/index.js"></script>\n'
+    "</head><body><div id=\"root\"></div></body></html>\n"
+)
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _make_web_root(tmp_path) -> str:
+    root = tmp_path / "dist"
+    (root / "assets").mkdir(parents=True)
+    (root / "index.html").write_text(INDEX_HTML, encoding="utf-8")
+    (root / "assets" / "index.js").write_text("console.log('hi');\n", encoding="utf-8")
+    (root / "favicon.svg").write_text("<svg/>", encoding="utf-8")
+    return str(root)
+
+
+# ---- pure ASGI wrapper ---------------------------------------------------
+
+
+async def _collect(app, scope):
+    """Drive an ASGI app once and return (status, headers, body)."""
+    sent: list[dict] = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    await app(scope, receive, send)
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+    headers = {k.lower(): v for k, v in start["headers"]}
+    return start["status"], headers, body
+
+
+def _http_scope(path: str, *, method: str = "GET", host: str = "console.test:9000", headers=None):
+    hdrs = [(b"host", host.encode())]
+    if headers:
+        hdrs.extend(headers)
+    return {"type": "http", "method": method, "path": path, "headers": hdrs, "scheme": "http"}
+
+
+@pytest.mark.asyncio
+async def test_serves_index_with_injected_runtime_config(tmp_path):
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover - must not be hit
+        raise AssertionError("inner should not be called for GET /")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    status, headers, body = await _collect(app, _http_scope("/"))
+    assert status == 200
+    assert headers[b"content-type"].startswith(b"text/html")
+    text = body.decode()
+    # Runtime endpoint global injected, derived from the request Host.
+    assert 'window.__HARMONOGRAF_API__ = "http://console.test:9000"' in text
+    # The original module script is still present.
+    assert "/assets/index.js" in text
+
+
+@pytest.mark.asyncio
+async def test_public_base_url_overrides_host_derivation(tmp_path):
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called")
+
+    app = build_static_router(
+        inner, web_root=root, web_port=7532, public_base_url="https://obs.example/"
+    )
+    _, _, body = await _collect(app, _http_scope("/"))
+    assert 'window.__HARMONOGRAF_API__ = "https://obs.example"' in body.decode()
+
+
+@pytest.mark.asyncio
+async def test_serves_static_asset(tmp_path):
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    status, headers, body = await _collect(app, _http_scope("/assets/index.js"))
+    assert status == 200
+    assert headers[b"content-type"].startswith(b"text/javascript")
+    assert b"console.log" in body
+
+
+@pytest.mark.asyncio
+async def test_spa_fallback_for_unknown_path(tmp_path):
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called for SPA fallback")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    status, headers, body = await _collect(app, _http_scope("/some/deep/route"))
+    assert status == 200
+    assert headers[b"content-type"].startswith(b"text/html")
+    assert "window.__HARMONOGRAF_API__" in body.decode()
+
+
+@pytest.mark.asyncio
+async def test_health_and_grpc_paths_pass_through(tmp_path):
+    root = _make_web_root(tmp_path)
+    forwarded: list[str] = []
+
+    async def inner(scope, receive, send):
+        forwarded.append(scope["path"])
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    # Health endpoints belong to the inner app.
+    await _collect_passthrough(app, _http_scope("/healthz"))
+    await _collect_passthrough(app, _http_scope("/readyz"))
+    # gRPC-shaped service path is never hijacked, even on GET.
+    await _collect_passthrough(app, _http_scope("/harmonograf.v1.Harmonograf/GetStats"))
+    # A gRPC-Web POST (by content-type) also passes through.
+    await _collect_passthrough(
+        app,
+        _http_scope(
+            "/harmonograf.v1.Harmonograf/GetStats",
+            method="POST",
+            headers=[(b"content-type", b"application/grpc-web+proto")],
+        ),
+    )
+
+    # Re-run against a forwarding inner to assert paths actually reached it.
+    app2 = build_static_router(inner, web_root=root, web_port=7532)
+
+    async def noop_send(_msg):
+        pass
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    for scope in (
+        _http_scope("/healthz"),
+        _http_scope("/harmonograf.v1.Harmonograf/GetStats"),
+    ):
+        await app2(scope, receive, noop_send)
+    assert "/healthz" in forwarded
+    assert forwarded.count("/harmonograf.v1.Harmonograf/GetStats") >= 1
+
+
+async def _collect_passthrough(app, scope):
+    """Assert the request reaches inner (which here records nothing/sends nothing)."""
+    sent: list[dict] = []
+
+    async def send(msg):  # pragma: no cover - inner may not send
+        sent.append(msg)
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    await app(scope, receive, send)
+
+
+@pytest.mark.asyncio
+async def test_no_bundle_forwards_everything(monkeypatch):
+    """With no locatable bundle, every request flows to inner unchanged.
+
+    We force ``locate_web_root`` to ``None`` because a repo checkout normally
+    has a built ``frontend/dist`` the locator would fall back to.
+    """
+    import harmonograf_server.static_site as ss
+
+    monkeypatch.setattr(ss, "locate_web_root", lambda *_a, **_k: None)
+
+    forwarded: list[str] = []
+
+    async def inner(scope, receive, send):
+        forwarded.append(scope["path"])
+
+    app = build_static_router(inner, web_root="", web_port=7532)
+
+    async def send(_msg):  # pragma: no cover
+        pass
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    await app(_http_scope("/"), receive, send)
+    await app(_http_scope("/anything"), receive, send)
+    assert forwarded == ["/", "/anything"]
+
+
+def test_locate_web_root_prefers_explicit(tmp_path):
+    root = _make_web_root(tmp_path)
+    assert locate_web_root(root) == os.path.abspath(root)
+    # A bogus explicit root falls through (here to the repo dev fallback or
+    # None); the function must not return the bogus path.
+    assert locate_web_root(str(tmp_path / "nope")) != str(tmp_path / "nope")
+
+
+# ---- end-to-end through Harmonograf -------------------------------------
+
+
+async def _wait_for_port(port: int, timeout: float = 3.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    last_err: Exception | None = None
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+            return
+        except OSError as e:
+            last_err = e
+            await asyncio.sleep(0.05)
+    raise TimeoutError(f"port {port} not ready after {timeout}s: {last_err}")
+
+
+async def _http_get(port: int, path: str) -> tuple[int, bytes, bytes]:
+    await _wait_for_port(port)
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    req = (
+        f"GET {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n"
+    )
+    writer.write(req.encode())
+    await writer.drain()
+    resp = b""
+    while True:
+        chunk = await reader.read(4096)
+        if not chunk:
+            break
+        resp += chunk
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except Exception:
+        pass
+    head, _, body = resp.partition(b"\r\n\r\n")
+    status = int(head.split(b"\r\n", 1)[0].split()[1])
+    return status, head, body
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_serves_spa_and_keeps_health(tmp_path):
+    root = _make_web_root(tmp_path)
+    cfg = ServerConfig(
+        host="127.0.0.1",
+        grpc_port=_free_port(),
+        web_port=_free_port(),
+        store_backend="memory",
+        data_dir="",
+        grace_seconds=0.5,
+        metrics_interval_seconds=0.0,
+        web_root=root,
+    )
+    app = await Harmonograf.from_config(cfg)
+    await app.start()
+    try:
+        # GET / → SPA with injected config.
+        status, head, body = await _http_get(cfg.web_port, "/")
+        assert status == 200
+        assert b"text/html" in head.lower()
+        text = body.decode()
+        assert "window.__HARMONOGRAF_API__" in text
+        assert f"127.0.0.1:{cfg.web_port}" in text
+
+        # Static asset.
+        status, head, body = await _http_get(cfg.web_port, "/assets/index.js")
+        assert status == 200
+        assert b"javascript" in head.lower()
+
+        # SPA fallback for an unknown deep path.
+        status, _, body = await _http_get(cfg.web_port, "/deeplink/here")
+        assert status == 200
+        assert b"window.__HARMONOGRAF_API__" in body
+
+        # Health still works alongside the SPA.
+        status, _, body = await _http_get(cfg.web_port, "/healthz")
+        assert status == 200
+        assert b"ok" in body
+        status, _, body = await _http_get(cfg.web_port, "/readyz")
+        assert status == 200
+        assert b"ready" in body
+    finally:
+        await app.stop()

--- a/server/tests/test_static_site.py
+++ b/server/tests/test_static_site.py
@@ -21,6 +21,8 @@ import pytest
 from harmonograf_server.config import ServerConfig
 from harmonograf_server.main import Harmonograf
 from harmonograf_server.static_site import (
+    _inject_runtime_config,
+    _safe_join,
     build_static_router,
     locate_web_root,
 )
@@ -225,6 +227,73 @@ def test_locate_web_root_prefers_explicit(tmp_path):
     # A bogus explicit root falls through (here to the repo dev fallback or
     # None); the function must not return the bogus path.
     assert locate_web_root(str(tmp_path / "nope")) != str(tmp_path / "nope")
+
+
+@pytest.mark.asyncio
+async def test_missing_file_like_path_returns_404(tmp_path):
+    """A request for a concrete asset that doesn't exist must 404, not serve
+    the SPA fallback (returning index.html for a missing .js/.svg only yields
+    MIME errors in the browser)."""
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    status, headers, body = await _collect(app, _http_scope("/does-not-exist.js"))
+    assert status == 404
+    assert headers[b"content-type"].startswith(b"text/plain")
+    assert b"window.__HARMONOGRAF_API__" not in body
+
+
+@pytest.mark.asyncio
+async def test_assets_get_immutable_cache_header(tmp_path):
+    """Vite content-hashes /assets/*, so they are served cache-immutable."""
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    _, headers, _ = await _collect(app, _http_scope("/assets/index.js"))
+    assert b"immutable" in headers.get(b"cache-control", b"")
+
+
+@pytest.mark.asyncio
+async def test_head_request_sends_no_body_but_keeps_content_length(tmp_path):
+    """HEAD carries the headers (incl. the GET Content-Length) but no body."""
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    status, headers, body = await _collect(app, _http_scope("/", method="HEAD"))
+    assert status == 200
+    assert body == b""
+    # Content-Length reflects what a GET would have returned (non-zero).
+    assert int(headers[b"content-length"]) > 0
+
+
+def test_safe_join_rejects_traversal(tmp_path):
+    """Path traversal must not escape the web root."""
+    root = _make_web_root(tmp_path)
+    # A benign nested path resolves inside root.
+    inside = _safe_join(root, "/assets/index.js")
+    assert inside is not None and inside.startswith(os.path.abspath(root))
+    # Climbing out of root is refused.
+    assert _safe_join(root, "/../../etc/passwd") is None
+    assert _safe_join(root, "/../" + os.path.basename(root) + "_sibling/x") is None
+
+
+def test_inject_runtime_config_escapes_hostile_url():
+    """A crafted endpoint can't break out of the JS string or the <script>."""
+    html = '<html><head><script type="module" src="/a.js"></script></head></html>'
+    out = _inject_runtime_config(html, '"></script><script>alert(1)//')
+    # No raw closing tag survives to terminate our injected <script> early.
+    assert "</script><script>alert(1)" not in out
+    # The original module script is preserved exactly once.
+    assert out.count('<script type="module"') == 1
 
 
 # ---- end-to-end through Harmonograf -------------------------------------


### PR DESCRIPTION
Make `harmonograf-server` self-serve its console UI, so consumers (e.g. zicato) get the dashboard with no separate build/serve step and without a backend URL baked at build time. Today the server runs gRPC + gRPC-Web + `/healthz` only; the SPA is a separate Vite build that nothing serves, so deep-links 404 and a shipped bundle can't reach a dynamic web port.

## What changed
1. **Serve the built SPA on the web port** (`server/harmonograf_server/static_site.py`). `build_static_router` wraps the existing gRPC-Web/health app: non-API GET/HEAD paths serve `index.html` + real files from the web root; unknown non-file paths fall back to `index.html` so client-side hash routes (`#/session/<id>`) load the SPA. gRPC-Web (by content-type), gRPC service-method paths (matched even on GET, so auth stays enforced), and `/healthz`/`/readyz` always pass through. The bundle is located via `--web-root` → packaged `_console/` (`importlib.resources`) → `../frontend/dist` dev fallback; if none is found it logs a warning and keeps serving gRPC-Web + health (graceful).
2. **Runtime endpoint config** (`static_site.py` + `frontend/src/rpc/transport.ts`). The served `index.html` gets `<script>window.__HARMONOGRAF_API__ = "<url>"</script>` injected (URL derived from `Host`/`X-Forwarded-*`, or `--public-base-url`). The frontend resolves `window.__HARMONOGRAF_API__` → `VITE_HARMONOGRAF_API` → the compiled-in default, so one built bundle works behind any host/port.
3. **`#/session/<id>` deep-link routing** (`frontend/src/App.tsx` + `frontend/src/lib/sessionRoute.ts`). Parse the hash on load and on `hashchange`, select that session (pre-empting the newest-first auto-select), and re-apply once the session list arrives.
4. **Packaging** (`server/pyproject.toml` hatchling + `Makefile`). `make console` builds the frontend into `server/harmonograf_server/_console/`; the wheel ships it via `tool.hatch.build.targets.wheel.artifacts`, so `pip/uv install harmonograf-server` brings the console. `_console/` is gitignored and omitted silently when absent, so editable installs / dev checkouts still work.

New CLI flags: `--web-root`, `--public-base-url`.

## Verification
- `pnpm install --frozen-lockfile && pnpm build` clean (tsc + vite).
- Live server (`--web-port 17532`): `GET /` → `200 text/html` with the injected `window.__HARMONOGRAF_API__`; `GET /session/<id>` → SPA fallback; `GET /assets/*` → served; gRPC-Web POST → `200 application/grpc-web+proto` (not hijacked); GET on a gRPC path → reaches the gRPC layer; `/healthz` → `200`.
- Server suite: 462 passed, 1 skipped (+8 new `test_static_site.py`, incl. no-bundle degradation, verified CI-safe with no `dist`/`_console` present).
- Frontend: +9 new tests pass (`transport.test.ts` precedence, `sessionDeepLink.test.tsx`); full suite 731 passed.
- `uv build --wheel` after `make console` → wheel contains `harmonograf_server/_console/index.html` + assets.

## Notes for review
- **CI**: the repo's CI runs tests only; there is no wheel-build/publish job. A future release workflow must run `make console` before `uv build` to bake the UI into the wheel (documented in `server/README.md`). The existing server-test job is unaffected — tests pass with or without a built bundle.
- Pre-existing: `index.html` references `/favicon.svg` but the frontend emits none (no `frontend/public/`), so `GET /favicon.svg` hits the SPA fallback — out of scope here.
- Two pre-existing `TrajectoryView.headerMath` frontend test failures predate this branch and are unrelated.
