### PR TITLE
Sequence diagram primary + directional transfer chord + compose parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ tests/reference_agents/presentation_agent/output/
 
 # Python build artifacts
 client/build/
+# Console SPA staged into the server wheel by `make console` (built output;
+# the canonical source lives in frontend/, see server/pyproject.toml).
+server/harmonograf_server/_console/
 
 # Demo output tarballs
 waffle.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CLIENT_PB := $(ROOT)/client/harmonograf_client/pb
 FRONTEND_PB := $(ROOT)/frontend/src/pb
 
 .PHONY: help proto proto-python proto-ts \
-        server-install client-install frontend-install install \
+        server-install client-install frontend-install install console \
         server-run frontend-dev demo demo-presentation demo-presentation-orchestrated demo-standalone .demo-agents-stage \
         test server-test client-test frontend-test e2e \
         lint format clean stats
@@ -24,6 +24,7 @@ help:
 	@echo "  proto-python     Regenerate Python stubs under server/ and client/"
 	@echo "  proto-ts         Regenerate TypeScript stubs under frontend/"
 	@echo "  install          Install all components"
+	@echo "  console          Build the frontend and stage it into the server wheel"
 	@echo "  server-run       Run the server in dev mode"
 	@echo "  frontend-dev     Run the Vite dev server"
 	@echo "  demo             Boot server + frontend + adk web (shows both presentation_agent variants)"
@@ -106,6 +107,26 @@ client-install:
 
 frontend-install:
 	@cd $(ROOT)/frontend && pnpm install --frozen-lockfile
+
+# ---------------------------------------------------------------------------
+# Console bundle (ship the built SPA inside the server wheel)
+# ---------------------------------------------------------------------------
+
+# Where the wheel expects the bundled console (see server/pyproject.toml
+# force-include + static_site.py importlib.resources lookup).
+CONSOLE_DIR := $(ROOT)/server/harmonograf_server/_console
+
+# Build the frontend and stage it into the server package so the wheel ships
+# the UI. Run this before packaging the server (`uv build server`, etc.).
+# The server's static_site.py also auto-locates ../frontend/dist in a repo
+# checkout, so `make console` is only required for producing a distributable
+# wheel — local `make server-run` works without it.
+console:
+	@cd $(ROOT)/frontend && pnpm install --frozen-lockfile && pnpm build
+	@rm -rf $(CONSOLE_DIR)
+	@mkdir -p $(CONSOLE_DIR)
+	@cp -R $(ROOT)/frontend/dist/. $(CONSOLE_DIR)/
+	@echo "Console staged into $(CONSOLE_DIR) (shipped in the server wheel)."
 
 # ---------------------------------------------------------------------------
 # Run
@@ -322,4 +343,5 @@ clean:
 	@find $(ROOT) -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
 	@find $(ROOT) -type d -name .pytest_cache -prune -exec rm -rf {} + 2>/dev/null || true
 	@rm -rf $(ROOT)/frontend/dist
+	@rm -rf $(CONSOLE_DIR)
 	@echo "Clean done. Run 'make proto' to regenerate stubs."

--- a/docs/design/zicato-ui-study/BRIEF.md
+++ b/docs/design/zicato-ui-study/BRIEF.md
@@ -1,0 +1,201 @@
+# BRIEF — harmonograf UI study in the zicato design language
+
+This is the **single source of truth** for the team building this study. Read it
+fully, then read the source files it points to. Where this brief and a source
+file disagree about a token/hex/class, **the source file wins** — re-grep.
+
+## 0. Goal & deliverable
+
+Produce a **UI study**: a self-contained set of HTML pages that show
+harmonograf's console redrawn in **zicato's design language**, theme-switchable
+across all 16 themes, with before/after comparisons per surface. This is a
+*design artifact*, not production code — standalone HTML/CSS/JS, no build step,
+opens from `file://`.
+
+The native form of a study in this ecosystem is zicato's
+`~/git/zicato/docs/design/tournament-viz-study/` — **clone its conventions
+exactly** (self-contained pages, ported token block, `_embed.js` with
+`?only/?bare/?theme`, a `compose.html`). Match its quality bar.
+
+**Output dir:** `~/git/harmonograf/docs/design/zicato-ui-study/` (this dir).
+
+## 1. The two design languages
+
+**zicato** — canonical docs (read both, fully):
+- `~/git/zicato/docs/design/DESIGN-LANGUAGE.md` — the *language* (tokens, type,
+  line-art figure grammar §5, motion/digest-gating §7, a11y §9, and §10 a worked
+  "build a harmonograf execution timeline" example — **use it**).
+- `~/git/zicato/docs/design/CONSOLE-DESIGN-LANGUAGE.md` — the dashboard's
+  *application* of it (figure catalogue §4.1, mark conventions §4.2).
+- Authoritative token sheet: `~/git/zicato/src/zicato/dashboard/static/css/variants/T/console4.css`.
+- A clonable study page (port its `--v2-*`→local token block + structure):
+  `~/git/zicato/docs/design/tournament-viz-study/single-matchup.html`, and the
+  shared `_embed.js` + `compose.html` in that dir.
+
+Ethos in one line: **Tufte data-ink line-art, monospace-forward, a calm ground
+with signal earned by direction, theme-adaptive by pure CSS swap, never
+flashing.**
+
+**harmonograf today** — what we are restyling (read the chrome + Gantt):
+- `~/git/harmonograf/frontend/src/index.css` — ALL chrome classes (`.hg-*`):
+  shell grid, appbar, rail, strip, transport, drawer, picker, help, panels.
+- `~/git/harmonograf/frontend/src/theme/themes.ts` — MD3 tokens + the span-kind
+  and goldfive-category hues we must re-home.
+- `~/git/harmonograf/frontend/src/gantt/colors.ts` — kind×status → fill/stroke/
+  treatment (the 2-axis encoding; preserve it, §3).
+- `~/git/harmonograf/frontend/src/gantt/renderer.ts` — 3-layer canvas Gantt.
+- Components: `frontend/src/components/{Gantt,OrchestrationTimeline,TaskStages,LiveActivity,Interventions,SessionPicker,TransportBar,shell}`.
+
+It is **Material Design 3**: `--md-sys-color-*`, system-ui sans, elevation
+containers, rounded radii, blue primary, several `animation:…infinite` pulses.
+
+## 2. THE CENTRAL DECISION — full categorical palette from Gogh ANSI
+
+zicato's "one green accent, everything else neutral" is built for a binary
+promote/reject surface. harmonograf is a **categorical instrument**: many
+agents, 9 span kinds, goldfive call categories. We are **keeping the full
+categorical palette** — but sourcing every categorical hue from the active
+theme's **terminal ANSI palette** (the Gogh scheme each zicato theme derives
+from). This ties the categorical encoding to the theme system instead of
+fighting it: switch theme → the whole palette re-skins, ANSI and all.
+
+Preserve harmonograf's elegant **2-axis encoding**:
+- **KIND = hue** → mapped to a theme ANSI color (full categorical, below).
+- **STATUS = treatment** → mapped to zicato semantic roles + treatments
+  (running → the *one* `--accent` + breathing; FAILED → `--bad` + error glyph;
+  PENDING/CANCELLED → reduced opacity / hatch; planned → dashed). Status is the
+  only place good/bad/accent appear, so zicato's "earned by direction" rule
+  holds: a span is never red for its identity, only when it failed.
+
+### 2.1 Span KIND → ANSI slot (proposed; foundation worker finalizes)
+
+ANSI slots: `color_01..08` = black,red,green,yellow,blue,magenta,cyan,white;
+`color_09..16` = bright variants.
+
+| harmonograf kind | ANSI slot | rationale |
+|---|---|---|
+| `INVOCATION` | `color_09` bright-black/grey | structural container, recedes |
+| `LLM_CALL` | `color_05` blue | |
+| `TOOL_CALL` | `color_07` cyan | |
+| `USER_MESSAGE` | `color_03` green | |
+| `AGENT_MESSAGE` | `color_11` bright-green | distinct from user |
+| `TRANSFER` | `color_04` yellow | |
+| `WAIT_FOR_HUMAN` | `color_06` magenta | attention, but NOT red (red=failed) |
+| `PLANNED` | `color_09` grey + dashed | ghost/planned |
+| `CUSTOM` | `color_08` white/neutral | |
+
+goldfive lane categories: judge severity → roles (on-task `--good`, warning
+`--caution`, critical `--bad`, neutral `--flat`); `refine` → magenta `color_06`;
+`plan` → cyan `color_07`; `reflective` → grey `color_09`.
+
+### 2.2 Agent identity ramp
+
+Agents (lanes/lifelines) get an **ordinal ramp** derived from tokens, not 8
+saturated primaries — a low-sat sequence so lanes are distinguishable without
+competing with kind hues or the accent. Build with `color-mix()` off ANSI
+slots or an OKLCH spin; foundation worker decides and documents it.
+
+## 3. Token / type mapping (MD3 → zicato roles)
+
+| harmonograf (MD3) | zicato role / token |
+|---|---|
+| `surface` / `surface-container*` elevation ladder | `--paper` ground + ONE `--panel` lift; elevation→hairline `--rule`, not shadow |
+| `primary` (#a8c8ff) | `--accent` — reserved for now/selected/live ONLY |
+| `error` / `error-container` | `--bad` / `--bad-soft` |
+| `tertiary` / transfer / wait hues | `--caution` |
+| 9 `--hg-kind-*` | per-theme ANSI categorical (§2.1) |
+| `outline` / `outline-variant` | `--rule` / `--rule-soft` |
+| `on-surface` / `-variant` | `--ink` / `--ink-soft` / `--ink-faint` |
+| system-ui body, 14px | `--mono`/prose-mono; data uses code-mono + `tabular-nums` |
+| radii 4/8/12, pill chips | panels 4px, bars `rx:3`, `.dn-pill` mono outline-first |
+
+Use the zicato `--v2-*` role values from `console4.css` /
+`single-matchup.html` (paper/panel/ink/ink-soft/ink-faint/rule/rule-soft/
+good/good-soft/bad/bad-soft/caution/accent/flat/cell-empty) for all 16 themes,
+ported into local tokens exactly as the study pages do.
+
+## 4. Surfaces to redesign (each gets before/after + rationale + legend)
+
+1. **shell.html** — chrome: AppBar→zicato **topbar** (inline-SVG `zıcato`
+   wordmark w/ dotless-ı + green dot, breadcrumbs, swatch theme picker, typeface
+   switch, scale pill, status/RUN pill); NavRail; CurrentTaskStrip; TransportBar
+   (transport controls, LIVE pill, clock); Drawer/inspector (tabs, attrs, code).
+2. **gantt.html** — THE HERO. The execution Gantt in line-art: hairline
+   gridlines (`--rule-soft`, 0.6w), `rx:3` bars at reduced fill-opacity lifting
+   to 1 on hover, full categorical kind hues (§2), status treatments, the accent
+   for the "now" cursor / selected span, agent gutter + lifelines, context band.
+   Present BOTH options: (a) keep canvas, restyle via tokens; (b) fit-to-width
+   SVG line-art. Use realistic mock multi-agent trace data.
+3. **figures.html** — OrchestrationTimeline, TaskStages, LiveActivity (table as
+   `.dn-board-table` idiom), Interventions, SessionPicker (⌘K). Pills mono
+   outline-first; hovercards; tabular-nums.
+
+## 5. File layout
+
+```
+zicato-ui-study/
+  BRIEF.md            # this file
+  STYLE-GUIDE.md      # foundation worker writes: final span→ANSI map, token map, do/dont
+  _refs/gogh-palettes.json  # palette worker writes: 16 themes × full ANSI
+  _tokens.css         # 16 themes: --v2 roles (from console4) + ANSI categorical (from json)
+  _study.css          # shared page chrome + the .hg-* zicato-language component CSS
+  _embed.js           # ported from zicato tournament-viz-study (?only/?bare/?theme)
+  index.html          # overview + the categorical-palette thesis + links + theme picker
+  shell.html
+  gantt.html
+  figures.html
+  compose.html        # side-by-side, theme-synced, iframes of the above
+```
+
+Each page: ports/links the token block, ships the swatch theme picker
+(default `monokai`), sets `<html data-theme="...">`, includes `_embed.js`.
+
+## 6. Conventions to honor (from DESIGN-LANGUAGE.md)
+
+- **Token-only color.** No hardcoded hex in any mark/component — read `--*`
+  tokens so a theme swap is a pure re-skin. (The per-theme blocks in `_tokens.css`
+  are the only place hex appears.)
+- **Fit-to-width**, no pan/zoom; figures `width:100%` + `viewBox` + `role="img"`.
+- **Motion discipline** (§7): the only keyframe is a status/now pulse, gated
+  behind `@media (prefers-reduced-motion: reduce)`. No `animation:…infinite` on
+  structure. Note digest-gating in the rationale (harmonograf already half-does
+  it: "React never drives the render loop").
+- **Focus rings**: `2px solid var(--accent)` `:focus-visible`, small offset.
+- **Mono-forward** type; `tabular-nums` on all numerics/durations.
+- **Verify in BOTH** a light theme (`paper`) and a dark one (`monokai`).
+
+## 7. Gogh palette sourcing (palette worker)
+
+Source: `https://raw.githubusercontent.com/Gogh-Co/Gogh/master/themes/<Name>.yml`.
+Format (verified): `color_01..16` + `background` + `foreground`. color_01-08
+normal black/red/green/yellow/blue/magenta/cyan/white; 09-16 bright.
+
+Fetch these 16 (confirmed filenames in **bold**; others try canonical casing and
+verify): **Belafonte Day**, **Belafonte Night**, **Dracula**, **Espresso**,
+**Ubuntu**; Monokai, Solarized Dark, Solarized Light, Google Dark, Google Light,
+Lunaria Light, Lunaria Eclipse, Paper, Zenburn, Selenized Black, Relaxed.
+
+**Self-check:** each Gogh `background` MUST equal zicato's `--v2-paper` for that
+theme (e.g. Dracula bg `#282A36` ✓, Belafonte Night `#20111B` ✓, Espresso
+`#323232`, Ubuntu `#300A24`, Monokai `#1e1f1c`). zicato `--v2-paper` per theme is
+in `DESIGN-LANGUAGE.md §2.2`. If a fetched bg doesn't match, you have the wrong
+file — find the right one or note the discrepancy in the json. Emit
+`_refs/gogh-palettes.json`: `{ "<theme-id>": { "ansi": {"black":..., "red":...,
+... "brightWhite":...}, "bg":..., "fg":... }, ... }` keyed by zicato theme id.
+
+## 8. Team structure (an agent team with an explicit LEAD)
+
+- **Lead** owns the whole deliverable, coherence, and final QA. The Lead:
+  reads this brief + sources; builds the foundation (`_tokens.css`,
+  `_study.css`, `_embed.js`, `STYLE-GUIDE.md`) AFTER the palette worker returns
+  (or builds it in parallel and wires the json last); spawns the three surface
+  workers in parallel with crisp specs + the foundation contract; reviews each
+  returned page for token-only color, fit-to-width, theme correctness, and
+  cross-page visual coherence; assembles `index.html` + `compose.html`; runs the
+  §6 validation in both `monokai` and `paper`; returns a summary of what was
+  built, key decisions, and any open questions.
+- **Palette worker** → §7, returns `_refs/gogh-palettes.json`.
+- **Shell / Gantt / Figures workers** → §4, one page each, against the foundation.
+
+Keep every page self-contained and theme-switchable. The bar is zicato's own
+study pages — match it.

--- a/docs/design/zicato-ui-study/README.md
+++ b/docs/design/zicato-ui-study/README.md
@@ -1,0 +1,51 @@
+# harmonograf UI study — in the zicato design language
+
+A self-contained, theme-switchable study showing harmonograf's MD3 console
+redrawn in **zicato's design language**, keeping harmonograf's full categorical
+palette but sourcing every categorical hue from each theme's **Gogh terminal
+ANSI palette**. Standalone HTML/CSS/vanilla-JS — no build step.
+
+## Open it
+
+Everything opens straight from `file://` — no build step, no server. Start at
+**`index.html`** (the thesis, surface links, 16-theme wall), or jump to
+**`compose.html`** for the full interactive console.
+
+## Files
+
+```
+index.html       overview + the categorical-palette thesis + links + theme picker
+shell.html       chrome before/after: topbar · rail · strip · transport · drawer
+gantt.html       THE HERO — the execution timeline (SVG line-art + canvas options)
+sequence.html    how the agents talk: the vertical sequence diagram (recommended)
+                 + the directional transfer chord (topology) + the score (alt)
+figures.html     OrchestrationTimeline · TaskStages · LiveActivity · Interventions · ⌘K
+grammar.html     fourteen new figures: seismograph · ladder · sankey · strata ·
+                 plan DAG · delegation score · chord · fingerprint · …
+brand.html       harmonograf's own mark — the Lissajous α, wordmark, lockups
+compose.html     THE COMPOSED CONSOLE — interactive, three whole-UI proposals:
+                 A·observatory (rail-switched views + inspector), B·score
+                 (sequence-first + minimap + drift margin), C·mission control
+                 (fingerprint fleet). Clickable spans, ⌘K session switch.
+
+_tokens.css      16 themes: zicato --v2 roles + --ansi-* + the --hg-* categorical
+_study.css       shared page chrome + the .hg-* zicato-language component CSS
+_embed.js        ?only / ?bare / ?theme (ported from zicato tournament-viz-study)
+_refs/gogh-palettes.json   16 themes × full ANSI, self-checked vs --v2-paper
+
+STYLE-GUIDE.md   the foundation contract: span-KIND→ANSI map, agent ramp,
+                 MD3→zicato token map, the accent-collision rule, do/don'ts,
+                 and the open questions
+BRIEF.md         the original brief (single source of truth)
+```
+
+## The one idea
+
+zicato spends **one** green accent on a calm ground. harmonograf is a
+**categorical** instrument, so this study keeps the full palette but sources
+every hue from the active theme's **terminal ANSI** set. The 2-axis encoding
+holds: **KIND = hue** (an ANSI slot), **STATUS = treatment** (running → the one
+`--accent` + breathe; failed → `--bad` + `✕`; pending → faint; cancelled → hatch;
+planned → dashed). good / bad / accent appear **only** for status — a span is
+never red for its identity, only when it failed. Switch theme → the whole thing
+re-skins, ANSI and all, with no re-render. See `STYLE-GUIDE.md`.

--- a/docs/design/zicato-ui-study/README.md
+++ b/docs/design/zicato-ui-study/README.md
@@ -23,10 +23,18 @@ figures.html     OrchestrationTimeline · TaskStages · LiveActivity · Interven
 grammar.html     fourteen new figures: seismograph · ladder · sankey · strata ·
                  plan DAG · delegation score · chord · fingerprint · …
 brand.html       harmonograf's own mark — the Lissajous α, wordmark, lockups
-compose.html     THE COMPOSED CONSOLE — interactive, three whole-UI proposals:
-                 A·observatory (rail-switched views + inspector), B·score
-                 (sequence-first + minimap + drift margin), C·mission control
-                 (fingerprint fleet). Clickable spans, ⌘K session switch.
+compose.html     THE COMPOSED CONSOLE — interactive. The gantt as its own hero
+                 view + one coalesced "instruments" view leading with the plan:
+                 the plan REEL sits above the plan DAG and DRIVES it — click a
+                 revision and the DAG redraws that version's task set (added in
+                 accent, dropped-since-prior ghosted/dashed). Then sequence ·
+                 projectable topology chord · and ONE coordinated time-track
+                 stack: the drift seismograph with the judge heartbeat folded in
+                 (one time axis) over the time-aligned intervention ladder.
+                 Sessions ONLY via the ⌘K fingerprint picker (no sidebar).
+                 Clickable spans → inspector. ?ver= deep-links a reel revision.
+                 (The earlier A/B/C whole-UI proposals + fleet sidebar live in
+                 git history.)
 
 _tokens.css      16 themes: zicato --v2 roles + --ansi-* + the --hg-* categorical
 _study.css       shared page chrome + the .hg-* zicato-language component CSS

--- a/docs/design/zicato-ui-study/STYLE-GUIDE.md
+++ b/docs/design/zicato-ui-study/STYLE-GUIDE.md
@@ -1,0 +1,226 @@
+# STYLE-GUIDE — harmonograf in the zicato design language
+
+The foundation contract. Surface pages (`shell.html`, `gantt.html`,
+`figures.html`) build against this. It finalizes the proposals in
+[BRIEF.md](BRIEF.md): the span-KIND→ANSI map, the agent ramp, the MD3→zicato
+token map, and the do/don'ts. Where this and a source file disagree about a
+token, **the source wins** — re-grep.
+
+Files in this study:
+
+```
+_refs/gogh-palettes.json   16 themes × full ANSI, self-checked vs --v2-paper
+_tokens.css                16 theme blocks: --v2 roles + --ansi-* + --hg-* categorical
+_study.css                 shared page chrome + the .hg-* zicato-language components
+_embed.js                  ?only / ?bare / ?theme (ported from zicato study)
+STYLE-GUIDE.md             this file
+index.html  shell.html  gantt.html  figures.html  compose.html
+```
+
+---
+
+## 1. The thesis (why this study exists)
+
+zicato is a **binary** promote/reject surface: one green accent, everything else
+neutral. harmonograf is a **categorical instrument**: many agents, 9 span kinds,
+goldfive call categories. We keep harmonograf's full categorical palette — but
+**source every categorical hue from the active theme's terminal ANSI palette**
+(the Gogh scheme each zicato theme derives from). Switch theme → the whole
+categorical palette re-skins, ANSI and all. This ties the encoding to the theme
+system instead of fighting it.
+
+The elegant **2-axis encoding** is preserved:
+
+- **KIND = hue** → a theme ANSI slot (`--hg-kind-*`, full categorical).
+- **STATUS = treatment** → zicato semantic roles + treatments. Status is the
+  **only** place good / bad / accent appear, so zicato's "earned by direction"
+  rule holds: a span is never red for its identity, only when it failed.
+
+---
+
+## 2. Span KIND → ANSI slot (FINAL)
+
+ANSI slots map onto `--ansi-*` tokens in `_tokens.css`; the kind tokens alias them.
+
+| harmonograf kind | token | ANSI slot | rationale |
+|---|---|---|---|
+| `INVOCATION` | `--hg-kind-invocation` | bright-black (grey) | structural container, recedes (rendered at low opacity) |
+| `LLM_CALL` | `--hg-kind-llm-call` | blue | |
+| `TOOL_CALL` | `--hg-kind-tool-call` | cyan | |
+| `USER_MESSAGE` | `--hg-kind-user-message` | green | |
+| `AGENT_MESSAGE` | `--hg-kind-agent-message` | bright-green | distinct from user |
+| `TRANSFER` | `--hg-kind-transfer` | yellow | |
+| `WAIT_FOR_HUMAN` | `--hg-kind-wait-for-human` | magenta | attention, but **NOT red** (red = failed) |
+| `PLANNED` | `--hg-kind-planned` | bright-black (grey) | ghost / planned + **dashed** treatment |
+| `CUSTOM` | `--hg-kind-custom` | white / neutral | |
+
+**goldfive** lane categories (`--hg-gf-*`): judge severity → roles
+(`on-task`→`--good`, `warning`→`--caution`, `critical`→`--bad`,
+`neutral`→`--flat`); `refine`→magenta; `plan`→cyan; `reflective`→bright-black.
+
+### 2.1 STATUS treatments (the second axis)
+
+Applied **over** the kind hue. The renderer/marks read these; never bake a status
+color into a kind.
+
+| status | treatment |
+|---|---|
+| `COMPLETED` | kind hue at fill-opacity `0.55` idle → `1.0` on hover |
+| `RUNNING` | **`--accent`** stroke (w 2) + the breathing pulse (`hg-breathe`, reduced-motion → static) |
+| `FAILED` | fill `--bad` + the `✕` error glyph (1:1 overlay) |
+| `PENDING` | kind hue at opacity `0.35`, no stroke |
+| `CANCELLED` | opacity `0.30` + diagonal hatch |
+| `AWAITING_HUMAN` | fill `--bad-soft`, stroke `--bad`, the `⏱`/`◷` attention glyph; pulses |
+| `PLANNED` (kind) | `--rule-soft` fill + `--ink-faint` **dashed** outline |
+| `replaced` | opacity `0.30` (stacks with status) |
+
+---
+
+## 3. The accent-collision rule (the categorical-vs-one-accent tension)
+
+The hard part. Because zicato derived each theme's `--v2-accent` **from** its
+ANSI cyan/blue, in several themes a kind hue's base hex **equals** the accent:
+
+| collision | themes |
+|---|---|
+| `LLM_CALL` (blue) == accent | monokai, solarized-light, belafonte-day, paper, espresso |
+| `TOOL_CALL` (cyan) == accent | solarized-dark, google-dark, lunaria-light, relaxed |
+
+Resolution — **distinguish the accent by TREATMENT, never rely on hue:**
+
+1. **Kind hues are always quieted fills** (idle fill-opacity `0.5–0.6`, lifting to
+   `1` only on hover). The accent appears only as a **full-strength stroke** (the
+   now-cursor, the selected-span spine, a focus ring) + the breathing pulse — a
+   treatment **no kind fill ever takes**. So even when `LLM_CALL` and `--accent`
+   share a base hex, the live/selected mark is unmistakable: it is the stroked,
+   breathing one.
+2. **`--accent` is reserved** for now / selected / live / interactive focus —
+   full stop. It is never spent on a kind, a legend swatch's identity, or chrome
+   decoration.
+3. Legends label kind by **name + a quieted swatch**, so a blue==accent theme
+   still reads "LLM_CALL" unambiguously from the label, not the chip alone.
+
+This is the honest version of "keep the categorical palette": the categorical
+layer and the emphasis layer are separated by **role and treatment**, not by
+holding 9 hues that are all guaranteed distinct from the accent in all 16 themes
+(impossible given the derivation). Documented as an open question for Sunil (§8).
+
+---
+
+## 4. Agent identity ramp (FINAL)
+
+harmonograf today hashes `agent_id` onto **Tableau-10** (8 saturated primaries) —
+exactly the "8 saturated primaries" the brief says to replace. Instead, lanes get
+an **ordinal ramp** derived from tokens:
+
+```
+--hg-agent-1..8 : color-mix(in oklab, <ANSI slot> 62%, var(--v2-ink-faint))
+```
+
+slots, in order: `blue, cyan, green, yellow, magenta, bright-blue, bright-green,
+bright-yellow`. The 62% mix toward `--ink-faint` **desaturates** every lane so
+the gutter/lifelines stay distinguishable without competing with the (full-sat)
+kind hues on the bars or with the accent. Two synthetic actors are fixed:
+
+- `--hg-agent-user` — caution-mixed (warm neutral, reads as "person").
+- `--hg-agent-goldfive` — accent-mixed (cool neutral, reads as "orchestrator").
+
+Lifelines/gutter labels use the agent color at low strength; the bars on a lane
+take the **kind** hue, not the agent hue (agent identity is the lane, kind is the
+bar). All theme-adaptive: a swap re-mixes the ramp.
+
+---
+
+## 5. MD3 → zicato token map (FINAL)
+
+| harmonograf (MD3) | zicato role / token |
+|---|---|
+| `surface` / `surface-container*` elevation ladder | `--paper` ground + ONE `--panel` lift; elevation → hairline `--rule`, **not** shadow |
+| `primary` (#a8c8ff) | `--accent` — reserved (now / selected / live / focus) |
+| `primary-container` | `color-mix(--accent 14%, --panel)` for selected rows |
+| `error` / `error-container` | `--bad` / `--bad-soft` |
+| `tertiary` / transfer / wait hues | `--caution` (chrome) ; kind hues use ANSI (§2) |
+| `secondary-container` (rail selected) | `color-mix(--accent 14%, --panel)` + accent text |
+| 9 `--hg-kind-*` | per-theme ANSI categorical (§2) |
+| `outline` / `outline-variant` | `--rule` / `--rule-soft` |
+| `on-surface` / `-variant` | `--ink` / `--ink-soft` / `--ink-faint` |
+| system-ui body, 14px | `--mono` everywhere; data uses mono + `tabular-nums` |
+| radii 4 / 8 / 12, pill chips | panels **4px**, bars `rx:3`, `.dn-pill` mono outline-first 10px |
+
+### 5.1 Type
+
+All-mono, terminal-forward (the study's default face stack is
+`ui-monospace, "JetBrains Mono", …`). `tabular-nums` on every numeric / duration /
+clock. Headings = same mono, slightly heavier; section eyebrows uppercase with
+`0.12em` tracking. No system-ui sans anywhere.
+
+### 5.2 The dotless-ı wordmark
+
+The topbar carries the inline-SVG `zıcato` wordmark (dotless ı U+0131, the green
+accent circle **is** the i's dot) + the spiral brand mark, both `currentColor`
+strokes with `var(--zicato-accent)` dots — ported from the zicato compose.html
+(`MARK_SPIRAL` / the wordmark builder). A `.dt-brand-variant` tag reads
+`console`.
+
+---
+
+## 6. Line-art conventions (from DESIGN-LANGUAGE.md §5)
+
+- Hairline gridlines: `stroke:var(--rule-soft); stroke-width:0.6; vector-effect:
+  non-scaling-stroke`. No gridframe, no 3-D, no chartjunk.
+- Bars: `rx:3`, fill the **kind** token at reduced `fill-opacity` (`0.55`),
+  lifting to `1` on hover. `stroke:none` except status treatments.
+- The one emphasis: `--accent`, stroke-width 2–2.4 (now-cursor / selected spine).
+- Reference / planned: `--ink-faint` dashed (`stroke-dasharray:3 3` / `4 3`).
+- Every figure **fit-to-width**: `width:100%` + `viewBox` + `role="img"`; a glyph
+  that must stay round goes in a separate 1:1 overlay. No pan/zoom, no fixed px
+  width that overflows.
+- Hovercards: a singleton card on `--panel` / `--rule`, mono, `pointer-events:
+  none`, outside any gated render.
+
+## 7. Motion & a11y
+
+- The **only** keyframe is a now/running pulse (`hg-breathe`, `hg-now-pulse`),
+  gated behind `@media (prefers-reduced-motion: reduce)` → static. **No**
+  `animation:…infinite` on structure (kills harmonograf's MD3 `*-pulse` loops).
+- Note in rationale: harmonograf already half-does digest-gating ("React never
+  drives the render loop" — `renderer.ts`); the study makes that explicit.
+- Focus rings: `2px solid var(--accent)`, small offset, `:focus-visible`.
+- Verify every page in BOTH `paper` (light) and `monokai` (dark).
+
+## 8. Do / Don't (study-specific)
+
+**Do** — read color from `--*` tokens only; earn good/bad by direction; reserve
+`--accent`; quiet kind fills, full-strength only on hover/selection; mono + tabular
+everywhere; one `--panel` lift, hairlines not shadows; gate motion.
+
+**Don't** — hardcode hex in a mark (the per-theme `_tokens.css` blocks are the
+only hex); spend `--accent` on a kind or chrome decoration; color a span red for
+its identity (only FAILED is red); use system-ui sans; run structure on
+`animation:…infinite`; force horizontal scroll; pin a figure to a fixed px width.
+
+### 8.1 Open questions for Sunil
+
+1. **Accent collisions (§3).** Resolved by treatment, not hue. If you'd rather the
+   kind hues be guaranteed-distinct from the accent in every theme, we'd nudge
+   `LLM_CALL`/`TOOL_CALL` off the accent slot per-theme (a per-theme override
+   table) — more faithful-to-ANSI vs. more separable. Current choice favors ANSI
+   fidelity + treatment-based distinction.
+2. **Monokai ANSI source.** zicato's `monokai` is "original" lineage, not Gogh;
+   its closest Gogh file (Monokai Soda, bg `#1A1A1A`) doesn't match `--v2-paper`
+   `#1e1f1c` and uses different greens. We sourced monokai's ANSI from the
+   **classic** Monokai terminal palette (matches zicato's good/bad/accent roles).
+   Flagged in `gogh-palettes.json`.
+3. **Zenburn green.** Zenburn's ANSI "green" slot is actually a yellow; we used
+   its sage (`#7f9f7f`) so USER_MESSAGE stays green-ish. Muted by design.
+4. **belafonte-night hue-collapse.** On this ONE theme the ANSI kind slots
+   collapse into near-identical warm greys (blue `#426A79` / cyan `#989A9C` /
+   green `#858162` / white `#968C83` / bright-black `#5E5252`), so the categorical
+   *hues* blur there — kinds stay legible by **treatment + named legend/hovercard**
+   (FAILED red, RUNNING accent-stroke, TRANSFER yellow, dashed/hatch, gutter
+   ticks), not by hue. Same "more separable vs more ANSI-faithful" tradeoff as
+   §8.1.1: a remedy would spin belafonte-night's collapsed kinds apart in
+   `_tokens.css`. Left ANSI-faithful by default; flagged by the Gantt + Figures
+   review pass. (The collision-theme recheck — espresso / solarized-light /
+   google-dark / dracula — otherwise PASSED, validating the treatment-based §3
+   resolution.)

--- a/docs/design/zicato-ui-study/_embed.js
+++ b/docs/design/zicato-ui-study/_embed.js
@@ -1,0 +1,100 @@
+/* ===================================================================
+   EMBED MODE — shared across the harmonograf zicato-UI-study pages.
+   Ported from zicato tournament-viz-study/_embed.js. Honors URL params
+   so a page can be composed into compose.html via an <iframe>. The
+   NORMAL (no-param) view is left 100% unchanged: this script no-ops
+   unless ?only / ?bare / ?theme is present.
+
+   Contract:
+     ?only=N   (1-based)  render ONLY section N (hide the others)
+     ?bare=1              strip page chrome (header/footer/intro + each
+                          section's title/rationale/legend/caption),
+                          leaving just the section's primary figure(s).
+     ?theme=NAME          set <html data-theme=NAME> at load (16 themes)
+
+   Per-page config in window.__EMBED_CFG__ (set just before this runs):
+     optSel    CSS selector for the SURFACE sections, in order.
+     bareHide  [selectors] hidden inside a kept section in bare mode
+               (titles / rationales / legends / captions / before-panels).
+   =================================================================== */
+(function () {
+  var P = new URLSearchParams(location.search);
+  var only = P.get('only');
+  var bare = P.get('bare') === '1' || P.get('bare') === 'true';
+  var theme = P.get('theme');
+  if (only == null && !bare && !theme) return; // normal view untouched
+
+  var CFG = window.__EMBED_CFG__ || {};
+  var THEME_IDS = (window.THEME_IDS) || [];
+
+  function apply() {
+    if (theme && (!THEME_IDS.length || THEME_IDS.indexOf(theme) >= 0)) {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+    document.documentElement.classList.add('embed');
+    if (bare) document.documentElement.classList.add('embed-bare');
+
+    var opts = CFG.optSel ? Array.prototype.slice.call(document.querySelectorAll(CFG.optSel)) : [];
+
+    var keepIdx = null;
+    if (only != null) {
+      keepIdx = parseInt(only, 10) - 1;
+      opts.forEach(function (o, i) { if (i !== keepIdx) o.style.display = 'none'; });
+    }
+    var kept = (keepIdx != null && opts[keepIdx]) ? [opts[keepIdx]]
+             : (opts.length ? opts : []);
+
+    if (!bare) return;
+
+    var header = document.querySelector('header');
+    if (header) header.style.display = 'none';
+    var footer = document.querySelector('footer');
+    if (footer) footer.style.display = 'none';
+
+    var main = document.querySelector('main');
+    var keepSet = kept;
+    if (main) {
+      Array.prototype.slice.call(main.children).forEach(function (child) {
+        if (keepSet.indexOf(child) >= 0) return;
+        if (child.querySelector && keepSet.some(function (k) { return child.contains(k); })) return;
+        child.style.display = 'none';
+      });
+    }
+    document.body.style.padding = '0';
+    document.body.style.margin = '0';
+
+    (CFG.bareHide || []).forEach(function (sel) {
+      kept.forEach(function (k) {
+        Array.prototype.slice.call(k.querySelectorAll(sel)).forEach(function (n) { n.style.display = 'none'; });
+      });
+    });
+    kept.forEach(function (k) {
+      k.style.margin = '0';
+      k.style.border = 'none';
+      k.style.background = 'transparent';
+      k.style.padding = '6px 14px';
+    });
+  }
+
+  /* report content height to the composer so it can size the iframe */
+  function reportHeight() {
+    try {
+      var h = Math.max(
+        document.body.scrollHeight, document.documentElement.scrollHeight,
+        document.body.offsetHeight, document.documentElement.offsetHeight
+      );
+      parent.postMessage({ __hgEmbedHeight: h, key: P.get('lvl') || null }, '*');
+    } catch (e) {}
+  }
+
+  function run() {
+    apply();
+    requestAnimationFrame(function () { requestAnimationFrame(reportHeight); });
+    setTimeout(reportHeight, 120);
+    setTimeout(reportHeight, 400);
+    window.addEventListener('resize', reportHeight);
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') run();
+  else document.addEventListener('DOMContentLoaded', run);
+})();

--- a/docs/design/zicato-ui-study/_refs/gogh-palettes.json
+++ b/docs/design/zicato-ui-study/_refs/gogh-palettes.json
@@ -1,0 +1,217 @@
+{
+  "_meta": {
+    "purpose": "16 zicato themes × full terminal ANSI palette, sourced from the Gogh terminal colour schemes each zicato theme derives from. Keyed by zicato theme id (the [data-theme] value). Consumed by _tokens.css to wire the categorical encoding (span KIND → ANSI slot) so a theme swap re-skins the whole categorical palette, ANSI and all.",
+    "source": "https://raw.githubusercontent.com/Gogh-Co/Gogh/master/themes/<Name>.yml",
+    "ansi_slots": "ANSI normal black/red/green/yellow/blue/magenta/cyan/white = color_01..08; bright variants = color_09..16.",
+    "self_check": "Each `bg` was checked against zicato --v2-paper (DESIGN-LANGUAGE.md §2.2). Matches noted true; the two nudged 'original'-lineage themes (monokai, solarized-dark/light) carry a `bg_note`.",
+    "keys": "black,red,green,yellow,blue,magenta,cyan,white,brightBlack,brightRed,brightGreen,brightYellow,brightBlue,brightMagenta,brightCyan,brightWhite"
+  },
+
+  "monokai": {
+    "gogh_file": "Monokai (classic) — NOT Monokai Soda. zicato's monokai is 'original' lineage; its --v2-* roles encode the classic Monokai signal hues. Soda's bg/greens differ, so the classic Monokai terminal palette is used here to stay consistent with zicato's good/bad/accent.",
+    "bg": "#1e1f1c",
+    "bg_note": "zicato --v2-paper #1e1f1c (original). Closest Gogh file 'Monokai Soda' is #1A1A1A; not an exact match — expected for an original-lineage theme.",
+    "fg": "#f8f8f2",
+    "ansi": {
+      "black": "#272822", "red": "#f92672", "green": "#a6e22e", "yellow": "#e6db74",
+      "blue": "#66d9ef", "magenta": "#ae81ff", "cyan": "#a1efe4", "white": "#f8f8f2",
+      "brightBlack": "#75715e", "brightRed": "#f92672", "brightGreen": "#a6e22e", "brightYellow": "#e6db74",
+      "brightBlue": "#66d9ef", "brightMagenta": "#ae81ff", "brightCyan": "#a1efe4", "brightWhite": "#f9f8f5"
+    }
+  },
+
+  "solarized-dark": {
+    "gogh_file": "Solarized Dark.yml",
+    "bg": "#04222B",
+    "bg_note": "zicato --v2-paper #04222B (original/nudged). Gogh 'Solarized Dark' background is #002B36 — zicato darkened it. ANSI below is verbatim Gogh.",
+    "fg": "#839496",
+    "ansi": {
+      "black": "#073642", "red": "#DC322F", "green": "#859900", "yellow": "#B58900",
+      "blue": "#268BD2", "magenta": "#D33682", "cyan": "#2AA198", "white": "#EEE8D5",
+      "brightBlack": "#657B83", "brightRed": "#CB4B16", "brightGreen": "#586E75", "brightYellow": "#657B83",
+      "brightBlue": "#6c71c4", "brightMagenta": "#D33682", "brightCyan": "#2AA198", "brightWhite": "#FDF6E3"
+    }
+  },
+
+  "solarized-light": {
+    "gogh_file": "Solarized Light.yml",
+    "bg": "#FDF6E3",
+    "bg_note": "zicato --v2-paper #FDF6E3 == Gogh background ✓.",
+    "fg": "#657B83",
+    "ansi": {
+      "black": "#EEE8D5", "red": "#DC322F", "green": "#859900", "yellow": "#B58900",
+      "blue": "#268BD2", "magenta": "#D33682", "cyan": "#2AA198", "white": "#073642",
+      "brightBlack": "#93A1A1", "brightRed": "#CB4B16", "brightGreen": "#586E75", "brightYellow": "#839496",
+      "brightBlue": "#6C71C4", "brightMagenta": "#D33682", "brightCyan": "#2AA198", "brightWhite": "#002B36"
+    }
+  },
+
+  "google-light": {
+    "gogh_file": "Google Light.yml",
+    "bg": "#FFFFFF",
+    "bg_note": "zicato --v2-paper #FFFFFF == Gogh background ✓.",
+    "fg": "#373B41",
+    "ansi": {
+      "black": "#1D1F21", "red": "#CC342B", "green": "#198844", "yellow": "#FBA922",
+      "blue": "#3971ED", "magenta": "#A36AC7", "cyan": "#3971ED", "white": "#C5C8C6",
+      "brightBlack": "#969896", "brightRed": "#CC342B", "brightGreen": "#198844", "brightYellow": "#FBA922",
+      "brightBlue": "#3971ED", "brightMagenta": "#A36AC7", "brightCyan": "#3971ED", "brightWhite": "#FFFFFF"
+    }
+  },
+
+  "google-dark": {
+    "gogh_file": "Google Dark.yml",
+    "bg": "#202124",
+    "bg_note": "zicato --v2-paper #202124 == Gogh background ✓. Gogh cyan #24C1E0 == zicato google-dark --v2-accent ✓.",
+    "fg": "#E8EAED",
+    "ansi": {
+      "black": "#202124", "red": "#EA4335", "green": "#34A853", "yellow": "#FBBC04",
+      "blue": "#4285F4", "magenta": "#A142F4", "cyan": "#24C1E0", "white": "#E8EAED",
+      "brightBlack": "#5F6368", "brightRed": "#EA4335", "brightGreen": "#34A853", "brightYellow": "#FBBC05",
+      "brightBlue": "#4285F4", "brightMagenta": "#A142F4", "brightCyan": "#24C1E0", "brightWhite": "#FFFFFF"
+    }
+  },
+
+  "lunaria-light": {
+    "gogh_file": "Lunaria Light.yml",
+    "bg": "#EBE4E1",
+    "bg_note": "zicato --v2-paper #EBE4E1 == Gogh background ✓. Gogh cyan #3778A9 == zicato lunaria-light --v2-accent ✓.",
+    "fg": "#484646",
+    "ansi": {
+      "black": "#3E3C3D", "red": "#783C1F", "green": "#497D46", "yellow": "#8F750B",
+      "blue": "#3F3566", "magenta": "#793F62", "cyan": "#3778A9", "white": "#D5CFCC",
+      "brightBlack": "#484646", "brightRed": "#B06240", "brightGreen": "#7BC175", "brightYellow": "#DCB735",
+      "brightBlue": "#5C4F89", "brightMagenta": "#B56895", "brightCyan": "#64BAFF", "brightWhite": "#EBE4E1"
+    }
+  },
+
+  "lunaria-eclipse": {
+    "gogh_file": "Lunaria Eclipse.yml",
+    "bg": "#323F46",
+    "bg_note": "zicato --v2-paper #323F46 == Gogh background ✓.",
+    "fg": "#C9CDD7",
+    "ansi": {
+      "black": "#323F46", "red": "#83615B", "green": "#7F9781", "yellow": "#A69875",
+      "blue": "#53516F", "magenta": "#856880", "cyan": "#7D96B2", "white": "#C9CDD7",
+      "brightBlack": "#3D4950", "brightRed": "#BA9088", "brightGreen": "#BEDBC1", "brightYellow": "#F1DFB4",
+      "brightBlue": "#767495", "brightMagenta": "#BE9CB8", "brightCyan": "#BCDBFF", "brightWhite": "#DFE2ED"
+    }
+  },
+
+  "belafonte-day": {
+    "gogh_file": "Belafonte Day.yml",
+    "bg": "#D5CCBA",
+    "bg_note": "zicato --v2-paper #D5CCBA == Gogh background ✓. Gogh blue #426A79 == zicato belafonte-day --v2-accent ✓ (palette's cyan is a low-contrast neutral, so zicato keys accent off blue).",
+    "fg": "#45373C",
+    "ansi": {
+      "black": "#20111B", "red": "#BE100E", "green": "#858162", "yellow": "#EAA549",
+      "blue": "#426A79", "magenta": "#97522C", "cyan": "#989A9C", "white": "#968C83",
+      "brightBlack": "#5E5252", "brightRed": "#BE100E", "brightGreen": "#858162", "brightYellow": "#EAA549",
+      "brightBlue": "#426A79", "brightMagenta": "#97522C", "brightCyan": "#989A9C", "brightWhite": "#D5CCBA"
+    }
+  },
+
+  "belafonte-night": {
+    "gogh_file": "Belafonte Night.yml",
+    "bg": "#20111B",
+    "bg_note": "zicato --v2-paper #20111B == Gogh background ✓. Same ANSI ramp as Belafonte Day (the pair shares hues; only ground/ink flip).",
+    "fg": "#968C83",
+    "ansi": {
+      "black": "#20111B", "red": "#BE100E", "green": "#858162", "yellow": "#EAA549",
+      "blue": "#426A79", "magenta": "#97522C", "cyan": "#989A9C", "white": "#968C83",
+      "brightBlack": "#5E5252", "brightRed": "#BE100E", "brightGreen": "#858162", "brightYellow": "#EAA549",
+      "brightBlue": "#426A79", "brightMagenta": "#97522C", "brightCyan": "#989A9C", "brightWhite": "#D5CCBA"
+    }
+  },
+
+  "paper": {
+    "gogh_file": "Paper.yml",
+    "bg": "#f2eede",
+    "bg_note": "zicato --v2-paper #F2EEDE == Gogh background ✓. Gogh green #216609 / red #cc3e28 / blue #1e6fcc == zicato paper good/bad/accent ✓.",
+    "fg": "#000000",
+    "ansi": {
+      "black": "#000000", "red": "#cc3e28", "green": "#216609", "yellow": "#b58900",
+      "blue": "#1e6fcc", "magenta": "#5c21a5", "cyan": "#158c86", "white": "#aaaaaa",
+      "brightBlack": "#555555", "brightRed": "#cc3e28", "brightGreen": "#216609", "brightYellow": "#b58900",
+      "brightBlue": "#1e6fcc", "brightMagenta": "#5c21a5", "brightCyan": "#158c86", "brightWhite": "#aaaaaa"
+    }
+  },
+
+  "zenburn": {
+    "gogh_file": "Zenburn.yml",
+    "bg": "#3a3a3a",
+    "bg_note": "zicato --v2-paper #3A3A3A == Gogh background ✓. Note Zenburn's 'green' slot (color_03 #efef87) is a yellow; the soft sage #93b3a3 is its cyan. zicato keys good off the sage (#8FB28F-ish), so categorical green here is intentionally muted.",
+    "fg": "#dcdccc",
+    "ansi": {
+      "black": "#333333", "red": "#cc9393", "green": "#7f9f7f", "yellow": "#efef87",
+      "blue": "#c3bf97", "magenta": "#bca3a3", "cyan": "#93b3a3", "white": "#f0efd0",
+      "brightBlack": "#757575", "brightRed": "#dfaf87", "brightGreen": "#9fc59f", "brightYellow": "#ffff87",
+      "brightBlue": "#d7d7af", "brightMagenta": "#d7afaf", "brightCyan": "#93bea3", "brightWhite": "#dcdccc"
+    }
+  },
+
+  "selenized-black": {
+    "gogh_file": "Selenized Black.yml",
+    "bg": "#181818",
+    "bg_note": "zicato --v2-paper #181818 == Gogh background ✓. Gogh bright-cyan #56d8c9 == zicato selenized-black --v2-accent ✓.",
+    "fg": "#b9b9b9",
+    "ansi": {
+      "black": "#252525", "red": "#ed4a46", "green": "#70b433", "yellow": "#dbb32d",
+      "blue": "#368aeb", "magenta": "#eb6eb7", "cyan": "#3fc5b7", "white": "#777777",
+      "brightBlack": "#3b3b3b", "brightRed": "#ff5e56", "brightGreen": "#83c746", "brightYellow": "#efc541",
+      "brightBlue": "#4f9cfe", "brightMagenta": "#ff81ca", "brightCyan": "#56d8c9", "brightWhite": "#dedede"
+    }
+  },
+
+  "relaxed": {
+    "gogh_file": "Relaxed.yml",
+    "bg": "#353A44",
+    "bg_note": "zicato --v2-paper #353A44 == Gogh background ✓. Gogh bright-blue #7EAAC7 == zicato relaxed --v2-accent ✓.",
+    "fg": "#D9D9D9",
+    "ansi": {
+      "black": "#151515", "red": "#BC5653", "green": "#909D63", "yellow": "#EBC17A",
+      "blue": "#6A8799", "magenta": "#B06698", "cyan": "#7EAAC7", "white": "#D9D9D9",
+      "brightBlack": "#636363", "brightRed": "#BC5653", "brightGreen": "#A0AC77", "brightYellow": "#EBC17A",
+      "brightBlue": "#7EAAC7", "brightMagenta": "#B06698", "brightCyan": "#ACBBD0", "brightWhite": "#F7F7F7"
+    }
+  },
+
+  "espresso": {
+    "gogh_file": "Espresso.yml",
+    "bg": "#323232",
+    "bg_note": "zicato --v2-paper #323232 == Gogh background ✓. Gogh blue #6C99BB == zicato espresso --v2-accent ✓.",
+    "fg": "#FFFFFF",
+    "ansi": {
+      "black": "#353535", "red": "#D25252", "green": "#A5C261", "yellow": "#FFC66D",
+      "blue": "#6C99BB", "magenta": "#D197D9", "cyan": "#BED6FF", "white": "#EEEEEC",
+      "brightBlack": "#535353", "brightRed": "#F00C0C", "brightGreen": "#C2E075", "brightYellow": "#E1E48B",
+      "brightBlue": "#8AB7D9", "brightMagenta": "#EFB5F7", "brightCyan": "#DCF4FF", "brightWhite": "#FFFFFF"
+    }
+  },
+
+  "dracula": {
+    "gogh_file": "Dracula.yml",
+    "bg": "#282A36",
+    "bg_note": "zicato --v2-paper #282A36 == Gogh background ✓. Gogh bright-green #50FA7B / bright-red #FF5555 / bright-blue(purple) #BD93F9 == zicato dracula good/bad/accent ✓.",
+    "fg": "#F8F8F2",
+    "ansi": {
+      "black": "#262626", "red": "#E64747", "green": "#42E66C", "yellow": "#E4F34A",
+      "blue": "#9B6BDF", "magenta": "#E356A7", "cyan": "#75D7EC", "white": "#F8F8F2",
+      "brightBlack": "#7A7A7A", "brightRed": "#FF5555", "brightGreen": "#50FA7B", "brightYellow": "#F1FA8C",
+      "brightBlue": "#BD93F9", "brightMagenta": "#FF79C6", "brightCyan": "#8BE9FD", "brightWhite": "#F9F9FB"
+    }
+  },
+
+  "ubuntu": {
+    "gogh_file": "Clone Of Ubuntu.yml",
+    "bg": "#300A24",
+    "bg_note": "zicato --v2-paper #300A24 == Gogh background ✓. Gogh bright-green #8AE234 / red #CC0000 / bright-cyan #34E2E2 == zicato ubuntu good/bad/accent ✓.",
+    "fg": "#EEEEEC",
+    "ansi": {
+      "black": "#2E3436", "red": "#CC0000", "green": "#4E9A06", "yellow": "#C4A000",
+      "blue": "#3465A4", "magenta": "#75507B", "cyan": "#06989A", "white": "#D3D7CF",
+      "brightBlack": "#555753", "brightRed": "#EF2929", "brightGreen": "#8AE234", "brightYellow": "#FCE94F",
+      "brightBlue": "#729FCF", "brightMagenta": "#AD7FA8", "brightCyan": "#34E2E2", "brightWhite": "#EEEEEC"
+    }
+  }
+}

--- a/docs/design/zicato-ui-study/_study.css
+++ b/docs/design/zicato-ui-study/_study.css
@@ -1,0 +1,374 @@
+/* =====================================================================
+   _study.css — shared page chrome + the .hg-* zicato-language component
+   vocabulary for the harmonograf UI study. Linked by every surface page;
+   reads ONLY the tokens from _tokens.css (no hardcoded hue here). Mirrors
+   the zicato tournament-viz-study page chrome, retargeted to harmonograf's
+   surfaces (shell / Gantt / figures).
+
+   Sections:
+     0  reset + base type (all-mono, terminal-forward)
+     1  page chrome: header, brand, sections, lede, before/after, legends
+     2  the swatch THEME PICKER (16 themes) + typeface note
+     3  the .hg-* CONSOLE chrome restyled: topbar, rail, strip, transport, drawer
+     4  components: pills, board-table, cards, hovercard, ⌘K picker
+     5  the GANTT line-art classes (.hg-gantt-*) shared by gantt.html
+     6  motion (the single now/breathe pulse) + reduced-motion + a11y
+   ===================================================================== */
+
+/* ---- 0. reset + base ------------------------------------------------ */
+* { box-sizing: border-box; }
+html, body { margin: 0; }
+:root {
+  --mono: ui-monospace, "JetBrains Mono", "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
+  --brand-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --r-panel: 4px;   /* panels */
+  --r-pill: 10px;   /* pills */
+  --r-card: 5px;    /* cards / buttons */
+}
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 14px;
+  line-height: 1.5;
+  transition: background .18s ease, color .18s ease;
+  padding: 0 0 80px;
+}
+body.embed-bare, html.embed-bare body { padding: 0; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+code, .mono { font-family: var(--mono); }
+code {
+  background: var(--rule-soft); padding: 1px 5px; border-radius: 3px; font-size: 12px;
+}
+.tnum { font-variant-numeric: tabular-nums lining-nums; }
+
+/* ---- 1. page chrome ------------------------------------------------- */
+header.study {
+  position: sticky; top: 0; z-index: 30;
+  display: flex; align-items: center; gap: 16px;
+  padding: 13px 24px;
+  background: color-mix(in srgb, var(--paper) 88%, transparent);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--rule);
+}
+header.study .brand-row { display: inline-flex; align-items: center; gap: 10px; color: var(--ink); }
+header.study h1 { font-size: 14px; font-weight: 700; margin: 0; letter-spacing: .01em; }
+header.study .spacer { flex: 1; }
+header.study .legend-inline { font-size: 11px; color: var(--ink-faint); }
+header.study .legend-inline b { color: var(--ink-soft); font-weight: 600; }
+
+main.study { max-width: 1240px; margin: 0 auto; padding: 0 24px; }
+section.study { margin: 34px 0; }
+.study h2 {
+  font-size: 12px; text-transform: uppercase; letter-spacing: .14em;
+  color: var(--ink-faint); border-bottom: 1px solid var(--rule);
+  padding-bottom: 8px; margin: 0 0 6px;
+}
+.lede { color: var(--ink-soft); font-size: 13px; margin: 6px 0 18px; max-width: 88ch; }
+.lede code { font-size: 12px; }
+
+/* a surface block: an eyebrow, the before/after pair, a rationale, a legend */
+.surface {
+  border: 1px solid var(--rule); border-radius: var(--r-card); background: var(--panel);
+  padding: 18px 20px; margin-bottom: 22px;
+}
+.surface-head { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; margin-bottom: 8px; }
+.surface-num { font-size: 11px; letter-spacing: .14em; text-transform: uppercase; color: var(--accent); font-weight: 700; }
+.surface-name { font-size: 15px; font-weight: 700; color: var(--ink); }
+.surface-tech { font-size: 11px; color: var(--ink-faint); letter-spacing: .03em; }
+.rationale { font-size: 12px; color: var(--ink-soft); margin: 8px 0 14px; max-width: 90ch; }
+.rationale b { color: var(--ink); }
+.rationale code { font-size: 11px; }
+
+/* the before/after pair */
+.ba-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; align-items: start; }
+@media (max-width: 900px) { .ba-grid { grid-template-columns: 1fr; } }
+.ba-cell { min-width: 0; }
+.ba-tag {
+  font-size: 9.5px; letter-spacing: .12em; text-transform: uppercase;
+  color: var(--ink-faint); margin: 0 0 6px;
+}
+.ba-tag.after { color: var(--accent); }
+.ba-frame {
+  border: 1px solid var(--rule); border-radius: var(--r-panel); overflow: hidden;
+  background: var(--paper);
+}
+.ba-frame.before { opacity: .96; }
+
+/* per-surface legend */
+.legend { display: flex; gap: 16px; flex-wrap: wrap; font-size: 10.5px; color: var(--ink-faint); margin: 12px 0 2px; }
+.legend span { display: inline-flex; align-items: center; gap: 6px; }
+.legend .sw { width: 11px; height: 11px; border-radius: 2px; display: inline-block; flex: none; }
+.legend .ln { width: 16px; height: 0; border-top: 2px solid; display: inline-block; }
+
+footer.study {
+  max-width: 1240px; margin: 36px auto 0; padding: 18px 24px;
+  color: var(--ink-faint); font-size: 11px; border-top: 1px solid var(--rule);
+}
+
+/* ---- 2. THE SWATCH THEME PICKER (16 themes) ------------------------- */
+.theme-pick-label { font-size: 10px; letter-spacing: .12em; text-transform: uppercase; color: var(--ink-faint); }
+.dt-cd { position: relative; display: inline-flex; }
+.dt-cd-trigger { display: inline-flex; align-items: center; gap: 6px;
+  border: 1px solid var(--rule); border-radius: 5px; padding: 5px 9px;
+  background: var(--panel); color: var(--ink-soft); cursor: pointer;
+  font: inherit; font-size: 11px; transition: border-color .15s, color .15s; }
+.dt-cd-trigger:hover { color: var(--ink); border-color: var(--accent); }
+.dt-cd-trigger:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.dt-cd-name { color: var(--ink); white-space: nowrap; }
+.dt-cd-caret { color: var(--ink-faint); font-size: 8px; transition: transform .15s; }
+.dt-cd.dt-cd-open .dt-cd-caret { transform: rotate(180deg); }
+.dt-swatch-strip { display: inline-flex; border-radius: 3px; overflow: hidden; border: 1px solid var(--rule); }
+.dt-swatch { display: inline-block; width: 11px; height: 13px; }
+.dt-cd-list { display: none; position: absolute; top: calc(100% + 5px); right: 0; z-index: 60;
+  min-width: 210px; max-height: 70vh; overflow-y: auto;
+  background: var(--panel); border: 1px solid var(--rule); border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0,0,0,.28); padding: 4px; }
+.dt-cd.dt-cd-open .dt-cd-list { display: block; }
+.dt-cd-option { display: flex; align-items: center; gap: 8px; padding: 5px 7px; border-radius: 4px;
+  cursor: pointer; color: var(--ink-soft); transition: background .12s, color .12s; }
+.dt-cd-option .dt-cd-name { font-size: 10.5px; }
+.dt-cd-option:hover, .dt-cd-option.dt-cd-active { background: var(--rule-soft); color: var(--ink); }
+.dt-cd-option[aria-selected="true"] .dt-cd-name { color: var(--accent); }
+
+/* ---- 3. the .hg-* CONSOLE chrome, restyled in-language --------------- */
+/* topbar (AppBar → zicato topbar) */
+.hg-topbar {
+  display: flex; align-items: center; gap: 16px;
+  padding: 10px 18px;
+  background: color-mix(in srgb, var(--paper) 92%, transparent);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--rule);
+}
+.hg-brand { display: inline-flex; align-items: center; gap: 8px; color: var(--ink); }
+.hg-brand-mark { height: 24px; width: auto; display: block; flex: none; overflow: visible; }
+.hg-brand-name { height: 15px; width: auto; display: block; flex: none; color: var(--ink); overflow: visible; }
+.hg-brand-variant { font-size: 9px; letter-spacing: .16em; text-transform: uppercase; color: var(--accent); }
+.hg-crumbs { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; color: var(--ink-faint); }
+.hg-crumb { color: var(--ink-soft); }
+.hg-crumb:hover { color: var(--accent); text-decoration: none; }
+.hg-crumb-current { color: var(--ink); }
+.hg-crumb-sep { opacity: .5; }
+.hg-topbar-spacer { flex: 1; }
+.hg-typeswitch { display: inline-flex; border: 1px solid var(--rule); border-radius: 5px; overflow: hidden; }
+.hg-typeswitch button { font: inherit; font-size: 10.5px; color: var(--ink-soft); background: transparent;
+  border: none; border-right: 1px solid var(--rule); padding: 4px 8px; cursor: pointer; }
+.hg-typeswitch button:last-child { border-right: none; }
+.hg-typeswitch button[aria-pressed="true"] { color: var(--paper); background: var(--accent); }
+.hg-scale-pill { display: inline-flex; align-items: center; gap: 6px; font-size: 10.5px; color: var(--ink-faint);
+  border: 1px solid var(--rule); border-radius: var(--r-pill); padding: 3px 9px; }
+
+/* the live STATUS / RUN pill */
+.hg-status { display: inline-flex; align-items: center; gap: 5px; font-size: 10.5px; color: var(--ink-faint); }
+.hg-status-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--flat); transition: background .2s; }
+.hg-status.is-connected .hg-status-dot { background: var(--good); }
+.hg-status.is-running .hg-status-dot { background: var(--accent); }
+.hg-run-badge { display: none; align-items: center; gap: 5px; margin-left: 6px;
+  padding: 1px 7px; border-radius: 9px; border: 1px solid var(--rule);
+  background: var(--panel); color: var(--ink-soft); font-size: 10px; white-space: nowrap; }
+.hg-status.is-running .hg-run-badge { display: inline-flex; }
+.hg-run-pulse { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); flex: none;
+  box-shadow: 0 0 0 0 var(--accent); animation: hg-now-pulse 1.6s ease-out infinite; }
+.hg-run-label { color: var(--accent); }
+
+/* the nav rail */
+.hg-rail {
+  display: flex; flex-direction: column; gap: 4px; padding: 12px 8px;
+  background: var(--panel); border-right: 1px solid var(--rule);
+}
+.hg-rail-item {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px;
+  padding: 8px 4px; background: transparent; border: none; border-radius: var(--r-panel);
+  color: var(--ink-soft); cursor: pointer; font: inherit; font-size: 10px; letter-spacing: .04em;
+  transition: background .12s, color .12s;
+}
+.hg-rail-item:hover { background: var(--rule-soft); color: var(--ink); }
+.hg-rail-item[aria-selected="true"] {
+  background: color-mix(in srgb, var(--accent) 14%, var(--panel)); color: var(--accent);
+}
+.hg-rail-icon { font-size: 17px; line-height: 1; }
+
+/* current-task strip */
+.hg-strip {
+  display: flex; align-items: center; gap: 10px; padding: 5px 16px;
+  background: var(--panel-2); border-bottom: 1px solid var(--rule);
+  font-size: 11.5px; min-height: 26px; white-space: nowrap; overflow: hidden;
+}
+.hg-strip-label { color: var(--ink-faint); text-transform: uppercase; font-size: 9px; letter-spacing: .08em; }
+.hg-strip-title { flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; color: var(--ink); }
+.hg-strip-agent { color: var(--ink-soft); border: 1px solid var(--rule); padding: 1px 8px;
+  border-radius: var(--r-pill); font-size: 10.5px; }
+
+/* transport bar */
+.hg-transport {
+  display: flex; align-items: center; gap: 8px; padding: 0 14px;
+  background: var(--panel); border-top: 1px solid var(--rule); height: 42px;
+}
+.hg-transport-btn {
+  background: transparent; border: 1px solid var(--rule); border-radius: var(--r-panel);
+  padding: 4px 9px; cursor: pointer; color: var(--ink-soft); font: inherit; font-size: 11px;
+  transition: border-color .12s, color .12s;
+}
+.hg-transport-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--ink); }
+.hg-transport-btn:disabled { opacity: .4; cursor: default; }
+.hg-transport-group { display: inline-flex; align-items: center; gap: 4px; }
+.hg-transport-divider { width: 1px; height: 18px; background: var(--rule); }
+.hg-transport-spacer { flex: 1; }
+.hg-live-badge { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; font-weight: 700;
+  letter-spacing: .06em; color: var(--accent); }
+.hg-live-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent);
+  animation: hg-now-pulse 1.6s ease-out infinite; flex: none; }
+.hg-clock { font-size: 12px; color: var(--ink-soft); }
+
+/* inspector drawer */
+.hg-drawer {
+  display: flex; flex-direction: column; background: var(--panel);
+  border-left: 1px solid var(--rule); height: 100%; min-height: 0;
+}
+.hg-drawer-header { display: flex; align-items: center; gap: 8px; padding: 11px 14px;
+  border-bottom: 1px solid var(--rule); }
+.hg-drawer-title { font-weight: 600; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; }
+.hg-drawer-tabs { display: flex; gap: 2px; padding: 0 8px; border-bottom: 1px solid var(--rule); }
+.hg-drawer-tabs button { background: transparent; border: none; border-bottom: 2px solid transparent;
+  padding: 8px 11px; cursor: pointer; color: var(--ink-faint); font: inherit; font-size: 11.5px; }
+.hg-drawer-tabs button[aria-selected="true"] { color: var(--accent); border-bottom-color: var(--accent); }
+.hg-drawer-body { flex: 1; overflow-y: auto; padding: 12px 14px; font-size: 12.5px; }
+.hg-attrs { display: grid; grid-template-columns: max-content 1fr; gap: 5px 14px; font-size: 12px; }
+.hg-attrs dt { color: var(--ink-faint); }
+.hg-attrs dd { margin: 0; overflow-wrap: anywhere; }
+.hg-drawer-code {
+  display: block; background: var(--panel-2); padding: 9px 11px; border-radius: var(--r-panel);
+  border: 1px solid var(--rule); font-family: var(--mono); font-size: 11px;
+  white-space: pre-wrap; overflow-x: auto; max-height: 320px;
+}
+/* a faint json syntax tint — token-derived, not raw hex */
+.hg-j-key { color: var(--accent); }
+.hg-j-str { color: var(--good); }
+.hg-j-num { color: var(--caution); }
+.hg-j-bool { color: var(--bad); }
+.hg-j-null { color: var(--ink-faint); font-style: italic; }
+.hg-j-punct { color: var(--ink-soft); }
+
+/* ---- 4. components -------------------------------------------------- */
+/* pills — mono, outline-first */
+.dn-pill { display: inline-flex; align-items: center; gap: 5px; font-family: var(--mono); font-size: 10.5px;
+  padding: 2px 8px; border-radius: var(--r-pill); border: 1px solid var(--rule); color: var(--ink-faint);
+  white-space: nowrap; }
+.dn-pill.good { border-color: var(--good); color: var(--good); }
+.dn-pill.bad { border-color: var(--bad); color: var(--bad); }
+.dn-pill.caution { border-color: var(--caution); color: var(--caution); }
+.dn-pill.accent { border-color: var(--accent); color: var(--accent); }   /* in-flight / live — NOT red */
+.dn-pill.live { border-color: var(--accent); color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.dn-pill.flat { border-color: var(--rule); color: var(--ink-soft); }
+
+/* board table */
+.dn-board-table { border-collapse: collapse; width: 100%; font-size: 12px; }
+.dn-board-table th, .dn-board-table td { border: 1px solid var(--rule); padding: 5px 9px; text-align: left; }
+.dn-board-table thead th { background: var(--rule-soft); color: var(--ink-soft); font-weight: 600;
+  text-transform: uppercase; letter-spacing: .05em; font-size: 10px; }
+.dn-board-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.dn-board-table tbody tr:hover { background: var(--rule-soft); }
+.dn-board-table tr.is-live td { background: color-mix(in srgb, var(--accent) 8%, transparent); }
+
+/* card */
+.dn-card { border: 1px solid var(--rule); border-radius: var(--r-card); background: var(--panel);
+  padding: 12px 14px; transition: border-color .12s, transform .12s; }
+.dn-card:hover { border-color: var(--accent); transform: translateY(-1px); }
+.dn-card.is-current { border-color: var(--good); }
+
+/* the singleton hovercard */
+.hg-hovercard {
+  position: fixed; z-index: 200; pointer-events: none;
+  background: var(--panel); border: 1px solid var(--rule); border-radius: 6px;
+  padding: 7px 10px; font-family: var(--mono); font-size: 11px; color: var(--ink);
+  box-shadow: 0 8px 24px rgba(0,0,0,.3); max-width: 320px;
+  opacity: 0; transform: translateY(2px); transition: opacity .12s, transform .12s;
+}
+.hg-hovercard.on { opacity: 1; transform: translateY(0); }
+.hg-hc-title { color: var(--ink); font-weight: 700; margin-bottom: 3px; }
+.hg-hc-row { color: var(--ink-soft); font-size: 10.5px; }
+.hg-hc-row b { color: var(--ink); }
+
+/* ⌘K session picker */
+.hg-picker-backdrop { position: fixed; inset: 0; background: color-mix(in srgb, var(--paper) 30%, rgba(0,0,0,.55));
+  backdrop-filter: blur(4px); z-index: 900; display: flex; align-items: flex-start; justify-content: center;
+  padding-top: 12vh; }
+.hg-picker { background: var(--panel); border: 1px solid var(--rule); border-radius: 8px;
+  width: min(640px, 92vw); box-shadow: 0 20px 60px rgba(0,0,0,.5); overflow: hidden;
+  display: flex; flex-direction: column; max-height: 66vh; }
+.hg-picker-search { display: flex; align-items: center; gap: 8px; padding: 12px 16px; border-bottom: 1px solid var(--rule); }
+.hg-picker-search input { flex: 1; background: transparent; border: none; color: var(--ink); font: inherit; font-size: 14px; outline: none; }
+.hg-picker-kbd { font-size: 10px; color: var(--ink-faint); border: 1px solid var(--rule); border-radius: 4px; padding: 1px 5px; }
+.hg-picker-list { overflow-y: auto; }
+.hg-picker-section { padding: 8px 16px 4px; font-size: 10px; color: var(--ink-faint); text-transform: uppercase; letter-spacing: .08em; }
+.hg-picker-row { display: flex; align-items: center; gap: 12px; padding: 9px 16px; cursor: pointer;
+  border: none; background: transparent; color: var(--ink); width: 100%; text-align: left; font: inherit; }
+.hg-picker-row:hover, .hg-picker-row[aria-selected="true"] { background: var(--rule-soft); }
+.hg-picker-row-title { font-size: 13px; }
+.hg-picker-row-sub { font-size: 10.5px; color: var(--ink-faint); }
+.hg-picker-row-meta { margin-left: auto; font-size: 10.5px; color: var(--ink-faint); }
+
+/* ---- 5. GANTT line-art classes (shared by gantt.html) --------------- */
+svg.fig { width: 100%; height: auto; display: block; overflow: visible; }
+svg.fig text { font-family: var(--mono); }
+.hg-gantt-grid { stroke: var(--rule-soft); stroke-width: 0.6; vector-effect: non-scaling-stroke; }
+.hg-gantt-axis { fill: var(--ink-faint); font-size: 9.5px; }
+.hg-gantt-axis-major { fill: var(--ink-soft); font-size: 9.5px; }
+.hg-gantt-lane-label { fill: var(--ink-soft); font-size: 10px; }
+.hg-gantt-lane-sep { stroke: var(--rule-soft); stroke-width: 0.6; vector-effect: non-scaling-stroke; }
+.hg-gantt-gutter { fill: var(--panel-2); }
+.hg-gantt-bar { rx: 3; stroke: none; fill-opacity: .55; transition: fill-opacity .1s; }
+.hg-gantt-bar:hover { fill-opacity: 1; }
+.hg-gantt-bar.is-pending { fill-opacity: .32; }
+.hg-gantt-bar.is-invocation { fill-opacity: .30; }   /* container recedes */
+.hg-gantt-bar.is-planned { fill: var(--rule-soft); stroke: var(--ink-faint);
+  stroke-dasharray: 4 3; stroke-width: 1; vector-effect: non-scaling-stroke; fill-opacity: .5; }
+.hg-gantt-bar.is-running { stroke: var(--accent); stroke-width: 2; vector-effect: non-scaling-stroke; }
+.hg-gantt-bar.is-failed { fill: var(--bad); fill-opacity: .8; }
+.hg-gantt-bar.is-cancelled { fill-opacity: .28; }
+.hg-gantt-bar.is-selected { stroke: var(--accent); stroke-width: 2.2; vector-effect: non-scaling-stroke; fill-opacity: 1; }
+.hg-gantt-now { stroke: var(--accent); stroke-width: 2; vector-effect: non-scaling-stroke; }
+.hg-gantt-now-cap { fill: var(--accent); }
+.hg-gantt-now-label { fill: var(--accent); font-size: 9.5px; font-variant-numeric: tabular-nums; }
+.hg-gantt-glyph-fail { fill: var(--bad); font-size: 10px; }
+.hg-gantt-glyph-wait { fill: var(--caution); font-size: 10px; }
+.hg-gantt-edge { stroke: var(--ink-faint); stroke-width: 1; fill: none; vector-effect: non-scaling-stroke; opacity: .5; }
+.hg-gantt-edge.is-transfer { stroke: var(--hg-kind-transfer); stroke-dasharray: 3 2; }
+.hg-gantt-ctxband { fill: var(--caution); fill-opacity: .14; }
+.hg-gantt-ctxband-line { stroke: var(--caution); stroke-width: 0.8; fill: none; vector-effect: non-scaling-stroke; opacity: .6; }
+.hg-gantt-row:focus-visible, .hg-gantt-bar:focus-visible { outline: 2px solid var(--accent); }
+
+/* a diagonal hatch pattern host (defined once per svg via <defs>) used for cancelled */
+
+/* ---- 6. motion + a11y ----------------------------------------------- */
+@keyframes hg-now-pulse {
+  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 70%, transparent); opacity: 1; }
+  70%  { box-shadow: 0 0 0 5px transparent; opacity: .65; }
+  100% { box-shadow: 0 0 0 0 transparent; opacity: 1; }
+}
+@keyframes hg-breathe {
+  0%, 100% { opacity: .85; }
+  50% { opacity: 1; }
+}
+.hg-breathe { animation: hg-breathe 2s ease-in-out infinite; }
+
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0ms !important;
+  }
+}
+
+/* ---- 7. the harmonograf brand accent (the "now blue" dot) -------------
+   A FIXED pair, like zicato's #2FA46A/#3FB87A green — pinned per ground,
+   independent of the active theme's --accent. Ecosystem triad: goldfive
+   gold, zicato green, harmonograf blue. */
+:root { --hgraf-brand: #5EA3EC; }
+html[data-theme="solarized-light"], html[data-theme="google-light"],
+html[data-theme="lunaria-light"], html[data-theme="belafonte-day"],
+html[data-theme="paper"] { --hgraf-brand: #2F7FD0; }

--- a/docs/design/zicato-ui-study/_study.css
+++ b/docs/design/zicato-ui-study/_study.css
@@ -334,7 +334,7 @@ svg.fig text { font-family: var(--mono); }
 .hg-gantt-now-label { fill: var(--accent); font-size: 9.5px; font-variant-numeric: tabular-nums; }
 .hg-gantt-glyph-fail { fill: var(--bad); font-size: 10px; }
 .hg-gantt-glyph-wait { fill: var(--caution); font-size: 10px; }
-.hg-gantt-edge { stroke: var(--ink-faint); stroke-width: 1; fill: none; vector-effect: non-scaling-stroke; opacity: .5; }
+.hg-gantt-edge { stroke: var(--ink-faint); stroke-width: 1; fill: none; vector-effect: non-scaling-stroke; opacity: .62; }
 .hg-gantt-edge.is-transfer { stroke: var(--hg-kind-transfer); stroke-dasharray: 3 2; }
 .hg-gantt-ctxband { fill: var(--caution); fill-opacity: .14; }
 .hg-gantt-ctxband-line { stroke: var(--caution); stroke-width: 0.8; fill: none; vector-effect: non-scaling-stroke; opacity: .6; }

--- a/docs/design/zicato-ui-study/_tokens.css
+++ b/docs/design/zicato-ui-study/_tokens.css
@@ -1,0 +1,686 @@
+/* =====================================================================
+   _tokens.css — the 16-theme colour contract for the harmonograf
+   zicato-language UI study. GENERATED — see /tmp/gen_tokens.py in the
+   build notes (STYLE-GUIDE.md). The ONLY place raw hex appears.
+
+   Each html[data-theme="<id>"] block carries three layers:
+
+   1. zicato --v2-* ROLE CONTRACT (paper/panel/ink/.../accent/flat),
+      ported 1:1 from console4.css via single-matchup.html, plus the
+      study-local short aliases (--paper/--panel/--ink/...) the pages read.
+      Meaning is FIXED across all 16 themes (DESIGN-LANGUAGE.md §2.1):
+      good/bad earned by direction; --accent is the ONE structural emphasis.
+
+   2. the terminal ANSI palette (--ansi-*), wired from _refs/gogh-palettes.json
+      — the Gogh scheme each zicato theme derives from. 16 slots:
+      normal black/red/green/yellow/blue/magenta/cyan/white + bright variants.
+
+   3. the harmonograf CATEGORICAL encoding, ALL derived from (1)+(2):
+      · span KIND hue  → --hg-kind-*   (KIND = hue axis, BRIEF §2.1)
+      · goldfive class → --hg-gf-*
+      · agent identity → --hg-agent-1..8 (+ user / goldfive synthetic actors):
+        an ORDINAL ramp, each lane an ANSI slot color-mixed toward --ink-faint
+        so lanes stay distinguishable without competing with kind hues or accent.
+
+   STATUS (running/failed/pending/...) is NOT here — it is a treatment applied
+   over the kind hue (accent+breathe / bad+glyph / dashed / hatch), so good/bad/
+   accent appear ONLY for status, never for identity. See STYLE-GUIDE.md.
+
+   Default theme: monokai (set on <html data-theme> by each page).
+   ===================================================================== */
+
+html[data-theme="monokai"] {
+  --v2-paper:#1e1f1c; --v2-panel:#272822; --v2-panel-2:#23241f;
+  --v2-ink:#f8f8f2; --v2-ink-soft:#c9cabf; --v2-ink-faint:#8f908a;
+  --v2-rule:#3a3b34; --v2-rule-soft:#2f302a;
+  --v2-good:#a6e22e; --v2-good-soft:#2c361a; --v2-bad:#f92672; --v2-caution:#e6db74;
+  --v2-accent:#66d9ef; --v2-flat:#75715e;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#272822; --ansi-red:#f92672; --ansi-green:#a6e22e; --ansi-yellow:#e6db74;
+  --ansi-blue:#66d9ef; --ansi-magenta:#ae81ff; --ansi-cyan:#a1efe4; --ansi-white:#f8f8f2;
+  --ansi-bright-black:#75715e; --ansi-bright-red:#f92672; --ansi-bright-green:#a6e22e; --ansi-bright-yellow:#e6db74;
+  --ansi-bright-blue:#66d9ef; --ansi-bright-magenta:#ae81ff; --ansi-bright-cyan:#a1efe4; --ansi-bright-white:#f9f8f5;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="solarized-dark"] {
+  --v2-paper:#04222B; --v2-panel:#0A2D38; --v2-panel-2:#0A2730;
+  --v2-ink:#93A1A1; --v2-ink-soft:#839496; --v2-ink-faint:#5E7079;
+  --v2-rule:#0E3540; --v2-rule-soft:#0B2E39;
+  --v2-good:#8BB80E; --v2-good-soft:#1C3320; --v2-bad:#E0483C; --v2-caution:#C4920A;
+  --v2-accent:#2AA198; --v2-flat:#46606B;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#073642; --ansi-red:#DC322F; --ansi-green:#859900; --ansi-yellow:#B58900;
+  --ansi-blue:#268BD2; --ansi-magenta:#D33682; --ansi-cyan:#2AA198; --ansi-white:#EEE8D5;
+  --ansi-bright-black:#657B83; --ansi-bright-red:#CB4B16; --ansi-bright-green:#586E75; --ansi-bright-yellow:#657B83;
+  --ansi-bright-blue:#6c71c4; --ansi-bright-magenta:#D33682; --ansi-bright-cyan:#2AA198; --ansi-bright-white:#FDF6E3;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="solarized-light"] {
+  --v2-paper:#FDF6E3; --v2-panel:#FBF1D6; --v2-panel-2:#F2E9CE;
+  --v2-ink:#586E75; --v2-ink-soft:#657B83; --v2-ink-faint:#93A1A1;
+  --v2-rule:#E7DCBE; --v2-rule-soft:#F0E7CC;
+  --v2-good:#6B9B0B; --v2-good-soft:#E3ECCB; --v2-bad:#DC322F; --v2-caution:#B58900;
+  --v2-accent:#268BD2; --v2-flat:#93A1A1;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#EEE8D5; --ansi-red:#DC322F; --ansi-green:#859900; --ansi-yellow:#B58900;
+  --ansi-blue:#268BD2; --ansi-magenta:#D33682; --ansi-cyan:#2AA198; --ansi-white:#073642;
+  --ansi-bright-black:#93A1A1; --ansi-bright-red:#CB4B16; --ansi-bright-green:#586E75; --ansi-bright-yellow:#839496;
+  --ansi-bright-blue:#6C71C4; --ansi-bright-magenta:#D33682; --ansi-bright-cyan:#2AA198; --ansi-bright-white:#002B36;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="google-light"] {
+  --v2-paper:#FFFFFF; --v2-panel:#F4F4F4; --v2-panel-2:#F8F8F8;
+  --v2-ink:#474A4E; --v2-ink-soft:#5F6368; --v2-ink-faint:#9FA1A4;
+  --v2-rule:#E2E3E4; --v2-rule-soft:#F1F1F1;
+  --v2-good:#34A853; --v2-good-soft:#D2ECD9; --v2-bad:#EA4335; --v2-caution:#C99700;
+  --v2-accent:#1B9CB8; --v2-flat:#9AA0A6;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#1D1F21; --ansi-red:#CC342B; --ansi-green:#198844; --ansi-yellow:#FBA922;
+  --ansi-blue:#3971ED; --ansi-magenta:#A36AC7; --ansi-cyan:#3971ED; --ansi-white:#C5C8C6;
+  --ansi-bright-black:#969896; --ansi-bright-red:#CC342B; --ansi-bright-green:#198844; --ansi-bright-yellow:#FBA922;
+  --ansi-bright-blue:#3971ED; --ansi-bright-magenta:#A36AC7; --ansi-bright-cyan:#3971ED; --ansi-bright-white:#FFFFFF;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="google-dark"] {
+  --v2-paper:#202124; --v2-panel:#2C2D30; --v2-panel-2:#28292C;
+  --v2-ink:#FFFFFF; --v2-ink-soft:#E8EAED; --v2-ink-faint:#989A9D;
+  --v2-rule:#444548; --v2-rule-soft:#323336;
+  --v2-good:#34A853; --v2-good-soft:#243F2E; --v2-bad:#EA4335; --v2-caution:#FBBC05;
+  --v2-accent:#24C1E0; --v2-flat:#5F6368;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#202124; --ansi-red:#EA4335; --ansi-green:#34A853; --ansi-yellow:#FBBC04;
+  --ansi-blue:#4285F4; --ansi-magenta:#A142F4; --ansi-cyan:#24C1E0; --ansi-white:#E8EAED;
+  --ansi-bright-black:#5F6368; --ansi-bright-red:#EA4335; --ansi-bright-green:#34A853; --ansi-bright-yellow:#FBBC05;
+  --ansi-bright-blue:#4285F4; --ansi-bright-magenta:#A142F4; --ansi-bright-cyan:#24C1E0; --ansi-bright-white:#FFFFFF;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="lunaria-light"] {
+  --v2-paper:#EBE4E1; --v2-panel:#E2DCD9; --v2-panel-2:#E6DFDC;
+  --v2-ink:#363434; --v2-ink-soft:#484646; --v2-ink-faint:#898584;
+  --v2-rule:#CEC8C5; --v2-rule-soft:#DCD6D3;
+  --v2-good:#497D46; --v2-good-soft:#C7CDBF; --v2-bad:#783C1F; --v2-caution:#8F750B;
+  --v2-accent:#3778A9; --v2-flat:#898584;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#3E3C3D; --ansi-red:#783C1F; --ansi-green:#497D46; --ansi-yellow:#8F750B;
+  --ansi-blue:#3F3566; --ansi-magenta:#793F62; --ansi-cyan:#3778A9; --ansi-white:#D5CFCC;
+  --ansi-bright-black:#484646; --ansi-bright-red:#B06240; --ansi-bright-green:#7BC175; --ansi-bright-yellow:#DCB735;
+  --ansi-bright-blue:#5C4F89; --ansi-bright-magenta:#B56895; --ansi-bright-cyan:#64BAFF; --ansi-bright-white:#EBE4E1;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="lunaria-eclipse"] {
+  --v2-paper:#323F46; --v2-panel:#3B484F; --v2-panel-2:#38454C;
+  --v2-ink:#DFE2ED; --v2-ink-soft:#C9CDD7; --v2-ink-faint:#8D949D;
+  --v2-rule:#4D5960; --v2-rule-soft:#404C53;
+  --v2-good:#BEDBC1; --v2-good-soft:#516161; --v2-bad:#BA9088; --v2-caution:#F1DFB4;
+  --v2-accent:#C8429F; --v2-flat:#6B767D;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#323F46; --ansi-red:#83615B; --ansi-green:#7F9781; --ansi-yellow:#A69875;
+  --ansi-blue:#53516F; --ansi-magenta:#856880; --ansi-cyan:#7D96B2; --ansi-white:#C9CDD7;
+  --ansi-bright-black:#3D4950; --ansi-bright-red:#BA9088; --ansi-bright-green:#BEDBC1; --ansi-bright-yellow:#F1DFB4;
+  --ansi-bright-blue:#767495; --ansi-bright-magenta:#BE9CB8; --ansi-bright-cyan:#BCDBFF; --ansi-bright-white:#DFE2ED;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="belafonte-day"] {
+  --v2-paper:#D5CCBA; --v2-panel:#CCC3B2; --v2-panel-2:#D0C6B5;
+  --v2-ink:#34292D; --v2-ink-soft:#45373C; --v2-ink-faint:#7F736E;
+  --v2-rule:#BBB1A3; --v2-rule-soft:#C8BFAF;
+  --v2-good:#6E6A4E; --v2-good-soft:#C3BCA7; --v2-bad:#BE100E; --v2-caution:#B57A1E;
+  --v2-accent:#426A79; --v2-flat:#5E5252;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#20111B; --ansi-red:#BE100E; --ansi-green:#858162; --ansi-yellow:#EAA549;
+  --ansi-blue:#426A79; --ansi-magenta:#97522C; --ansi-cyan:#989A9C; --ansi-white:#968C83;
+  --ansi-bright-black:#5E5252; --ansi-bright-red:#BE100E; --ansi-bright-green:#858162; --ansi-bright-yellow:#EAA549;
+  --ansi-bright-blue:#426A79; --ansi-bright-magenta:#97522C; --ansi-bright-cyan:#989A9C; --ansi-bright-white:#D5CCBA;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="belafonte-night"] {
+  --v2-paper:#20111B; --v2-panel:#271821; --v2-panel-2:#25161F;
+  --v2-ink:#D5CCBA; --v2-ink-soft:#968C83; --v2-ink-faint:#675B59;
+  --v2-rule:#35272E; --v2-rule-soft:#2B1C24;
+  --v2-good:#A6A07A; --v2-good-soft:#362A2B; --v2-bad:#D6403E; --v2-caution:#EAA549;
+  --v2-accent:#6F8E97; --v2-flat:#5E5252;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#20111B; --ansi-red:#BE100E; --ansi-green:#858162; --ansi-yellow:#EAA549;
+  --ansi-blue:#426A79; --ansi-magenta:#97522C; --ansi-cyan:#989A9C; --ansi-white:#968C83;
+  --ansi-bright-black:#5E5252; --ansi-bright-red:#BE100E; --ansi-bright-green:#858162; --ansi-bright-yellow:#EAA549;
+  --ansi-bright-blue:#426A79; --ansi-bright-magenta:#97522C; --ansi-bright-cyan:#989A9C; --ansi-bright-white:#D5CCBA;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="paper"] {
+  --v2-paper:#F2EEDE; --v2-panel:#E6E2D3; --v2-panel-2:#E8E4D5;
+  --v2-ink:#1A1A1A; --v2-ink-soft:#33312B; --v2-ink-faint:#85837A;
+  --v2-rule:#C6C3B6; --v2-rule-soft:#DCD9CA;
+  --v2-good:#216609; --v2-good-soft:#CCD6B8; --v2-bad:#CC3E28; --v2-caution:#B58900;
+  --v2-accent:#1E6FCC; --v2-flat:#6E6A5E;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#000000; --ansi-red:#cc3e28; --ansi-green:#216609; --ansi-yellow:#b58900;
+  --ansi-blue:#1e6fcc; --ansi-magenta:#5c21a5; --ansi-cyan:#158c86; --ansi-white:#aaaaaa;
+  --ansi-bright-black:#555555; --ansi-bright-red:#cc3e28; --ansi-bright-green:#216609; --ansi-bright-yellow:#b58900;
+  --ansi-bright-blue:#1e6fcc; --ansi-bright-magenta:#5c21a5; --ansi-bright-cyan:#158c86; --ansi-bright-white:#aaaaaa;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="zenburn"] {
+  --v2-paper:#3A3A3A; --v2-panel:#424241; --v2-panel-2:#404040;
+  --v2-ink:#DCDCCC; --v2-ink-soft:#C5C5B8; --v2-ink-faint:#83837C;
+  --v2-rule:#575754; --v2-rule-soft:#494947;
+  --v2-good:#8FB28F; --v2-good-soft:#2E3A2E; --v2-bad:#CC9393; --v2-caution:#FFD7A7;
+  --v2-accent:#8CD0D3; --v2-flat:#757575;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#333333; --ansi-red:#cc9393; --ansi-green:#7f9f7f; --ansi-yellow:#efef87;
+  --ansi-blue:#c3bf97; --ansi-magenta:#bca3a3; --ansi-cyan:#93b3a3; --ansi-white:#f0efd0;
+  --ansi-bright-black:#757575; --ansi-bright-red:#dfaf87; --ansi-bright-green:#9fc59f; --ansi-bright-yellow:#ffff87;
+  --ansi-bright-blue:#d7d7af; --ansi-bright-magenta:#d7afaf; --ansi-bright-cyan:#93bea3; --ansi-bright-white:#dcdccc;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="selenized-black"] {
+  --v2-paper:#181818; --v2-panel:#202020; --v2-panel-2:#1E1E1E;
+  --v2-ink:#DEDEDE; --v2-ink-soft:#B9B9B9; --v2-ink-faint:#606060;
+  --v2-rule:#353535; --v2-rule-soft:#262626;
+  --v2-good:#83C746; --v2-good-soft:#243218; --v2-bad:#FF5E56; --v2-caution:#EFC541;
+  --v2-accent:#56D8C9; --v2-flat:#3B3B3B;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#252525; --ansi-red:#ed4a46; --ansi-green:#70b433; --ansi-yellow:#dbb32d;
+  --ansi-blue:#368aeb; --ansi-magenta:#eb6eb7; --ansi-cyan:#3fc5b7; --ansi-white:#777777;
+  --ansi-bright-black:#3b3b3b; --ansi-bright-red:#ff5e56; --ansi-bright-green:#83c746; --ansi-bright-yellow:#efc541;
+  --ansi-bright-blue:#4f9cfe; --ansi-bright-magenta:#ff81ca; --ansi-bright-cyan:#56d8c9; --ansi-bright-white:#dedede;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="relaxed"] {
+  --v2-paper:#353A44; --v2-panel:#3D424B; --v2-panel-2:#3C404A;
+  --v2-ink:#F7F7F7; --v2-ink-soft:#D9D9D9; --v2-ink-faint:#7F8287;
+  --v2-rule:#53575F; --v2-rule-soft:#444851;
+  --v2-good:#A0AC77; --v2-good-soft:#353D2E; --v2-bad:#BC5653; --v2-caution:#EBC17A;
+  --v2-accent:#7EAAC7; --v2-flat:#636363;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#151515; --ansi-red:#BC5653; --ansi-green:#909D63; --ansi-yellow:#EBC17A;
+  --ansi-blue:#6A8799; --ansi-magenta:#B06698; --ansi-cyan:#7EAAC7; --ansi-white:#D9D9D9;
+  --ansi-bright-black:#636363; --ansi-bright-red:#BC5653; --ansi-bright-green:#A0AC77; --ansi-bright-yellow:#EBC17A;
+  --ansi-bright-blue:#7EAAC7; --ansi-bright-magenta:#B06698; --ansi-bright-cyan:#ACBBD0; --ansi-bright-white:#F7F7F7;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="espresso"] {
+  --v2-paper:#323232; --v2-panel:#3A3A3A; --v2-panel-2:#383838;
+  --v2-ink:#FFFFFF; --v2-ink-soft:#D9D9D9; --v2-ink-faint:#8A8A8A;
+  --v2-rule:#4C4C4C; --v2-rule-soft:#3E3E3E;
+  --v2-good:#A5C261; --v2-good-soft:#353D24; --v2-bad:#D25252; --v2-caution:#FFC66D;
+  --v2-accent:#6C99BB; --v2-flat:#6E6E6E;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#353535; --ansi-red:#D25252; --ansi-green:#A5C261; --ansi-yellow:#FFC66D;
+  --ansi-blue:#6C99BB; --ansi-magenta:#D197D9; --ansi-cyan:#BED6FF; --ansi-white:#EEEEEC;
+  --ansi-bright-black:#535353; --ansi-bright-red:#F00C0C; --ansi-bright-green:#C2E075; --ansi-bright-yellow:#E1E48B;
+  --ansi-bright-blue:#8AB7D9; --ansi-bright-magenta:#EFB5F7; --ansi-bright-cyan:#DCF4FF; --ansi-bright-white:#FFFFFF;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="dracula"] {
+  --v2-paper:#282A36; --v2-panel:#343746; --v2-panel-2:#2E303D;
+  --v2-ink:#F8F8F2; --v2-ink-soft:#D4D4CF; --v2-ink-faint:#6272A4;
+  --v2-rule:#44475A; --v2-rule-soft:#353848;
+  --v2-good:#50FA7B; --v2-good-soft:#213A2A; --v2-bad:#FF5555; --v2-caution:#F1FA8C;
+  --v2-accent:#BD93F9; --v2-flat:#6272A4;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#262626; --ansi-red:#E64747; --ansi-green:#42E66C; --ansi-yellow:#E4F34A;
+  --ansi-blue:#9B6BDF; --ansi-magenta:#E356A7; --ansi-cyan:#75D7EC; --ansi-white:#F8F8F2;
+  --ansi-bright-black:#7A7A7A; --ansi-bright-red:#FF5555; --ansi-bright-green:#50FA7B; --ansi-bright-yellow:#F1FA8C;
+  --ansi-bright-blue:#BD93F9; --ansi-bright-magenta:#FF79C6; --ansi-bright-cyan:#8BE9FD; --ansi-bright-white:#F9F9FB;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+html[data-theme="ubuntu"] {
+  --v2-paper:#300A24; --v2-panel:#3D1530; --v2-panel-2:#371129;
+  --v2-ink:#EEEEEC; --v2-ink-soft:#CBC3C9; --v2-ink-faint:#8A7383;
+  --v2-rule:#4B2640; --v2-rule-soft:#3E1A32;
+  --v2-good:#8AE234; --v2-good-soft:#2E3320; --v2-bad:#CC0000; --v2-caution:#FCE94F;
+  --v2-accent:#34E2E2; --v2-flat:#847683;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#2E3436; --ansi-red:#CC0000; --ansi-green:#4E9A06; --ansi-yellow:#C4A000;
+  --ansi-blue:#3465A4; --ansi-magenta:#75507B; --ansi-cyan:#06989A; --ansi-white:#D3D7CF;
+  --ansi-bright-black:#555753; --ansi-bright-red:#EF2929; --ansi-bright-green:#8AE234; --ansi-bright-yellow:#FCE94F;
+  --ansi-bright-blue:#729FCF; --ansi-bright-magenta:#AD7FA8; --ansi-bright-cyan:#34E2E2; --ansi-bright-white:#EEEEEC;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}

--- a/docs/design/zicato-ui-study/brand.html
+++ b/docs/design/zicato-ui-study/brand.html
@@ -1,0 +1,446 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="monokai">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>harmonograf — brand &amp; logo study</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="_tokens.css">
+<link rel="stylesheet" href="_study.css">
+<style>
+  /* ---- brand-accent CANDIDATES (the one place hex is allowed: this IS a
+       token proposal, mirroring zicato's fixed #2FA46A/#3FB87A pair).
+       Dark-ground defaults; light-ground overrides below. ---- */
+  :root { --hgraf-green: #3FB87A; --hgraf-blue: #5EA3EC; --hgraf-brand: var(--hgraf-blue); }
+  html[data-theme="solarized-light"], html[data-theme="google-light"],
+  html[data-theme="lunaria-light"], html[data-theme="belafonte-day"],
+  html[data-theme="paper"] { --hgraf-green: #2FA46A; --hgraf-blue: #2F7FD0; }
+
+  .mark-row { display: grid; grid-template-columns: 210px 1fr; gap: 20px; align-items: start; }
+  @media (max-width: 760px) { .mark-row { grid-template-columns: 1fr; } }
+  .mark-hero { border: 1px solid var(--rule); border-radius: var(--r-panel); background: var(--paper);
+    display: flex; align-items: center; justify-content: center; padding: 22px; min-height: 190px; }
+  .mark-hero svg { width: 150px; height: 150px; overflow: visible; }
+  .size-ladder { display: flex; align-items: flex-end; gap: 26px; margin: 10px 0 4px; flex-wrap: wrap; }
+  .size-cell { text-align: center; color: var(--ink-faint); font-size: 9.5px; }
+  .size-cell svg { display: block; margin: 0 auto 5px; overflow: visible; }
+  .size-cell.on-panel svg { background: var(--panel); border-radius: 4px; }
+  .construction { font-size: 10.5px; color: var(--ink-faint); margin-top: 10px; max-width: 80ch; line-height: 1.6; }
+  .construction code { font-size: 10px; }
+  .wm-stage { display: flex; flex-direction: column; gap: 18px; padding: 22px;
+    border: 1px solid var(--rule); border-radius: var(--r-panel); background: var(--paper); }
+  .wm-stage svg { display: block; overflow: visible; }
+  .wm-cap { font-size: 9.5px; letter-spacing: .12em; text-transform: uppercase; color: var(--ink-faint); margin-top: -10px; }
+  .lockup-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 760px) { .lockup-grid { grid-template-columns: 1fr; } }
+  .lockup { border: 1px solid var(--rule); border-radius: var(--r-panel); background: var(--paper);
+    padding: 26px 22px; display: flex; align-items: center; justify-content: center; gap: 14px; min-height: 110px; }
+  .lockup.stacked { flex-direction: column; gap: 10px; }
+  .accent-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 760px) { .accent-grid { grid-template-columns: 1fr; } }
+  .accent-cell { border: 1px solid var(--rule); border-radius: var(--r-panel); background: var(--paper);
+    padding: 20px; text-align: center; }
+  .accent-cell .sw-row { display: inline-flex; align-items: center; gap: 8px; margin-top: 10px;
+    font-size: 10px; color: var(--ink-faint); }
+  .accent-cell .sw { width: 14px; height: 14px; border-radius: 50%; display: inline-block; border: 1px solid var(--rule); }
+  .triad { display: flex; gap: 22px; flex-wrap: wrap; margin: 12px 0; font-size: 11px; color: var(--ink-soft); }
+  .triad span { display: inline-flex; align-items: center; gap: 7px; }
+  .triad .sw { width: 11px; height: 11px; border-radius: 50%; display: inline-block; }
+  .dodont { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; font-size: 12px; color: var(--ink-soft); }
+  @media (max-width: 760px) { .dodont { grid-template-columns: 1fr; } }
+  .dodont h3 { font-size: 10.5px; letter-spacing: .12em; text-transform: uppercase; margin: 0 0 8px; }
+  .dodont .do h3 { color: var(--good); } .dodont .dont h3 { color: var(--bad); }
+  .dodont ul { margin: 0; padding-left: 18px; } .dodont li { margin-bottom: 6px; line-height: 1.55; }
+  .drawbtn { font: inherit; font-size: 11px; color: var(--ink-soft); background: transparent;
+    border: 1px solid var(--accent); border-radius: var(--r-card); padding: 4px 12px; cursor: pointer; }
+  .drawbtn:hover { background: var(--accent); color: var(--paper); }
+  .drawbtn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .namesake { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 14px 0 4px; }
+  @media (max-width: 760px) { .namesake { grid-template-columns: 1fr; } }
+  .namesake .nm { border: 1px solid var(--rule); border-radius: var(--r-panel); background: var(--panel);
+    padding: 14px 16px; font-size: 12px; color: var(--ink-soft); line-height: 1.6; }
+  .namesake .nm b { color: var(--ink); }
+  .namesake .nm .yr { color: var(--accent); font-weight: 700; }
+</style>
+</head>
+<body>
+
+<header class="study">
+  <div class="brand-row"><h1>harmonograf — brand &amp; logo study</h1></div>
+  <span class="legend-inline">line-art marks for the <b>standalone</b> console — not the zicato-embedded chrome</span>
+  <div class="spacer"></div>
+  <span class="theme-pick-label">theme</span>
+  <span data-theme-picker></span>
+</header>
+
+<main class="study">
+
+<section class="study">
+  <h2>The double namesake</h2>
+  <p class="lede">
+    The name is two instruments at once, and both peaked in the same decade. The brand should own that:
+    <b>the plan and the trace</b>.
+  </p>
+  <div class="namesake">
+    <div class="nm">
+      <b>Karol Adamiecki's harmonogram</b> (also <i>harmonograf</i>), <span class="yr">1896</span> —
+      the original interdependent-process schedule chart, invented <b>14 years before Gantt</b> published his.
+      Adamiecki's "law of harmony": matched tool speeds, coordinated timetables, real teamwork —
+      a multi-agent coordination thesis, a century early. <b>This is the Gantt's true name.</b>
+    </div>
+    <div class="nm">
+      <b>The Victorian harmonograph</b> (Blackburn, Tisley), <span class="yr">1870s–90s</span> —
+      coupled, damped pendulums driving a pen: <code>x(t) = A·sin(ft+p)·e^(−dt)</code> per axis.
+      Two oscillators in harmony trace a tight Lissajous figure; detuned, they precess and wander.
+      <b>Exactly what a multi-agent run does around its plan.</b>
+    </div>
+  </div>
+  <p class="lede">
+    Brand rules inherited from the ecosystem language: a <b>single line-art stroke in
+    <code>currentColor</code></b> (round caps, never recolored), <b>exactly one accent dot</b>, marks that are
+    <b>data, not decoration</b> — every curve below is generated live by the damped-oscillator equations, with the
+    parameters documented. Tufte's rule applied to identity: the logo is the instrument's own output.
+  </p>
+</section>
+
+<section class="study" data-opt>
+  <h2>Option A — “the trace” <button class="drawbtn" id="draw-a" style="float:right">▸ draw it</button></h2>
+  <div class="surface">
+    <div class="surface-head"><span class="surface-num">A</span><span class="surface-name">damped Lissajous, 3:2</span>
+      <span class="surface-tech">pure harmonograph — the pen left running</span></div>
+    <div class="mark-row">
+      <div class="mark-hero" id="hero-a"></div>
+      <div>
+        <p class="rationale">
+          The instrument's own drawing: a <b>3:2 chord</b> with a hair of detune (3 : 2.04) so the figure
+          <b>precesses</b> — it never quite repeats, like a real run. Damping pulls each pass inward; the
+          <b>accent dot is the pen's current position</b> — “now” — the same dot that rides the console's
+          time cursor. Distinctive at lockup size; at 16&nbsp;px the inner passes muddy (see ladder), so it
+          pairs with a simplified favicon cut (Option D), exactly as zicato's spiral pairs with its <code>z</code> favicon.
+        </p>
+        <div class="size-ladder" id="ladder-a"></div>
+        <div class="construction" id="con-a"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>Option B — “the harmonogram”</h2>
+  <div class="surface">
+    <div class="surface-head"><span class="surface-num">B</span><span class="surface-name">three bars and a now-rule</span>
+      <span class="surface-tech">pure Adamiecki — the schedule as emblem</span></div>
+    <div class="mark-row">
+      <div class="mark-hero" id="hero-b"></div>
+      <div>
+        <p class="rationale">
+          Adamiecki's chart reduced to its irreducible marks: three staggered <b>stroke-only bars</b>
+          (<code>rx:3</code>, the console's own bar radius) crossed by a vertical <b>now-rule</b>; the accent dot
+          sits where the rule meets the active bar. It is the product's hero view at glyph scale — and the only
+          option that stays fully legible at 16&nbsp;px. Risk: generic (three bars say “Gantt”, not “harmonograf”)
+          — it carries the chart lineage but drops the oscillation story.
+        </p>
+        <div class="size-ladder" id="ladder-b"></div>
+        <div class="construction">construction: bars (6,9)→28 · (14,20.5)→40 · (6,32)→23, h 7, <code>rx 3</code>,
+          stroke <code>currentColor</code> 2.0; now-rule x 31; dot r 2.6 at (31, 24).</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>Option C — “trace over plan” <span style="float:right;font-size:9.5px;letter-spacing:.12em;color:var(--accent)">RECOMMENDED · LOCKUP</span></h2>
+  <div class="surface">
+    <div class="surface-head"><span class="surface-num">C</span><span class="surface-name">the fusion — a drift trace threading the bars</span>
+      <span class="surface-tech">Adamiecki × Blackburn = the product</span></div>
+    <div class="mark-row">
+      <div class="mark-hero" id="hero-c"></div>
+      <div>
+        <p class="rationale">
+          Both namesakes in one figure: quiet harmonogram bars (<b>the plan</b>) with a damped oscillation
+          threading through the lanes (<b>the execution</b>), settling toward the center as the run converges —
+          drift decaying to harmony, which is the entire product promise. The dot is the pen <i>now</i>.
+          zicato's mark is a 1-D damped string; this is its 2-D sibling — unmistakably family, unmistakably
+          not the same instrument. Wide aspect (3:2) makes it a natural <b>lockup partner</b> for the wordmark;
+          for square favicon duty it hands off to D.
+        </p>
+        <div class="size-ladder" id="ladder-c"></div>
+        <div class="construction" id="con-c"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>Option D — “the alpha” <span style="float:right;font-size:9.5px;letter-spacing:.12em;color:var(--accent)">RECOMMENDED · FAVICON</span></h2>
+  <div class="surface">
+    <div class="surface-head"><span class="surface-num">D</span><span class="surface-name">closed 2:3 Lissajous, mirrored — a lowercase α</span>
+      <span class="surface-tech">one period, undamped, flipped about the vertical axis</span></div>
+    <div class="mark-row">
+      <div class="mark-hero" id="hero-d"></div>
+      <div>
+        <p class="rationale">
+          One clean period of the 2:3 figure, <b>mirrored about the vertical axis — and the knot becomes a
+          lowercase&nbsp;α</b>: loop on the left, tails flicking out to the right. The harmonograph's signature
+          shape <i>is</i> a letterform, and it's the letter the wordmark borrows (the “a” of <i>graf</i>).
+          <b>Crossing strokes, zero clutter</b>: it survives 16&nbsp;px and reads at a glance in a browser tab.
+          The dot rides the lower-right tail tip — the pen at rest after the final flick. This is the favicon /
+          avatar / app-icon cut <i>and</i> the chrome mark; A or C carry the large lockups.
+        </p>
+        <div class="size-ladder" id="ladder-d"></div>
+        <div class="construction">construction: <code>x = −19·cos 2t, y = 15·sin 3t</code> (the mirror is the flip),
+          t ∈ [0, 2π], closed; stroke <code>currentColor</code>, optical weights 1.7 / 2.6 / 3.4 by size;
+          dot r 2.4 at the lower-right tail (cx+19, cy+15).</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>The wordmark</h2>
+  <div class="surface">
+    <p class="rationale">
+      Set in the fixed <b>brand mono</b> (JetBrains Mono 700 — pinned, independent of any console typeface choice,
+      zicato's rule). The distinctive move — the analogue of zicato's dotless-ı: when the wordmark stands
+      <b>alone</b>, the <b>“a” of <i>graf</i> is the instrument's drawing</b> — the same Lissajous α as the mark,
+      at x-height, dot on its lower-right tail. <b>One alpha per lockup:</b> beside the α mark the wordmark is
+      <b>plain letters</b> — the glyph already carries the α and the dot, and doubling them is too much.
+      <code>hgraf</code> is the sanctioned short form (already used by the repo's skill names), same rule.
+    </p>
+    <div class="wm-stage">
+      <div id="wm-full"></div><div class="wm-cap">standalone — no mark present, so the drawn “a” carries the α</div>
+      <div id="wm-plain"></div><div class="wm-cap">beside the mark — plain letters; the glyph already carries the α + dot</div>
+      <div id="wm-short"></div><div class="wm-cap">short form, standalone — tab titles, CLI banners</div>
+    </div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>Lockups</h2>
+  <div class="lockup-grid">
+    <div class="lockup" id="lock-h"></div>
+    <div class="lockup stacked" id="lock-s"></div>
+  </div>
+  <p class="rationale" style="margin-top:12px">
+    Horizontal: Option C + the plain-letter wordmark — the console topbar lockup (this study's own chrome now uses
+    the α mark + plain <code>harmonograf</code> in place of the borrowed <code>zıcato</code> brand). Stacked:
+    Option D over plain letters — README hero, social card. <b>One alpha per lockup</b>: the mark carries the α and
+    the dot, so the letters stay plain; only a markless wordmark spells graf with the α. Clear space: one bar-height
+    (7 units) on all sides; minimum mark size 14&nbsp;px, below which use D only.
+  </p>
+</section>
+
+<section class="study" data-opt>
+  <h2>The accent question — which dot?</h2>
+  <p class="lede">
+    The ecosystem triad: <span class="triad"><span><span class="sw" style="background:#D4A445"></span>goldfive — gold (the judge)</span>
+    <span><span class="sw" style="background:var(--hgraf-green)"></span>zicato — green (the plucked note)</span>
+    <span><span class="sw" style="background:var(--hgraf-blue)"></span><b>harmonograf — “now” blue (the live cursor)</b></span></span>
+    zicato's own brand doc reserves the green dot for zicato. harmonograf's identity is the <b>live view</b> —
+    its dot should be the color its console already spends on <i>now</i>: the cursor, the running stroke, the selected span.
+  </p>
+  <div class="accent-grid">
+    <div class="accent-cell" style="--hgraf-brand: var(--hgraf-green)">
+      <div id="acc-green"></div>
+      <div class="sw-row"><span class="sw" style="background:var(--hgraf-green)"></span>family green — <code>#2FA46A / #3FB87A</code> · maximum ecosystem unity, but borrows zicato's signature</div>
+    </div>
+    <div class="accent-cell">
+      <div id="acc-blue"></div>
+      <div class="sw-row"><span class="sw" style="background:var(--hgraf-blue)"></span><b>now blue — <code>#2F7FD0 / #5EA3EC</code> · own identity; the dot literally means “now” (recommended)</b></div>
+    </div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>Usage — do / don't</h2>
+  <div class="surface">
+    <div class="dodont">
+      <div class="do"><h3>Do</h3><ul>
+        <li>Stroke every mark with <code>currentColor</code> — it flips dark/light with the ground for free.</li>
+        <li>Exactly <b>one</b> accent dot per lockup (<code>--hgraf-brand</code>); it always means the pen / now.</li>
+        <li><b>One alpha per lockup.</b> Mark present → plain-letter wordmark; wordmark standalone → the drawn “a” of graf.</li>
+        <li>Pin the wordmark to the brand mono; optical stroke weights by size (heavier small, lighter large).</li>
+        <li>Favicon = Option D (or B); lockup = C; the full trace A only at ≥ 96 px.</li>
+        <li>Animate only as a single <b>draw-on</b> (the pen drawing the figure once), gated behind <code>prefers-reduced-motion</code>.</li>
+      </ul></div>
+      <div class="dont"><h3>Don't</h3><ul>
+        <li>Recolor the stroke, gradient it, or add a second accent.</li>
+        <li>Pair the α mark with the α wordmark — two alphas is too much.</li>
+        <li>Loop any animation — the instrument draws once and rests (no <code>animation:…infinite</code>).</li>
+        <li>Ship the damped trace at 16 px (it muddies — that's what D is for).</li>
+        <li>Use the green dot on harmonograf surfaces — green is zicato's signature.</li>
+        <li>Outline, shadow, or fill the marks — line art only, data-ink only.</li>
+      </ul></div>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<footer class="study">
+  harmonograf brand study · marks generated live from the damped-oscillator equations (parameters in each construction note) ·
+  strokes <code>currentColor</code> · the one accent dot = <code>--hgraf-brand</code> · part of the
+  <a href="index.html">zicato-language UI study</a>
+</footer>
+
+<script>
+/* ===== theme picker (study-standard) ===== */
+window.THEME_IDS = ['monokai','solarized-dark','solarized-light','google-light','google-dark',
+  'lunaria-light','lunaria-eclipse','belafonte-day','belafonte-night','paper','zenburn',
+  'selenized-black','relaxed','espresso','dracula','ubuntu'];
+const THEME_SWATCHES = {
+  'monokai':['#1e1f1c','#272822','#f8f8f2','#a6e22e','#f92672','#66d9ef'],
+  'solarized-dark':['#04222B','#0A2D38','#93A1A1','#8BB80E','#E0483C','#2AA198'],
+  'solarized-light':['#FDF6E3','#FBF1D6','#586E75','#6B9B0B','#DC322F','#268BD2'],
+  'google-light':['#FFFFFF','#F4F4F4','#474A4E','#34A853','#EA4335','#1B9CB8'],
+  'google-dark':['#202124','#2C2D30','#FFFFFF','#34A853','#EA4335','#24C1E0'],
+  'lunaria-light':['#EBE4E1','#E2DCD9','#363434','#497D46','#783C1F','#3778A9'],
+  'lunaria-eclipse':['#323F46','#3B484F','#DFE2ED','#BEDBC1','#BA9088','#C8429F'],
+  'belafonte-day':['#D5CCBA','#CCC3B2','#34292D','#6E6A4E','#BE100E','#426A79'],
+  'belafonte-night':['#20111B','#271821','#D5CCBA','#A6A07A','#D6403E','#6F8E97'],
+  'paper':['#F2EEDE','#E6E2D3','#1A1A1A','#216609','#CC3E28','#1E6FCC'],
+  'zenburn':['#3A3A3A','#424241','#DCDCCC','#8FB28F','#CC9393','#8CD0D3'],
+  'selenized-black':['#181818','#202020','#DEDEDE','#83C746','#FF5E56','#56D8C9'],
+  'relaxed':['#353A44','#3D424B','#F7F7F7','#A0AC77','#BC5653','#7EAAC7'],
+  'espresso':['#323232','#3A3A3A','#FFFFFF','#A5C261','#D25252','#6C99BB'],
+  'dracula':['#282A36','#343746','#F8F8F2','#50FA7B','#FF5555','#BD93F9'],
+  'ubuntu':['#300A24','#3D1530','#EEEEEC','#8AE234','#CC0000','#34E2E2'],
+};
+const THEME_LABELS = {'monokai':'Monokai','solarized-dark':'Solarized Dark','solarized-light':'Solarized Light',
+  'google-light':'Google Light','google-dark':'Google Dark','lunaria-light':'Lunaria Light','lunaria-eclipse':'Lunaria Eclipse',
+  'belafonte-day':'Belafonte Day','belafonte-night':'Belafonte Night','paper':'Paper','zenburn':'Zenburn',
+  'selenized-black':'Selenized Black','relaxed':'Relaxed','espresso':'Espresso','dracula':'Dracula','ubuntu':'Ubuntu'};
+const THEME_KEY = 'hgraf-study-theme';
+function swatchStrip(id, sm){ const t = THEME_SWATCHES[id] || [];
+  return `<span class="dt-swatch-strip${sm?' dt-swatch-strip-sm':''}">`+t.map(c=>`<span class="dt-swatch" style="background:${c}"></span>`).join('')+`</span>`; }
+function currentTheme(){ return document.documentElement.getAttribute('data-theme') || 'monokai'; }
+function applyTheme(id){ document.documentElement.setAttribute('data-theme', id);
+  try { localStorage.setItem(THEME_KEY, id); } catch(e){}
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker); }
+function buildPicker(host){ const cur = currentTheme();
+  host.innerHTML = `<div class="dt-cd"><button class="dt-cd-trigger" aria-haspopup="listbox" aria-expanded="false">${swatchStrip(cur,true)}<span class="dt-cd-name">${THEME_LABELS[cur]}</span><span class="dt-cd-caret" aria-hidden="true">▾</span></button><div class="dt-cd-list" role="listbox" aria-label="theme">${window.THEME_IDS.map(id=>`<div class="dt-cd-option" role="option" data-id="${id}" aria-selected="${id===cur}">${swatchStrip(id)}<span class="dt-cd-name">${THEME_LABELS[id]}</span></div>`).join('')}</div></div>`;
+  const cd = host.querySelector('.dt-cd'), trig = host.querySelector('.dt-cd-trigger');
+  trig.addEventListener('click', e=>{ e.stopPropagation(); const open = cd.classList.toggle('dt-cd-open'); trig.setAttribute('aria-expanded', open); });
+  host.querySelectorAll('.dt-cd-option').forEach(o=> o.addEventListener('click', ()=>{ applyTheme(o.dataset.id); cd.classList.remove('dt-cd-open'); })); }
+document.addEventListener('click', ()=> document.querySelectorAll('.dt-cd-open').forEach(c=>c.classList.remove('dt-cd-open')));
+(function initTheme(){ let saved=null; try { saved=localStorage.getItem(THEME_KEY); } catch(e){}
+  const P=new URLSearchParams(location.search), fromUrl=P.get('theme');
+  const id=(fromUrl&&window.THEME_IDS.includes(fromUrl))?fromUrl:(saved&&window.THEME_IDS.includes(saved))?saved:'monokai';
+  document.documentElement.setAttribute('data-theme', id); })();
+
+/* ===== the instrument: damped Lissajous path generators ===== */
+function lissPath(o){ // {fx,fy,px,py,dx,dy,T,n,A,B,cx,cy, Amod}
+  const pts=[]; const Amod = o.Amod || (()=>1);
+  for(let i=0;i<=o.n;i++){ const t=o.T*i/o.n, m=Amod(t,o.T);
+    const x=o.cx + o.A*m*Math.exp(-(o.dx||0)*t)*Math.sin(o.fx*t+(o.px||0));
+    const y=o.cy + o.B*m*Math.exp(-(o.dy||0)*t)*Math.sin(o.fy*t+(o.py||0));
+    pts.push([x,y]); }
+  return { d: 'M'+pts.map(p=>p[0].toFixed(2)+','+p[1].toFixed(2)).join(' L'), end: pts[pts.length-1] };
+}
+function knotPath(cx,cy,A,B){ const pts=[]; // mirrored about the vertical axis → reads as a lowercase α
+  for(let i=0;i<=240;i++){ const t=2*Math.PI*i/240;
+    pts.push([cx-A*Math.cos(2*t), cy+B*Math.sin(3*t)]); }
+  return 'M'+pts.map(p=>p[0].toFixed(2)+','+p[1].toFixed(2)).join(' L')+' Z';
+}
+
+/* ---- the four marks: each (sizePx, strokeW) → svg string ---- */
+const TRACE = lissPath({fx:3, fy:2.04, px:Math.PI/2, py:0, dx:.032, dy:.032, T:24, n:1100, A:20, B:20, cx:24, cy:24});
+function markA(s, sw, cls){ return `<svg class="${cls||''}" width="${s}" height="${s}" viewBox="0 0 48 48" role="img" aria-label="harmonograf mark — damped Lissajous">
+  <path class="trace-path" d="${TRACE.d}" fill="none" stroke="currentColor" stroke-width="${sw}" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="${TRACE.end[0].toFixed(2)}" cy="${TRACE.end[1].toFixed(2)}" r="${Math.max(2.1, sw*1.25)}" fill="var(--hgraf-brand)"/></svg>`; }
+
+function markB(s, sw){ return `<svg width="${s}" height="${s}" viewBox="0 0 48 48" role="img" aria-label="harmonograf mark — harmonogram bars">
+  <g fill="none" stroke="currentColor" stroke-width="${sw}" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="6" y="9"    width="22" height="7" rx="3"/>
+    <rect x="14" y="20.5" width="26" height="7" rx="3"/>
+    <rect x="6" y="32"   width="17" height="7" rx="3"/>
+    <line x1="31" y1="5" x2="31" y2="43"/>
+  </g><circle cx="31" cy="24" r="${Math.max(2.2, sw*1.3)}" fill="var(--hgraf-brand)"/></svg>`; }
+
+const OVER = lissPath({fx:0, fy:.62, px:0, py:.9, dx:0, dy:.052, T:30, n:700, A:0, B:17, cx:0, cy:24});
+const OVER_PTS = (function(){ // re-parametrize x linearly across the box
+  const pts=[]; for(let i=0;i<=700;i++){ const t=30*i/700;
+    pts.push([(5 + 62*i/700), 24 + 17*Math.exp(-.052*t)*Math.sin(.62*t+.9)]); }
+  return { d:'M'+pts.map(p=>p[0].toFixed(2)+','+p[1].toFixed(2)).join(' L'), end:pts[pts.length-1] }; })();
+function markC(w, sw, cls){ const h=Math.round(w*48/72);
+  return `<svg class="${cls||''}" width="${w}" height="${h}" viewBox="0 0 72 48" role="img" aria-label="harmonograf mark — trace over plan">
+  <g fill="none" stroke="currentColor" stroke-width="${sw}" stroke-linecap="round" stroke-linejoin="round" opacity=".5">
+    <rect x="7" y="8"    width="30" height="7" rx="3"/>
+    <rect x="17" y="20.5" width="34" height="7" rx="3"/>
+    <rect x="11" y="33"  width="24" height="7" rx="3"/>
+  </g>
+  <path class="trace-path" d="${OVER_PTS.d}" fill="none" stroke="currentColor" stroke-width="${sw}" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="${OVER_PTS.end[0].toFixed(2)}" cy="${OVER_PTS.end[1].toFixed(2)}" r="${Math.max(2.1, sw*1.25)}" fill="var(--hgraf-brand)"/></svg>`; }
+
+const KNOT_D = knotPath(24,24,19,15);
+function markD(s, sw){ return `<svg width="${s}" height="${s}" viewBox="0 0 48 48" role="img" aria-label="harmonograf mark — Lissajous alpha">
+  <path d="${KNOT_D}" fill="none" stroke="currentColor" stroke-width="${sw}" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="43" cy="39" r="${Math.max(2.2, sw*1.3)}" fill="var(--hgraf-brand)"/></svg>`; }
+
+/* ---- wordmark ---- */
+function wmKnot(cx, cy, r, sw, dotR){ // mini α at x-height; dot at the lower-right tail — the pen at rest
+  const d = knotPath(cx, cy, r, r*0.78);
+  return `<path d="${d}" fill="none" stroke="currentColor" stroke-width="${sw}" stroke-linecap="round"/>
+    <circle cx="${(cx+r).toFixed(2)}" cy="${(cy+r*0.78).toFixed(2)}" r="${dotR}" fill="var(--hgraf-brand)"/>`; }
+function wordmark(kind, h){ // kind: full | plain | short
+  const FS=22, ADV=FS*0.6+0.9, X0=2, BASE=26, H=h||34;
+  if(kind==='short'){ const T='hgraf', W=X0*2+T.length*ADV;
+    const scx=X0+(3+0.5)*ADV, scy=BASE-6.4; // the a of hgraf, drawn
+    return `<svg height="${H}" viewBox="0 0 ${W} 34" role="img" aria-label="hgraf">
+      <text x="${X0}" y="${BASE}" font-family="var(--brand-mono)" font-size="${FS}" font-weight="700" textLength="${(T.length*ADV).toFixed(1)}" lengthAdjust="spacing" fill="currentColor" xml:space="preserve">hgr f</text>
+      ${wmKnot(scx, scy, 6.0, 1.7, 1.9)}</svg>`; }
+  const T='harmonograf', W=X0*2+T.length*ADV;
+  if(kind==='plain'){ return `<svg height="${H}" viewBox="0 0 ${W} 34" role="img" aria-label="harmonograf">
+      <text x="${X0}" y="${BASE}" font-family="var(--brand-mono)" font-size="${FS}" font-weight="700" textLength="${(T.length*ADV).toFixed(1)}" lengthAdjust="spacing" fill="currentColor" xml:space="preserve">${T}</text></svg>`; }
+  // full: the a of graf (index 9) is drawn by the instrument
+  const Tgap='harmonogr f'; const cx=X0+(9+0.5)*ADV, cy=BASE-6.4;
+  return `<svg height="${H}" viewBox="0 0 ${W} 34" role="img" aria-label="harmonograf">
+    <text x="${X0}" y="${BASE}" font-family="var(--brand-mono)" font-size="${FS}" font-weight="700" textLength="${(T.length*ADV).toFixed(1)}" lengthAdjust="spacing" fill="currentColor" xml:space="preserve">${Tgap}</text>
+    ${wmKnot(cx, cy, 6.0, 1.7, 1.9)}</svg>`; }
+
+/* ---- mount everything ---- */
+function ladder(markFn, widths, isWide){ // optical stroke weights by size
+  const sw = {l:1.7, m:2.6, s:3.4};
+  return `
+    <div class="size-cell">${markFn(widths[0], sw.l)}<br>${widths[0]}px · lockup</div>
+    <div class="size-cell">${markFn(widths[1], sw.m)}<br>${widths[1]}px · chrome</div>
+    <div class="size-cell on-panel">${markFn(widths[2], sw.s)}<br>${widths[2]}px · favicon</div>`;
+}
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker);
+  document.getElementById('hero-a').innerHTML = markA(150, 1.45, 'drawable');
+  document.getElementById('ladder-a').innerHTML = ladder((s,w)=>markA(s,w), [72,28,16]);
+  document.getElementById('con-a').textContent =
+    'construction: x = 20·e^(−0.032t)·sin(3t+π/2), y = 20·e^(−0.032t)·sin(2.04t), t ∈ [0,24] · 1100 samples · dot at the final pen position · optical stroke 1.45 / 2.6 / 3.4 by size.';
+  document.getElementById('hero-b').innerHTML = markB(150, 2.0);
+  document.getElementById('ladder-b').innerHTML = ladder((s,w)=>markB(s,w), [72,28,16]);
+  document.getElementById('hero-c').innerHTML = markC(190, 1.6, 'drawable');
+  document.getElementById('ladder-c').innerHTML = ladder((s,w)=>markC(s,w), [96,40,24], true);
+  document.getElementById('con-c').textContent =
+    'construction: three plan bars at half-ink (opacity .5); trace x = linear time, y = 24 + 17·e^(−0.052t)·sin(0.62t+0.9) — the drift settling into the middle lane. Wide 3:2 frame; favicon duty hands off to D.';
+  document.getElementById('hero-d').innerHTML = markD(150, 1.7);
+  document.getElementById('ladder-d').innerHTML = ladder((s,w)=>markD(s,w), [72,28,16]);
+  document.getElementById('wm-full').innerHTML = wordmark('full');
+  document.getElementById('wm-plain').innerHTML = wordmark('plain');
+  document.getElementById('wm-short').innerHTML = wordmark('short');
+  document.getElementById('lock-h').innerHTML = markC(54, 2.2) + wordmark('plain', 28);
+  document.getElementById('lock-s').innerHTML = markD(64, 2.0) + wordmark('plain', 24);
+  document.getElementById('acc-green').innerHTML = markC(140, 1.6);
+  document.getElementById('acc-blue').innerHTML  = markC(140, 1.6);
+
+  /* draw-on demo: the pen draws the figure once (reduced-motion → instant) */
+  const reduce = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  function drawOn(host){ host.querySelectorAll('.trace-path').forEach(p=>{
+    const L = p.getTotalLength();
+    if (reduce) return;
+    p.style.transition='none'; p.style.strokeDasharray=L; p.style.strokeDashoffset=L;
+    requestAnimationFrame(()=>{ p.style.transition='stroke-dashoffset 2.8s cubic-bezier(.3,.6,.4,1)'; p.style.strokeDashoffset=0; }); }); }
+  document.getElementById('draw-a').addEventListener('click', ()=>{ drawOn(document.getElementById('hero-a')); drawOn(document.getElementById('hero-c')); });
+});
+</script>
+<script>window.__EMBED_CFG__ = { optSel: '[data-opt]', bareHide: ['h2', '.rationale', '.construction', '.wm-cap'] };</script>
+<script src="_embed.js"></script>
+</body>
+</html>

--- a/docs/design/zicato-ui-study/compose.html
+++ b/docs/design/zicato-ui-study/compose.html
@@ -11,20 +11,15 @@
 <link rel="stylesheet" href="_study.css">
 <style>
   body { padding: 0; overflow: hidden; }
-  header.study { position: static; }
-  .prop-switch { display: inline-flex; border: 1px solid var(--rule); border-radius: 6px; overflow: hidden; }
-  .prop-switch button { font: inherit; font-size: 11px; color: var(--ink-soft); background: transparent;
-    border: none; border-right: 1px solid var(--rule); padding: 5px 12px; cursor: pointer; }
-  .prop-switch button:last-child { border-right: none; }
-  .prop-switch button[aria-pressed="true"] { color: var(--paper); background: var(--accent); }
+  /* keep the header positioned: it loses the base rule's z-index as static, and
+     the .app paints after it — the open theme dropdown must clear the app */
+  header.study { position: relative; z-index: 60; }
   .prop-note { font-size: 10.5px; color: var(--ink-faint); }
 
   .app { height: calc(100vh - 59px); display: flex; flex-direction: column; min-height: 0; position: relative; }
-  .app-body { flex: 1; display: grid; min-height: 0; }
-  .app-body.p-observatory { grid-template-columns: 60px minmax(0,1fr) auto; }
-  .app-body.p-score { grid-template-columns: minmax(0,1fr) 210px; grid-template-rows: 96px minmax(0,1fr); }
-  .app-body.p-score .minimap { grid-column: 1 / -1; border-bottom: 1px solid var(--rule); padding: 4px 14px; }
-  .app-body.p-mission { grid-template-columns: 252px minmax(0,1fr); }
+  /* rail (observatory) · main · inspector — sessions live ONLY in the ⌘K picker */
+  .app-body { flex: 1; display: grid; min-height: 0;
+    grid-template-columns: 84px minmax(0,1fr) auto; }
   .app-main { overflow: auto; padding: 14px 18px; min-width: 0; }
   .app-main h3 { font-size: 10.5px; text-transform: uppercase; letter-spacing: .12em; color: var(--ink-faint);
     margin: 16px 0 8px; font-weight: 600; }
@@ -35,31 +30,17 @@
   .hg-drawer-host { width: 0; overflow: hidden; transition: width .16s ease; }
   .hg-drawer-host.open { width: 320px; }
   .hg-drawer-host .hg-drawer { width: 320px; }
-  /* the inspector as a floating overlay — used by proposals B & C so the
-     span-payload is reachable everywhere without disturbing their layout */
-  .hg-drawer-float { position: absolute; top: 64px; right: 14px; width: 320px; z-index: 30;
-    background: var(--panel); border: 1px solid var(--rule); border-radius: var(--r-card);
-    box-shadow: 0 0 0 1px var(--rule-soft); max-height: calc(100vh - 150px); overflow: auto; }
-  .hg-drawer-float .hg-drawer { width: 320px; }
   .hg-drawer-close { background: transparent; border: none; color: var(--ink-faint); cursor: pointer;
     font: inherit; font-size: 14px; padding: 2px 6px; border-radius: 4px; }
   .hg-drawer-close:hover { color: var(--ink); background: var(--rule-soft); }
 
-  .margin-col { border-left: 1px solid var(--rule); background: var(--panel); overflow-y: auto; padding: 12px; }
-  .margin-col h4 { font-size: 9.5px; text-transform: uppercase; letter-spacing: .12em; color: var(--ink-faint); margin: 12px 0 6px; }
-  .margin-col h4:first-child { margin-top: 0; }
   .margin-item { font-size: 10.5px; color: var(--ink-soft); margin: 4px 0; }
 
-  .fleet { border-right: 1px solid var(--rule); background: var(--panel); overflow-y: auto; padding: 10px; }
-  .fleet h4 { font-size: 9.5px; text-transform: uppercase; letter-spacing: .12em; color: var(--ink-faint); margin: 4px 4px 8px; }
-  .fleet-item { display: flex; align-items: center; gap: 9px; width: 100%; text-align: left; font: inherit;
-    background: transparent; border: 1px solid transparent; border-radius: var(--r-card); padding: 7px 8px;
-    cursor: pointer; color: var(--ink-soft); margin-bottom: 4px; }
-  .fleet-item:hover { border-color: var(--rule); }
-  .fleet-item[aria-selected="true"] { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, transparent); }
-  .fleet-item svg { flex: none; }
-  .fleet-name { font-size: 11.5px; color: var(--ink); display: block; }
-  .fleet-sub { font-size: 9.5px; color: var(--ink-faint); display: block; margin-top: 1px; }
+  /* chord interactivity: hover/click an agent to PROJECT its conversations */
+  .topo-chord g[data-agent] { cursor: pointer; }
+  .topo-chord [data-ribbon], .topo-chord [data-ahead], .topo-chord [data-agent] { transition: opacity .15s ease; }
+  .tch-count { fill: var(--ink); font-size: 9px; font-variant-numeric: tabular-nums; pointer-events: none;
+    paint-order: stroke; stroke: var(--paper); stroke-width: 3px; opacity: 0; transition: opacity .15s ease; }
 
   .sess-head { display: flex; align-items: center; gap: 14px; margin-bottom: 6px; }
   .sess-title { font-size: 15px; font-weight: 700; }
@@ -85,6 +66,19 @@
   .gm-seam { stroke: var(--rule); stroke-width: 1; stroke-dasharray: 5 4; vector-effect: non-scaling-stroke; }
   .gm-spine { stroke: var(--accent); stroke-width: 2.2; vector-effect: non-scaling-stroke; }
   .gantt-click .hg-gantt-bar, .gantt-click .sq-act { cursor: pointer; }
+
+  /* the plan reel drives the DAG: each version stop is a button */
+  .plan-reel .reel-stop[data-ver] { cursor: pointer; }
+  .plan-reel .reel-stop[data-ver]:hover .reel-hit,
+  .plan-reel .reel-stop[data-ver]:focus-visible .reel-hit { fill: color-mix(in srgb, var(--accent) 14%, transparent); }
+  .plan-reel .reel-stop[data-ver]:focus { outline: none; }
+  .plan-reel .reel-stop[data-ver]:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 50%; }
+  #dag-host, .reel-host { display: block; }
+
+  /* the coordinated time-track stack: seismograph over the time-aligned ladder.
+     They share padL/padR/width, so a reading at t lines up vertically. */
+  .track-stack { display: block; }
+  .track-stack .track-sub { font-size: 9.5px; color: var(--ink-faint); margin: 2px 0 0; padding-left: 76px; }
 </style>
 </head>
 <body>
@@ -92,9 +86,8 @@
 <header class="study">
   <span class="brand-row"><span data-brand-mark="22"></span><span data-brand-wordmark></span></span>
   <h1>the composed console</h1>
-  <span class="prop-note" id="prop-note"></span>
+  <span class="prop-note">the gantt stands alone · the instruments coalesce plans (DAG + reel), sequence, topology &amp; drift · sessions live in the ⌘K picker</span>
   <span class="spacer"></span>
-  <span class="prop-switch" id="prop-switch" role="group" aria-label="UI proposal"></span>
   <span class="theme-pick-label">theme</span>
   <span data-theme-picker></span>
 </header>
@@ -208,8 +201,12 @@ const PRIMARY = {
   heart: (()=>{ const r=lcg(7), e=[]; for(let i=0;i<30;i++){ const t=2+i*2.5+r();
     e.push([t, (i===12||i===13)?'warn':(i===15?'crit':'ok')]); } return e; })(),
   plan: {
-    nodes: { 'design-api':{x:0,y:0,st:'done'}, 'impl-core':{x:1,y:0,st:'done'}, 'wire-cli':{x:2,y:-1,st:'running'},
-             'run-suite':{x:2,y:1,st:'done'}, 'polish-ux':{x:3,y:0,st:'pending'}, 'write-docs':{x:1,y:2,st:'ghost'} },
+    // tid bridges each DAG node to its strata task-id (T1…T7) so the reel can
+    // drive the DAG: the live DAG below == version v3's task set {T1,T2,T4,T6,T7}
+    // plus write-docs (T3) carried as the dropped-at-replan ghost.
+    nodes: { 'design-api':{x:0,y:0,st:'done',tid:'T1'}, 'impl-core':{x:1,y:0,st:'done',tid:'T2'},
+             'wire-cli':{x:2,y:-1,st:'running',tid:'T6'}, 'run-suite':{x:2,y:1,st:'done',tid:'T4'},
+             'polish-ux':{x:3,y:0,st:'pending',tid:'T7'}, 'write-docs':{x:1,y:2,st:'ghost',tid:'T3'} },
     edges: [ ['design-api','impl-core',1],['impl-core','wire-cli',1],['impl-core','run-suite',0],
              ['wire-cli','polish-ux',1],['run-suite','polish-ux',0],['design-api','write-docs','ghost'] ],
     strata: [ {v:'v3 · live', has:['T1','T2','T4','T6','T7'], added:['T7'], live:true},
@@ -343,7 +340,10 @@ function seqDiagramSVG(s, o){ o=o||{};
   g+=`<line class="hg-gantt-now" x1="${padL-4}" y1="${ny}" x2="${W-12}" y2="${ny}"/><text class="hg-gantt-now-label" x="${padL}" y="${ny-5}">now ${s.now}s</text>`;
   g+=`</svg>`; return g;
 }
-/* ----- the directional transfer chord (communication topology) ----- */
+/* ----- the directional transfer chord (communication topology) -----
+   Scaling discipline: ribbon width grows with √count and CAPS, so a chatty
+   pair can never flood the figure; hover an agent to PROJECT its conversations
+   (everything else fades), click to pin, click empty space to clear. ----- */
 function topoChordSVG(s, W){ W=W||320;
   const agents=['user','planner','coder','tester','reviewer'].filter(a=>s.agents.includes(a)||a==='user');
   const idx=a=>agents.indexOf(a);
@@ -360,41 +360,106 @@ function topoChordSVG(s, W){ W=W||320;
     :`var(--hg-agent-${['planner','coder','tester','reviewer'].indexOf(a)+1})`;
   const outN=agents.map(()=>0), inN=agents.map(()=>0); flows.forEach(([a,b,c])=>{outN[a]+=c;inN[b]+=c;});
   const outUsed=agents.map(()=>0), inUsed=agents.map(()=>0);
-  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="directional transfer chord — who initiates and who receives · ${s.id}">`;
+  let g=`<svg class="fig topo-chord" viewBox="0 0 ${W} ${H}" role="img" aria-label="directional transfer chord — who initiates and who receives · ${s.id}">`;
   agents.forEach((a,i)=>{ const th=ang(i), oA=th+SECTOR/2,oB=th+0.05,iA=th-0.05,iB=th-SECTOR/2;
     const arc=(thA,thB,attrs)=>{ const [xA,yA]=onArc(thA,R),[xB,yB]=onArc(thB,R);
-      return `<path d="M${xA.toFixed(1)},${yA.toFixed(1)} A${R},${R} 0 0 ${thA>thB?1:0} ${xB.toFixed(1)},${yB.toFixed(1)}" fill="none" ${attrs}/>`; };
+      return `<path data-agent="${a}" d="M${xA.toFixed(1)},${yA.toFixed(1)} A${R},${R} 0 0 ${thA>thB?1:0} ${xB.toFixed(1)},${yB.toFixed(1)}" fill="none" ${attrs}/>`; };
     if(outN[i]) g+=arc(oA,oB,`stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9"`);
     if(inN[i])  g+=arc(iA,iB,`stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9" stroke-dasharray="1.5 2.4"`);
   });
+  let cLabels='';
   flows.forEach(([a,b,c],fi)=>{ const ths=ang(a),thd=ang(b);
     const sF=(outUsed[a]+c/2)/Math.max(outN[a],1); outUsed[a]+=c;
     const dF=(inUsed[b]+c/2)/Math.max(inN[b],1);  inUsed[b]+=c;
     const sTh=ths+0.07+(SECTOR/2-0.07)*sF, dTh=thd-0.07-(SECTOR/2-0.07)*dF;
-    const wS=1.6,wT=Math.max(5,c*2.6), [sx,sy]=onArc(sTh,R-4),[dx,dy]=onArc(dTh,R-9);
+    // √count with a hard cap: heavy traffic thickens slowly and can never flood
+    const wS=1.6, wT=Math.min(15, 4+Math.sqrt(c)*3.4), [sx,sy]=onArc(sTh,R-4),[dx,dy]=onArc(dTh,R-9);
     const tS=[Math.sin(sTh),Math.cos(sTh)],tD=[Math.sin(dTh),Math.cos(dTh)];
     const s1=[sx+tS[0]*wS/2,sy+tS[1]*wS/2],s2=[sx-tS[0]*wS/2,sy-tS[1]*wS/2];
     const t1=[dx+tD[0]*wT/2,dy+tD[1]*wT/2],t2=[dx-tD[0]*wT/2,dy-tD[1]*wT/2];
     const mid=[(sx+dx)/2+(cx-(sx+dx)/2)*0.62,(sy+dy)/2+((cyA-34)-(sy+dy)/2)*0.5], gid=`tch${s.id}${fi}`;
+    const FT=`data-f="${agents[a]}" data-t="${agents[b]}"`;
     g+=`<defs><linearGradient id="${gid}" x1="${sx.toFixed(1)}" y1="${sy.toFixed(1)}" x2="${dx.toFixed(1)}" y2="${dy.toFixed(1)}" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="${aColor(a)}" stop-opacity=".32"/><stop offset="1" stop-color="${aColor(b)}" stop-opacity=".95"/></linearGradient></defs>`;
-    g+=`<path fill="url(#${gid})" stroke="none" d="M${s1[0].toFixed(1)},${s1[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${t1[0].toFixed(1)},${t1[1].toFixed(1)} L${t2[0].toFixed(1)},${t2[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${s2[0].toFixed(1)},${s2[1].toFixed(1)} Z"><title>${agents[a]} → ${agents[b]} · ${c} (${agents[a]} initiates)</title></path>`;
+      <stop offset="0" stop-color="${aColor(agents[a])}" stop-opacity=".32"/><stop offset="1" stop-color="${aColor(agents[b])}" stop-opacity=".95"/></linearGradient></defs>`;
+    g+=`<path data-ribbon="1" ${FT} fill="url(#${gid})" stroke="none" d="M${s1[0].toFixed(1)},${s1[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${t1[0].toFixed(1)},${t1[1].toFixed(1)} L${t2[0].toFixed(1)},${t2[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${s2[0].toFixed(1)},${s2[1].toFixed(1)} Z"><title>${agents[a]} → ${agents[b]} · ${c} (${agents[a]} initiates)</title></path>`;
     const outward=[Math.cos(dTh),-Math.sin(dTh)], tip=onArc(dTh,R-1), base=[tip[0]-outward[0]*8,tip[1]-outward[1]*8];
-    g+=`<path d="M${(base[0]+tD[0]*4).toFixed(1)},${(base[1]+tD[1]*4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(base[0]-tD[0]*4).toFixed(1)},${(base[1]-tD[1]*4).toFixed(1)} Z" fill="${aColor(b)}"/>`;
+    g+=`<path data-ahead="1" ${FT} d="M${(base[0]+tD[0]*4).toFixed(1)},${(base[1]+tD[1]*4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(base[0]-tD[0]*4).toFixed(1)},${(base[1]-tD[1]*4).toFixed(1)} Z" fill="${aColor(agents[b])}"/>`;
+    cLabels+=`<text class="tch-count" data-count="1" ${FT} x="${mid[0].toFixed(1)}" y="${(mid[1]+3).toFixed(1)}" text-anchor="middle">${c}×</text>`;
   });
   agents.forEach((a,i)=>{ const th=ang(i),[x,y]=onArc(th,R);
-    g+=`<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3" fill="${aColor(a)}"/>`;
     const [lx,ly]=onArc(th,R+14), anc= lx<cx-10?'end':(lx>cx+10?'start':'middle');
-    g+=`<text class="sq-lbl" x="${lx.toFixed(1)}" y="${(ly+(ly<36?-2:4)).toFixed(1)}" text-anchor="${anc}" fill="var(--ink)">${a}</text>`; });
-  g+=`</svg>`; return g;
+    g+=`<g data-agent="${a}" tabindex="0" role="button" aria-label="project ${a}'s conversations">
+      <circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="12" fill="transparent" stroke="none"/>
+      <circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3" fill="${aColor(a)}"/>
+      <text class="sq-lbl" x="${lx.toFixed(1)}" y="${(ly+(ly<36?-2:4)).toFixed(1)}" text-anchor="${anc}" fill="var(--ink)">${a}</text></g>`; });
+  g+=cLabels+`</svg>`; return g;
 }
-function seismoSVG(s, lanes, W){
-  W=W||940; const rowH=54, padL=W<400?40:76, padR=14, H=lanes.length*rowH+24, X=t=>padL+(W-padL-padR)*t/s.T, TOL=8;
-  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="drift seismograph — ${s.id}">`;
+/* hover an agent → project (dim everything not involving it); click → pin */
+function wireChord(scope){
+  scope.querySelectorAll('svg.topo-chord').forEach(svg=>{
+    let pinned=null;
+    const apply=f=>{
+      svg.querySelectorAll('[data-ribbon],[data-ahead]').forEach(p=>{
+        p.style.opacity = (!f || p.dataset.f===f || p.dataset.t===f) ? '' : .05; });
+      svg.querySelectorAll('[data-count]').forEach(tx=>{
+        tx.style.opacity = (f && (tx.dataset.f===f || tx.dataset.t===f)) ? 1 : ''; });
+      svg.querySelectorAll('[data-agent]').forEach(n=>{
+        n.style.opacity = (!f || n.dataset.agent===f) ? '' : .3; });
+    };
+    svg.querySelectorAll('g[data-agent]').forEach(h=>{
+      h.addEventListener('mouseenter',()=>{ if(!pinned) apply(h.dataset.agent); });
+      h.addEventListener('mouseleave',()=>{ if(!pinned) apply(null); });
+      h.addEventListener('click',e=>{ e.stopPropagation();
+        pinned = pinned===h.dataset.agent ? null : h.dataset.agent; apply(pinned); });
+      h.addEventListener('keydown',e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); h.click(); } });
+    });
+    svg.addEventListener('click',()=>{ if(pinned){ pinned=null; apply(null); } });
+    const want=new URLSearchParams(location.search).get('chord');
+    if(want && svg.querySelector(`g[data-agent="${want}"]`)){ pinned=want; apply(want); }
+  });
+}
+/* Shared time-track geometry — the seismograph, the heartbeat overlay, and the
+   intervention ladder ALL derive padL/padR/X from this, so a reading at time t
+   sits at the same x in every panel of the stack. */
+function trackGeom(s, W){ const padL=W<400?40:76, padR=14;
+  return { padL, padR, X:t=>padL+(W-padL-padR)*t/s.T }; }
+function timeAxisSVG(s, W, H){ const {padL,padR,X}=trackGeom(s,W); let g='';
   for(let i=0;i<=4;i++){ const gx=X(s.T*i/4);
-    g+=`<line class="hg-gantt-grid" x1="${gx}" y1="4" x2="${gx}" y2="${H-18}"/><text class="gm-axis" x="${gx-7}" y="${H-5}">${Math.round(s.T*i/4)}s</text>`; }
+    g+=`<line class="hg-gantt-grid" x1="${gx}" y1="2" x2="${gx}" y2="${H}"/>`; }
+  return g;
+}
+/* ONE combined drift+judge instrument: the seismograph traces as before, with
+   the judge-firing HEARTBEAT folded in as a strip along the same time axis —
+   ok ticks in the judge (goldfive) KIND hue, warnings/criticals carried by the
+   STATUS treatment (caution / bad). One axis, two readings. */
+/* wire the reel: clicking/keying a version sets state.planVer and repaints ONLY
+   the plan block (DAG + reel marks) — no console-wide re-render. */
+function wireReel(scope){
+  scope.querySelectorAll('.reel-stop[data-ver]').forEach(stop=>{
+    const pick=()=>{ const vi=+stop.dataset.ver; if(vi===state.planVer) return; state.planVer=vi; repaintPlan(); };
+    stop.addEventListener('click', pick);
+    stop.addEventListener('keydown', e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); pick(); } });
+  });
+}
+function seismoSVG(s, lanes, W, opts){ opts=opts||{};
+  W=W||940; const {padL,padR,X}=trackGeom(s,W), TOL=8;
+  const heart=opts.heart!==false, heartH=heart?30:0, rowH=54;
+  const top=heartH, H=top+lanes.length*rowH+(opts.axis===false?6:24);
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="drift seismograph + judge heartbeat — ${s.id}">`;
+  for(let i=0;i<=4;i++){ const gx=X(s.T*i/4);
+    g+=`<line class="hg-gantt-grid" x1="${gx}" y1="4" x2="${gx}" y2="${H-(opts.axis===false?6:18)}"/>`;
+    if(opts.axis!==false) g+=`<text class="gm-axis" x="${gx-7}" y="${H-5}">${Math.round(s.T*i/4)}s</text>`; }
+  // judge heartbeat strip — KIND hue baseline, STATUS treatment on warn/crit
+  if(heart){ const hy=heartH-10;
+    g+=`<text class="gm-label" x="6" y="${hy+4}" fill="var(--hg-agent-goldfive)">judges</text>`;
+    g+=`<line class="gm-onplan" x1="${X(0)}" y1="${hy}" x2="${X(s.T)}" y2="${hy}"/>`;
+    s.heart.forEach(([t,k])=>{ if(t>s.T) return; const x=X(t);
+      if(k==='ok')   g+=`<circle cx="${x}" cy="${hy}" r="1.7" fill="var(--hg-agent-goldfive)" opacity=".8"><title>judge fired · on-task @ ${t.toFixed(0)}s</title></circle>`;
+      if(k==='warn') g+=`<line x1="${x}" y1="${hy-6}" x2="${x}" y2="${hy+6}" stroke="var(--caution)" stroke-width="1.4" vector-effect="non-scaling-stroke"/><text x="${x-3.5}" y="${hy+3}" font-size="8.5" fill="var(--caution)">▲</text>`;
+      if(k==='crit') g+=`<line x1="${x}" y1="${hy-7}" x2="${x}" y2="${hy+7}" stroke="var(--bad)" stroke-width="1.6" vector-effect="non-scaling-stroke"/><text x="${x-3.5}" y="${hy+3.5}" font-size="9.5" fill="var(--bad)" font-weight="700">✕</text>`; });
+    g+=`<line class="gm-seam" x1="${X(0)}" y1="${heartH-1}" x2="${X(s.T)}" y2="${heartH-1}" opacity=".5"/>`; }
   lanes.forEach((a,li)=>{ const keys=s.judges[a]; if(!keys) return;
-    const base=10+li*rowH+rowH-16, rnd=lcg(40+li), yOf=v=>base-v*1.9;
+    const base=top+10+li*rowH+rowH-16, rnd=lcg(40+li), yOf=v=>base-v*1.9;
     g+=`<text class="gm-label" x="6" y="${base-12}">${a}</text>`;
     g+=`<rect class="gm-tol" x="${X(0)}" y="${yOf(TOL)}" width="${X(s.T)-X(0)}" height="${yOf(0)-yOf(TOL)}"/>`;
     g+=`<line class="gm-onplan" x1="${X(0)}" y1="${base}" x2="${X(s.T)}" y2="${base}"/>`;
@@ -409,87 +474,122 @@ function seismoSVG(s, lanes, W){
       g+=`<line class="gm-tick" x1="${tx}" y1="${base-rowH+22}" x2="${tx}" y2="${base+3}"><title>intervention · ${lbl}</title></line>`;
       g+=`<text class="gm-tick-label" x="${tx+3}" y="${base-rowH+27}">${lbl.split(' ')[0]}</text>`; }); });
   const nx=X(Math.min(s.now,s.T));
-  g+=`<line class="hg-gantt-now" x1="${nx}" y1="4" x2="${nx}" y2="${H-18}"/>`;
+  g+=`<line class="hg-gantt-now" x1="${nx}" y1="4" x2="${nx}" y2="${H-(opts.axis===false?6:18)}"/>`;
   g+=`</svg>`; return g;
 }
+/* heartbeat as its own small figure is still available (e.g. the inspector),
+   but the console folds it into the seismograph above. */
 function heartSVG(s, W){ W=W||940; const H=40, padL=W<400?40:76, X=t=>padL+(W-padL-14)*t/s.T;
   let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="judge heartbeat — ${s.id}">`;
-  g+=`<text class="gm-label" x="6" y="22">judges</text>`;
+  g+=`<text class="gm-label" x="6" y="22" fill="var(--hg-agent-goldfive)">judges</text>`;
   g+=`<line class="gm-onplan" x1="${X(0)}" y1="26" x2="${X(s.T)}" y2="26"/>`;
   s.heart.forEach(([t,k])=>{ if(t>s.T) return; const x=X(t);
-    if(k==='ok') g+=`<circle cx="${x}" cy="18" r="1.5" fill="var(--hg-gf-judge-on-task)" opacity=".75"/>`;
+    if(k==='ok') g+=`<circle cx="${x}" cy="18" r="1.5" fill="var(--hg-agent-goldfive)" opacity=".8"/>`;
     if(k==='warn') g+=`<text x="${x-3.5}" y="22" font-size="9" fill="var(--caution)">▲</text>`;
     if(k==='crit') g+=`<text x="${x-3.5}" y="22" font-size="10" fill="var(--bad)" font-weight="700">✕</text>`; });
   g+=`</svg>`; return g;
 }
-function ladderSVG(dots, W){ W=W||440; const H=128, padL=66, X=t=>padL+(W-padL-12)*t/96;
-  const RUNGS=['nudge','refine','replan','escalate'], rungY=i=>100-i*26;
-  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="intervention ladder">`;
+/* The intervention ladder, time-scale-LOCKED to the seismograph: pass the same
+   session + width and it derives an identical x-domain (padL/padR/X via
+   trackGeom over s.T), so a rung-dot at time t sits directly beneath the drift
+   reading at t. The legacy fixed-width call (no session) still works. */
+function ladderSVG(dots, W, s){ W=W||440; const H=124;
+  const geo = s ? trackGeom(s, W) : { padL:66, X:t=>66+(W-66-12)*t/96 };
+  const padL=geo.padL, X=geo.X;
+  const RUNGS=['nudge','refine','replan','escalate'], rungY=i=>96-i*25;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="intervention ladder${s?' (time-aligned to the seismograph)':''}">`;
+  if(s){ for(let i=0;i<=4;i++){ const gx=X(s.T*i/4);
+    g+=`<line class="hg-gantt-grid" x1="${gx}" y1="2" x2="${gx}" y2="${rungY(3)-6}" opacity=".5"/>`; } }
   RUNGS.forEach((r,i)=>{ const y=rungY(i);
-    g+=`<line x1="${padL}" y1="${y}" x2="${W-12}" y2="${y}" stroke="var(--rule)" stroke-width="1" vector-effect="non-scaling-stroke"/><text class="gm-faint" x="8" y="${y+3}">${r}</text>`; });
+    g+=`<line x1="${padL}" y1="${y}" x2="${W-(s?geo.padR:12)}" y2="${y}" stroke="var(--rule)" stroke-width="1" vector-effect="non-scaling-stroke"/><text class="gm-faint" x="8" y="${y+3}">${r}</text>`; });
   if(dots.length>1) g+=`<path d="${dots.map((d,i)=>(i?'L':'M')+X(d[0]).toFixed(1)+','+rungY(d[1]).toFixed(1)).join(' ')}" fill="none" stroke="var(--ink-faint)" stroke-width="0.8" stroke-dasharray="2 3" opacity=".7" vector-effect="non-scaling-stroke"/>`;
   dots.forEach(d=>{ g+=`<circle cx="${X(d[0])}" cy="${rungY(d[1])}" r="3.2" fill="${d[1]===3?'var(--bad)':'var(--ink-soft)'}"><title>${RUNGS[d[1]]} @ ${d[0]}s</title></circle>`; });
   if(!dots.length) g+=`<text class="gm-faint" x="${padL+10}" y="${rungY(0)-8}" font-style="italic">no interventions — never left the ground</text>`;
+  if(s){ for(let i=0;i<=4;i++){ const gx=X(s.T*i/4);
+    g+=`<text class="gm-axis" x="${gx-7}" y="${H-4}">${Math.round(s.T*i/4)}s</text>`; } }
   g+=`</svg>`; return g;
 }
-function dagSVG(p, W){ W=W||940; const H=216, BW=118, BH=24;
+/* The DAG can render either the LIVE plan (no version arg) or a specific reel
+   version's plan: pass {strata, vi} and each node is reframed by that version's
+   task set — `added` tasks get the accent "new" treatment, tasks dropped since
+   the previous (older) revision are ghosted/dashed exactly like the live ghost. */
+function dagSVG(p, W, sel){ W=W||940; const H=216, BW=118, BH=24;
   const LX=[80,300,520,740], LY=v=>92+v*44;
-  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="plan dependency DAG">`;
+  // per-node role under the selected version: present / added / dropped / absent
+  let role=null;
+  if(sel){ const cur=p.strata[sel.vi], prev=p.strata[sel.vi+1];
+    role=id=>{ const tid=p.nodes[id].tid;
+      if(!tid) return cur.has.length?'absent':'present';
+      if(cur.has.includes(tid)) return cur.added.includes(tid)?'added':'present';
+      if(prev && prev.has.includes(tid)) return 'dropped';   // present last revision, gone now
+      return 'absent'; }; }
+  const ghosted=id=>{ if(!sel) return p.nodes[id].st==='ghost'; const r=role(id); return r==='dropped'||r==='absent'; };
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="plan dependency DAG${sel?' · '+p.strata[sel.vi].v:''}">`;
   p.edges.forEach(([a,b,crit])=>{ const A=p.nodes[a], B=p.nodes[b];
     const x0=LX[A.x]+BW/2, y0=LY(A.y), x1=LX[B.x]-BW/2, y1=LY(B.y), c=(x0+x1)/2;
-    const stroke = crit===1?'var(--accent)':'var(--ink-faint)';
-    const extra = crit==='ghost'?` stroke-dasharray="3 4" opacity=".45"`:crit===1?` stroke-width="2"`:` stroke-width="1" opacity=".6"`;
-    g+=`<path d="M${x0},${y0} C ${c},${y0} ${c},${y1} ${x1},${y1}" fill="none" stroke="${stroke}"${extra} vector-effect="non-scaling-stroke"><title>${a} → ${b}${crit===1?' · critical path':''}</title></path>`; });
-  Object.entries(p.nodes).forEach(([id,n])=>{ const x=LX[n.x], y=LY(n.y), ghost=n.st==='ghost';
-    const stroke = n.st==='done'?'var(--good)':n.st==='running'?'var(--accent)':ghost?'var(--rule)':'var(--ink-faint)';
-    const glyph = n.st==='done'?['✓','var(--good)']:n.st==='running'?['●','var(--accent)']:ghost?['✕','var(--bad)']:['○','var(--ink-faint)'];
-    g+=`<rect x="${x-BW/2}" y="${y-BH/2}" width="${BW}" height="${BH}" rx="4" fill="var(--panel)" stroke="${stroke}" stroke-width="${n.st==='running'?2:1.2}"${ghost?` stroke-dasharray="4 3" opacity=".55"`:''} vector-effect="non-scaling-stroke"><title>${id} · ${ghost?'dropped at replan v2':n.st}</title></rect>`;
+    const eGhost = ghosted(a)||ghosted(b)||crit==='ghost';
+    const stroke = eGhost?'var(--ink-faint)':crit===1?'var(--accent)':'var(--ink-faint)';
+    const extra = eGhost?` stroke-dasharray="3 4" opacity=".45"`:crit===1?` stroke-width="2"`:` stroke-width="1" opacity=".6"`;
+    g+=`<path d="M${x0},${y0} C ${c},${y0} ${c},${y1} ${x1},${y1}" fill="none" stroke="${stroke}"${extra} vector-effect="non-scaling-stroke"><title>${a} → ${b}${crit===1&&!eGhost?' · critical path':''}</title></path>`; });
+  Object.entries(p.nodes).forEach(([id,n])=>{ const x=LX[n.x], y=LY(n.y);
+    const r = sel?role(id):null, ghost=ghosted(id), added=r==='added';
+    const stroke = ghost?'var(--rule)':added?'var(--accent)':n.st==='done'?'var(--good)':n.st==='running'?'var(--accent)':'var(--ink-faint)';
+    const glyph = ghost?(r==='dropped'||(!sel&&n.st==='ghost')?['✕','var(--bad)']:['·','var(--ink-faint)'])
+      :added?['○','var(--accent)']:n.st==='done'?['✓','var(--good)']:n.st==='running'?['●','var(--accent)']:['○','var(--ink-faint)'];
+    const sw = (n.st==='running'&&!ghost)||added?2:1.2;
+    const tip = ghost?(r==='dropped'?`dropped at ${p.strata[sel.vi].v} (was in ${p.strata[sel.vi+1].v})`:!sel?'dropped at replan v2':'not in this revision')
+      :added?`added in ${p.strata[sel.vi].v}`:n.st;
+    g+=`<rect x="${x-BW/2}" y="${y-BH/2}" width="${BW}" height="${BH}" rx="4" fill="var(--panel)" stroke="${stroke}" stroke-width="${sw}"${ghost?` stroke-dasharray="4 3" opacity=".55"`:''} vector-effect="non-scaling-stroke"><title>${id}${n.tid?' · '+n.tid:''} · ${tip}</title></rect>`;
     g+=`<text x="${x-BW/2+9}" y="${y+3.5}" font-size="10" fill="${ghost?'var(--ink-faint)':'var(--ink-soft)'}">${id}</text>`;
     g+=`<text x="${x+BW/2-15}" y="${y+4}" font-size="9.5" fill="${glyph[1]}">${glyph[0]}</text>`; });
-  g+=`<text class="gm-faint" x="10" y="${H-8}">the accent spine = the critical path · ghost = dropped at replan</text></svg>`; return g;
+  const cap = sel ? `${p.strata[sel.vi].v} · ○ accent = added at this revision · dashed = dropped since the prior revision`
+    : 'the accent spine = the critical path · ghost = dropped at replan';
+  g+=`<text class="gm-faint" x="10" y="${H-8}">${cap}</text></svg>`; return g;
 }
-function strataSVG(p, W){ W=W||940; const rowH=44, tasks={T1:0,T2:1,T3:2,T4:3,T5:4,T6:5,T7:6};
-  const tx=i=>92+i*116, BW=88, BH=13, H=p.strata.length*rowH+26;
-  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="plan strata">`;
-  Object.entries(tasks).forEach(([t,i])=>{ g+=`<text class="gm-faint" x="${tx(i)+BW/2-8}" y="11">${t}</text>`; });
-  p.strata.forEach((st,si)=>{ const y0=18+si*rowH, cy=y0+rowH/2;
-    g+=`<text class="gm-label" x="8" y="${cy+3}"${st.live?' fill="var(--accent)"':''}>${st.v}</text>`;
-    if(st.live) g+=`<line class="gm-spine" x1="76" y1="${y0+4}" x2="76" y2="${y0+rowH-8}"/>`;
-    st.has.forEach(t=>{ const x=tx(tasks[t]); const op = st.live?.8:(.45-si*.08);
-      g+=`<rect x="${x}" y="${cy-BH/2}" width="${BW}" height="${BH}" rx="3" fill="var(--ink-soft)" fill-opacity="${op.toFixed(2)}"><title>${t} in ${st.v}</title></rect>`;
-      if(st.added.includes(t)) g+=`<text x="${x-10}" y="${cy+3.5}" font-size="9" fill="var(--accent)">○</text>`; });
-    if(si>0){ const newer=p.strata[si-1];
-      st.has.filter(t=>!newer.has.includes(t)).forEach(t=>{ g+=`<text x="${tx(tasks[t])+BW+4}" y="${cy+3.5}" font-size="9" fill="var(--bad)">✕</text>`; }); }
-    if(st.seam){ const sy=y0-2; g+=`<line class="gm-seam" x1="76" y1="${sy}" x2="${W-180}" y2="${sy}"/><text class="gm-tick-label" x="${W-172}" y="${sy+3}">${st.seam}</text>`; } });
-  g+=`</svg>`; return g;
-}
-function reelSVG(p, W){ W=W||940; const H=86, xs=[0.12,0.36,0.6,0.84].map(f=>Math.round(W*f));
-  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="plan reel">`;
-  g+=`<line class="gm-spine" x1="${xs[0]}" y1="44" x2="${xs[3]}" y2="44"/>`;
+/* The plan reel is the version timeline (v0…v3) with its replan-trigger seams.
+   It reads oldest→newest left to right, while p.strata is stored newest-first —
+   so version index `i` here maps to strata index `(strata.length-1)-i`. Each
+   stop is a button (data-ver=strata index) that drives the DAG; `selVi` marks
+   which strata version is active. */
+function reelSVG(p, W, selVi){ W=W||940; const H=92, xs=[0.12,0.36,0.6,0.84].map(f=>Math.round(W*f));
+  const n=p.strata.length;  // strata is newest-first; the reel reads oldest→newest
+  let g=`<svg class="fig plan-reel" viewBox="0 0 ${W} ${H}" role="img" aria-label="plan reel — click a version to drive the DAG">`;
+  g+=`<line class="gm-spine" x1="${xs[0]}" y1="50" x2="${xs[3]}" y2="50"/>`;
   const trig=['','scope-creep','goal-drift','tool-misuse'];
-  xs.forEach((x,i)=>{ if(i>0) g+=`<text class="gm-tick-label" x="${(xs[i-1]+x)/2-26}" y="26">↯ ${trig[i]}</text>`;
-    g+=`<circle cx="${x}" cy="44" r="${i===3?5.5:4}" fill="${i===3?'var(--accent)':'var(--panel)'}" stroke="${i===3?'var(--accent)':'var(--ink-soft)'}" stroke-width="1.5"/>`;
-    g+=`<text class="gm-label" x="${x-8}" y="63">v${i}</text><text class="gm-axis" x="${x-24}" y="77">${p.rem[i]} tasks left</text>`;
-    if(i>0) g+=`<text x="${(xs[i-1]+x)/2-10}" y="40" font-size="9" fill="var(--good)">−${p.rem[i-1]-p.rem[i]}</text>`; });
+  xs.forEach((x,i)=>{
+    // stops 1..3 are real strata versions (newest at the rightmost); stop 0 is the v0 origin
+    const sIdx = i===0 ? null : (n-1)-(i-1);  // i=1→v1=strata[n-1]; i=3→v3=strata[0]
+    const active = sIdx!=null && sIdx===selVi, latest=i===xs.length-1;
+    if(i>0) g+=`<text class="gm-tick-label" x="${(xs[i-1]+x)/2-26}" y="30">↯ ${trig[i]}</text>`;
+    const dotFill = active?'var(--accent)':latest?'var(--accent)':'var(--panel)';
+    const dotStroke = active||latest?'var(--accent)':'var(--ink-soft)';
+    g+=`<g class="reel-stop" ${sIdx!=null?`data-ver="${sIdx}" tabindex="0" role="button" aria-pressed="${active}" aria-label="show plan ${p.strata[sIdx].v}"`:''}>`;
+    if(active) g+=`<circle cx="${x}" cy="50" r="10" fill="none" stroke="var(--accent)" stroke-width="1.4" opacity=".9"/>`;
+    g+=`<circle class="reel-hit" cx="${x}" cy="50" r="14" fill="transparent"/>`;
+    g+=`<circle cx="${x}" cy="50" r="${latest||active?5.5:4}" fill="${dotFill}" stroke="${dotStroke}" stroke-width="1.5"/>`;
+    g+=`<text class="gm-label" x="${x-8}" y="71"${active?' fill="var(--accent)" font-weight="600"':''}>v${i}</text>`;
+    g+=`<text class="gm-axis" x="${x-24}" y="85">${p.rem[i]} tasks left</text></g>`;
+    if(i>0) g+=`<text x="${(xs[i-1]+x)/2-10}" y="46" font-size="9" fill="var(--good)">−${p.rem[i-1]-p.rem[i]}</text>`; });
   g+=`</svg>`; return g;
 }
 
-/* ===== app state + shell ===== */
-const PROPOSALS = { observatory: 'A · observatory', score: 'B · score', mission: 'C · mission control' };
-const PROP_NOTES = {
-  observatory: 'one session, one hero view — the rail switches gantt / sequence / drift / plans; click a span for the inspector',
-  score: 'sequence-first — the sequence diagram is the view, the gantt is a minimap, drift + topology + plans ride the margin',
-  mission: 'fleet-first — fingerprints are the navigation; each session gets the full compact instrument set',
-};
+/* ===== app state + shell =====
+   Sessions are navigated ONLY through the ⌘K picker (fingerprint rows) — no
+   sidebar. The rail keeps the GANTT as its own hero view; every other reading
+   — plans (DAG + reel, leading), sequence, topology, drift, interventions —
+   coalesces into one scrolling INSTRUMENTS view. */
 const state = {
-  proposal: 'observatory', view: 'gantt', sessionId: 'checkout-refactor',
+  view: 'gantt', sessionId: 'checkout-refactor',
   drawerSpan: null, drawerOpen: true, live: true, elapsed: 80, picker: false,
+  planVer: 0,   // selected reel version as a strata index (0 = newest/live); drives the DAG
 };
 (function initState(){ const P=new URLSearchParams(location.search);
-  const pr=P.get('proposal'); if(pr && PROPOSALS[pr]) state.proposal=pr;
-  const v=P.get('view'); if(v && ['gantt','sequence','drift','plans'].includes(v)) state.view=v;
-  // deep-link a span's inspector (reachable from every proposal)
-  const sp=P.get('span'); if(sp){ state.drawerSpan=sp; state.drawerOpen=true; if(state.proposal==='observatory') state.view='sequence'; } })();
+  const v=P.get('view'); if(v && ['gantt','instruments'].includes(v)) state.view=v;
+  const s=P.get('session'); if(s && SESSIONS[s]) state.sessionId=s;
+  // deep-link a span's inspector
+  const sp=P.get('span'); if(sp){ state.drawerSpan=sp; state.drawerOpen=true; }
+  // deep-link a reel version (strata index) to drive the DAG
+  const pv=P.get('ver'); if(pv!=null && SESSIONS[state.sessionId].plan.strata[+pv]) state.planVer=+pv; })();
 const S = () => SESSIONS[state.sessionId];
 
 function statusPill(s){ return s.status==='live' ? `<span class="dn-pill live">● live</span>`
@@ -525,7 +625,7 @@ function transportHTML(){
     <span class="hg-transport-spacer"></span>
     <span class="prop-note">zoom: fit · scrubbing disabled in the mock</span></div>`;
 }
-function drawerHTML(float){ const s=S(); const sp = s.spans.find(x=>x.id===state.drawerSpan);
+function drawerHTML(){ const s=S(); const sp = s.spans.find(x=>x.id===state.drawerSpan);
   let body;
   if(sp){ body = `
     <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px">
@@ -553,7 +653,6 @@ function drawerHTML(float){ const s=S(); const sp = s.spans.find(x=>x.id===state
     <div class="hg-drawer-header"><span class="hg-drawer-title">${sp?sp.label:'session'}</span>
       <button class="hg-drawer-close" id="drawer-close" title="close">×</button></div>
     <div class="hg-drawer-body">${body}</div></div>`;
-  if(float){ if(!state.drawerSpan) return ''; return `<div class="hg-drawer-float">${inner}</div>`; }
   return `<div class="hg-drawer-host ${state.drawerOpen?'open':''}">${inner}</div>`;
 }
 function pickerHTML(){ if(!state.picker) return '';
@@ -562,94 +661,72 @@ function pickerHTML(){ if(!state.picker) return '';
     <div class="hg-picker-list"><div class="hg-picker-section">sessions</div>
     ${Object.values(SESSIONS).map(s=>`<button class="hg-picker-row" data-sess="${s.id}" aria-selected="${s.id===state.sessionId}">
       ${fpSVG(s,30)}<span><span class="hg-picker-row-title">${s.id}</span><br><span class="hg-picker-row-sub">${s.goal}</span></span>
-      <span class="hg-picker-row-meta">${s.status}</span></button>`).join('')}</div></div></div>`;
+      <span class="hg-picker-row-meta">${s.status}</span></button>`).join('')}
+    <div class="hg-picker-section" style="padding-bottom:10px;text-transform:none;letter-spacing:0">
+      fingerprint: x = plan progress · y = drift, damped — tight = harmonic, scribble = drifting,
+      outward spiral = diverging; the dot is status, earned</div></div></div></div>`;
 }
 
-/* ----- proposal A: the observatory ----- */
-function mainObservatory(){ const s=S();
-  if(state.view==='gantt') return `<h3>execution — gantt</h3><div class="gantt-click">${ganttSVG(s,{selected:state.drawerSpan})}</div>
-    <h3>judge heartbeat</h3>${heartSVG(s)}`;
-  if(state.view==='sequence') return `<h3>sequence — who said what to whom, when</h3>
-    <div class="panes-2"><div class="gantt-click"><h3 style="margin-top:0">time-ordered</h3>${seqDiagramSVG(s)}</div>
-      <div><h3 style="margin-top:0">topology — who initiates, who receives</h3>${topoChordSVG(s,300)}</div></div>`;
-  if(state.view==='drift') return `<h3>drift seismograph</h3>${seismoSVG(s,['coder','reviewer','planner'])}
-    <div class="panes-2"><div><h3>intervention ladder</h3>${ladderSVG(s.ladder,460)}</div>
-    <div><h3>judge heartbeat</h3>${heartSVG(s,460)}</div></div>`;
-  return `<h3>plan DAG — interdependence (the critical path is the spine)</h3>${dagSVG(s.plan)}
-    <h3>plan strata — revisions as sediment</h3>${strataSVG(s.plan)}
-    <h3>plan reel — remaining work across revisions</h3>${reelSVG(s.plan)}`;
+/* ----- the plan block: the reel sits DIRECTLY ABOVE the DAG, sharing the same
+   horizontal alignment, and each reel version drives the DAG below it. The DAG
+   lives in its own host so a reel click re-renders ONLY the DAG (digest-gated —
+   no full re-render, no flash). ----- */
+function planBlockHTML(s){ const sel=state.planVer, ver=s.plan.strata[sel];
+  return `<h3>plan reel — pick a revision to drive the DAG below</h3>
+    <div class="reel-host">${reelSVG(s.plan, 940, sel)}</div>
+    <h3>plan DAG — ${ver.v}'s plan · interdependence (the critical path is the spine)</h3>
+    <div id="dag-host">${dagSVG(s.plan, 940, {vi:sel})}</div>`;
+}
+/* re-render ONLY the DAG host + the reel's active marks — local UI state, no
+   structural repaint of the rest of the console. */
+function repaintPlan(){ const s=S(), host=document.getElementById('dag-host');
+  if(!host) return; host.innerHTML=dagSVG(s.plan, 940, {vi:state.planVer});
+  const h3=host.previousElementSibling; if(h3&&h3.tagName==='H3')
+    h3.textContent=`plan DAG — ${s.plan.strata[state.planVer].v}'s plan · interdependence (the critical path is the spine)`;
+  const reel=document.querySelector('.reel-host'); if(reel){ reel.innerHTML=reelSVG(s.plan,940,state.planVer); wireReel(reel); }
+}
+/* ----- the two rail views ----- */
+function mainHybrid(){ const s=S();
+  if(state.view==='gantt')
+    // the gantt stands alone: the one hero reading, full size, nothing competing
+    return `<h3>execution — gantt</h3><div class="gantt-click">${ganttSVG(s,{selected:state.drawerSpan})}</div>
+      <h3>judge heartbeat</h3>${heartSVG(s)}`;
+  // the instruments: everything that is NOT the gantt, coalesced into one
+  // mission-control scroll — THE PLAN LEADS (reel → DAG), then conversation,
+  // topology, and ONE coordinated time-track stack: drift+judge seismograph
+  // over the time-aligned intervention ladder.
+  return `<div class="sess-head">${fpSVG(s,58)}<div><div class="sess-title">${s.id}</div>
+      <div style="font-size:11px;color:var(--ink-faint)">${s.goal}</div></div>
+      <span style="flex:1"></span><span class="sess-stats">${statusPill(s)}
+      <span class="dn-pill flat tnum">${s.spans.length} spans</span><span class="dn-pill flat tnum">${s.now}s</span></span></div>
+    ${planBlockHTML(s)}
+    <div class="panes-2"><div class="gantt-click"><h3>sequence — who said what to whom, when</h3>${seqDiagramSVG(s,{W:520,H:380})}</div>
+      <div><h3>topology — who initiates, who receives</h3>${topoChordSVG(s,300)}
+        <p class="prop-note" style="margin:6px 2px 0;line-height:1.5">hover an agent to <b>project</b> its
+        conversations (click to pin · click away to clear) · ribbon width grows with √count and caps, so heavy
+        traffic can never flood the figure</p></div></div>
+    <h3>drift seismograph + judge heartbeat — one instrument, one time axis</h3>
+    <div class="track-stack">${seismoSVG(s,['coder','reviewer','planner'],940,{axis:false})}
+      <div class="track-sub">interventions, time-aligned beneath the drift above ↓</div>
+      ${ladderSVG(s.ladder,940,s)}</div>`;
 }
 function railHTML(){
-  const items=[['gantt','▤'],['sequence','♒'],['drift','〰'],['plans','⧉']];
+  const items=[['gantt','▤'],['instruments','⧉']];
   return `<nav class="hg-rail">${items.map(([v,ic])=>
     `<button class="hg-rail-item" data-view="${v}" aria-selected="${state.view===v}"><span class="hg-rail-icon">${ic}</span><span>${v}</span></button>`).join('')}</nav>`;
 }
-function appObservatory(){
-  return topbarHTML()+stripHTML()+`<div class="app-body p-observatory">${railHTML()}
-    <main class="app-main">${mainObservatory()}</main>${drawerHTML()}</div>`+transportHTML();
-}
-/* ----- proposal B: the score (sequence-first) -----
-   The corrected sequence diagram IS the view; the gantt is a minimap; drift,
-   topology, plans, and interventions ride the margin so every piece of session
-   information the other proposals surface is reachable here too. */
-function appScore(){ const s=S();
-  return topbarHTML()+`<div class="app-body p-score">
-    <div class="minimap">${ganttSVG(s,{mini:true})}</div>
-    <main class="app-main gantt-click"><h3>the sequence diagram — who said what to whom, when</h3>${seqDiagramSVG(s,{W:760,H:430})}
-      <h3>plan DAG — interdependence</h3>${dagSVG(s.plan)}
-      <h3>plan strata — revisions as sediment</h3>${strataSVG(s.plan)}</main>
-    <aside class="margin-col"><h4>session</h4>
-      <div style="text-align:center">${fpSVG(s,84)}</div>
-      <div style="text-align:center;margin:4px 0 8px">${statusPill(s)}</div>
-      <h4>topology — who initiates</h4>${topoChordSVG(s,186)}
-      <h4>drift margin — coder</h4>${seismoSVG(s,['coder'],186)}
-      <h4>interventions</h4>
-      ${(s.ticks.coder||[]).map(([t,l])=>`<div class="margin-item">◆ ${l} <span class="tnum" style="color:var(--ink-faint)">@${t}s</span></div>`).join('')||'<div class="margin-item" style="font-style:italic">none</div>'}
-      <h4>escalation ladder</h4>${ladderSVG(s.ladder,186)}
-      <h4>remaining work</h4>${reelSVG(s.plan,186)}
-      <h4>heartbeat</h4>${heartSVG(s,186)}
-      <p class="prop-note" style="margin-top:8px">click any span → inspector</p></aside>
-  </div>`+drawerHTML(true)+transportHTML();
-}
-/* ----- proposal C: mission control ----- */
-function appMission(){ const s=S();
-  return topbarHTML()+`<div class="app-body p-mission">
-    <aside class="fleet"><h4>fleet · ${Object.keys(SESSIONS).length} sessions</h4>
-      ${Object.values(SESSIONS).map(x=>`<button class="fleet-item" data-sess="${x.id}" aria-selected="${x.id===state.sessionId}">
-        ${fpSVG(x,44)}<span style="min-width:0"><span class="fleet-name">${x.id}</span><span class="fleet-sub">${x.status} · ${x.spans.length} spans</span></span></button>`).join('')}
-      <h4 style="margin-top:14px">why fingerprints</h4>
-      <div class="margin-item" style="font-size:9.5px">x = plan progress · y = drift, damped. tight = harmonic; scribble = drifting; outward spiral = diverging. the dot is status, earned.</div></aside>
-    <main class="app-main">
-      <div class="sess-head">${fpSVG(s,58)}<div><div class="sess-title">${s.id}</div>
-        <div style="font-size:11px;color:var(--ink-faint)">${s.goal}</div></div>
-        <span style="flex:1"></span><span class="sess-stats">${statusPill(s)}
-        <span class="dn-pill flat tnum">${s.spans.length} spans</span><span class="dn-pill flat tnum">${s.now}s</span></span></div>
-      <h3>execution</h3><div class="gantt-click">${ganttSVG(s,{compact:true,selected:state.drawerSpan})}</div>
-      <div class="panes-2"><div class="gantt-click"><h3>sequence — who said what to whom</h3>${seqDiagramSVG(s,{W:520,H:360})}</div>
-        <div><h3>topology — who initiates</h3>${topoChordSVG(s,300)}</div></div>
-      <h3>drift</h3>${seismoSVG(s,['coder'])}
-      <h3>judge heartbeat</h3>${heartSVG(s)}
-      <div class="panes-2"><div><h3>intervention ladder</h3>${ladderSVG(s.ladder,460)}</div>
-        <div><h3>plan reel</h3>${reelSVG(s.plan,460)}</div></div>
-      <h3>plan DAG — interdependence</h3>${dagSVG(s.plan)}
-      <h3>plan strata — revisions as sediment</h3>${strataSVG(s.plan)}
-    </main></div>`+drawerHTML(true)+transportHTML();
+function appHybrid(){
+  return topbarHTML()+stripHTML()+`<div class="app-body">${railHTML()}
+    <main class="app-main">${mainHybrid()}</main>${drawerHTML()}</div>`+transportHTML();
 }
 
 /* ----- render + wire ----- */
 function render(){
   const app=document.getElementById('app');
-  app.innerHTML = (state.proposal==='observatory'?appObservatory():state.proposal==='score'?appScore():appMission()) + pickerHTML();
-  document.getElementById('prop-note').textContent = PROP_NOTES[state.proposal];
-  const sw=document.getElementById('prop-switch');
-  sw.innerHTML = Object.entries(PROPOSALS).map(([id,lbl])=>
-    `<button data-prop="${id}" aria-pressed="${state.proposal===id}">${lbl}</button>`).join('');
-  sw.querySelectorAll('button').forEach(b=>b.addEventListener('click',()=>{ state.proposal=b.dataset.prop; state.drawerSpan=null; state.drawerOpen = b.dataset.prop==='observatory'; render(); }));
+  app.innerHTML = appHybrid() + pickerHTML();
   mountBrand();
   app.querySelectorAll('.hg-rail-item').forEach(b=>b.addEventListener('click',()=>{ state.view=b.dataset.view; render(); }));
   app.querySelectorAll('[data-span]').forEach(el=>el.addEventListener('click',()=>{
-    // the inspector payload is reachable in every proposal: A docks it in the
-    // rail drawer, B & C float it as an overlay.
     state.drawerSpan=el.dataset.span; state.drawerOpen=true; render(); }));
   const dc=app.querySelector('#drawer-close'); if(dc) dc.addEventListener('click',()=>{
     if(state.drawerSpan){ state.drawerSpan=null; } else { state.drawerOpen=false; } render(); });
@@ -658,10 +735,10 @@ function render(){
   const pb=app.querySelector('#picker-backdrop'); if(pb){
     pb.addEventListener('click',e=>{ if(e.target===pb){ state.picker=false; render(); } });
     pb.querySelectorAll('[data-sess]').forEach(b=>b.addEventListener('click',()=>{
-      state.sessionId=b.dataset.sess; state.picker=false; state.drawerSpan=null; state.elapsed=S().now; render(); }));
+      state.sessionId=b.dataset.sess; state.picker=false; state.drawerSpan=null; state.planVer=0; state.elapsed=S().now; render(); }));
     const pi=app.querySelector('#picker-input'); if(pi) pi.focus(); }
-  app.querySelectorAll('.fleet-item').forEach(b=>b.addEventListener('click',()=>{
-    state.sessionId=b.dataset.sess; state.drawerSpan=null; state.elapsed=S().now; render(); }));
+  wireChord(app);
+  const rh=app.querySelector('.reel-host'); if(rh) wireReel(rh);
 }
 document.addEventListener('keydown',e=>{
   if(e.key==='Escape'){ if(state.picker){ state.picker=false; render(); } else if(state.drawerSpan){ state.drawerSpan=null; render(); } }

--- a/docs/design/zicato-ui-study/compose.html
+++ b/docs/design/zicato-ui-study/compose.html
@@ -1,0 +1,678 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="monokai">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>harmonograf — the composed console (interactive)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="_tokens.css">
+<link rel="stylesheet" href="_study.css">
+<style>
+  body { padding: 0; overflow: hidden; }
+  header.study { position: static; }
+  .prop-switch { display: inline-flex; border: 1px solid var(--rule); border-radius: 6px; overflow: hidden; }
+  .prop-switch button { font: inherit; font-size: 11px; color: var(--ink-soft); background: transparent;
+    border: none; border-right: 1px solid var(--rule); padding: 5px 12px; cursor: pointer; }
+  .prop-switch button:last-child { border-right: none; }
+  .prop-switch button[aria-pressed="true"] { color: var(--paper); background: var(--accent); }
+  .prop-note { font-size: 10.5px; color: var(--ink-faint); }
+
+  .app { height: calc(100vh - 59px); display: flex; flex-direction: column; min-height: 0; position: relative; }
+  .app-body { flex: 1; display: grid; min-height: 0; }
+  .app-body.p-observatory { grid-template-columns: 60px minmax(0,1fr) auto; }
+  .app-body.p-score { grid-template-columns: minmax(0,1fr) 210px; grid-template-rows: 96px minmax(0,1fr); }
+  .app-body.p-score .minimap { grid-column: 1 / -1; border-bottom: 1px solid var(--rule); padding: 4px 14px; }
+  .app-body.p-mission { grid-template-columns: 252px minmax(0,1fr); }
+  .app-main { overflow: auto; padding: 14px 18px; min-width: 0; }
+  .app-main h3 { font-size: 10.5px; text-transform: uppercase; letter-spacing: .12em; color: var(--ink-faint);
+    margin: 16px 0 8px; font-weight: 600; }
+  .app-main h3:first-child { margin-top: 0; }
+  .panes-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  @media (max-width: 1100px) { .panes-2 { grid-template-columns: 1fr; } }
+
+  .hg-drawer-host { width: 0; overflow: hidden; transition: width .16s ease; }
+  .hg-drawer-host.open { width: 320px; }
+  .hg-drawer-host .hg-drawer { width: 320px; }
+  /* the inspector as a floating overlay — used by proposals B & C so the
+     span-payload is reachable everywhere without disturbing their layout */
+  .hg-drawer-float { position: absolute; top: 64px; right: 14px; width: 320px; z-index: 30;
+    background: var(--panel); border: 1px solid var(--rule); border-radius: var(--r-card);
+    box-shadow: 0 0 0 1px var(--rule-soft); max-height: calc(100vh - 150px); overflow: auto; }
+  .hg-drawer-float .hg-drawer { width: 320px; }
+  .hg-drawer-close { background: transparent; border: none; color: var(--ink-faint); cursor: pointer;
+    font: inherit; font-size: 14px; padding: 2px 6px; border-radius: 4px; }
+  .hg-drawer-close:hover { color: var(--ink); background: var(--rule-soft); }
+
+  .margin-col { border-left: 1px solid var(--rule); background: var(--panel); overflow-y: auto; padding: 12px; }
+  .margin-col h4 { font-size: 9.5px; text-transform: uppercase; letter-spacing: .12em; color: var(--ink-faint); margin: 12px 0 6px; }
+  .margin-col h4:first-child { margin-top: 0; }
+  .margin-item { font-size: 10.5px; color: var(--ink-soft); margin: 4px 0; }
+
+  .fleet { border-right: 1px solid var(--rule); background: var(--panel); overflow-y: auto; padding: 10px; }
+  .fleet h4 { font-size: 9.5px; text-transform: uppercase; letter-spacing: .12em; color: var(--ink-faint); margin: 4px 4px 8px; }
+  .fleet-item { display: flex; align-items: center; gap: 9px; width: 100%; text-align: left; font: inherit;
+    background: transparent; border: 1px solid transparent; border-radius: var(--r-card); padding: 7px 8px;
+    cursor: pointer; color: var(--ink-soft); margin-bottom: 4px; }
+  .fleet-item:hover { border-color: var(--rule); }
+  .fleet-item[aria-selected="true"] { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, transparent); }
+  .fleet-item svg { flex: none; }
+  .fleet-name { font-size: 11.5px; color: var(--ink); display: block; }
+  .fleet-sub { font-size: 9.5px; color: var(--ink-faint); display: block; margin-top: 1px; }
+
+  .sess-head { display: flex; align-items: center; gap: 14px; margin-bottom: 6px; }
+  .sess-title { font-size: 15px; font-weight: 700; }
+  .sess-stats { display: flex; gap: 6px; flex-wrap: wrap; }
+
+  .sq-act { fill-opacity: .55; } .sq-act:hover { fill-opacity: 1; }
+  .sq-staff { stroke: var(--rule); stroke-width: 1; vector-effect: non-scaling-stroke; }
+  .sq-life { stroke: var(--rule); stroke-width: 1.1; stroke-dasharray: 1 4; vector-effect: non-scaling-stroke; }
+  .sq-chip { fill: var(--panel); stroke: var(--rule); }
+  .sq-msg { fill: none; stroke-width: 1.4; vector-effect: non-scaling-stroke; }
+  .sq-head { stroke-width: 1.2; fill: none; vector-effect: non-scaling-stroke; }
+  .sq-name { fill: var(--ink); font-size: 10px; font-weight: 500; }
+  .sq-lbl { fill: var(--ink-soft); font-size: 8.5px; }
+  .gm-onplan { stroke: var(--ink-faint); stroke-width: 1; stroke-dasharray: 3 3; vector-effect: non-scaling-stroke; }
+  .gm-tol { fill: var(--good); fill-opacity: .07; }
+  .gm-trace { stroke: var(--ink); stroke-width: 1.3; fill: none; vector-effect: non-scaling-stroke; }
+  .gm-excursion { fill: var(--bad); fill-opacity: .14; }
+  .gm-tick { stroke: var(--caution); stroke-width: 1.5; vector-effect: non-scaling-stroke; }
+  .gm-tick-label { fill: var(--caution); font-size: 8.5px; }
+  .gm-label { fill: var(--ink-soft); font-size: 10px; }
+  .gm-faint { fill: var(--ink-faint); font-size: 9px; }
+  .gm-axis { fill: var(--ink-faint); font-size: 9px; font-variant-numeric: tabular-nums; }
+  .gm-seam { stroke: var(--rule); stroke-width: 1; stroke-dasharray: 5 4; vector-effect: non-scaling-stroke; }
+  .gm-spine { stroke: var(--accent); stroke-width: 2.2; vector-effect: non-scaling-stroke; }
+  .gantt-click .hg-gantt-bar, .gantt-click .sq-act { cursor: pointer; }
+</style>
+</head>
+<body>
+
+<header class="study">
+  <span class="brand-row"><span data-brand-mark="22"></span><span data-brand-wordmark></span></span>
+  <h1>the composed console</h1>
+  <span class="prop-note" id="prop-note"></span>
+  <span class="spacer"></span>
+  <span class="prop-switch" id="prop-switch" role="group" aria-label="UI proposal"></span>
+  <span class="theme-pick-label">theme</span>
+  <span data-theme-picker></span>
+</header>
+
+<div class="app" id="app"></div>
+
+<script>
+/* ===== theme picker (study-standard) ===== */
+window.THEME_IDS = ['monokai','solarized-dark','solarized-light','google-light','google-dark',
+  'lunaria-light','lunaria-eclipse','belafonte-day','belafonte-night','paper','zenburn',
+  'selenized-black','relaxed','espresso','dracula','ubuntu'];
+const THEME_SWATCHES = {
+  'monokai':['#1e1f1c','#272822','#f8f8f2','#a6e22e','#f92672','#66d9ef'],
+  'solarized-dark':['#04222B','#0A2D38','#93A1A1','#8BB80E','#E0483C','#2AA198'],
+  'solarized-light':['#FDF6E3','#FBF1D6','#586E75','#6B9B0B','#DC322F','#268BD2'],
+  'google-light':['#FFFFFF','#F4F4F4','#474A4E','#34A853','#EA4335','#1B9CB8'],
+  'google-dark':['#202124','#2C2D30','#FFFFFF','#34A853','#EA4335','#24C1E0'],
+  'lunaria-light':['#EBE4E1','#E2DCD9','#363434','#497D46','#783C1F','#3778A9'],
+  'lunaria-eclipse':['#323F46','#3B484F','#DFE2ED','#BEDBC1','#BA9088','#C8429F'],
+  'belafonte-day':['#D5CCBA','#CCC3B2','#34292D','#6E6A4E','#BE100E','#426A79'],
+  'belafonte-night':['#20111B','#271821','#D5CCBA','#A6A07A','#D6403E','#6F8E97'],
+  'paper':['#F2EEDE','#E6E2D3','#1A1A1A','#216609','#CC3E28','#1E6FCC'],
+  'zenburn':['#3A3A3A','#424241','#DCDCCC','#8FB28F','#CC9393','#8CD0D3'],
+  'selenized-black':['#181818','#202020','#DEDEDE','#83C746','#FF5E56','#56D8C9'],
+  'relaxed':['#353A44','#3D424B','#F7F7F7','#A0AC77','#BC5653','#7EAAC7'],
+  'espresso':['#323232','#3A3A3A','#FFFFFF','#A5C261','#D25252','#6C99BB'],
+  'dracula':['#282A36','#343746','#F8F8F2','#50FA7B','#FF5555','#BD93F9'],
+  'ubuntu':['#300A24','#3D1530','#EEEEEC','#8AE234','#CC0000','#34E2E2'],
+};
+const THEME_LABELS = {'monokai':'Monokai','solarized-dark':'Solarized Dark','solarized-light':'Solarized Light',
+  'google-light':'Google Light','google-dark':'Google Dark','lunaria-light':'Lunaria Light','lunaria-eclipse':'Lunaria Eclipse',
+  'belafonte-day':'Belafonte Day','belafonte-night':'Belafonte Night','paper':'Paper','zenburn':'Zenburn',
+  'selenized-black':'Selenized Black','relaxed':'Relaxed','espresso':'Espresso','dracula':'Dracula','ubuntu':'Ubuntu'};
+const THEME_KEY = 'hgraf-study-theme';
+function swatchStrip(id, sm){ const t = THEME_SWATCHES[id] || [];
+  return `<span class="dt-swatch-strip${sm?' dt-swatch-strip-sm':''}">`+t.map(c=>`<span class="dt-swatch" style="background:${c}"></span>`).join('')+`</span>`; }
+function currentTheme(){ return document.documentElement.getAttribute('data-theme') || 'monokai'; }
+function applyTheme(id){ document.documentElement.setAttribute('data-theme', id);
+  try { localStorage.setItem(THEME_KEY, id); } catch(e){}
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker); }
+function buildPicker(host){ const cur = currentTheme();
+  host.innerHTML = `<div class="dt-cd"><button class="dt-cd-trigger" aria-haspopup="listbox" aria-expanded="false">${swatchStrip(cur,true)}<span class="dt-cd-name">${THEME_LABELS[cur]}</span><span class="dt-cd-caret" aria-hidden="true">▾</span></button><div class="dt-cd-list" role="listbox" aria-label="theme">${window.THEME_IDS.map(id=>`<div class="dt-cd-option" role="option" data-id="${id}" aria-selected="${id===cur}">${swatchStrip(id)}<span class="dt-cd-name">${THEME_LABELS[id]}</span></div>`).join('')}</div></div>`;
+  const cd = host.querySelector('.dt-cd'), trig = host.querySelector('.dt-cd-trigger');
+  trig.addEventListener('click', e=>{ e.stopPropagation(); const open = cd.classList.toggle('dt-cd-open'); trig.setAttribute('aria-expanded', open); });
+  host.querySelectorAll('.dt-cd-option').forEach(o=> o.addEventListener('click', ()=>{ applyTheme(o.dataset.id); cd.classList.remove('dt-cd-open'); })); }
+document.addEventListener('click', ()=> document.querySelectorAll('.dt-cd-open').forEach(c=>c.classList.remove('dt-cd-open')));
+(function initTheme(){ let saved=null; try { saved=localStorage.getItem(THEME_KEY); } catch(e){}
+  const P=new URLSearchParams(location.search), fromUrl=P.get('theme');
+  const id=(fromUrl&&window.THEME_IDS.includes(fromUrl))?fromUrl:(saved&&window.THEME_IDS.includes(saved))?saved:'monokai';
+  document.documentElement.setAttribute('data-theme', id); })();
+
+/* harmonograf brand — the Option-D alpha: one period of the 2:3 Lissajous,
+   MIRRORED about the vertical axis (x = cx − A·cos2t, y = cy + B·sin3t) so the
+   knot reads as a lowercase α — still a Lissajous, loop left, tails right.
+   Stroke currentColor; the one dot rides the lower-right tail tip: the pen at
+   rest. ONE ALPHA PER LOCKUP: beside this mark the wordmark is PLAIN LETTERS
+   (the glyph already carries the α and the dot); only a STANDALONE wordmark
+   spells the "a" of graf with the drawn α. */
+function hgAlphaPath(cx, cy, A, B){ const pts=[];
+  for(let i=0;i<=240;i++){ const t=2*Math.PI*i/240;
+    pts.push((cx - A*Math.cos(2*t)).toFixed(2)+','+(cy + B*Math.sin(3*t)).toFixed(2)); }
+  return 'M'+pts.join(' L')+' Z'; }
+function hgBrandMarkSVG(h){ return `<svg class="hg-brand-mark" style="height:${h||24}px" viewBox="0 0 48 48" role="img" aria-label="harmonograf" focusable="false"><path d="${hgAlphaPath(24,24,19,15)}" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/><circle cx="43" cy="39" r="3.2" fill="var(--hgraf-brand, #5EA3EC)"/></svg>`; }
+function hgWordmarkSVG(){ const T='harmonograf', X0=1, ADV=9.6, BASE=15; const W=X0*2+T.length*ADV;
+  return `<svg class="hg-brand-name" viewBox="0 0 ${W} 18" role="img" aria-label="harmonograf" focusable="false"><text x="${X0}" y="${BASE}" font-family="var(--brand-mono)" font-size="15" font-weight="700" textLength="${T.length*ADV}" lengthAdjust="spacing" fill="currentColor" xml:space="preserve">${T}</text></svg>`; }
+function mountBrand(){ document.querySelectorAll('[data-brand-mark]').forEach(n=>{ n.innerHTML=hgBrandMarkSVG(+n.dataset.brandMark||24); });
+  document.querySelectorAll('[data-brand-wordmark]').forEach(n=>{ n.innerHTML=hgWordmarkSVG(); }); }
+
+/* ===================================================================== */
+/* ===== mock data: four sessions, one rich =============================*/
+const KIND = k => `var(--hg-kind-${k})`;
+function lerpKeys(keys, t){ if(t<=keys[0][0]) return keys[0][1];
+  for(let i=1;i<keys.length;i++){ if(t<=keys[i][0]){ const [t0,v0]=keys[i-1],[t1,v1]=keys[i];
+    return v0+(v1-v0)*(t-t0)/(t1-t0); } } return keys[keys.length-1][1]; }
+function lcg(seed){ let s=seed>>>0; return ()=>((s=(s*1664525+1013904223)>>>0)/4294967296); }
+
+const PRIMARY = {
+  id: 'checkout-refactor', status: 'live', T: 96, now: 80,
+  goal: 'refactor checkout to the streaming api',
+  agents: ['planner','coder','tester','reviewer','goldfive'],
+  fp: {fx:3.0, fy:2.03, px:Math.PI/2, d:.013, corrAt:13},
+  spans: [
+    {id:'s2', agent:'planner', kind:'user-message', t0:0,  t1:3,  label:'user: refactor checkout → streaming', status:'done'},
+    {id:'s3', agent:'planner', kind:'llm-call',     t0:3,  t1:14, label:'draft plan v1', status:'done'},
+    {id:'s4', agent:'planner', kind:'agent-message',t0:14, t1:16, label:'plan posted', status:'done'},
+    {id:'s5', agent:'coder',   kind:'llm-call',     t0:18, t1:30, label:'implement core', status:'done'},
+    {id:'s6', agent:'coder',   kind:'tool-call',    t0:30, t1:38, label:'edit 12 files', status:'done'},
+    {id:'s7', agent:'coder',   kind:'tool-call',    t0:38, t1:44, label:'tsc --noEmit', status:'failed'},
+    {id:'s8', agent:'coder',   kind:'llm-call',     t0:44, t1:54, label:'fix types', status:'done'},
+    {id:'sD', agent:'tester',  kind:'tool-call',    t0:56, t1:68, label:'run suite · 38k tok (delegated)', status:'done'},
+    {id:'s9', agent:'reviewer',kind:'llm-call',     t0:72, t1:76, label:'review diff', status:'done'},
+    {id:'sW', agent:'reviewer',kind:'wait-for-human',t0:76,t1:80, label:'approve api change', status:'awaiting'},
+    {id:'sG1',agent:'goldfive',kind:'custom',       t0:20, t1:22, label:'judge · on-task', status:'done', gf:'judge-on-task'},
+    {id:'sG2',agent:'goldfive',kind:'custom',       t0:40, t1:42, label:'judge · warning (drift 14)', status:'done', gf:'judge-warning'},
+    {id:'sG3',agent:'goldfive',kind:'custom',       t0:42, t1:46, label:'refine · re-anchor plan', status:'done', gf:'refine'},
+    {id:'sG4',agent:'goldfive',kind:'custom',       t0:60, t1:62, label:'judge · on-task', status:'done', gf:'judge-on-task'},
+    {id:'sP1',agent:'coder',   kind:'planned',      t0:84, t1:90, label:'lint pass', status:'planned'},
+    {id:'sP2',agent:'reviewer',kind:'planned',      t0:88, t1:94, label:'merge', status:'planned'},
+    {id:'sR', agent:'coder',   kind:'llm-call',     t0:80, t1:96, label:'address review notes', status:'running'},
+  ],
+  transfers: [ {t:16, from:'planner', to:'coder'}, {t:70, from:'coder', to:'reviewer'} ],
+  delegation: {from:'coder', to:'tester', t0:54, t1:70, tokens:'38k', verdict:'✓ 214 passed'},
+  judges: {
+    coder:    [[0,1],[6,2],[10,3],[13,11],[15,14],[17,6],[22,3],[26,2],[30,4],[36,12],[40,15],[44,7],[52,3],[64,2],[80,2]],
+    reviewer: [[0,1],[20,2],[40,2],[60,3],[70,6],[76,4],[80,3]],
+    planner:  [[0,.5],[12,1.5],[30,1],[50,2],[80,1]],
+  },
+  ticks: { coder: [[35,'nudge · operator'],[42,'refine · goldfive']], reviewer: [], planner: [] },
+  ladder: [[35,0],[42,1]],
+  ctx: [[0,.10],[18,.22],[30,.44],[44,.62],[54,.78],[55,.34],[68,.5],[80,.62],[96,.66]],
+  heart: (()=>{ const r=lcg(7), e=[]; for(let i=0;i<30;i++){ const t=2+i*2.5+r();
+    e.push([t, (i===12||i===13)?'warn':(i===15?'crit':'ok')]); } return e; })(),
+  plan: {
+    nodes: { 'design-api':{x:0,y:0,st:'done'}, 'impl-core':{x:1,y:0,st:'done'}, 'wire-cli':{x:2,y:-1,st:'running'},
+             'run-suite':{x:2,y:1,st:'done'}, 'polish-ux':{x:3,y:0,st:'pending'}, 'write-docs':{x:1,y:2,st:'ghost'} },
+    edges: [ ['design-api','impl-core',1],['impl-core','wire-cli',1],['impl-core','run-suite',0],
+             ['wire-cli','polish-ux',1],['run-suite','polish-ux',0],['design-api','write-docs','ghost'] ],
+    strata: [ {v:'v3 · live', has:['T1','T2','T4','T6','T7'], added:['T7'], live:true},
+              {v:'v2', has:['T1','T2','T4','T5','T6'], added:['T6'], seam:'replan · goal-drift'},
+              {v:'v1', has:['T1','T2','T3','T4','T5'], added:[], seam:'replan · scope-creep'} ],
+    rem: [12,9,5,2],
+  },
+};
+function makeVariant(id){
+  const s = JSON.parse(JSON.stringify(PRIMARY)); s.id = id;
+  if(id==='nightly-eval'){ s.status='done'; s.now=96; s.goal='nightly eval sweep · board 7';
+    s.fp={fx:3.0, fy:2.02, px:Math.PI/2, d:.025};
+    s.spans=s.spans.filter(x=>x.status!=='planned').map(x=>({...x,
+      status: (x.status==='awaiting'||x.status==='running'||x.status==='failed')?'done':x.status,
+      label: x.id==='s7'?'tsc --noEmit ✓':x.label}));
+    s.judges.coder=[[0,1],[20,3],[40,2],[60,3],[80,2],[96,1]]; s.ticks.coder=[]; s.ladder=[];
+  }
+  if(id==='data-migration'){ s.status='failed'; s.now=64; s.T=64; s.goal='migrate orders db → v2 schema';
+    s.fp={fx:2.6, fy:1.7, px:.3, d:-.012, T:26, grow:true};
+    s.spans=s.spans.filter(x=>x.t0<54&&x.status!=='planned'&&x.status!=='running').map(x=>({...x,
+      status:x.status==='awaiting'?'failed':x.status}));
+    s.spans.push({id:'sF', agent:'coder', kind:'llm-call', t0:54, t1:62, label:'rollback — irrecoverable', status:'failed'});
+    s.judges.coder=[[0,2],[10,5],[20,9],[30,13],[40,16],[50,19],[60,22],[64,24]];
+    s.ticks.coder=[[22,'nudge'],[34,'refine'],[46,'replan']]; s.ladder=[[22,0],[34,1],[46,2],[58,3]];
+  }
+  if(id==='docs-sweep'){ s.status='live'; s.now=40; s.T=64; s.goal='sweep + regenerate user docs';
+    s.fp={fx:1.0, fy:1.0, px:Math.PI/2, d:.02};
+    s.spans=s.spans.filter(x=>['s2','s3','s4','s5','s6'].includes(x.id));
+    s.spans.push({id:'sR', agent:'coder', kind:'tool-call', t0:34, t1:64, label:'render docs', status:'running'});
+    s.judges.coder=[[0,1],[10,2],[20,1.5],[30,2],[40,2]]; s.ticks.coder=[]; s.ladder=[];
+  }
+  return s;
+}
+const SESSIONS = { 'checkout-refactor': PRIMARY, 'nightly-eval': makeVariant('nightly-eval'),
+  'data-migration': makeVariant('data-migration'), 'docs-sweep': makeVariant('docs-sweep') };
+
+/* ===== figure renderers (all token-only, fit-to-width) ===== */
+function fpSVG(s, size){
+  const o=s.fp, n=800, T=o.T||30, pts=[];
+  for(let i=0;i<=n;i++){ const t=T*i/n;
+    let m = o.grow ? .3+.55*t/T : (o.corrAt!=null ? (t<o.corrAt?1:(t<o.corrAt+3?1-(t-o.corrAt)/3*.55:.45)) : 1);
+    pts.push([32+24*m*Math.exp(-(o.d||0)*t)*Math.sin(o.fx*t+(o.px||0)), 32+24*m*Math.exp(-(o.d||0)*t)*Math.sin(o.fy*t)]); }
+  const end=pts[pts.length-1];
+  const dot = s.status==='failed' ? 'var(--bad)' : s.status==='done' ? 'var(--good)' : 'var(--accent)';
+  return `<svg width="${size}" height="${size}" viewBox="0 0 64 64" role="img" aria-label="fingerprint ${s.id}">
+    <path d="M${pts.map(p=>p[0].toFixed(1)+','+p[1].toFixed(1)).join(' L')}" fill="none" stroke="currentColor" stroke-width="0.9" opacity=".7"/>
+    <circle cx="${end[0].toFixed(1)}" cy="${end[1].toFixed(1)}" r="2.4" fill="${dot}"/></svg>`;
+}
+function ganttSVG(s, o){ // o: {compact, mini, selected}
+  o=o||{}; const W=940, rowH=o.compact?24:30, padL=o.mini?8:76, padR=14;
+  const agents = o.mini ? s.agents.filter(a=>a!=='goldfive') : s.agents;
+  const H = agents.length*rowH + (o.mini?10:30), X=t=>padL+(W-padL-padR)*t/s.T;
+  const Y={}; agents.forEach((a,i)=>Y[a]= (o.mini?5:12)+i*rowH+rowH/2);
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="execution gantt — ${s.id}">`;
+  if(!o.mini){ for(let i=0;i<=8;i++){ const gx=X(s.T*i/8);
+    g+=`<line class="hg-gantt-grid" x1="${gx}" y1="6" x2="${gx}" y2="${H-22}"/><text class="gm-axis" x="${gx-7}" y="${H-8}">${Math.round(s.T*i/8)}s</text>`; } }
+  agents.forEach(a=>{ const y=Y[a];
+    if(!o.mini) g+=`<text class="hg-gantt-lane-label" x="6" y="${y+3}">${a}</text>`;
+    g+=`<line class="hg-gantt-lane-sep" x1="${padL}" y1="${y+rowH/2-2}" x2="${W-padR}" y2="${y+rowH/2-2}" opacity=".35"/>`; });
+  if(!o.mini && !o.compact && s.ctx && Y.coder){ const y=Y.coder+rowH/2-3;
+    let d='M'+X(0)+','+y; s.ctx.forEach(([t,v])=>{ if(t<=s.T) d+=` L${X(t).toFixed(1)},${(y-v*9).toFixed(1)}`; });
+    g+=`<path d="${d}" fill="none" stroke="var(--caution)" stroke-width="0.8" opacity=".5" vector-effect="non-scaling-stroke"><title>coder context window · compaction at 54s</title></path>`; }
+  s.spans.forEach(sp=>{ if(!Y[sp.agent]) return; const y=Y[sp.agent], x0=X(sp.t0), w=Math.max(4,X(sp.t1)-x0), bh=o.mini?6:12;
+    const fill = sp.status==='failed' ? 'var(--bad)' : sp.gf ? `var(--hg-gf-${sp.gf})` : KIND(sp.kind);
+    let cls='hg-gantt-bar is-'+sp.kind + (sp.status==='running'?' is-running':'') + (sp.status==='planned'?' is-planned':'')
+      + (o.selected===sp.id?' is-selected':'');
+    let extra = sp.status==='awaiting' ? ` stroke="${KIND('wait-for-human')}" stroke-dasharray="3 2" stroke-width="1.2"` : '';
+    g+=`<rect class="${cls}" data-span="${sp.id}" x="${x0}" y="${y-bh/2}" width="${w}" height="${bh}" rx="3"${sp.status==='planned'?'':` fill="${fill}"`}${extra} tabindex="${o.mini?-1:0}"><title>${sp.agent} · ${sp.label} · ${sp.t0}–${sp.t1}s · ${sp.status}</title></rect>`;
+    if(!o.mini && sp.status==='failed') g+=`<text class="hg-gantt-glyph-fail" x="${x0+w-11}" y="${y-bh/2-2}">✕</text>`;
+    if(!o.mini && sp.status==='awaiting') g+=`<text class="hg-gantt-glyph-wait" x="${x0+w+3}" y="${y+3.5}">◷</text>`; });
+  if(!o.mini){ s.transfers.forEach(tr=>{ if(!Y[tr.from]||!Y[tr.to]) return; const x=X(tr.t);
+    g+=`<path class="hg-gantt-edge is-transfer" d="M${x},${Y[tr.from]+7} C ${x+2},${(Y[tr.from]+Y[tr.to])/2} ${x+2},${(Y[tr.from]+Y[tr.to])/2} ${x+4},${Y[tr.to]-7}"><title>transfer ${tr.from} → ${tr.to}</title></path>`; });
+    if(s.delegation && Y[s.delegation.to]){ const d=s.delegation;
+      g+=`<path class="hg-gantt-edge" d="M${X(d.t0)},${Y[d.from]+7} C ${X(d.t0)+3},${Y[d.to]-20} ${X(d.t0)+3},${Y[d.to]-16} ${X(d.t0)+6},${Y[d.to]-7}"><title>delegate → ${d.to} · ${d.tokens} tok</title></path>`;
+      g+=`<path class="hg-gantt-edge" d="M${X(d.t1)-6},${Y[d.to]-7} C ${X(d.t1)-3},${Y[d.to]-16} ${X(d.t1)-3},${Y[d.to]-20} ${X(d.t1)},${Y[d.from]+7}"><title>rejoin · ${d.verdict}</title></path>`;
+      g+=`<text x="${X(d.t1)+2}" y="${Y[d.from]+18}" font-size="9" fill="var(--good)">✓</text>`; } }
+  const nx=X(Math.min(s.now,s.T));
+  g+=`<line class="hg-gantt-now" x1="${nx}" y1="4" x2="${nx}" y2="${H-(o.mini?6:22)}"/>`;
+  if(!o.mini) g+=`<circle class="hg-gantt-now-cap" cx="${nx}" cy="4" r="2.5"/><text class="hg-gantt-now-label" x="${nx+5}" y="11">now ${s.now}s</text>`;
+  g+=`</svg>`; return g;
+}
+/* ----- the agent-interaction messages, derived from the session model ----- */
+function sessionMessages(s){
+  const msgs=[];
+  const um=s.spans.find(x=>x.kind==='user-message'); if(um) msgs.push([um.t0,'user',um.agent,'user-message','user: '+s.goal.split(' ').slice(0,4).join(' ')+'…']);
+  (s.transfers||[]).forEach(tr=>msgs.push([tr.t,tr.from,tr.to,'transfer','transfer']));
+  if(s.delegation){ const d=s.delegation;
+    msgs.push([d.t0,d.from,d.to,'delegate','delegate · '+d.tokens+' tok']);
+    msgs.push([d.t1,d.to,d.from,'result',d.verdict]); }
+  const am=s.spans.find(x=>x.kind==='agent-message'); if(am) msgs.push([am.t1||am.t0,am.agent,'user','agent-message','approval requested']);
+  return msgs.sort((a,b)=>a[0]-b[0]);
+}
+/* ----- RECOMMENDED sequence diagram: lifelines down, time down, each message
+   a horizontal connector with a clear arrowhead (call=solid, return=dashed) ----- */
+function seqDiagramSVG(s, o){ o=o||{};
+  const cols=['user','planner','coder','tester','reviewer'].filter(a=>s.agents.includes(a)||a==='user');
+  const W=o.W||720, padT=52, H=o.H||440, padL=58;
+  const step=(W-padL-44)/(cols.length-1), X={}; cols.forEach((a,i)=>X[a]=padL+30+i*step);
+  const yT=t=>padT+(t/s.T)*(H-padT-26);
+  const aColor=a=> a==='user'?'var(--hg-agent-user)':a==='goldfive'?'var(--hg-agent-goldfive)'
+    :`var(--hg-agent-${['planner','coder','tester','reviewer'].indexOf(a)+1})`;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="agent-interaction sequence diagram — ${s.id}">`;
+  for(let i=0;i<=6;i++){ const y=yT(s.T*i/6);
+    g+=`<line class="hg-gantt-grid" x1="${padL-4}" y1="${y}" x2="${W-12}" y2="${y}" opacity=".5"/><text class="gm-axis" x="26" y="${y+3}">${Math.round(s.T*i/6)}s</text>`; }
+  cols.forEach(a=>{ const x=X[a];
+    g+=`<line class="sq-life" x1="${x}" y1="30" x2="${x}" y2="${H-14}" stroke="${aColor(a)}" opacity=".8"/>`;
+    g+=`<rect class="sq-chip" x="${x-34}" y="10" width="68" height="19" rx="4" stroke="${aColor(a)}"/>`;
+    g+=`<text class="sq-name" x="${x}" y="${23}" text-anchor="middle">${a}</text>`; });
+  s.spans.forEach(sp=>{ if(!X[sp.agent]||sp.status==='planned'||sp.gf) return;
+    const x=X[sp.agent], y0=yT(sp.t0), h=Math.max(6,yT(sp.t1)-y0);
+    const fill = sp.status==='failed'?'var(--bad)':sp.status==='awaiting'?KIND('wait-for-human'):KIND(sp.kind);
+    g+=`<rect class="sq-act" data-span="${sp.id}" x="${x-4}" y="${y0}" width="8" height="${h}" rx="2.5" fill="${fill}" fill-opacity="${sp.status==='awaiting'?.4:sp.status==='failed'?.85:.55}" tabindex="0"><title>${sp.agent} · ${sp.label} · ${sp.status}</title></rect>`;
+    if(sp.status==='failed') g+=`<text x="${x+9}" y="${y0+h/2+3}" font-size="8.5" fill="var(--bad)">✕</text>`; });
+  // messages with min-row-gap layout (each message its own row, time-ordered)
+  const MINGAP=24; let prevY=-1e9;
+  sessionMessages(s).forEach(([t,f,o2,k,lbl])=>{ if(!X[f]||!X[o2]) return;
+    let y=Math.max(yT(t), prevY+MINGAP); prevY=y; const x0=X[f], x1=X[o2], dir=x1>x0?1:-1;
+    const isReturn=k==='result';
+    const color = k==='transfer'?KIND('transfer'):k==='user-message'?KIND('user-message')
+      :k==='delegate'?'var(--ink-soft)':isReturn?'var(--ink-faint)':KIND('agent-message');
+    const dash = k==='transfer'?` stroke-dasharray="5 3"`:isReturn?` stroke-dasharray="4 3"`:'';
+    g+=`<line class="sq-msg" x1="${x0+4*dir}" y1="${y}" x2="${x1-9*dir}" y2="${y}" stroke="${color}"${dash}><title>${f} → ${o2} · ${lbl} · ${t}s</title></line>`;
+    const ah = isReturn
+      ? `<path d="M${x1-9*dir},${y-4} L${x1-1*dir},${y} L${x1-9*dir},${y+4}" fill="none" stroke="${color}" stroke-width="1.3" vector-effect="non-scaling-stroke"/>`
+      : `<path d="M${x1-9*dir},${y-4} L${x1-1*dir},${y} L${x1-9*dir},${y+4} Z" fill="${color}"/>`;
+    g+=ah;
+    g+=`<text class="sq-lbl" x="${x0+16*dir}" y="${y-5}" text-anchor="${dir>0?'start':'end'}" fill="${color}">${lbl}</text>`; });
+  const wait=s.spans.find(x=>x.status==='awaiting');
+  if(wait&&X[wait.agent]) g+=`<circle cx="${X[wait.agent]}" cy="${yT(Math.min(wait.t1,s.T))}" r="5.5" fill="none" stroke="var(--ink-soft)" stroke-width="1.4"><title>gate · deciding…</title></circle>`;
+  const ny=yT(Math.min(s.now,s.T));
+  g+=`<line class="hg-gantt-now" x1="${padL-4}" y1="${ny}" x2="${W-12}" y2="${ny}"/><text class="hg-gantt-now-label" x="${padL}" y="${ny-5}">now ${s.now}s</text>`;
+  g+=`</svg>`; return g;
+}
+/* ----- the directional transfer chord (communication topology) ----- */
+function topoChordSVG(s, W){ W=W||320;
+  const agents=['user','planner','coder','tester','reviewer'].filter(a=>s.agents.includes(a)||a==='user');
+  const idx=a=>agents.indexOf(a);
+  const counts={};
+  const bump=(f,o)=>{ if(idx(f)<0||idx(o)<0) return; const k=idx(f)+'>'+idx(o); counts[k]=(counts[k]||0)+1; };
+  const um=s.spans.find(x=>x.kind==='user-message'); if(um) bump('user',um.agent);
+  (s.transfers||[]).forEach(tr=>bump(tr.from,tr.to));
+  if(s.delegation){ bump(s.delegation.from,s.delegation.to); bump(s.delegation.to,s.delegation.from); }
+  const am=s.spans.find(x=>x.kind==='agent-message'); if(am) bump(am.agent,'user');
+  const flows=Object.entries(counts).map(([k,c])=>{ const [a,b]=k.split('>').map(Number); return [a,b,c]; });
+  const H=Math.round(W*0.82), cx=W/2, cyA=H-26, R=W*0.34, n=agents.length, SECTOR=Math.PI/n*0.74;
+  const ang=i=>Math.PI-Math.PI*i/(n-1), onArc=(th,r)=>[cx+r*Math.cos(th), cyA-r*Math.sin(th)];
+  const aColor=a=> a==='user'?'var(--hg-agent-user)':a==='goldfive'?'var(--hg-agent-goldfive)'
+    :`var(--hg-agent-${['planner','coder','tester','reviewer'].indexOf(a)+1})`;
+  const outN=agents.map(()=>0), inN=agents.map(()=>0); flows.forEach(([a,b,c])=>{outN[a]+=c;inN[b]+=c;});
+  const outUsed=agents.map(()=>0), inUsed=agents.map(()=>0);
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="directional transfer chord — who initiates and who receives · ${s.id}">`;
+  agents.forEach((a,i)=>{ const th=ang(i), oA=th+SECTOR/2,oB=th+0.05,iA=th-0.05,iB=th-SECTOR/2;
+    const arc=(thA,thB,attrs)=>{ const [xA,yA]=onArc(thA,R),[xB,yB]=onArc(thB,R);
+      return `<path d="M${xA.toFixed(1)},${yA.toFixed(1)} A${R},${R} 0 0 ${thA>thB?1:0} ${xB.toFixed(1)},${yB.toFixed(1)}" fill="none" ${attrs}/>`; };
+    if(outN[i]) g+=arc(oA,oB,`stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9"`);
+    if(inN[i])  g+=arc(iA,iB,`stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9" stroke-dasharray="1.5 2.4"`);
+  });
+  flows.forEach(([a,b,c],fi)=>{ const ths=ang(a),thd=ang(b);
+    const sF=(outUsed[a]+c/2)/Math.max(outN[a],1); outUsed[a]+=c;
+    const dF=(inUsed[b]+c/2)/Math.max(inN[b],1);  inUsed[b]+=c;
+    const sTh=ths+0.07+(SECTOR/2-0.07)*sF, dTh=thd-0.07-(SECTOR/2-0.07)*dF;
+    const wS=1.6,wT=Math.max(5,c*2.6), [sx,sy]=onArc(sTh,R-4),[dx,dy]=onArc(dTh,R-9);
+    const tS=[Math.sin(sTh),Math.cos(sTh)],tD=[Math.sin(dTh),Math.cos(dTh)];
+    const s1=[sx+tS[0]*wS/2,sy+tS[1]*wS/2],s2=[sx-tS[0]*wS/2,sy-tS[1]*wS/2];
+    const t1=[dx+tD[0]*wT/2,dy+tD[1]*wT/2],t2=[dx-tD[0]*wT/2,dy-tD[1]*wT/2];
+    const mid=[(sx+dx)/2+(cx-(sx+dx)/2)*0.62,(sy+dy)/2+((cyA-34)-(sy+dy)/2)*0.5], gid=`tch${s.id}${fi}`;
+    g+=`<defs><linearGradient id="${gid}" x1="${sx.toFixed(1)}" y1="${sy.toFixed(1)}" x2="${dx.toFixed(1)}" y2="${dy.toFixed(1)}" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="${aColor(a)}" stop-opacity=".32"/><stop offset="1" stop-color="${aColor(b)}" stop-opacity=".95"/></linearGradient></defs>`;
+    g+=`<path fill="url(#${gid})" stroke="none" d="M${s1[0].toFixed(1)},${s1[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${t1[0].toFixed(1)},${t1[1].toFixed(1)} L${t2[0].toFixed(1)},${t2[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${s2[0].toFixed(1)},${s2[1].toFixed(1)} Z"><title>${agents[a]} → ${agents[b]} · ${c} (${agents[a]} initiates)</title></path>`;
+    const outward=[Math.cos(dTh),-Math.sin(dTh)], tip=onArc(dTh,R-1), base=[tip[0]-outward[0]*8,tip[1]-outward[1]*8];
+    g+=`<path d="M${(base[0]+tD[0]*4).toFixed(1)},${(base[1]+tD[1]*4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(base[0]-tD[0]*4).toFixed(1)},${(base[1]-tD[1]*4).toFixed(1)} Z" fill="${aColor(b)}"/>`;
+  });
+  agents.forEach((a,i)=>{ const th=ang(i),[x,y]=onArc(th,R);
+    g+=`<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3" fill="${aColor(a)}"/>`;
+    const [lx,ly]=onArc(th,R+14), anc= lx<cx-10?'end':(lx>cx+10?'start':'middle');
+    g+=`<text class="sq-lbl" x="${lx.toFixed(1)}" y="${(ly+(ly<36?-2:4)).toFixed(1)}" text-anchor="${anc}" fill="var(--ink)">${a}</text>`; });
+  g+=`</svg>`; return g;
+}
+function seismoSVG(s, lanes, W){
+  W=W||940; const rowH=54, padL=W<400?40:76, padR=14, H=lanes.length*rowH+24, X=t=>padL+(W-padL-padR)*t/s.T, TOL=8;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="drift seismograph — ${s.id}">`;
+  for(let i=0;i<=4;i++){ const gx=X(s.T*i/4);
+    g+=`<line class="hg-gantt-grid" x1="${gx}" y1="4" x2="${gx}" y2="${H-18}"/><text class="gm-axis" x="${gx-7}" y="${H-5}">${Math.round(s.T*i/4)}s</text>`; }
+  lanes.forEach((a,li)=>{ const keys=s.judges[a]; if(!keys) return;
+    const base=10+li*rowH+rowH-16, rnd=lcg(40+li), yOf=v=>base-v*1.9;
+    g+=`<text class="gm-label" x="6" y="${base-12}">${a}</text>`;
+    g+=`<rect class="gm-tol" x="${X(0)}" y="${yOf(TOL)}" width="${X(s.T)-X(0)}" height="${yOf(0)-yOf(TOL)}"/>`;
+    g+=`<line class="gm-onplan" x1="${X(0)}" y1="${base}" x2="${X(s.T)}" y2="${base}"/>`;
+    const pts=[]; for(let i=0;i<=260;i++){ const t=s.T*i/260;
+      const v=Math.max(0, lerpKeys(keys,t)+Math.sin(t*2.3+li)*0.5+(rnd()-0.5)*0.9); pts.push([X(t),yOf(v),v]); }
+    let seg=null; const segs=[];
+    pts.forEach(p=>{ if(p[2]>TOL){ if(!seg) seg=[]; seg.push(p); } else if(seg){ segs.push(seg); seg=null; } });
+    if(seg) segs.push(seg);
+    segs.forEach(sg=>{ g+=`<polygon class="gm-excursion" points="${sg.map(p=>p[0].toFixed(1)+','+p[1].toFixed(1)).join(' ')} ${sg[sg.length-1][0].toFixed(1)},${yOf(TOL).toFixed(1)} ${sg[0][0].toFixed(1)},${yOf(TOL).toFixed(1)}"/>`; });
+    g+=`<path class="gm-trace" d="M${pts.map(p=>p[0].toFixed(1)+','+p[1].toFixed(1)).join(' L')}"/>`;
+    (s.ticks[a]||[]).forEach(([t,lbl])=>{ const tx=X(t);
+      g+=`<line class="gm-tick" x1="${tx}" y1="${base-rowH+22}" x2="${tx}" y2="${base+3}"><title>intervention · ${lbl}</title></line>`;
+      g+=`<text class="gm-tick-label" x="${tx+3}" y="${base-rowH+27}">${lbl.split(' ')[0]}</text>`; }); });
+  const nx=X(Math.min(s.now,s.T));
+  g+=`<line class="hg-gantt-now" x1="${nx}" y1="4" x2="${nx}" y2="${H-18}"/>`;
+  g+=`</svg>`; return g;
+}
+function heartSVG(s, W){ W=W||940; const H=40, padL=W<400?40:76, X=t=>padL+(W-padL-14)*t/s.T;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="judge heartbeat — ${s.id}">`;
+  g+=`<text class="gm-label" x="6" y="22">judges</text>`;
+  g+=`<line class="gm-onplan" x1="${X(0)}" y1="26" x2="${X(s.T)}" y2="26"/>`;
+  s.heart.forEach(([t,k])=>{ if(t>s.T) return; const x=X(t);
+    if(k==='ok') g+=`<circle cx="${x}" cy="18" r="1.5" fill="var(--hg-gf-judge-on-task)" opacity=".75"/>`;
+    if(k==='warn') g+=`<text x="${x-3.5}" y="22" font-size="9" fill="var(--caution)">▲</text>`;
+    if(k==='crit') g+=`<text x="${x-3.5}" y="22" font-size="10" fill="var(--bad)" font-weight="700">✕</text>`; });
+  g+=`</svg>`; return g;
+}
+function ladderSVG(dots, W){ W=W||440; const H=128, padL=66, X=t=>padL+(W-padL-12)*t/96;
+  const RUNGS=['nudge','refine','replan','escalate'], rungY=i=>100-i*26;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="intervention ladder">`;
+  RUNGS.forEach((r,i)=>{ const y=rungY(i);
+    g+=`<line x1="${padL}" y1="${y}" x2="${W-12}" y2="${y}" stroke="var(--rule)" stroke-width="1" vector-effect="non-scaling-stroke"/><text class="gm-faint" x="8" y="${y+3}">${r}</text>`; });
+  if(dots.length>1) g+=`<path d="${dots.map((d,i)=>(i?'L':'M')+X(d[0]).toFixed(1)+','+rungY(d[1]).toFixed(1)).join(' ')}" fill="none" stroke="var(--ink-faint)" stroke-width="0.8" stroke-dasharray="2 3" opacity=".7" vector-effect="non-scaling-stroke"/>`;
+  dots.forEach(d=>{ g+=`<circle cx="${X(d[0])}" cy="${rungY(d[1])}" r="3.2" fill="${d[1]===3?'var(--bad)':'var(--ink-soft)'}"><title>${RUNGS[d[1]]} @ ${d[0]}s</title></circle>`; });
+  if(!dots.length) g+=`<text class="gm-faint" x="${padL+10}" y="${rungY(0)-8}" font-style="italic">no interventions — never left the ground</text>`;
+  g+=`</svg>`; return g;
+}
+function dagSVG(p, W){ W=W||940; const H=216, BW=118, BH=24;
+  const LX=[80,300,520,740], LY=v=>92+v*44;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="plan dependency DAG">`;
+  p.edges.forEach(([a,b,crit])=>{ const A=p.nodes[a], B=p.nodes[b];
+    const x0=LX[A.x]+BW/2, y0=LY(A.y), x1=LX[B.x]-BW/2, y1=LY(B.y), c=(x0+x1)/2;
+    const stroke = crit===1?'var(--accent)':'var(--ink-faint)';
+    const extra = crit==='ghost'?` stroke-dasharray="3 4" opacity=".45"`:crit===1?` stroke-width="2"`:` stroke-width="1" opacity=".6"`;
+    g+=`<path d="M${x0},${y0} C ${c},${y0} ${c},${y1} ${x1},${y1}" fill="none" stroke="${stroke}"${extra} vector-effect="non-scaling-stroke"><title>${a} → ${b}${crit===1?' · critical path':''}</title></path>`; });
+  Object.entries(p.nodes).forEach(([id,n])=>{ const x=LX[n.x], y=LY(n.y), ghost=n.st==='ghost';
+    const stroke = n.st==='done'?'var(--good)':n.st==='running'?'var(--accent)':ghost?'var(--rule)':'var(--ink-faint)';
+    const glyph = n.st==='done'?['✓','var(--good)']:n.st==='running'?['●','var(--accent)']:ghost?['✕','var(--bad)']:['○','var(--ink-faint)'];
+    g+=`<rect x="${x-BW/2}" y="${y-BH/2}" width="${BW}" height="${BH}" rx="4" fill="var(--panel)" stroke="${stroke}" stroke-width="${n.st==='running'?2:1.2}"${ghost?` stroke-dasharray="4 3" opacity=".55"`:''} vector-effect="non-scaling-stroke"><title>${id} · ${ghost?'dropped at replan v2':n.st}</title></rect>`;
+    g+=`<text x="${x-BW/2+9}" y="${y+3.5}" font-size="10" fill="${ghost?'var(--ink-faint)':'var(--ink-soft)'}">${id}</text>`;
+    g+=`<text x="${x+BW/2-15}" y="${y+4}" font-size="9.5" fill="${glyph[1]}">${glyph[0]}</text>`; });
+  g+=`<text class="gm-faint" x="10" y="${H-8}">the accent spine = the critical path · ghost = dropped at replan</text></svg>`; return g;
+}
+function strataSVG(p, W){ W=W||940; const rowH=44, tasks={T1:0,T2:1,T3:2,T4:3,T5:4,T6:5,T7:6};
+  const tx=i=>92+i*116, BW=88, BH=13, H=p.strata.length*rowH+26;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="plan strata">`;
+  Object.entries(tasks).forEach(([t,i])=>{ g+=`<text class="gm-faint" x="${tx(i)+BW/2-8}" y="11">${t}</text>`; });
+  p.strata.forEach((st,si)=>{ const y0=18+si*rowH, cy=y0+rowH/2;
+    g+=`<text class="gm-label" x="8" y="${cy+3}"${st.live?' fill="var(--accent)"':''}>${st.v}</text>`;
+    if(st.live) g+=`<line class="gm-spine" x1="76" y1="${y0+4}" x2="76" y2="${y0+rowH-8}"/>`;
+    st.has.forEach(t=>{ const x=tx(tasks[t]); const op = st.live?.8:(.45-si*.08);
+      g+=`<rect x="${x}" y="${cy-BH/2}" width="${BW}" height="${BH}" rx="3" fill="var(--ink-soft)" fill-opacity="${op.toFixed(2)}"><title>${t} in ${st.v}</title></rect>`;
+      if(st.added.includes(t)) g+=`<text x="${x-10}" y="${cy+3.5}" font-size="9" fill="var(--accent)">○</text>`; });
+    if(si>0){ const newer=p.strata[si-1];
+      st.has.filter(t=>!newer.has.includes(t)).forEach(t=>{ g+=`<text x="${tx(tasks[t])+BW+4}" y="${cy+3.5}" font-size="9" fill="var(--bad)">✕</text>`; }); }
+    if(st.seam){ const sy=y0-2; g+=`<line class="gm-seam" x1="76" y1="${sy}" x2="${W-180}" y2="${sy}"/><text class="gm-tick-label" x="${W-172}" y="${sy+3}">${st.seam}</text>`; } });
+  g+=`</svg>`; return g;
+}
+function reelSVG(p, W){ W=W||940; const H=86, xs=[0.12,0.36,0.6,0.84].map(f=>Math.round(W*f));
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="plan reel">`;
+  g+=`<line class="gm-spine" x1="${xs[0]}" y1="44" x2="${xs[3]}" y2="44"/>`;
+  const trig=['','scope-creep','goal-drift','tool-misuse'];
+  xs.forEach((x,i)=>{ if(i>0) g+=`<text class="gm-tick-label" x="${(xs[i-1]+x)/2-26}" y="26">↯ ${trig[i]}</text>`;
+    g+=`<circle cx="${x}" cy="44" r="${i===3?5.5:4}" fill="${i===3?'var(--accent)':'var(--panel)'}" stroke="${i===3?'var(--accent)':'var(--ink-soft)'}" stroke-width="1.5"/>`;
+    g+=`<text class="gm-label" x="${x-8}" y="63">v${i}</text><text class="gm-axis" x="${x-24}" y="77">${p.rem[i]} tasks left</text>`;
+    if(i>0) g+=`<text x="${(xs[i-1]+x)/2-10}" y="40" font-size="9" fill="var(--good)">−${p.rem[i-1]-p.rem[i]}</text>`; });
+  g+=`</svg>`; return g;
+}
+
+/* ===== app state + shell ===== */
+const PROPOSALS = { observatory: 'A · observatory', score: 'B · score', mission: 'C · mission control' };
+const PROP_NOTES = {
+  observatory: 'one session, one hero view — the rail switches gantt / sequence / drift / plans; click a span for the inspector',
+  score: 'sequence-first — the sequence diagram is the view, the gantt is a minimap, drift + topology + plans ride the margin',
+  mission: 'fleet-first — fingerprints are the navigation; each session gets the full compact instrument set',
+};
+const state = {
+  proposal: 'observatory', view: 'gantt', sessionId: 'checkout-refactor',
+  drawerSpan: null, drawerOpen: true, live: true, elapsed: 80, picker: false,
+};
+(function initState(){ const P=new URLSearchParams(location.search);
+  const pr=P.get('proposal'); if(pr && PROPOSALS[pr]) state.proposal=pr;
+  const v=P.get('view'); if(v && ['gantt','sequence','drift','plans'].includes(v)) state.view=v;
+  // deep-link a span's inspector (reachable from every proposal)
+  const sp=P.get('span'); if(sp){ state.drawerSpan=sp; state.drawerOpen=true; if(state.proposal==='observatory') state.view='sequence'; } })();
+const S = () => SESSIONS[state.sessionId];
+
+function statusPill(s){ return s.status==='live' ? `<span class="dn-pill live">● live</span>`
+  : s.status==='done' ? `<span class="dn-pill good">✓ done</span>` : `<span class="dn-pill bad">✕ failed</span>`; }
+function fmtClock(sec){ const m=String(Math.floor(sec/60)).padStart(2,'0'), x=String(sec%60).padStart(2,'0'); return `00:${m}:${x}`; }
+
+function topbarHTML(){ const s=S();
+  return `<div class="hg-topbar">
+    <span class="hg-brand"><span data-brand-mark="20"></span><span data-brand-wordmark></span></span>
+    <span class="hg-crumbs"><span class="hg-crumb">~/ws</span><span class="hg-crumb-sep">▸</span>
+      <button class="hg-crumb hg-crumb-current" id="open-picker" style="background:none;border:none;cursor:pointer;font:inherit;padding:0">${s.id} ▾</button>
+      <span class="hg-picker-kbd">⌘K</span></span>
+    <span class="hg-topbar-spacer"></span>
+    <span class="hg-status ${s.status==='live'?'is-running':'is-connected'}">
+      <span class="hg-status-dot"></span><span>${s.status==='live'?'streaming':'connected'}</span>
+      <span class="hg-run-badge"><span class="hg-run-pulse"></span><span class="hg-run-label">${s.agents.length} agents</span><span>· ${s.spans.filter(x=>x.status==='running'||x.status==='awaiting').length} in flight</span></span>
+    </span></div>`;
+}
+function stripHTML(){ const s=S(); const run=s.spans.find(x=>x.status==='running')||s.spans.find(x=>x.status==='awaiting');
+  return `<div class="hg-strip"><span class="hg-strip-label">goal</span><span class="hg-strip-title">${s.goal}</span>
+    ${run?`<span class="hg-strip-agent">${run.agent}</span><span class="dn-pill ${run.status==='awaiting'?'caution':'accent'}">${run.status==='awaiting'?'◷ awaiting human':'● '+run.label}</span>`:''}
+    <span style="flex:1"></span>${statusPill(s)}</div>`;
+}
+function transportHTML(){
+  return `<div class="hg-transport">
+    <span class="hg-transport-group">
+      <button class="hg-transport-btn" title="jump to start">⏮</button>
+      <button class="hg-transport-btn" id="btn-live" title="toggle live">${state.live?'⏸ pause':'▶ resume'}</button>
+      <button class="hg-transport-btn" title="jump to now">⏭</button></span>
+    <span class="hg-transport-divider"></span>
+    ${state.live?`<span class="hg-live-badge"><span class="hg-live-dot"></span>LIVE</span>`:`<span class="dn-pill flat">paused</span>`}
+    <span class="hg-clock tnum" id="clock">${fmtClock(state.elapsed)}</span>
+    <span class="hg-transport-spacer"></span>
+    <span class="prop-note">zoom: fit · scrubbing disabled in the mock</span></div>`;
+}
+function drawerHTML(float){ const s=S(); const sp = s.spans.find(x=>x.id===state.drawerSpan);
+  let body;
+  if(sp){ body = `
+    <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px">
+      <span class="dn-pill flat">${sp.kind}</span>
+      <span class="dn-pill ${sp.status==='failed'?'bad':sp.status==='running'?'accent':sp.status==='awaiting'?'caution':'good'}">${sp.status}</span></div>
+    <dl class="hg-attrs"><dt>agent</dt><dd>${sp.agent}</dd><dt>label</dt><dd>${sp.label}</dd>
+      <dt>start</dt><dd class="tnum">${sp.t0}s</dd><dt>end</dt><dd class="tnum">${sp.t1}s</dd>
+      <dt>duration</dt><dd class="tnum">${sp.t1-sp.t0}s</dd>${sp.gf?`<dt>gf category</dt><dd>${sp.gf}</dd>`:''}</dl>
+    <h3 style="font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--ink-faint);margin:14px 0 6px">payload</h3>
+    <code class="hg-drawer-code"><span class="hg-j-punct">{</span> <span class="hg-j-key">"span_id"</span><span class="hg-j-punct">:</span> <span class="hg-j-str">"${sp.id}"</span><span class="hg-j-punct">,</span>
+  <span class="hg-j-key">"kind"</span><span class="hg-j-punct">:</span> <span class="hg-j-str">"${sp.kind.toUpperCase().replaceAll('-','_')}"</span><span class="hg-j-punct">,</span>
+  <span class="hg-j-key">"tokens"</span><span class="hg-j-punct">:</span> <span class="hg-j-num">${(sp.t1-sp.t0)*310}</span><span class="hg-j-punct">,</span>
+  <span class="hg-j-key">"ok"</span><span class="hg-j-punct">:</span> <span class="hg-j-bool">${sp.status!=='failed'}</span> <span class="hg-j-punct">}</span></code>`;
+  } else { body = `
+    <div style="display:flex;align-items:center;gap:12px;margin-bottom:10px">${fpSVG(s,72)}
+      <div><div style="font-weight:700">${s.id}</div><div style="font-size:10.5px;color:var(--ink-faint)">${s.goal}</div>
+      <div style="margin-top:5px">${statusPill(s)}</div></div></div>
+    <dl class="hg-attrs"><dt>agents</dt><dd>${s.agents.length}</dd><dt>spans</dt><dd class="tnum">${s.spans.length}</dd>
+      <dt>elapsed</dt><dd class="tnum">${s.now}s</dd>
+      <dt>interventions</dt><dd class="tnum">${(s.ticks.coder||[]).length}</dd></dl>
+    <h3 style="font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--ink-faint);margin:14px 0 4px">judge heartbeat</h3>
+    ${heartSVG(s, 290)}
+    <p style="font-size:10px;color:var(--ink-faint)">click any span for its detail · Esc closes</p>`; }
+  const inner = `<div class="hg-drawer">
+    <div class="hg-drawer-header"><span class="hg-drawer-title">${sp?sp.label:'session'}</span>
+      <button class="hg-drawer-close" id="drawer-close" title="close">×</button></div>
+    <div class="hg-drawer-body">${body}</div></div>`;
+  if(float){ if(!state.drawerSpan) return ''; return `<div class="hg-drawer-float">${inner}</div>`; }
+  return `<div class="hg-drawer-host ${state.drawerOpen?'open':''}">${inner}</div>`;
+}
+function pickerHTML(){ if(!state.picker) return '';
+  return `<div class="hg-picker-backdrop" id="picker-backdrop"><div class="hg-picker">
+    <div class="hg-picker-search"><span style="color:var(--ink-faint)">⌕</span><input placeholder="switch session…" id="picker-input"><span class="hg-picker-kbd">esc</span></div>
+    <div class="hg-picker-list"><div class="hg-picker-section">sessions</div>
+    ${Object.values(SESSIONS).map(s=>`<button class="hg-picker-row" data-sess="${s.id}" aria-selected="${s.id===state.sessionId}">
+      ${fpSVG(s,30)}<span><span class="hg-picker-row-title">${s.id}</span><br><span class="hg-picker-row-sub">${s.goal}</span></span>
+      <span class="hg-picker-row-meta">${s.status}</span></button>`).join('')}</div></div></div>`;
+}
+
+/* ----- proposal A: the observatory ----- */
+function mainObservatory(){ const s=S();
+  if(state.view==='gantt') return `<h3>execution — gantt</h3><div class="gantt-click">${ganttSVG(s,{selected:state.drawerSpan})}</div>
+    <h3>judge heartbeat</h3>${heartSVG(s)}`;
+  if(state.view==='sequence') return `<h3>sequence — who said what to whom, when</h3>
+    <div class="panes-2"><div class="gantt-click"><h3 style="margin-top:0">time-ordered</h3>${seqDiagramSVG(s)}</div>
+      <div><h3 style="margin-top:0">topology — who initiates, who receives</h3>${topoChordSVG(s,300)}</div></div>`;
+  if(state.view==='drift') return `<h3>drift seismograph</h3>${seismoSVG(s,['coder','reviewer','planner'])}
+    <div class="panes-2"><div><h3>intervention ladder</h3>${ladderSVG(s.ladder,460)}</div>
+    <div><h3>judge heartbeat</h3>${heartSVG(s,460)}</div></div>`;
+  return `<h3>plan DAG — interdependence (the critical path is the spine)</h3>${dagSVG(s.plan)}
+    <h3>plan strata — revisions as sediment</h3>${strataSVG(s.plan)}
+    <h3>plan reel — remaining work across revisions</h3>${reelSVG(s.plan)}`;
+}
+function railHTML(){
+  const items=[['gantt','▤'],['sequence','♒'],['drift','〰'],['plans','⧉']];
+  return `<nav class="hg-rail">${items.map(([v,ic])=>
+    `<button class="hg-rail-item" data-view="${v}" aria-selected="${state.view===v}"><span class="hg-rail-icon">${ic}</span><span>${v}</span></button>`).join('')}</nav>`;
+}
+function appObservatory(){
+  return topbarHTML()+stripHTML()+`<div class="app-body p-observatory">${railHTML()}
+    <main class="app-main">${mainObservatory()}</main>${drawerHTML()}</div>`+transportHTML();
+}
+/* ----- proposal B: the score (sequence-first) -----
+   The corrected sequence diagram IS the view; the gantt is a minimap; drift,
+   topology, plans, and interventions ride the margin so every piece of session
+   information the other proposals surface is reachable here too. */
+function appScore(){ const s=S();
+  return topbarHTML()+`<div class="app-body p-score">
+    <div class="minimap">${ganttSVG(s,{mini:true})}</div>
+    <main class="app-main gantt-click"><h3>the sequence diagram — who said what to whom, when</h3>${seqDiagramSVG(s,{W:760,H:430})}
+      <h3>plan DAG — interdependence</h3>${dagSVG(s.plan)}
+      <h3>plan strata — revisions as sediment</h3>${strataSVG(s.plan)}</main>
+    <aside class="margin-col"><h4>session</h4>
+      <div style="text-align:center">${fpSVG(s,84)}</div>
+      <div style="text-align:center;margin:4px 0 8px">${statusPill(s)}</div>
+      <h4>topology — who initiates</h4>${topoChordSVG(s,186)}
+      <h4>drift margin — coder</h4>${seismoSVG(s,['coder'],186)}
+      <h4>interventions</h4>
+      ${(s.ticks.coder||[]).map(([t,l])=>`<div class="margin-item">◆ ${l} <span class="tnum" style="color:var(--ink-faint)">@${t}s</span></div>`).join('')||'<div class="margin-item" style="font-style:italic">none</div>'}
+      <h4>escalation ladder</h4>${ladderSVG(s.ladder,186)}
+      <h4>remaining work</h4>${reelSVG(s.plan,186)}
+      <h4>heartbeat</h4>${heartSVG(s,186)}
+      <p class="prop-note" style="margin-top:8px">click any span → inspector</p></aside>
+  </div>`+drawerHTML(true)+transportHTML();
+}
+/* ----- proposal C: mission control ----- */
+function appMission(){ const s=S();
+  return topbarHTML()+`<div class="app-body p-mission">
+    <aside class="fleet"><h4>fleet · ${Object.keys(SESSIONS).length} sessions</h4>
+      ${Object.values(SESSIONS).map(x=>`<button class="fleet-item" data-sess="${x.id}" aria-selected="${x.id===state.sessionId}">
+        ${fpSVG(x,44)}<span style="min-width:0"><span class="fleet-name">${x.id}</span><span class="fleet-sub">${x.status} · ${x.spans.length} spans</span></span></button>`).join('')}
+      <h4 style="margin-top:14px">why fingerprints</h4>
+      <div class="margin-item" style="font-size:9.5px">x = plan progress · y = drift, damped. tight = harmonic; scribble = drifting; outward spiral = diverging. the dot is status, earned.</div></aside>
+    <main class="app-main">
+      <div class="sess-head">${fpSVG(s,58)}<div><div class="sess-title">${s.id}</div>
+        <div style="font-size:11px;color:var(--ink-faint)">${s.goal}</div></div>
+        <span style="flex:1"></span><span class="sess-stats">${statusPill(s)}
+        <span class="dn-pill flat tnum">${s.spans.length} spans</span><span class="dn-pill flat tnum">${s.now}s</span></span></div>
+      <h3>execution</h3><div class="gantt-click">${ganttSVG(s,{compact:true,selected:state.drawerSpan})}</div>
+      <div class="panes-2"><div class="gantt-click"><h3>sequence — who said what to whom</h3>${seqDiagramSVG(s,{W:520,H:360})}</div>
+        <div><h3>topology — who initiates</h3>${topoChordSVG(s,300)}</div></div>
+      <h3>drift</h3>${seismoSVG(s,['coder'])}
+      <h3>judge heartbeat</h3>${heartSVG(s)}
+      <div class="panes-2"><div><h3>intervention ladder</h3>${ladderSVG(s.ladder,460)}</div>
+        <div><h3>plan reel</h3>${reelSVG(s.plan,460)}</div></div>
+      <h3>plan DAG — interdependence</h3>${dagSVG(s.plan)}
+      <h3>plan strata — revisions as sediment</h3>${strataSVG(s.plan)}
+    </main></div>`+drawerHTML(true)+transportHTML();
+}
+
+/* ----- render + wire ----- */
+function render(){
+  const app=document.getElementById('app');
+  app.innerHTML = (state.proposal==='observatory'?appObservatory():state.proposal==='score'?appScore():appMission()) + pickerHTML();
+  document.getElementById('prop-note').textContent = PROP_NOTES[state.proposal];
+  const sw=document.getElementById('prop-switch');
+  sw.innerHTML = Object.entries(PROPOSALS).map(([id,lbl])=>
+    `<button data-prop="${id}" aria-pressed="${state.proposal===id}">${lbl}</button>`).join('');
+  sw.querySelectorAll('button').forEach(b=>b.addEventListener('click',()=>{ state.proposal=b.dataset.prop; state.drawerSpan=null; state.drawerOpen = b.dataset.prop==='observatory'; render(); }));
+  mountBrand();
+  app.querySelectorAll('.hg-rail-item').forEach(b=>b.addEventListener('click',()=>{ state.view=b.dataset.view; render(); }));
+  app.querySelectorAll('[data-span]').forEach(el=>el.addEventListener('click',()=>{
+    // the inspector payload is reachable in every proposal: A docks it in the
+    // rail drawer, B & C float it as an overlay.
+    state.drawerSpan=el.dataset.span; state.drawerOpen=true; render(); }));
+  const dc=app.querySelector('#drawer-close'); if(dc) dc.addEventListener('click',()=>{
+    if(state.drawerSpan){ state.drawerSpan=null; } else { state.drawerOpen=false; } render(); });
+  const bl=app.querySelector('#btn-live'); if(bl) bl.addEventListener('click',()=>{ state.live=!state.live; render(); });
+  const op=app.querySelector('#open-picker'); if(op) op.addEventListener('click',()=>{ state.picker=true; render(); });
+  const pb=app.querySelector('#picker-backdrop'); if(pb){
+    pb.addEventListener('click',e=>{ if(e.target===pb){ state.picker=false; render(); } });
+    pb.querySelectorAll('[data-sess]').forEach(b=>b.addEventListener('click',()=>{
+      state.sessionId=b.dataset.sess; state.picker=false; state.drawerSpan=null; state.elapsed=S().now; render(); }));
+    const pi=app.querySelector('#picker-input'); if(pi) pi.focus(); }
+  app.querySelectorAll('.fleet-item').forEach(b=>b.addEventListener('click',()=>{
+    state.sessionId=b.dataset.sess; state.drawerSpan=null; state.elapsed=S().now; render(); }));
+}
+document.addEventListener('keydown',e=>{
+  if(e.key==='Escape'){ if(state.picker){ state.picker=false; render(); } else if(state.drawerSpan){ state.drawerSpan=null; render(); } }
+  if((e.metaKey||e.ctrlKey)&&e.key.toLowerCase()==='k'){ e.preventDefault(); state.picker=!state.picker; render(); }
+});
+// the clock ticks while live — text-only mutation, never a repaint of structure
+setInterval(()=>{ if(!state.live) return; state.elapsed++;
+  const c=document.getElementById('clock'); if(c) c.textContent=fmtClock(state.elapsed); }, 1000);
+
+window.addEventListener('DOMContentLoaded', ()=>{ state.elapsed=S().now;
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker); mountBrand(); render(); });
+</script>
+</body>
+</html>

--- a/docs/design/zicato-ui-study/compose.html
+++ b/docs/design/zicato-ui-study/compose.html
@@ -163,6 +163,17 @@ function lerpKeys(keys, t){ if(t<=keys[0][0]) return keys[0][1];
   for(let i=1;i<keys.length;i++){ if(t<=keys[i][0]){ const [t0,v0]=keys[i-1],[t1,v1]=keys[i];
     return v0+(v1-v0)*(t-t0)/(t1-t0); } } return keys[keys.length-1][1]; }
 function lcg(seed){ let s=seed>>>0; return ()=>((s=(s*1664525+1013904223)>>>0)/4294967296); }
+/* The judge heartbeat is DERIVED from the drift the judges watch, so every
+   firing mark sits exactly above the drift reading that earned it: a steady ok
+   cadence, a warn (▲) when the worst watched lane crosses the tolerance band,
+   a crit (✕) at a deep excursion. Same lanes, same time mapping as the
+   seismograph — the heartbeat and the drift trace cannot disagree. */
+function judgeBeats(s, lanes){ lanes=lanes||['coder','reviewer','planner']; const TOL=8, beats=[];
+  const end=Math.min(s.now, s.T);
+  for(let t=2; t<=end+0.001; t+=2.6){
+    let d=0; lanes.forEach(a=>{ if(s.judges[a]) d=Math.max(d, lerpKeys(s.judges[a], t)); });
+    beats.push([t, d>=TOL*1.5 ? 'crit' : d>=TOL ? 'warn' : 'ok']); }
+  return beats; }
 
 const PRIMARY = {
   id: 'checkout-refactor', status: 'live', T: 96, now: 80,
@@ -198,8 +209,6 @@ const PRIMARY = {
   ticks: { coder: [[35,'nudge · operator'],[42,'refine · goldfive']], reviewer: [], planner: [] },
   ladder: [[35,0],[42,1]],
   ctx: [[0,.10],[18,.22],[30,.44],[44,.62],[54,.78],[55,.34],[68,.5],[80,.62],[96,.66]],
-  heart: (()=>{ const r=lcg(7), e=[]; for(let i=0;i<30;i++){ const t=2+i*2.5+r();
-    e.push([t, (i===12||i===13)?'warn':(i===15?'crit':'ok')]); } return e; })(),
   plan: {
     // tid bridges each DAG node to its strata task-id (T1…T7) so the reel can
     // drive the DAG: the live DAG below == version v3's task set {T1,T2,T4,T6,T7}
@@ -277,12 +286,25 @@ function ganttSVG(s, o){ // o: {compact, mini, selected}
     g+=`<rect class="${cls}" data-span="${sp.id}" x="${x0}" y="${y-bh/2}" width="${w}" height="${bh}" rx="3"${sp.status==='planned'?'':` fill="${fill}"`}${extra} tabindex="${o.mini?-1:0}"><title>${sp.agent} · ${sp.label} · ${sp.t0}–${sp.t1}s · ${sp.status}</title></rect>`;
     if(!o.mini && sp.status==='failed') g+=`<text class="hg-gantt-glyph-fail" x="${x0+w-11}" y="${y-bh/2-2}">✕</text>`;
     if(!o.mini && sp.status==='awaiting') g+=`<text class="hg-gantt-glyph-wait" x="${x0+w+3}" y="${y+3.5}">◷</text>`; });
-  if(!o.mini){ s.transfers.forEach(tr=>{ if(!Y[tr.from]||!Y[tr.to]) return; const x=X(tr.t);
-    g+=`<path class="hg-gantt-edge is-transfer" d="M${x},${Y[tr.from]+7} C ${x+2},${(Y[tr.from]+Y[tr.to])/2} ${x+2},${(Y[tr.from]+Y[tr.to])/2} ${x+4},${Y[tr.to]-7}"><title>transfer ${tr.from} → ${tr.to}</title></path>`; });
-    if(s.delegation && Y[s.delegation.to]){ const d=s.delegation;
-      g+=`<path class="hg-gantt-edge" d="M${X(d.t0)},${Y[d.from]+7} C ${X(d.t0)+3},${Y[d.to]-20} ${X(d.t0)+3},${Y[d.to]-16} ${X(d.t0)+6},${Y[d.to]-7}"><title>delegate → ${d.to} · ${d.tokens} tok</title></path>`;
-      g+=`<path class="hg-gantt-edge" d="M${X(d.t1)-6},${Y[d.to]-7} C ${X(d.t1)-3},${Y[d.to]-16} ${X(d.t1)-3},${Y[d.to]-20} ${X(d.t1)},${Y[d.from]+7}"><title>rejoin · ${d.verdict}</title></path>`;
-      g+=`<text x="${X(d.t1)+2}" y="${Y[d.from]+18}" font-size="9" fill="var(--good)">✓</text>`; } }
+  if(!o.mini){
+    // Edges connect the END of the source span to the START of the receiver's
+    // next span: a smooth S anchored on the bar edges, with an open line-art
+    // chevron landing on the receiver, so a hand-off visibly joins the two bars.
+    // (The chevron is classless on purpose — a CSS class rule would override its
+    //  presentation attributes; classless, its own dash/colour/opacity hold.)
+    const spanStart=(ag,t)=>{ let b=null; s.spans.forEach(sp=>{ if(sp.agent===ag&&Y[sp.agent]&&sp.t0>=t-3&&(!b||sp.t0<b.t0)) b=sp; }); return b; };
+    const edge=(x0,y0,x1,y1,cls,col,tip)=>{ const vs=Math.sign(y1-y0)||1, ya=y0+vs*5, yb=y1-vs*5;
+      const dx=Math.max(10,Math.abs(x1-x0)*0.5), ad=x1>=x0?1:-1;
+      return `<path class="hg-gantt-edge${cls}" d="M${x0.toFixed(1)},${ya.toFixed(1)} C ${(x0+dx).toFixed(1)},${ya.toFixed(1)} ${(x1-dx).toFixed(1)},${yb.toFixed(1)} ${x1.toFixed(1)},${yb.toFixed(1)}"><title>${tip}</title></path>`
+        + `<path d="M${(x1-3*ad).toFixed(1)},${(yb-1.4).toFixed(1)} L${x1.toFixed(1)},${yb.toFixed(1)} L${(x1-3*ad).toFixed(1)},${(yb+1.4).toFixed(1)} Z" fill="${col}" stroke="none" opacity="0.85"/>`; };
+    s.transfers.forEach(tr=>{ if(!Y[tr.from]||!Y[tr.to]||tr.t>s.T) return; const dst=spanStart(tr.to,tr.t);
+      g+=edge(X(tr.t), Y[tr.from], X(dst?dst.t0:tr.t), Y[tr.to], ' is-transfer',
+        'var(--hg-kind-transfer)', `transfer ${tr.from} → ${tr.to} · ${tr.t}s`); });
+    if(s.delegation && Y[s.delegation.to]){ const d=s.delegation, out=spanStart(d.to,d.t0);
+      if(out && d.t0<s.T){
+        g+=edge(X(d.t0), Y[d.from], X(out.t0), Y[d.to], '', 'var(--ink-soft)', `delegate → ${d.to} · ${d.tokens} tok`);
+        g+=edge(X(Math.min(out.t1,s.T)), Y[d.to], X(Math.min(d.t1,s.T)), Y[d.from], '', 'var(--ink-soft)', `rejoin · ${d.verdict}`);
+        g+=`<text x="${X(Math.min(d.t1,s.T))+3}" y="${Y[d.from]+16}" font-size="9" fill="var(--good)">✓</text>`; } } }
   const nx=X(Math.min(s.now,s.T));
   g+=`<line class="hg-gantt-now" x1="${nx}" y1="4" x2="${nx}" y2="${H-(o.mini?6:22)}"/>`;
   if(!o.mini) g+=`<circle class="hg-gantt-now-cap" cx="${nx}" cy="4" r="2.5"/><text class="hg-gantt-now-label" x="${nx+5}" y="11">now ${s.now}s</text>`;
@@ -329,10 +351,9 @@ function seqDiagramSVG(s, o){ o=o||{};
       :k==='delegate'?'var(--ink-soft)':isReturn?'var(--ink-faint)':KIND('agent-message');
     const dash = k==='transfer'?` stroke-dasharray="5 3"`:isReturn?` stroke-dasharray="4 3"`:'';
     g+=`<line class="sq-msg" x1="${x0+4*dir}" y1="${y}" x2="${x1-9*dir}" y2="${y}" stroke="${color}"${dash}><title>${f} → ${o2} · ${lbl} · ${t}s</title></line>`;
-    const ah = isReturn
-      ? `<path d="M${x1-9*dir},${y-4} L${x1-1*dir},${y} L${x1-9*dir},${y+4}" fill="none" stroke="${color}" stroke-width="1.3" vector-effect="non-scaling-stroke"/>`
-      : `<path d="M${x1-9*dir},${y-4} L${x1-1*dir},${y} L${x1-9*dir},${y+4} Z" fill="${color}"/>`;
-    g+=ah;
+    // a small SOLID arrowhead at the receiver; the SOLID-vs-DASHED connector
+    // (and the hue) carries the call/return distinction
+    g+=`<path d="M${x1-6*dir},${y-2.2} L${x1-1*dir},${y} L${x1-6*dir},${y+2.2} Z" fill="${color}" stroke="none"/>`;
     g+=`<text class="sq-lbl" x="${x0+16*dir}" y="${y-5}" text-anchor="${dir>0?'start':'end'}" fill="${color}">${lbl}</text>`; });
   const wait=s.spans.find(x=>x.status==='awaiting');
   if(wait&&X[wait.agent]) g+=`<circle cx="${X[wait.agent]}" cy="${yT(Math.min(wait.t1,s.T))}" r="5.5" fill="none" stroke="var(--ink-soft)" stroke-width="1.4"><title>gate · deciding…</title></circle>`;
@@ -364,26 +385,29 @@ function topoChordSVG(s, W){ W=W||320;
   agents.forEach((a,i)=>{ const th=ang(i), oA=th+SECTOR/2,oB=th+0.05,iA=th-0.05,iB=th-SECTOR/2;
     const arc=(thA,thB,attrs)=>{ const [xA,yA]=onArc(thA,R),[xB,yB]=onArc(thB,R);
       return `<path data-agent="${a}" d="M${xA.toFixed(1)},${yA.toFixed(1)} A${R},${R} 0 0 ${thA>thB?1:0} ${xB.toFixed(1)},${yB.toFixed(1)}" fill="none" ${attrs}/>`; };
-    if(outN[i]) g+=arc(oA,oB,`stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9"`);
-    if(inN[i])  g+=arc(iA,iB,`stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9" stroke-dasharray="1.5 2.4"`);
+    if(outN[i]) g+=arc(oA,oB,`stroke="${aColor(a)}" stroke-width="4.5" stroke-linecap="round" vector-effect="non-scaling-stroke" opacity=".9"`);
+    if(inN[i])  g+=arc(iA,iB,`stroke="${aColor(a)}" stroke-width="4.5" stroke-linecap="round" vector-effect="non-scaling-stroke" opacity=".9" stroke-dasharray="1.5 2.4"`);
   });
   let cLabels='';
   flows.forEach(([a,b,c],fi)=>{ const ths=ang(a),thd=ang(b);
     const sF=(outUsed[a]+c/2)/Math.max(outN[a],1); outUsed[a]+=c;
     const dF=(inUsed[b]+c/2)/Math.max(inN[b],1);  inUsed[b]+=c;
     const sTh=ths+0.07+(SECTOR/2-0.07)*sF, dTh=thd-0.07-(SECTOR/2-0.07)*dF;
-    // √count with a hard cap: heavy traffic thickens slowly and can never flood
-    const wS=1.6, wT=Math.min(15, 4+Math.sqrt(c)*3.4), [sx,sy]=onArc(sTh,R-4),[dx,dy]=onArc(dTh,R-9);
-    const tS=[Math.sin(sTh),Math.cos(sTh)],tD=[Math.sin(dTh),Math.cos(dTh)];
-    const s1=[sx+tS[0]*wS/2,sy+tS[1]*wS/2],s2=[sx-tS[0]*wS/2,sy-tS[1]*wS/2];
-    const t1=[dx+tD[0]*wT/2,dy+tD[1]*wT/2],t2=[dx-tD[0]*wT/2,dy-tD[1]*wT/2];
+    // ribbon = a THIN stroked curve, not a fat filled teardrop: width is a
+    // restrained √count, hard-capped, and non-scaling so it stays a crisp
+    // hairline at any container width. Direction still reads from the gradient
+    // (faint source → bright target), the solid/dashed arc split and the
+    // arrowhead — the swelling teardrop was a redundant fourth cue.
+    const w=Math.min(4, 0.9+Math.sqrt(c)*1.1), [sx,sy]=onArc(sTh,R-4),[dx,dy]=onArc(dTh,R-6);
+    const tD=[Math.sin(dTh),Math.cos(dTh)];
     const mid=[(sx+dx)/2+(cx-(sx+dx)/2)*0.62,(sy+dy)/2+((cyA-34)-(sy+dy)/2)*0.5], gid=`tch${s.id}${fi}`;
     const FT=`data-f="${agents[a]}" data-t="${agents[b]}"`;
     g+=`<defs><linearGradient id="${gid}" x1="${sx.toFixed(1)}" y1="${sy.toFixed(1)}" x2="${dx.toFixed(1)}" y2="${dy.toFixed(1)}" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="${aColor(agents[a])}" stop-opacity=".32"/><stop offset="1" stop-color="${aColor(agents[b])}" stop-opacity=".95"/></linearGradient></defs>`;
-    g+=`<path data-ribbon="1" ${FT} fill="url(#${gid})" stroke="none" d="M${s1[0].toFixed(1)},${s1[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${t1[0].toFixed(1)},${t1[1].toFixed(1)} L${t2[0].toFixed(1)},${t2[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${s2[0].toFixed(1)},${s2[1].toFixed(1)} Z"><title>${agents[a]} → ${agents[b]} · ${c} (${agents[a]} initiates)</title></path>`;
-    const outward=[Math.cos(dTh),-Math.sin(dTh)], tip=onArc(dTh,R-1), base=[tip[0]-outward[0]*8,tip[1]-outward[1]*8];
-    g+=`<path data-ahead="1" ${FT} d="M${(base[0]+tD[0]*4).toFixed(1)},${(base[1]+tD[1]*4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(base[0]-tD[0]*4).toFixed(1)},${(base[1]-tD[1]*4).toFixed(1)} Z" fill="${aColor(agents[b])}"/>`;
+      <stop offset="0" stop-color="${aColor(agents[a])}" stop-opacity=".45"/><stop offset="1" stop-color="${aColor(agents[b])}" stop-opacity=".95"/></linearGradient></defs>`;
+    g+=`<path data-ribbon="1" ${FT} fill="none" stroke="url(#${gid})" stroke-width="${w.toFixed(2)}" stroke-linecap="round" vector-effect="non-scaling-stroke" d="M${sx.toFixed(1)},${sy.toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${dx.toFixed(1)},${dy.toFixed(1)}"><title>${agents[a]} → ${agents[b]} · ${c} (${agents[a]} initiates)</title></path>`;
+    const outward=[Math.cos(dTh),-Math.sin(dTh)], tip=[dx+outward[0]*4,dy+outward[1]*4];
+    // a small SOLID arrowhead tipping the chord onto the receiver
+    g+=`<path data-ahead="1" ${FT} d="M${(dx+tD[0]*1.4).toFixed(1)},${(dy+tD[1]*1.4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(dx-tD[0]*1.4).toFixed(1)},${(dy-tD[1]*1.4).toFixed(1)} Z" fill="${aColor(agents[b])}" stroke="none"/>`;
     cLabels+=`<text class="tch-count" data-count="1" ${FT} x="${mid[0].toFixed(1)}" y="${(mid[1]+3).toFixed(1)}" text-anchor="middle">${c}×</text>`;
   });
   agents.forEach((a,i)=>{ const th=ang(i),[x,y]=onArc(th,R);
@@ -453,7 +477,7 @@ function seismoSVG(s, lanes, W, opts){ opts=opts||{};
   if(heart){ const hy=heartH-10;
     g+=`<text class="gm-label" x="6" y="${hy+4}" fill="var(--hg-agent-goldfive)">judges</text>`;
     g+=`<line class="gm-onplan" x1="${X(0)}" y1="${hy}" x2="${X(s.T)}" y2="${hy}"/>`;
-    s.heart.forEach(([t,k])=>{ if(t>s.T) return; const x=X(t);
+    judgeBeats(s, lanes).forEach(([t,k])=>{ if(t>s.T) return; const x=X(t);
       if(k==='ok')   g+=`<circle cx="${x}" cy="${hy}" r="1.7" fill="var(--hg-agent-goldfive)" opacity=".8"><title>judge fired · on-task @ ${t.toFixed(0)}s</title></circle>`;
       if(k==='warn') g+=`<line x1="${x}" y1="${hy-6}" x2="${x}" y2="${hy+6}" stroke="var(--caution)" stroke-width="1.4" vector-effect="non-scaling-stroke"/><text x="${x-3.5}" y="${hy+3}" font-size="8.5" fill="var(--caution)">▲</text>`;
       if(k==='crit') g+=`<line x1="${x}" y1="${hy-7}" x2="${x}" y2="${hy+7}" stroke="var(--bad)" stroke-width="1.6" vector-effect="non-scaling-stroke"/><text x="${x-3.5}" y="${hy+3.5}" font-size="9.5" fill="var(--bad)" font-weight="700">✕</text>`; });
@@ -483,7 +507,7 @@ function heartSVG(s, W){ W=W||940; const H=40, padL=W<400?40:76, X=t=>padL+(W-pa
   let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="judge heartbeat — ${s.id}">`;
   g+=`<text class="gm-label" x="6" y="22" fill="var(--hg-agent-goldfive)">judges</text>`;
   g+=`<line class="gm-onplan" x1="${X(0)}" y1="26" x2="${X(s.T)}" y2="26"/>`;
-  s.heart.forEach(([t,k])=>{ if(t>s.T) return; const x=X(t);
+  judgeBeats(s).forEach(([t,k])=>{ if(t>s.T) return; const x=X(t);
     if(k==='ok') g+=`<circle cx="${x}" cy="18" r="1.5" fill="var(--hg-agent-goldfive)" opacity=".8"/>`;
     if(k==='warn') g+=`<text x="${x-3.5}" y="22" font-size="9" fill="var(--caution)">▲</text>`;
     if(k==='crit') g+=`<text x="${x-3.5}" y="22" font-size="10" fill="var(--bad)" font-weight="700">✕</text>`; });

--- a/docs/design/zicato-ui-study/figures.html
+++ b/docs/design/zicato-ui-study/figures.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="monokai">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>harmonograf × zicato — figures (components) study</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="_tokens.css">
+<link rel="stylesheet" href="_study.css">
+<style>
+  .fig-frame { border:1px solid var(--rule); border-radius:var(--r-panel); background:var(--paper); padding:12px 14px; }
+  .two-col { display:grid; grid-template-columns:1fr 1fr; gap:16px; align-items:start; }
+  @media (max-width:880px){ .two-col { grid-template-columns:1fr; } }
+  .stage-rail { display:flex; align-items:center; gap:0; margin:6px 0; }
+  .stage { display:flex; flex-direction:column; align-items:center; gap:5px; flex:1; min-width:0; position:relative; }
+  .stage-dot { width:14px; height:14px; border-radius:50%; border:2px solid var(--rule); background:var(--panel); z-index:1; }
+  .stage.done .stage-dot { background:var(--good); border-color:var(--good); }
+  .stage.now .stage-dot { background:var(--accent); border-color:var(--accent); }
+  .stage.now .stage-dot { animation:hg-now-pulse 1.6s ease-out infinite; }
+  .stage.failed .stage-dot { background:var(--bad); border-color:var(--bad); }
+  .stage.pending .stage-dot { background:var(--panel); border-color:var(--rule); }
+  .stage-label { font-size:10px; color:var(--ink-soft); white-space:nowrap; }
+  .stage.now .stage-label { color:var(--accent); }
+  .stage-line { position:absolute; top:6px; left:50%; right:-50%; height:2px; background:var(--rule); z-index:0; }
+  .stage.done .stage-line { background:var(--good); }
+  .stage:last-child .stage-line { display:none; }
+  .rev-badge { display:inline-flex; align-items:center; gap:5px; font-size:10px; color:var(--ink-faint);
+    border:1px solid var(--rule); border-radius:var(--r-pill); padding:1px 8px; }
+  .rev-badge b { color:var(--caution); }
+  .interv-row { display:grid; grid-template-columns:88px 1fr auto; gap:10px; align-items:center;
+    padding:8px 4px; border-bottom:1px solid var(--rule-soft); cursor:default; }
+  .interv-row:last-child { border-bottom:none; }
+  .interv-time { font-size:11px; color:var(--ink-faint); font-variant-numeric:tabular-nums; }
+  .interv-body { min-width:0; }
+  .interv-title { font-size:12.5px; color:var(--ink); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .interv-sub { font-size:10.5px; color:var(--ink-faint); }
+  .live-dot-sm { width:7px; height:7px; border-radius:50%; background:var(--accent); display:inline-block;
+    animation:hg-now-pulse 1.6s ease-out infinite; }
+  .kbd { font-size:10px; color:var(--ink-faint); border:1px solid var(--rule); border-radius:4px; padding:1px 5px; }
+  .picker-static { position:static; background:transparent; padding:0; display:block; }
+  .picker-static .hg-picker { box-shadow:none; max-height:none; }
+  /* a narrow viewport scrolls the table inside its frame, never the page (zicato §6.4) */
+  .dn-table-scroll { overflow-x:auto; }
+  .dn-table-scroll .dn-board-table { min-width:560px; }
+</style>
+</head>
+<body>
+<header class="study">
+  <span class="brand-row"><span data-brand-mark="22"></span><span data-brand-wordmark></span></span>
+  <h1>figures — the component catalogue</h1>
+  <span class="spacer"></span>
+  <span class="legend-inline">mono · outline-first · <b>tabular-nums</b></span>
+  <span class="theme-pick-label">theme</span>
+  <span data-theme-picker></span>
+</header>
+
+<main class="study">
+  <p class="lede" style="margin-top:22px">
+    The supporting surfaces, each redrawn in-language: pills are <b>mono, outline-first</b> (filling the accent only on
+    hover); numerics use <code>tabular-nums</code>; tables follow the zicato <code>.dn-board-table</code> idiom;
+    hover-for-detail uses the singleton hovercard. An in-flight item is neutral <code>--accent</code>, <b>never red</b>.
+  </p>
+
+  <!-- ===== OrchestrationTimeline + TaskStages ===== -->
+  <section class="study" data-surface>
+    <h2>OrchestrationTimeline &amp; TaskStages</h2>
+    <p class="rationale">
+      The run lifecycle as a line-art phase rail (the <code>reignGantt</code> idiom): completed phases read
+      <code>--good</code>, the current phase is the one <code>--accent</code> (breathing), a failed phase
+      <code>--bad</code>, planned phases faint. The plan's revision count rides as a mono <code>--caution</code> badge.
+    </p>
+    <div class="two-col">
+      <div>
+        <p class="ba-tag">orchestration timeline</p>
+        <div class="fig-frame">
+          <div class="stage-rail" id="orch-rail"></div>
+          <div style="display:flex;justify-content:space-between;font-size:10px;color:var(--ink-faint);margin-top:4px" class="tnum">
+            <span>00:00.0</span><span>elapsed 00:14.7</span>
+          </div>
+        </div>
+      </div>
+      <div>
+        <p class="ba-tag">task stages · plan v3</p>
+        <div class="fig-frame">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px">
+            <span class="dn-pill accent">in progress</span>
+            <span class="rev-badge">plan revisions <b>×3</b></span>
+            <span style="margin-left:auto;font-size:10.5px;color:var(--ink-faint)">mode: <span class="dn-pill flat">parallel</span></span>
+          </div>
+          <div class="stage-rail" id="stage-rail"></div>
+          <p style="font-size:10.5px;color:var(--ink-faint);margin:10px 0 0">
+            revision <b style="color:var(--caution)">v3</b> steered by <span style="color:var(--hg-gf-refine)">refine_steer</span>
+            after a judge flagged scope drift.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== LiveActivity ===== -->
+  <section class="study" data-surface>
+    <h2>LiveActivity — the active-items board</h2>
+    <p class="rationale">
+      The live table in the zicato <code>.dn-board-table</code> idiom: hairline cells, an uppercase header on
+      <code>--rule-soft</code>, numeric columns right-aligned with <code>tabular-nums</code>, the live row tinted
+      <code>color-mix(--accent 8%)</code>. Kind reads its categorical hue; status is a mono outline-first pill.
+    </p>
+    <div class="fig-frame" style="padding:0;overflow:hidden">
+      <!-- contained scroll: a narrow viewport scrolls THIS, never the page (zicato §6.4) -->
+      <div class="dn-table-scroll">
+        <table class="dn-board-table">
+          <thead><tr>
+            <th style="width:64px">when</th><th>agent</th><th>kind</th><th>detail</th>
+            <th class="num" style="width:78px">elapsed</th><th style="width:120px">status</th>
+          </tr></thead>
+          <tbody id="live-rows"></tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== Interventions ===== -->
+  <section class="study" data-surface>
+    <h2>Interventions — goldfive steering</h2>
+    <p class="rationale">
+      goldfive's steers and judge verdicts. Judge severity maps to roles (<code>--good</code> on-task,
+      <code>--caution</code> warning, <code>--bad</code> critical); <code>refine</code> reads magenta, <code>plan</code>
+      cyan, <code>reflective</code> grey — all from the theme ANSI. Each row opens its detail in the hovercard. The
+      categorical hues here are <b>identity</b>, never status, so red appears only for a critical verdict.
+    </p>
+    <div class="fig-frame">
+      <div id="interv-list"></div>
+    </div>
+    <div class="legend">
+      <span><span class="sw" style="background:var(--hg-gf-judge-on-task)"></span> judge · on-task</span>
+      <span><span class="sw" style="background:var(--hg-gf-judge-warning)"></span> judge · warning</span>
+      <span><span class="sw" style="background:var(--hg-gf-judge-critical)"></span> judge · critical</span>
+      <span><span class="sw" style="background:var(--hg-gf-refine)"></span> refine</span>
+      <span><span class="sw" style="background:var(--hg-gf-plan)"></span> plan</span>
+      <span><span class="sw" style="background:var(--hg-gf-reflective)"></span> reflective</span>
+    </div>
+  </section>
+
+  <!-- ===== SessionPicker ===== -->
+  <section class="study" data-surface>
+    <h2>SessionPicker (⌘K)</h2>
+    <p class="rationale">
+      The command palette, in-language: a <code>--panel</code> card with hairline rows, mono titles, an attention count
+      as a quiet <code>--bad</code> pill (only when a session is genuinely awaiting a human), and the selected row on
+      <code>--rule-soft</code>. The accent rings the search field on focus. Shown inline here (live it floats over a
+      blurred backdrop).
+    </p>
+    <div class="fig-frame">
+      <div class="hg-picker-backdrop picker-static">
+        <div class="hg-picker">
+          <div class="hg-picker-search">
+            <span style="color:var(--ink-faint)">⌕</span>
+            <input value="checkout" aria-label="search sessions" />
+            <span class="kbd">esc</span>
+          </div>
+          <div class="hg-picker-list" id="picker-list"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer class="study">
+  harmonograf UI study · <b>figures</b> · component catalogue · mono outline-first pills · tabular-nums · token-only colour
+  · verify in <code>paper</code> + <code>monokai</code>.
+</footer>
+
+<div class="hg-hovercard" id="hovercard" role="tooltip"></div>
+
+<!-- shared chrome -->
+<script>
+window.THEME_IDS = ['monokai','solarized-dark','solarized-light','google-light','google-dark',
+  'lunaria-light','lunaria-eclipse','belafonte-day','belafonte-night','paper','zenburn',
+  'selenized-black','relaxed','espresso','dracula','ubuntu'];
+const THEME_SWATCHES = {
+  'monokai':['#1e1f1c','#272822','#f8f8f2','#a6e22e','#f92672','#66d9ef'],
+  'solarized-dark':['#04222B','#0A2D38','#93A1A1','#8BB80E','#E0483C','#2AA198'],
+  'solarized-light':['#FDF6E3','#FBF1D6','#586E75','#6B9B0B','#DC322F','#268BD2'],
+  'google-light':['#FFFFFF','#F4F4F4','#474A4E','#34A853','#EA4335','#1B9CB8'],
+  'google-dark':['#202124','#2C2D30','#FFFFFF','#34A853','#EA4335','#24C1E0'],
+  'lunaria-light':['#EBE4E1','#E2DCD9','#363434','#497D46','#783C1F','#3778A9'],
+  'lunaria-eclipse':['#323F46','#3B484F','#DFE2ED','#BEDBC1','#BA9088','#C8429F'],
+  'belafonte-day':['#D5CCBA','#CCC3B2','#34292D','#6E6A4E','#BE100E','#426A79'],
+  'belafonte-night':['#20111B','#271821','#D5CCBA','#A6A07A','#D6403E','#6F8E97'],
+  'paper':['#F2EEDE','#E6E2D3','#1A1A1A','#216609','#CC3E28','#1E6FCC'],
+  'zenburn':['#3A3A3A','#424241','#DCDCCC','#8FB28F','#CC9393','#8CD0D3'],
+  'selenized-black':['#181818','#202020','#DEDEDE','#83C746','#FF5E56','#56D8C9'],
+  'relaxed':['#353A44','#3D424B','#F7F7F7','#A0AC77','#BC5653','#7EAAC7'],
+  'espresso':['#323232','#3A3A3A','#FFFFFF','#A5C261','#D25252','#6C99BB'],
+  'dracula':['#282A36','#343746','#F8F8F2','#50FA7B','#FF5555','#BD93F9'],
+  'ubuntu':['#300A24','#3D1530','#EEEEEC','#8AE234','#CC0000','#34E2E2'],
+};
+const THEME_LABELS = {'monokai':'Monokai','solarized-dark':'Solarized Dark','solarized-light':'Solarized Light',
+  'google-light':'Google Light','google-dark':'Google Dark','lunaria-light':'Lunaria Light','lunaria-eclipse':'Lunaria Eclipse',
+  'belafonte-day':'Belafonte Day','belafonte-night':'Belafonte Night','paper':'Paper','zenburn':'Zenburn',
+  'selenized-black':'Selenized Black','relaxed':'Relaxed','espresso':'Espresso','dracula':'Dracula','ubuntu':'Ubuntu'};
+const THEME_KEY = 'hgraf-study-theme';
+let themeListeners = []; function onThemeChange(fn){ themeListeners.push(fn); }
+function swatchStrip(id, sm){ const t = THEME_SWATCHES[id] || [];
+  return `<span class="dt-swatch-strip${sm?' dt-swatch-strip-sm':''}">`+t.map(c=>`<span class="dt-swatch" style="background:${c}"></span>`).join('')+`</span>`; }
+function currentTheme(){ return document.documentElement.getAttribute('data-theme') || 'monokai'; }
+function applyTheme(id){ document.documentElement.setAttribute('data-theme', id);
+  try { localStorage.setItem(THEME_KEY, id); } catch(e){}
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker);
+  themeListeners.forEach(fn=>{ try{fn();}catch(e){} }); }
+function buildPicker(host){ const cur = currentTheme();
+  host.innerHTML = `<div class="dt-cd"><button class="dt-cd-trigger" aria-haspopup="listbox" aria-expanded="false">${swatchStrip(cur,true)}<span class="dt-cd-name">${THEME_LABELS[cur]}</span><span class="dt-cd-caret" aria-hidden="true">▾</span></button><div class="dt-cd-list" role="listbox" aria-label="theme">${window.THEME_IDS.map(id=>`<div class="dt-cd-option" role="option" data-id="${id}" aria-selected="${id===cur}">${swatchStrip(id)}<span class="dt-cd-name">${THEME_LABELS[id]}</span></div>`).join('')}</div></div>`;
+  const cd = host.querySelector('.dt-cd'), trig = host.querySelector('.dt-cd-trigger');
+  trig.addEventListener('click', e=>{ e.stopPropagation(); const open = cd.classList.toggle('dt-cd-open'); trig.setAttribute('aria-expanded', open); });
+  host.querySelectorAll('.dt-cd-option').forEach(o=> o.addEventListener('click', ()=>{ applyTheme(o.dataset.id); cd.classList.remove('dt-cd-open'); })); }
+document.addEventListener('click', ()=> document.querySelectorAll('.dt-cd-open').forEach(c=>c.classList.remove('dt-cd-open')));
+(function initTheme(){ let saved=null; try { saved=localStorage.getItem(THEME_KEY); } catch(e){}
+  const P=new URLSearchParams(location.search), fromUrl=P.get('theme');
+  const id=(fromUrl&&window.THEME_IDS.includes(fromUrl))?fromUrl:(saved&&window.THEME_IDS.includes(saved))?saved:'monokai';
+  document.documentElement.setAttribute('data-theme', id); })();
+/* harmonograf brand — the Option-D alpha: one period of the 2:3 Lissajous,
+   MIRRORED about the vertical axis (x = cx − A·cos2t, y = cy + B·sin3t) so the
+   knot reads as a lowercase α — still a Lissajous, loop left, tails right.
+   Stroke currentColor; the one dot rides the lower-right tail tip: the pen at
+   rest. ONE ALPHA PER LOCKUP: beside this mark the wordmark is PLAIN LETTERS
+   (the glyph already carries the α and the dot); only a STANDALONE wordmark
+   spells the "a" of graf with the drawn α. */
+function hgAlphaPath(cx, cy, A, B){ const pts=[];
+  for(let i=0;i<=240;i++){ const t=2*Math.PI*i/240;
+    pts.push((cx - A*Math.cos(2*t)).toFixed(2)+','+(cy + B*Math.sin(3*t)).toFixed(2)); }
+  return 'M'+pts.join(' L')+' Z'; }
+function hgBrandMarkSVG(h){ return `<svg class="hg-brand-mark" style="height:${h||24}px" viewBox="0 0 48 48" role="img" aria-label="harmonograf" focusable="false"><path d="${hgAlphaPath(24,24,19,15)}" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/><circle cx="43" cy="39" r="3.2" fill="var(--hgraf-brand, #5EA3EC)"/></svg>`; }
+function hgWordmarkSVG(){ const T='harmonograf', X0=1, ADV=9.6, BASE=15; const W=X0*2+T.length*ADV;
+  return `<svg class="hg-brand-name" viewBox="0 0 ${W} 18" role="img" aria-label="harmonograf" focusable="false"><text x="${X0}" y="${BASE}" font-family="var(--brand-mono)" font-size="15" font-weight="700" textLength="${T.length*ADV}" lengthAdjust="spacing" fill="currentColor" xml:space="preserve">${T}</text></svg>`; }
+function mountBrand(){ document.querySelectorAll('[data-brand-mark]').forEach(n=>{ n.innerHTML=hgBrandMarkSVG(+n.dataset.brandMark||24); });
+  document.querySelectorAll('[data-brand-wordmark]').forEach(n=>{ n.innerHTML=hgWordmarkSVG(); }); }
+</script>
+
+<!-- the figures -->
+<script>
+const ORCH_PHASES = [
+  {label:'derive goal', state:'done'}, {label:'plan', state:'done'},
+  {label:'delegate', state:'done'}, {label:'execute', state:'now'},
+  {label:'review', state:'pending'}, {label:'merge', state:'pending'},
+];
+const STAGE_PHASES = [
+  {label:'scaffold', state:'done'}, {label:'pricing client', state:'done'},
+  {label:'tests', state:'failed'}, {label:'retry', state:'now'},
+  {label:'review', state:'pending'},
+];
+const LIVE = [
+  {t:'+14.7', agent:'reviewer', kind:'llm-call',   detail:'review diff', el:'2.1s', status:'running'},
+  {t:'+14.2', agent:'planner',  kind:'wait-for-human', detail:'approve merge?', el:'0.5s', status:'awaiting'},
+  {t:'+12.0', agent:'coder-b',  kind:'tool-call',  detail:'run_tests (3 failed)', el:'1.8s', status:'failed'},
+  {t:'+9.7',  agent:'coder-a',  kind:'agent-message', detail:'report → planner', el:'1.5s', status:'completed'},
+  {t:'+5.5',  agent:'goldfive', kind:'custom',     detail:'judge_reasoning', el:'1.8s', status:'completed'},
+];
+const INTERV = [
+  {t:'00:11.2', cat:'refine',  title:'refine_steer → planner', sub:'narrowed scope after drift flag', sev:null,
+    tip:'goldfive refine · target: planner · "Constrain the diff to the pricing module; tests for the rest are out of scope this turn."'},
+  {t:'00:08.4', cat:'judge',   title:'judge_goal_drift', sub:'severity: warning · off-task 0.34', sev:'warning',
+    tip:'judge · goal-drift · severity warning · on_task=false (0.34) · "Sub-agent began editing unrelated auth code."'},
+  {t:'00:05.5', cat:'judge',   title:'judge_reasoning', sub:'on-task · score 0.91', sev:'on-task',
+    tip:'judge · reasoning · on_task=true (0.91) · "Plan decomposition is sound and matches the brief."'},
+  {t:'00:03.1', cat:'plan',    title:'plan_generate v2', sub:'4 steps · parallel', sev:null,
+    tip:'goldfive plan · plan_generate · produced 4 steps, parallel mode, 2 delegated to coder agents.'},
+  {t:'00:12.6', cat:'judge',   title:'judge_output', sub:'severity: critical · schema break', sev:'critical',
+    tip:'judge · output · severity CRITICAL · "Returned malformed JSON; schema validation failed on field `price_cents`."'},
+  {t:'00:13.4', cat:'reflective', title:'reflective_check', sub:'neutral · continue', sev:null,
+    tip:'goldfive reflective · reflective_check · no action; run is proceeding within budget.'},
+];
+const SESSIONS = [
+  {title:'checkout-refactor', sub:'planner · 6 agents · running', meta:'live', attn:0, live:true},
+  {title:'checkout-pricing-migration', sub:'coordinator · 3 agents · awaiting human', meta:'2m', attn:1},
+  {title:'checkout-tax-rules', sub:'solo · completed', meta:'1h', attn:0},
+  {title:'checkout-tests-flake', sub:'coder · failed', meta:'3h', attn:0},
+];
+const KIND_LABELS = {'invocation':'INVOCATION','llm-call':'LLM_CALL','tool-call':'TOOL_CALL','user-message':'USER_MESSAGE',
+  'agent-message':'AGENT_MESSAGE','transfer':'TRANSFER','wait-for-human':'WAIT_FOR_HUMAN','custom':'CUSTOM'};
+
+function statusPill(s){
+  if(s==='running') return '<span class="dn-pill accent">running</span>';
+  if(s==='awaiting') return '<span class="dn-pill bad">awaiting human</span>';
+  if(s==='failed') return '<span class="dn-pill bad">failed</span>';
+  if(s==='completed') return '<span class="dn-pill good">done</span>';
+  return '<span class="dn-pill flat">'+s+'</span>';
+}
+function gfColorVar(cat, sev){
+  if(cat==='judge'){ return sev==='on-task'?'--hg-gf-judge-on-task':sev==='warning'?'--hg-gf-judge-warning':sev==='critical'?'--hg-gf-judge-critical':'--hg-gf-judge-neutral'; }
+  return cat==='refine'?'--hg-gf-refine':cat==='plan'?'--hg-gf-plan':'--hg-gf-reflective';
+}
+
+function buildOrch(){
+  const host=document.getElementById('orch-rail'); if(host)
+    host.innerHTML = ORCH_PHASES.map(p=>`<div class="stage ${p.state}"><span class="stage-line"></span><span class="stage-dot"></span><span class="stage-label">${p.label}</span></div>`).join('');
+  const sh=document.getElementById('stage-rail'); if(sh)
+    sh.innerHTML = STAGE_PHASES.map(p=>`<div class="stage ${p.state}"><span class="stage-line"></span><span class="stage-dot"></span><span class="stage-label">${p.label}</span></div>`).join('');
+}
+function buildLive(){
+  const host=document.getElementById('live-rows'); if(!host) return;
+  host.innerHTML = LIVE.map(r=>`<tr class="${r.status==='running'?'is-live':''}">
+    <td class="tnum" style="color:var(--ink-faint)">${r.t}</td>
+    <td>${r.agent}</td>
+    <td><span style="display:inline-block;width:9px;height:9px;border-radius:2px;background:var(--hg-kind-${r.kind});opacity:.7;vertical-align:middle;margin-right:6px"></span>${KIND_LABELS[r.kind]}</td>
+    <td>${r.detail}</td>
+    <td class="num tnum">${r.el}</td>
+    <td>${r.status==='running'?'<span class="live-dot-sm"></span> ':''}${statusPill(r.status)}</td>
+  </tr>`).join('');
+}
+// escape for safe interpolation into a double-quoted HTML attribute — the tips carry
+// embedded quotes/backticks that would otherwise truncate data-tip and drop the detail.
+function esc(s){ return String(s).replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+function buildInterv(){
+  const host=document.getElementById('interv-list'); if(!host) return;
+  const sorted=[...INTERV].sort((a,b)=>b.t.localeCompare(a.t));
+  host.innerHTML = sorted.map((r,i)=>{
+    const cv=gfColorVar(r.cat,r.sev);
+    // severity → semantic role; the non-severity categories (refine/plan/reflective) carry
+    // identity via the coloured dot, so the pill stays a neutral outline — --accent is reserved.
+    const pillCls = r.sev==='critical'?'bad':r.sev==='warning'?'caution':r.sev==='on-task'?'good':'flat';
+    return `<div class="interv-row" data-tip="${esc(r.tip)}" tabindex="0" role="button" aria-label="${esc(r.title)}">
+      <span class="interv-time tnum">${r.t}</span>
+      <div class="interv-body">
+        <div class="interv-title"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:var(${cv});margin-right:7px;vertical-align:middle"></span>${r.title}</div>
+        <div class="interv-sub">${r.sub}</div>
+      </div>
+      <span class="dn-pill ${pillCls}">${r.cat}${r.sev?' · '+r.sev:''}</span>
+    </div>`;
+  }).join('');
+  wireHovercards(host);
+}
+function buildPickerList(){
+  const host=document.getElementById('picker-list'); if(!host) return;
+  host.innerHTML = `<div class="hg-picker-section">sessions</div>` + SESSIONS.map((s,i)=>`
+    <button class="hg-picker-row" aria-selected="${i===0}">
+      <span style="color:var(--ink-faint)">${s.live?'<span class="live-dot-sm"></span>':'▸'}</span>
+      <span style="flex:1;min-width:0"><span class="hg-picker-row-title" style="display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${s.title}</span><span class="hg-picker-row-sub" style="display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${s.sub}</span></span>
+      ${s.attn?`<span class="dn-pill bad" style="padding:1px 7px">${s.attn} ◷</span>`:''}
+      <span class="hg-picker-row-meta tnum">${s.meta}</span>
+    </button>`).join('');
+}
+function wireHovercards(host){
+  const hc=document.getElementById('hovercard');
+  host.querySelectorAll('[data-tip]').forEach(el=>{
+    const show=(cx,cy)=>{ hc.innerHTML=`<div class="hg-hc-row">${el.getAttribute('data-tip')}</div>`; hc.classList.add('on');
+      const pad=12; let lx=cx+pad, ly=cy+pad; const r=hc.getBoundingClientRect();
+      if(lx+r.width>innerWidth) lx=cx-r.width-pad; if(ly+r.height>innerHeight) ly=cy-r.height-pad;
+      hc.style.left=lx+'px'; hc.style.top=ly+'px'; };
+    el.addEventListener('mousemove', e=>show(e.clientX,e.clientY));
+    el.addEventListener('mouseleave', ()=>hc.classList.remove('on'));
+    el.addEventListener('focus', ()=>{ const r=el.getBoundingClientRect(); show(r.left, r.bottom-10); });
+    el.addEventListener('blur', ()=>hc.classList.remove('on'));
+  });
+}
+function renderAll(){ buildOrch(); buildLive(); buildInterv(); buildPickerList(); }
+onThemeChange(renderAll);
+window.addEventListener('DOMContentLoaded', ()=>{
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker);
+  mountBrand(); renderAll();
+});
+</script>
+<script>window.__EMBED_CFG__ = { optSel: '[data-surface]', bareHide: ['h2', '.rationale', '.legend', '.ba-tag'] };</script>
+<script src="_embed.js"></script>
+</body>
+</html>

--- a/docs/design/zicato-ui-study/gantt.html
+++ b/docs/design/zicato-ui-study/gantt.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="monokai">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>harmonograf × zicato — Gantt (the hero) study</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="_tokens.css">
+<link rel="stylesheet" href="_study.css">
+<style>
+  .gantt-frame { border:1px solid var(--rule); border-radius:var(--r-panel); background:var(--paper); padding:10px 12px 6px; }
+  .gantt-canvas-wrap { position:relative; width:100%; }
+  canvas.gantt-canvas { display:block; width:100%; height:auto; }
+  .opt-toggle { display:inline-flex; border:1px solid var(--rule); border-radius:7px; overflow:hidden; margin:2px 0 14px; }
+  .opt-toggle button { font:inherit; font-size:11.5px; color:var(--ink-soft); background:transparent;
+    border:none; border-right:1px solid var(--rule); padding:6px 13px; cursor:pointer; }
+  .opt-toggle button:last-child { border-right:none; }
+  .opt-toggle button[aria-pressed="true"] { color:var(--paper); background:var(--accent); font-weight:700; }
+  .kindlegend { display:flex; gap:14px 18px; flex-wrap:wrap; font-size:10.5px; color:var(--ink-faint); margin:10px 0 2px; }
+  .kindlegend span { display:inline-flex; align-items:center; gap:6px; }
+  .kindlegend .sw { width:14px; height:10px; border-radius:2px; display:inline-block; opacity:.55; }
+  .statuslegend { display:flex; gap:14px 18px; flex-wrap:wrap; font-size:10.5px; color:var(--ink-faint); margin:6px 0 2px; }
+  .statuslegend span { display:inline-flex; align-items:center; gap:6px; }
+  .statuslegend .mk { width:16px; height:12px; border-radius:2px; display:inline-flex; align-items:center; justify-content:center; }
+</style>
+</head>
+<body>
+<header class="study">
+  <span class="brand-row"><span data-brand-mark="22"></span><span data-brand-wordmark></span></span>
+  <h1>gantt — the execution timeline (the hero)</h1>
+  <span class="spacer"></span>
+  <span class="legend-inline"><b>KIND</b> = hue · <b>STATUS</b> = treatment</span>
+  <span class="theme-pick-label">theme</span>
+  <span data-theme-picker></span>
+</header>
+
+<main class="study">
+  <p class="lede" style="margin-top:22px">
+    The execution Gantt is harmonograf's instrument. It preserves the elegant <b>2-axis encoding</b>:
+    <b>KIND&nbsp;=&nbsp;hue</b> (9 span kinds, each a terminal ANSI slot from the active theme) and
+    <b>STATUS&nbsp;=&nbsp;treatment</b> (running → the one <code>--accent</code> + breathing; failed → <code>--bad</code>
+    + an <code>✕</code>; pending → faint; cancelled → hatch; planned → dashed). Status is the <b>only</b> place
+    good/bad/accent appear, so a span is never red for its identity — only when it failed. Below, the same realistic
+    multi-agent trace is drawn two ways.
+  </p>
+
+  <!-- ===== the two options ===== -->
+  <section class="study" data-surface>
+    <h2>Option A — fit-to-width SVG line-art <span style="color:var(--accent)">(recommended)</span></h2>
+    <p class="rationale">
+      A pure <code>viewBox</code> SVG at <code>width:100%</code>: hairline gridlines (<code>--rule-soft</code>, 0.6w),
+      <code>rx:3</code> bars at reduced fill-opacity lifting to 1 on hover, the agent gutter + lifelines, a context-window
+      band (<code>--caution</code> tint) along the coordinator, <code>TRANSFER</code> hand-off edges, the <b>accent
+      "now" cursor</b>, the <code>✕</code> on a failed span, the <code>◷</code> on an awaiting-human span, a dashed
+      <code>PLANNED</code> ghost ahead of now, and the goldfive lane in its <code>--hg-gf-*</code> call-category hues
+      (judge → <code>--good</code>, refine → magenta). Token-only: a theme swap re-skins every mark with no re-render.
+      Hover any bar.
+    </p>
+    <div class="gantt-frame"><div id="svg-gantt"></div></div>
+    <div class="kindlegend" id="kind-legend"></div>
+    <div class="statuslegend" id="status-legend"></div>
+  </section>
+
+  <section class="study" data-surface>
+    <h2>Option B — keep the canvas, restyle via tokens</h2>
+    <p class="rationale">
+      harmonograf's production Gantt is a 3-layer <code>&lt;canvas&gt;</code> (background · blocks · overlay) where
+      "React never drives the render loop" — already half the zicato digest-gating discipline. This option keeps that
+      renderer and only changes its inputs: every <code>fillStyle</code> reads a resolved <code>--hg-kind-*</code> /
+      <code>--hg-gf-*</code> / <code>--v2-*</code> token (via <code>getComputedStyle</code>) at draw time, so a theme
+      switch re-colors on the next frame. Same trace, same encoding as Option A — every kind hue, status treatment,
+      transfer edge and planned ghost — rendered to a real canvas here to prove the re-skin.
+    </p>
+    <div class="gantt-frame gantt-canvas-wrap"><canvas class="gantt-canvas" id="canvas-gantt" width="1120" height="320"></canvas></div>
+    <p class="rationale" style="margin-top:10px">
+      <b>Trade-off.</b> Canvas keeps harmonograf's existing hit-testing, dirty-rect batching and 60fps live cursor, but
+      marks aren't in the DOM (no per-bar <code>:focus-visible</code>, no CSS hover — those are hand-rolled). The SVG
+      option is fit-to-width and accessible by construction (every bar is <code>role="img"</code>-able, focusable,
+      hoverable) but redraws the whole figure on a structural change. For the hero surface the <b>SVG line-art</b> is the
+      recommendation; the canvas stays the right call for very long, deeply-zoomed live runs.
+    </p>
+  </section>
+
+  <!-- ===== the encoding reference ===== -->
+  <section class="study" data-surface>
+    <h2>The encoding, in full</h2>
+    <p class="rationale">Both renderers read the same map. KIND picks the hue (ANSI slot); STATUS applies the treatment.</p>
+    <div style="overflow-x:auto">
+      <table class="dn-board-table" style="max-width:760px">
+        <thead><tr><th>span kind</th><th>ANSI slot</th><th>swatch</th></tr></thead>
+        <tbody id="encoding-rows"></tbody>
+      </table>
+    </div>
+  </section>
+</main>
+
+<footer class="study">
+  harmonograf UI study · <b>gantt</b> (the hero) · realistic mock multi-agent trace · token-only colour · fit-to-width ·
+  verify in <code>paper</code> + <code>monokai</code>.
+</footer>
+
+<div class="hg-hovercard" id="hovercard" role="tooltip"></div>
+
+<!-- shared chrome (theme picker + brand mark) -->
+<script>
+window.THEME_IDS = ['monokai','solarized-dark','solarized-light','google-light','google-dark',
+  'lunaria-light','lunaria-eclipse','belafonte-day','belafonte-night','paper','zenburn',
+  'selenized-black','relaxed','espresso','dracula','ubuntu'];
+const THEME_SWATCHES = {
+  'monokai':['#1e1f1c','#272822','#f8f8f2','#a6e22e','#f92672','#66d9ef'],
+  'solarized-dark':['#04222B','#0A2D38','#93A1A1','#8BB80E','#E0483C','#2AA198'],
+  'solarized-light':['#FDF6E3','#FBF1D6','#586E75','#6B9B0B','#DC322F','#268BD2'],
+  'google-light':['#FFFFFF','#F4F4F4','#474A4E','#34A853','#EA4335','#1B9CB8'],
+  'google-dark':['#202124','#2C2D30','#FFFFFF','#34A853','#EA4335','#24C1E0'],
+  'lunaria-light':['#EBE4E1','#E2DCD9','#363434','#497D46','#783C1F','#3778A9'],
+  'lunaria-eclipse':['#323F46','#3B484F','#DFE2ED','#BEDBC1','#BA9088','#C8429F'],
+  'belafonte-day':['#D5CCBA','#CCC3B2','#34292D','#6E6A4E','#BE100E','#426A79'],
+  'belafonte-night':['#20111B','#271821','#D5CCBA','#A6A07A','#D6403E','#6F8E97'],
+  'paper':['#F2EEDE','#E6E2D3','#1A1A1A','#216609','#CC3E28','#1E6FCC'],
+  'zenburn':['#3A3A3A','#424241','#DCDCCC','#8FB28F','#CC9393','#8CD0D3'],
+  'selenized-black':['#181818','#202020','#DEDEDE','#83C746','#FF5E56','#56D8C9'],
+  'relaxed':['#353A44','#3D424B','#F7F7F7','#A0AC77','#BC5653','#7EAAC7'],
+  'espresso':['#323232','#3A3A3A','#FFFFFF','#A5C261','#D25252','#6C99BB'],
+  'dracula':['#282A36','#343746','#F8F8F2','#50FA7B','#FF5555','#BD93F9'],
+  'ubuntu':['#300A24','#3D1530','#EEEEEC','#8AE234','#CC0000','#34E2E2'],
+};
+const THEME_LABELS = {'monokai':'Monokai','solarized-dark':'Solarized Dark','solarized-light':'Solarized Light',
+  'google-light':'Google Light','google-dark':'Google Dark','lunaria-light':'Lunaria Light','lunaria-eclipse':'Lunaria Eclipse',
+  'belafonte-day':'Belafonte Day','belafonte-night':'Belafonte Night','paper':'Paper','zenburn':'Zenburn',
+  'selenized-black':'Selenized Black','relaxed':'Relaxed','espresso':'Espresso','dracula':'Dracula','ubuntu':'Ubuntu'};
+const THEME_KEY = 'hgraf-study-theme';
+let themeListeners = [];
+function onThemeChange(fn){ themeListeners.push(fn); }
+function swatchStrip(id, sm){ const t = THEME_SWATCHES[id] || [];
+  return `<span class="dt-swatch-strip${sm?' dt-swatch-strip-sm':''}">`+t.map(c=>`<span class="dt-swatch" style="background:${c}"></span>`).join('')+`</span>`; }
+function currentTheme(){ return document.documentElement.getAttribute('data-theme') || 'monokai'; }
+function applyTheme(id){ document.documentElement.setAttribute('data-theme', id);
+  try { localStorage.setItem(THEME_KEY, id); } catch(e){}
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker);
+  themeListeners.forEach(fn=>{ try{fn();}catch(e){} }); }
+function buildPicker(host){ const cur = currentTheme();
+  host.innerHTML = `<div class="dt-cd"><button class="dt-cd-trigger" aria-haspopup="listbox" aria-expanded="false">${swatchStrip(cur,true)}<span class="dt-cd-name">${THEME_LABELS[cur]}</span><span class="dt-cd-caret" aria-hidden="true">▾</span></button><div class="dt-cd-list" role="listbox" aria-label="theme">${window.THEME_IDS.map(id=>`<div class="dt-cd-option" role="option" data-id="${id}" aria-selected="${id===cur}">${swatchStrip(id)}<span class="dt-cd-name">${THEME_LABELS[id]}</span></div>`).join('')}</div></div>`;
+  const cd = host.querySelector('.dt-cd'), trig = host.querySelector('.dt-cd-trigger');
+  trig.addEventListener('click', e=>{ e.stopPropagation(); const open = cd.classList.toggle('dt-cd-open'); trig.setAttribute('aria-expanded', open); });
+  host.querySelectorAll('.dt-cd-option').forEach(o=> o.addEventListener('click', ()=>{ applyTheme(o.dataset.id); cd.classList.remove('dt-cd-open'); })); }
+document.addEventListener('click', ()=> document.querySelectorAll('.dt-cd-open').forEach(c=>c.classList.remove('dt-cd-open')));
+(function initTheme(){ let saved=null; try { saved=localStorage.getItem(THEME_KEY); } catch(e){}
+  const P=new URLSearchParams(location.search), fromUrl=P.get('theme');
+  const id=(fromUrl&&window.THEME_IDS.includes(fromUrl))?fromUrl:(saved&&window.THEME_IDS.includes(saved))?saved:'monokai';
+  document.documentElement.setAttribute('data-theme', id); })();
+/* harmonograf brand — the Option-D alpha: one period of the 2:3 Lissajous,
+   MIRRORED about the vertical axis (x = cx − A·cos2t, y = cy + B·sin3t) so the
+   knot reads as a lowercase α — still a Lissajous, loop left, tails right.
+   Stroke currentColor; the one dot rides the lower-right tail tip: the pen at
+   rest. ONE ALPHA PER LOCKUP: beside this mark the wordmark is PLAIN LETTERS
+   (the glyph already carries the α and the dot); only a STANDALONE wordmark
+   spells the "a" of graf with the drawn α. */
+function hgAlphaPath(cx, cy, A, B){ const pts=[];
+  for(let i=0;i<=240;i++){ const t=2*Math.PI*i/240;
+    pts.push((cx - A*Math.cos(2*t)).toFixed(2)+','+(cy + B*Math.sin(3*t)).toFixed(2)); }
+  return 'M'+pts.join(' L')+' Z'; }
+function hgBrandMarkSVG(h){ return `<svg class="hg-brand-mark" style="height:${h||24}px" viewBox="0 0 48 48" role="img" aria-label="harmonograf" focusable="false"><path d="${hgAlphaPath(24,24,19,15)}" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/><circle cx="43" cy="39" r="3.2" fill="var(--hgraf-brand, #5EA3EC)"/></svg>`; }
+function hgWordmarkSVG(){ const T='harmonograf', X0=1, ADV=9.6, BASE=15; const W=X0*2+T.length*ADV;
+  return `<svg class="hg-brand-name" viewBox="0 0 ${W} 18" role="img" aria-label="harmonograf" focusable="false"><text x="${X0}" y="${BASE}" font-family="var(--brand-mono)" font-size="15" font-weight="700" textLength="${T.length*ADV}" lengthAdjust="spacing" fill="currentColor" xml:space="preserve">${T}</text></svg>`; }
+function mountBrand(){ document.querySelectorAll('[data-brand-mark]').forEach(n=>{ n.innerHTML=hgBrandMarkSVG(+n.dataset.brandMark||24); });
+  document.querySelectorAll('[data-brand-wordmark]').forEach(n=>{ n.innerHTML=hgWordmarkSVG(); }); }
+</script>
+
+<!-- the Gantt: trace + both renderers -->
+<script>
+/* =====================================================================
+   MOCK MULTI-AGENT TRACE — a realistic harmonograf run.
+   Time is a 0..1 fraction of the visible window (wall-clock 0–18.4s).
+   Lanes are agents; the coordinator carries a context-window band.
+   NOW sits at t=0.80; one span is RUNNING (the live edge), one FAILED,
+   one PLANNED ghost sits ahead of now, one CANCELLED, one AWAITING_HUMAN.
+   ===================================================================== */
+const NOW = 0.80;
+const LANES = [
+  { id:'user',      label:'user',       ramp:'user' },
+  { id:'planner',   label:'planner',    ramp:1, ctx:true },
+  { id:'coder-a',   label:'coder-a',    ramp:3 },
+  { id:'coder-b',   label:'coder-b',    ramp:4 },
+  { id:'reviewer',  label:'reviewer',   ramp:5 },
+  { id:'goldfive',  label:'goldfive',   ramp:'goldfive' },
+];
+// each span: lane, kind, t0, t1, status. (status default COMPLETED)
+const SPANS = [
+  { lane:'user',     kind:'user-message',  t0:0.00, t1:0.05, status:'COMPLETED', name:'task: refactor checkout' },
+  { lane:'planner',  kind:'invocation',    t0:0.02, t1:0.99, status:'RUNNING',   name:'planner invocation' },
+  { lane:'planner',  kind:'llm-call',      t0:0.05, t1:0.16, status:'COMPLETED', name:'plan_generate' },
+  { lane:'planner',  kind:'transfer',      t0:0.16, t1:0.185,status:'COMPLETED', name:'→ coder-a', edgeTo:'coder-a', edgeAt:0.19 },
+  { lane:'planner',  kind:'transfer',      t0:0.40, t1:0.425,status:'COMPLETED', name:'→ coder-b', edgeTo:'coder-b', edgeAt:0.43 },
+  { lane:'planner',  kind:'llm-call',      t0:0.66, t1:0.80, status:'RUNNING',   name:'synthesize results' },
+  { lane:'planner',  kind:'wait-for-human',t0:0.86, t1:0.95, status:'AWAITING_HUMAN', name:'approve merge?' },
+  { lane:'coder-a',  kind:'invocation',    t0:0.19, t1:0.62, status:'COMPLETED', name:'coder-a invocation' },
+  { lane:'coder-a',  kind:'llm-call',      t0:0.20, t1:0.30, status:'COMPLETED', name:'draft pricing client' },
+  { lane:'coder-a',  kind:'tool-call',     t0:0.31, t1:0.40, status:'COMPLETED', name:'read_file service.ts' },
+  { lane:'coder-a',  kind:'tool-call',     t0:0.41, t1:0.52, status:'COMPLETED', name:'write_file service.ts' },
+  { lane:'coder-a',  kind:'agent-message', t0:0.53, t1:0.61, status:'COMPLETED', name:'report → planner' },
+  { lane:'coder-b',  kind:'invocation',    t0:0.43, t1:0.78, status:'COMPLETED', name:'coder-b invocation' },
+  { lane:'coder-b',  kind:'llm-call',      t0:0.44, t1:0.55, status:'COMPLETED', name:'update tests' },
+  { lane:'coder-b',  kind:'tool-call',     t0:0.56, t1:0.66, status:'FAILED',    name:'run_tests (3 failed)' },
+  { lane:'coder-b',  kind:'tool-call',     t0:0.67, t1:0.72, status:'CANCELLED', name:'retry_tests (superseded)' },
+  { lane:'coder-b',  kind:'agent-message', t0:0.73, t1:0.78, status:'COMPLETED', name:'report → planner' },
+  { lane:'reviewer', kind:'invocation',    t0:0.62, t1:0.80, status:'RUNNING',   name:'reviewer invocation' },
+  { lane:'reviewer', kind:'llm-call',      t0:0.63, t1:0.80, status:'RUNNING',   name:'review diff' },
+  { lane:'reviewer', kind:'tool-call',     t0:0.83, t1:0.88, status:'PENDING',   name:'lint (queued)' },
+  { lane:'goldfive', kind:'custom',        t0:0.30, t1:0.40, status:'COMPLETED', name:'judge_reasoning', gf:'judge' },
+  { lane:'goldfive', kind:'custom',        t0:0.58, t1:0.66, status:'COMPLETED', name:'refine_steer', gf:'refine' },
+];
+const PLANNED = [ // ghost spans ahead of NOW (speculative, not yet scheduled)
+  { lane:'reviewer', t0:0.90, t1:0.97, name:'format' },
+  { lane:'planner',  t0:0.95, t1:0.99, name:'merge' },
+];
+const KIND_LABELS = {
+  'invocation':'INVOCATION','llm-call':'LLM_CALL','tool-call':'TOOL_CALL','user-message':'USER_MESSAGE',
+  'agent-message':'AGENT_MESSAGE','transfer':'TRANSFER','wait-for-human':'WAIT_FOR_HUMAN','planned':'PLANNED','custom':'CUSTOM',
+};
+const KIND_SLOT = {
+  'invocation':'bright-black','llm-call':'blue','tool-call':'cyan','user-message':'green',
+  'agent-message':'bright-green','transfer':'yellow','wait-for-human':'magenta','planned':'bright-black','custom':'white',
+};
+const STATUS_NOTE = {
+  COMPLETED:'completed', RUNNING:'running (now) · accent + breathe', FAILED:'failed · ✕',
+  PENDING:'pending · faint', CANCELLED:'cancelled · hatch', AWAITING_HUMAN:'awaiting human · ◷',
+};
+
+/* ---------- shared geometry ---------- */
+const cssVar = n => getComputedStyle(document.documentElement).getPropertyValue(n).trim() || '#888';
+function laneAgentVar(ramp){ return ramp==='user'?'--hg-agent-user':ramp==='goldfive'?'--hg-agent-goldfive':`--hg-agent-${ramp}`; }
+// goldfive call category → its --hg-gf-* hue (STYLE-GUIDE §2). A span on the
+// goldfive lane carries a `gf` class; its bar takes the category hue, not the
+// generic CUSTOM neutral — this is the goldfive categorical layer.
+const GF_VAR = { judge:'--hg-gf-judge-on-task', refine:'--hg-gf-refine', plan:'--hg-gf-plan', reflective:'--hg-gf-reflective' };
+// The base hue token for a span: goldfive category if present, else kind hue.
+function spanHueVar(s){ return s.gf ? (GF_VAR[s.gf]||`--hg-kind-${s.kind}`) : `--hg-kind-${s.kind}`; }
+const WALL = 18.4; // seconds across the window
+const fmtT = f => (f*WALL).toFixed(1)+'s';
+// escape strings interpolated into data-tip / aria-label so an embedded quote
+// can't close the attribute early (parity with figures.html; latent here since
+// the mock strings carry no quotes, but robust against future trace data).
+const esc = s => String(s).replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+
+/* ===================================================================
+   OPTION A — the SVG line-art renderer (the hero).
+   =================================================================== */
+function renderSvgGantt(){
+  const host = document.getElementById('svg-gantt'); if(!host) return;
+  const W=1120, padL=92, padR=18, top=30, rowH=34, padB=34;
+  const laneCount = LANES.length;
+  const H = top + laneCount*rowH + padB;
+  const x = f => padL + f*(W-padL-padR);
+  const laneY = i => top + i*rowH;
+  const laneIdx = id => LANES.findIndex(l=>l.id===id);
+  let g = `<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="multi-agent execution timeline">`;
+  // defs: a diagonal hatch for CANCELLED, theme-derived
+  g += `<defs><pattern id="hatch" width="5" height="5" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+          <line x1="0" y1="0" x2="0" y2="5" stroke="var(--ink-faint)" stroke-width="1"/></pattern></defs>`;
+  // agent gutter
+  g += `<rect class="hg-gantt-gutter" x="0" y="${top-4}" width="${padL-6}" height="${laneCount*rowH+8}"/>`;
+  // time axis ticks + hairline gridlines
+  for(let i=0;i<=8;i++){ const f=i/8, gx=x(f);
+    g += `<line class="hg-gantt-grid" x1="${gx}" y1="${top-4}" x2="${gx}" y2="${top+laneCount*rowH}"/>`;
+    g += `<text class="hg-gantt-axis" x="${gx}" y="${top-9}" text-anchor="middle" style="font-variant-numeric:tabular-nums">${fmtT(f)}</text>`; }
+  // lifelines + lane labels + agent identity tick
+  LANES.forEach((ln,i)=>{ const cy=laneY(i)+rowH/2;
+    g += `<line class="hg-gantt-lane-sep" x1="0" y1="${laneY(i)}" x2="${W-padR}" y2="${laneY(i)}"/>`;
+    g += `<rect x="6" y="${cy-7}" width="3" height="14" rx="1.5" fill="var(${laneAgentVar(ln.ramp)})"/>`;
+    g += `<text class="hg-gantt-lane-label" x="14" y="${cy+3}">${ln.label}</text>`; });
+  g += `<line class="hg-gantt-lane-sep" x1="0" y1="${laneY(laneCount)}" x2="${W-padR}" y2="${laneY(laneCount)}"/>`;
+  // context-window band along the coordinator lane (rises as context fills)
+  const pl = laneIdx('planner'); if(pl>=0){ const cy=laneY(pl);
+    let pts=[]; for(let k=0;k<=20;k++){ const f=k/20; const ratio=Math.min(1, 0.18+f*0.7); const yy=cy+rowH-ratio*(rowH-6);
+      pts.push(`${x(f).toFixed(1)},${yy.toFixed(1)}`); }
+    g += `<polyline class="hg-gantt-ctxband-line" points="${pts.join(' ')}"/>`;
+    g += `<polygon class="hg-gantt-ctxband" points="${x(0)},${cy+rowH} ${pts.join(' ')} ${x(1)},${cy+rowH}"/>`; }
+  // transfer edges (slanted hand-off lines)
+  SPANS.filter(s=>s.edgeTo).forEach(s=>{ const fi=laneIdx(s.lane), ti=laneIdx(s.edgeTo);
+    if(fi<0||ti<0) return; const x1=x(s.t1), y1=laneY(fi)+rowH/2, x2=x(s.edgeAt), y2=laneY(ti)+rowH/2;
+    g += `<path class="hg-gantt-edge is-transfer" d="M${x1},${y1} C${x1+18},${y1} ${x2-18},${y2} ${x2},${y2}"/>`; });
+  // planned ghosts
+  PLANNED.forEach(p=>{ const li=laneIdx(p.lane); if(li<0) return; const cy=laneY(li)+rowH/2;
+    const w=Math.max(5,x(p.t1)-x(p.t0));
+    g += `<rect class="hg-gantt-bar is-planned" x="${x(p.t0)}" y="${cy-7}" width="${w}" height="14" rx="3"
+            tabindex="0" role="img" data-tip="${esc(p.name)} · PLANNED" aria-label="${esc(p.name)} planned"/>`; });
+  // spans
+  SPANS.forEach(s=>{ const li=laneIdx(s.lane); if(li<0) return; const cy=laneY(li)+rowH/2;
+    const isInv = s.kind==='invocation';
+    const h = isInv ? 20 : 14; const y = cy - h/2;
+    const w = Math.max(4, x(s.t1)-x(s.t0));
+    let cls='hg-gantt-bar is-'+s.kind;
+    if(s.status==='RUNNING') cls+=' is-running hg-breathe';
+    if(s.status==='FAILED') cls+=' is-failed';
+    if(s.status==='PENDING') cls+=' is-pending';
+    if(s.status==='CANCELLED') cls+=' is-cancelled';
+    const fill = s.status==='FAILED' ? 'var(--bad)'
+               : s.status==='AWAITING_HUMAN' ? 'var(--bad-soft)'
+               : `var(${spanHueVar(s)})`;
+    const gfTip = s.gf ? ` · gf:${s.gf}` : '';
+    const tip = `${s.name} · ${KIND_LABELS[s.kind]}${gfTip} · ${fmtT(s.t1-s.t0)} · ${STATUS_NOTE[s.status]||s.status}`;
+    g += `<rect class="${cls}" x="${x(s.t0)}" y="${y}" width="${w}" height="${h}" rx="3" fill="${fill}"
+            tabindex="0" role="img" data-tip="${esc(tip)}" aria-label="${esc(tip)}"/>`;
+    // CANCELLED hatch overlay
+    if(s.status==='CANCELLED')
+      g += `<rect x="${x(s.t0)}" y="${y}" width="${w}" height="${h}" rx="3" fill="url(#hatch)" pointer-events="none" opacity="0.5"/>`;
+    // AWAITING_HUMAN stroke + glyph
+    if(s.status==='AWAITING_HUMAN'){
+      g += `<rect x="${x(s.t0)}" y="${y}" width="${w}" height="${h}" rx="3" fill="none" stroke="var(--bad)" stroke-width="1.4" vector-effect="non-scaling-stroke" pointer-events="none"/>`;
+      g += `<text class="hg-gantt-glyph-wait" x="${x(s.t0)+w-9}" y="${cy+3.2}" pointer-events="none">◷</text>`; }
+    // FAILED ✕ glyph
+    if(s.status==='FAILED')
+      g += `<text class="hg-gantt-glyph-fail" x="${x(s.t1)-8}" y="${cy+3.2}" pointer-events="none">✕</text>`;
+  });
+  // the NOW cursor (the one accent) + cap
+  const nx=x(NOW);
+  g += `<line class="hg-gantt-now" x1="${nx}" y1="${top-6}" x2="${nx}" y2="${top+laneCount*rowH+4}"/>`;
+  g += `<circle class="hg-gantt-now-cap" cx="${nx}" cy="${top-6}" r="3"/>`;
+  // now label: accent, to tie it to the cursor. Uses the dedicated
+  // .hg-gantt-now-label class (its own --accent fill, so no axis-major override).
+  g += `<text class="hg-gantt-now-label" x="${nx}" y="${top+laneCount*rowH+18}" text-anchor="middle" font-weight="500">now ${fmtT(NOW)}</text>`;
+  g += `</svg>`;
+  host.innerHTML = g;
+  wireHovercards(host);
+}
+
+/* ---------- hovercard wiring (the singleton card) ---------- */
+function wireHovercards(host){
+  const hc = document.getElementById('hovercard');
+  host.querySelectorAll('[data-tip]').forEach(el=>{
+    el.addEventListener('mousemove', e=>{
+      hc.innerHTML = `<div class="hg-hc-row">${el.getAttribute('data-tip')}</div>`;
+      hc.classList.add('on');
+      const pad=12; let lx=e.clientX+pad, ly=e.clientY+pad;
+      const r=hc.getBoundingClientRect();
+      if(lx+r.width>innerWidth) lx=e.clientX-r.width-pad;
+      if(ly+r.height>innerHeight) ly=e.clientY-r.height-pad;
+      hc.style.left=lx+'px'; hc.style.top=ly+'px';
+    });
+    el.addEventListener('mouseleave', ()=> hc.classList.remove('on'));
+    el.addEventListener('focus', ()=>{ hc.innerHTML=`<div class="hg-hc-row">${el.getAttribute('data-tip')}</div>`;
+      const r=el.getBoundingClientRect(); hc.classList.add('on'); hc.style.left=r.left+'px'; hc.style.top=(r.bottom+6)+'px'; });
+    el.addEventListener('blur', ()=> hc.classList.remove('on'));
+  });
+}
+
+/* ===================================================================
+   OPTION B — the canvas renderer (token-driven re-skin).
+   Mirrors harmonograf's 3-layer canvas: it reads --hg-kind-* / --v2-*
+   via getComputedStyle at draw time, so a theme swap re-colours on the
+   next frame. Drawn once here (a live run would rAF the overlay layer).
+   =================================================================== */
+function renderCanvasGantt(){
+  const cv = document.getElementById('canvas-gantt'); if(!cv) return;
+  const dpr = Math.min(2, window.devicePixelRatio||1);
+  const cssW = cv.clientWidth || 1120, cssH = 320;
+  cv.width = cssW*dpr; cv.height = cssH*dpr;
+  cv.style.height = cssH+'px';
+  const ctx = cv.getContext('2d'); ctx.setTransform(dpr,0,0,dpr,0,0);
+  ctx.clearRect(0,0,cssW,cssH);
+  const padL=92, padR=18, top=28, rowH=42, padB=30;
+  const x = f => padL + f*(cssW-padL-padR);
+  const laneY = i => top + i*rowH;
+  const laneIdx = id => LANES.findIndex(l=>l.id===id);
+  const V = n => cssVar(n);
+  // gutter
+  ctx.fillStyle = V('--panel-2'); ctx.fillRect(0, top-4, padL-6, LANES.length*rowH+8);
+  // gridlines + axis
+  ctx.font = '9.5px ui-monospace, monospace'; ctx.textAlign='center';
+  for(let i=0;i<=8;i++){ const gx=x(i/8);
+    ctx.strokeStyle=V('--rule-soft'); ctx.lineWidth=0.6; ctx.beginPath(); ctx.moveTo(gx,top-4); ctx.lineTo(gx,top+LANES.length*rowH); ctx.stroke();
+    ctx.fillStyle=V('--ink-faint'); ctx.fillText((i/8*WALL).toFixed(1)+'s', gx, top-9); }
+  // lanes + labels + agent tick
+  ctx.textAlign='left';
+  LANES.forEach((ln,i)=>{ const cy=laneY(i)+rowH/2;
+    ctx.strokeStyle=V('--rule-soft'); ctx.lineWidth=0.6; ctx.beginPath(); ctx.moveTo(0,laneY(i)); ctx.lineTo(cssW-padR,laneY(i)); ctx.stroke();
+    ctx.fillStyle=V(laneAgentVar(ln.ramp)); ctx.fillRect(6, cy-7, 3, 14);
+    ctx.fillStyle=V('--ink-soft'); ctx.font='10px ui-monospace, monospace'; ctx.fillText(ln.label, 14, cy+3); });
+  // context band along planner
+  const pl=laneIdx('planner'); if(pl>=0){ const cy=laneY(pl);
+    ctx.beginPath(); ctx.moveTo(x(0), cy+rowH);
+    for(let k=0;k<=20;k++){ const f=k/20, ratio=Math.min(1,0.18+f*0.7); ctx.lineTo(x(f), cy+rowH-ratio*(rowH-6)); }
+    ctx.lineTo(x(1), cy+rowH); ctx.closePath();
+    ctx.fillStyle = mix(V('--caution'), 0.14); ctx.fill(); }
+  // transfer hand-off edges (slanted, dashed, in the TRANSFER hue) — same as SVG
+  ctx.save(); ctx.setLineDash([3,2]); ctx.strokeStyle=V('--hg-kind-transfer'); ctx.lineWidth=1; ctx.globalAlpha=0.7;
+  SPANS.filter(s=>s.edgeTo).forEach(s=>{ const fi=laneIdx(s.lane), ti=laneIdx(s.edgeTo); if(fi<0||ti<0) return;
+    const x1=x(s.t1), y1=laneY(fi)+rowH/2, x2=x(s.edgeAt), y2=laneY(ti)+rowH/2;
+    ctx.beginPath(); ctx.moveTo(x1,y1); ctx.bezierCurveTo(x1+18,y1,x2-18,y2,x2,y2); ctx.stroke(); });
+  ctx.restore();
+  // planned ghosts (dashed --ink-faint on --rule-soft) ahead of now — same as SVG
+  PLANNED.forEach(p=>{ const li=laneIdx(p.lane); if(li<0) return; const cy=laneY(li)+rowH/2;
+    const w=Math.max(5,x(p.t1)-x(p.t0)), y=cy-8;
+    ctx.globalAlpha=0.5; ctx.fillStyle=V('--rule-soft'); roundRect(ctx,x(p.t0),y,w,16,3); ctx.fill(); ctx.globalAlpha=1;
+    ctx.save(); ctx.setLineDash([4,3]); ctx.strokeStyle=V('--ink-faint'); ctx.lineWidth=1; roundRect(ctx,x(p.t0),y,w,16,3); ctx.stroke(); ctx.restore(); });
+  // spans
+  SPANS.forEach(s=>{ const li=laneIdx(s.lane); if(li<0) return; const cy=laneY(li)+rowH/2;
+    const isInv=s.kind==='invocation'; const h=isInv?22:16; const y=cy-h/2;
+    const w=Math.max(3, x(s.t1)-x(s.t0));
+    let fill = s.status==='FAILED' ? V('--bad')
+             : s.status==='AWAITING_HUMAN' ? V('--bad-soft') : V(spanHueVar(s));
+    let alpha = 0.55; if(isInv) alpha=0.30; if(s.status==='PENDING') alpha=0.32; if(s.status==='CANCELLED') alpha=0.28;
+    if(s.status==='AWAITING_HUMAN') alpha=1;
+    roundRect(ctx, x(s.t0), y, w, h, 3);
+    ctx.globalAlpha = alpha; ctx.fillStyle = fill; ctx.fill(); ctx.globalAlpha = 1;
+    if(s.status==='RUNNING'){ ctx.strokeStyle=V('--accent'); ctx.lineWidth=2; roundRect(ctx,x(s.t0),y,w,h,3); ctx.stroke(); }
+    if(s.status==='AWAITING_HUMAN'){ ctx.strokeStyle=V('--bad'); ctx.lineWidth=1.4; roundRect(ctx,x(s.t0),y,w,h,3); ctx.stroke();
+      ctx.fillStyle=V('--caution'); ctx.font='10px ui-monospace,monospace'; ctx.textAlign='right'; ctx.fillText('◷', x(s.t1)-3, cy+3.2); ctx.textAlign='left'; }
+    if(s.status==='FAILED'){ ctx.fillStyle=V('--bad'); ctx.font='10px ui-monospace,monospace'; ctx.textAlign='right'; ctx.fillText('✕', x(s.t1)-3, cy+3); ctx.textAlign='left'; }
+    if(s.status==='CANCELLED'){ hatchRect(ctx, x(s.t0), y, w, h, V('--ink-faint')); }
+  });
+  // now cursor (the one accent)
+  const nx=x(NOW);
+  ctx.strokeStyle=V('--accent'); ctx.lineWidth=2; ctx.beginPath(); ctx.moveTo(nx,top-6); ctx.lineTo(nx,top+LANES.length*rowH+4); ctx.stroke();
+  ctx.fillStyle=V('--accent'); ctx.beginPath(); ctx.arc(nx,top-6,3,0,7); ctx.fill();
+  ctx.textAlign='center'; ctx.font='9.5px ui-monospace,monospace'; ctx.fillText('now '+(NOW*WALL).toFixed(1)+'s', nx, top+LANES.length*rowH+18);
+}
+function roundRect(ctx,x,y,w,h,r){ r=Math.min(r,h/2,w/2); ctx.beginPath();
+  ctx.moveTo(x+r,y); ctx.arcTo(x+w,y,x+w,y+h,r); ctx.arcTo(x+w,y+h,x,y+h,r); ctx.arcTo(x,y+h,x,y,r); ctx.arcTo(x,y,x+w,y,r); ctx.closePath(); }
+function hatchRect(ctx,x,y,w,h,color){ ctx.save(); roundRect(ctx,x,y,w,h,3); ctx.clip();
+  ctx.strokeStyle=color; ctx.lineWidth=1; for(let i=-h;i<w;i+=5){ ctx.beginPath(); ctx.moveTo(x+i,y+h); ctx.lineTo(x+i+h,y); ctx.stroke(); } ctx.restore(); }
+function mix(hex, a){ // hex → rgba with alpha (for canvas fills that need transparency)
+  hex=hex.replace('#',''); if(hex.length===3) hex=hex.split('').map(c=>c+c).join('');
+  const n=parseInt(hex,16); return `rgba(${(n>>16)&255},${(n>>8)&255},${n&255},${a})`; }
+
+/* ---------- legends + encoding table ---------- */
+function buildLegends(){
+  const kl=document.getElementById('kind-legend');
+  if(kl) kl.innerHTML = Object.keys(KIND_SLOT).filter(k=>k!=='planned')
+    .map(k=>`<span><span class="sw" style="background:var(--hg-kind-${k})"></span>${KIND_LABELS[k]}</span>`).join('')
+    + `<span><span class="sw" style="background:var(--hg-gf-refine)"></span>goldfive (gf category)</span>`
+    + `<span><span class="sw" style="background:var(--rule-soft);border:1px dashed var(--ink-faint);opacity:1"></span>PLANNED (dashed)</span>`;
+  const sl=document.getElementById('status-legend');
+  if(sl) sl.innerHTML = [
+    ['running','<span class="mk" style="border:2px solid var(--accent)"></span>','RUNNING · accent + breathe (now)'],
+    ['failed','<span class="mk" style="background:var(--bad);color:var(--paper)">✕</span>','FAILED · bad + ✕'],
+    ['await','<span class="mk" style="background:var(--bad-soft);border:1.4px solid var(--bad);color:var(--caution)">◷</span>','AWAITING_HUMAN'],
+    ['pending','<span class="mk" style="background:var(--hg-kind-tool-call);opacity:.32"></span>','PENDING · faint'],
+    ['cancelled','<span class="mk" style="background:var(--ink-faint);opacity:.4"></span>','CANCELLED · hatch'],
+    ['now','<span class="mk" style="background:var(--accent)"></span>','NOW cursor (the one accent)'],
+  ].map(([k,mk,lab])=>`<span>${mk}${lab}</span>`).join('');
+  const er=document.getElementById('encoding-rows');
+  if(er) er.innerHTML = Object.keys(KIND_SLOT)
+    .map(k=>`<tr><td>${KIND_LABELS[k]}</td><td>${KIND_SLOT[k]}</td>
+      <td><span style="display:inline-block;width:40px;height:13px;border-radius:2px;background:var(--hg-kind-${k});opacity:.7"></span></td></tr>`).join('');
+}
+
+function renderAll(){ renderSvgGantt(); renderCanvasGantt(); buildLegends(); }
+onThemeChange(renderAll);
+window.addEventListener('resize', ()=>{ renderCanvasGantt(); });
+window.addEventListener('DOMContentLoaded', ()=>{
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker);
+  mountBrand();
+  renderAll();
+});
+</script>
+<script>window.__EMBED_CFG__ = { optSel: '[data-surface]', bareHide: ['h2', '.rationale'] };</script>
+<script src="_embed.js"></script>
+</body>
+</html>

--- a/docs/design/zicato-ui-study/grammar.html
+++ b/docs/design/zicato-ui-study/grammar.html
@@ -1,0 +1,767 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="monokai">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>harmonograf — the figure grammar (new marks)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="_tokens.css">
+<link rel="stylesheet" href="_study.css">
+<style>
+  /* grammar-page marks — token-only */
+  .gm-onplan { stroke: var(--ink-faint); stroke-width: 1; stroke-dasharray: 3 3; vector-effect: non-scaling-stroke; }
+  .gm-tol { fill: var(--good); fill-opacity: .07; }
+  .gm-trace { stroke: var(--ink); stroke-width: 1.3; fill: none; vector-effect: non-scaling-stroke; }
+  .gm-trace-soft { stroke: var(--ink-soft); stroke-width: 1.1; fill: none; vector-effect: non-scaling-stroke; }
+  .gm-excursion { fill: var(--bad); fill-opacity: .14; }
+  .gm-tick { stroke: var(--caution); stroke-width: 1.5; vector-effect: non-scaling-stroke; }
+  .gm-tick-label { fill: var(--caution); font-size: 8.5px; }
+  .gm-label { fill: var(--ink-soft); font-size: 10px; }
+  .gm-faint { fill: var(--ink-faint); font-size: 9px; }
+  .gm-axis { fill: var(--ink-faint); font-size: 9px; font-variant-numeric: tabular-nums; }
+  .gm-good { fill: var(--good); } .gm-bad { fill: var(--bad); } .gm-flat { fill: var(--flat, var(--ink-faint)); }
+  .gm-accent { fill: var(--accent); }
+  .gm-ln-good { stroke: var(--good); } .gm-ln-bad { stroke: var(--bad); } .gm-ln-flat { stroke: var(--flat, var(--ink-faint)); }
+  .gm-spine { stroke: var(--accent); stroke-width: 2.2; vector-effect: non-scaling-stroke; }
+  .gm-node { fill: var(--panel); stroke: var(--rule); }
+  .gm-ribbon { fill: var(--ink); fill-opacity: .14; transition: fill-opacity .12s; }
+  .gm-ribbon:hover { fill-opacity: .38; }
+  .gm-seam { stroke: var(--rule); stroke-width: 1; stroke-dasharray: 5 4; vector-effect: non-scaling-stroke; }
+  .gm-band { fill-opacity: .5; }
+  .gm-gate { fill: none; stroke: var(--ink-soft); stroke-width: 1.4; }
+  .fp-row { display: flex; gap: 26px; flex-wrap: wrap; align-items: flex-start; }
+  .fp-cell { text-align: center; font-size: 10px; color: var(--ink-soft); }
+  .fp-cell svg { display: block; margin: 0 auto 6px; border: 1px solid var(--rule); border-radius: var(--r-panel); background: var(--paper); }
+  .fp-pill { display: inline-block; font-size: 9px; padding: 1px 7px; border: 1px solid var(--rule); border-radius: var(--r-pill); color: var(--ink-faint); margin-top: 3px; }
+  .fp-pill.live { color: var(--accent); border-color: var(--accent); }
+  .fp-pill.done { color: var(--good); border-color: var(--good); }
+  .fp-pill.fail { color: var(--bad); border-color: var(--bad); }
+  .sm-row { display: flex; gap: 14px; flex-wrap: wrap; }
+  .sm-cell { text-align: center; font-size: 9px; color: var(--ink-faint); }
+  .sm-cell svg { display: block; border: 1px solid var(--rule-soft); border-radius: var(--r-panel); background: var(--paper); margin-bottom: 4px; }
+  .figwrap { border: 1px solid var(--rule); border-radius: var(--r-panel); background: var(--paper); padding: 12px 14px; }
+</style>
+</head>
+<body>
+
+<header class="study">
+  <div class="brand-row"><h1>harmonograf — the figure grammar</h1></div>
+  <span class="legend-inline">thirteen new marks · drift &amp; correction · plans · sequence · steering · all token-only, all fit-to-width</span>
+  <div class="spacer"></div>
+  <span class="theme-pick-label">theme</span>
+  <span data-theme-picker></span>
+</header>
+
+<main class="study">
+
+<section class="study">
+  <h2>Premise</h2>
+  <p class="lede">
+    zicato's figure language is built on <b>oscillation around a reference rule</b> — good below, bad above,
+    one accent spine. harmonograf's domain — drift and correction — <i>is</i> oscillation around a reference.
+    These prototypes extend the grammar with harmonograf's nouns: the plan-rule replaces the champion-rule, the
+    intervention replaces the gate, and the run's own trace becomes the brand. Conventions inherited whole:
+    hairline gridlines, <code>rx:3</code> bars, status earns color / identity never does, <code>--accent</code>
+    only for now &amp; selection, every figure <code>width:100%</code> + <code>viewBox</code>.
+  </p>
+</section>
+
+<section class="study" data-opt>
+  <h2>01 · the harmonograph fingerprint — a session identicon that is data</h2>
+  <div class="surface">
+    <p class="rationale">
+      Each session gets a glyph drawn by the instrument itself: <b>x driven by plan progress, y by execution
+      drift</b>, damped. Aligned runs trace tight decaying figures; detuned runs precess; a corrected run visibly
+      <b>tightens</b> mid-figure where the intervention landed; a failing run spirals outward. The dot is the pen —
+      and its color is <i>status, earned</i>: accent while live, good when done, bad when failed. For session
+      pickers, fleet cards, tab titles — an identicon operators learn to read.
+    </p>
+    <div class="fp-row" id="fig-fp"></div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>02 · the drift seismograph — the headline figure</h2>
+  <div class="surface">
+    <p class="rationale">
+      Per agent: a dashed <b>on-plan rule</b>, a <b>tolerance band</b> hugging it (good-soft), and the goldfive
+      judge series as a thin ink trace. The trace stays neutral until it <b>escapes the band</b> — the excursion
+      area fills bad-soft, severity is <i>distance, not color</i>. Interventions are caution ticks; watch the trace
+      decay back after each one. Answers the operator's only question — “is it wandering, did my correction take?” —
+      with zero labels.
+    </p>
+    <div class="figwrap" id="fig-seismo"></div>
+    <div class="legend">
+      <span><span class="ln" style="border-color:var(--ink)"></span>judge drift series</span>
+      <span><span class="sw" style="background:var(--good);opacity:.25"></span>tolerance band</span>
+      <span><span class="sw" style="background:var(--bad);opacity:.3"></span>excursion</span>
+      <span><span class="ln" style="border-color:var(--caution)"></span>intervention tick</span>
+      <span><span class="ln" style="border-color:var(--accent)"></span>now</span>
+    </div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>03 · the judge heartbeat strip — word-sized verdicts</h2>
+  <div class="surface">
+    <p class="rationale">
+      A <code>genDots</code>-style strip under a lane: one glyph per judge call — <code>·</code> on-task,
+      <code>▲</code> warning, <code>✕</code> critical — in the goldfive category hue at quiet opacity. The EKG of
+      the run; trellis it across sessions for the fleet view.
+    </p>
+    <div class="figwrap" id="fig-heart"></div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>04 · the intervention ladder — escalation made literal</h2>
+  <div class="surface">
+    <p class="rationale">
+      goldfive's escalation ladder drawn as a ladder: rungs in ascending severity, the session's interventions as
+      dots placed on their rung over time, a faint step-path connecting them. <b>A healthy run lives on the bottom
+      rung; a run climbing the ladder is visibly escalating.</b> The escalate-rung dot is bad — earned, terminal.
+    </p>
+    <div class="ba-grid">
+      <div class="ba-cell"><p class="ba-tag">healthy session — stays low</p><div class="ba-frame" id="fig-lad-a"></div></div>
+      <div class="ba-cell"><p class="ba-tag after">escalating session — climbs</p><div class="ba-frame" id="fig-lad-b"></div></div>
+    </div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>05 · correction slopegraphs — did the steering work?</h2>
+  <div class="surface">
+    <p class="rationale">
+      At every intervention, a two-point slope: <b>drift before → drift after</b>. Down-slope good, up-slope bad,
+      flat flat — zicato's <code>pairedSlopegraph</code> verbatim, new noun. A row of these in the Interventions
+      panel is an efficacy record of the operator and of goldfive's own refinements.
+    </p>
+    <div class="sm-row" id="fig-slopes"></div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>06 · the drift sankey — what causes what</h2>
+  <div class="surface">
+    <p class="rationale">
+      <b>drift kind → intervention → outcome</b>, ribbon width ∝ count. The figure that says “tool-misuse resolves
+      with a nudge, goal-drift recurs even after replans” — the exact shape zicato's meta-loop wants as input.
+      Outcome nodes earn good / bad; everything upstream stays neutral ink.
+    </p>
+    <div class="figwrap" id="fig-sankey"></div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>07 · plan strata — revisions as sediment</h2>
+  <div class="surface">
+    <p class="rationale">
+      Plans are geology: newest on top. Each revision is a stratum; tasks keep their column, so <b>persistence reads
+      as vertical alignment</b>. A dropped task ends with <code>✕</code> at the seam; an added one enters with
+      <code>○</code>. Each dashed seam is annotated with the drift kind that forced the replan — the <i>why</i> is
+      on the figure. The live stratum carries the accent spine.
+    </p>
+    <div class="figwrap" id="fig-strata"></div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>08 · the replan slopegraph — one seam, magnified</h2>
+  <div class="surface">
+    <p class="rationale">
+      Plan v2 → v3: kept tasks run flat, reordered tasks cross, dropped tasks terminate (<code>✕</code>), added
+      tasks enter (<code>○</code>, accent-dashed). Crossing density <i>is</i> plan churn — ten seconds tells you
+      whether the replan was a tweak or an upheaval.
+    </p>
+    <div class="figwrap" id="fig-replan"></div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>09 · the plan reel — the spine across revisions</h2>
+  <div class="surface">
+    <p class="rationale">
+      zicato's <code>roundTimeline</code> spine, one node per plan revision, annotated with <b>remaining work</b> —
+      a loss-floor that should descend. Seam triggers ride above in caution; a revision that <i>added</i> work would
+      step up and read as bad, earned by direction.
+    </p>
+    <div class="figwrap" id="fig-reel"></div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>10 · the delegation score — fork, run beneath, rejoin</h2>
+  <div class="surface">
+    <p class="rationale">
+      Not a UML sequence diagram — a score. A delegation <b>branches off the parent lane, runs beneath it, and
+      rejoins</b> with its verdict glyph at the merge; band thickness ∝ tokens spent, so an expensive delegation is
+      visibly heavy. Peer transfers are dashed hand-off arcs in TRANSFER yellow. elimFlow's convergence idiom,
+      inverted into fork-and-return.
+    </p>
+    <div class="figwrap" id="fig-score"></div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>11 · the transfer chord — who talks to whom, <i>and in which direction</i></h2>
+  <div class="surface">
+    <p class="rationale">
+      Agents on an arc, transfer counts as chords, width ∝ frequency, quiet agent-ramp hues. A plain chord hides the
+      one thing the operator most needs — <b>who initiates vs. who receives</b> — so this one is <b>directional three
+      ways at once</b>: (1) each agent's sector is split into an <b>outbound half</b> (solid, source side) and an
+      <b>inbound half</b> (hollow tick, target side); (2) every ribbon is an <b>asymmetric teardrop</b> — pinched at
+      the source, broad at the target — so the chord visibly <i>flows</i> toward whom it reaches; (3) it carries the
+      <b>source→target hue</b> and ends in a small arrowhead on the target arc. A coordinator-and-spokes system fans
+      <i>out</i> from one sector; <b>if it looks like a web, something's off</b>. The session-summary topology check.
+    </p>
+    <div class="figwrap" id="fig-chord"></div>
+    <div class="legend">
+      <span><span class="sw" style="background:var(--hg-agent-1);opacity:.8"></span>outbound (source) half</span>
+      <span><span class="sw" style="background:var(--panel);border:1px solid var(--rule)"></span>inbound (target) half</span>
+      <span>pinched ▸ source · broad ▸ target · ▸ arrowhead at the receiver</span>
+    </div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>12 · conductor's marks — steering in the margin</h2>
+  <div class="surface">
+    <p class="rationale">
+      Operator actions live in the <b>margin</b>, like a conductor's pencil on the score: a magenta <code>◷</code>
+      where the run paused for a human, an accent tick where a steering message landed, an approval <b>gate</b> on
+      the lane (○ deciding → ✓ continues). The discipline: <b>operator presence annotates the work, never recolors
+      it</b> — identity doesn't earn color, even human identity.
+    </p>
+    <div class="figwrap" id="fig-steer"></div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>13 · the context tide — breathing room</h2>
+  <div class="surface">
+    <p class="rationale">
+      Context-window occupancy as a tide under the lane, rising toward the dashed ceiling; the surface mixes toward
+      caution as it nears the limit. A <b>compaction is a relief seam</b> — the tide visibly drops and the run
+      breathes again.
+    </p>
+    <div class="figwrap" id="fig-tide"></div>
+  </div>
+</section>
+
+<section class="study" data-opt>
+  <h2>14 · the plan DAG — interdependent processes, Adamiecki's own subject</h2>
+  <div class="surface">
+    <p class="rationale">
+      The harmonogram's whole point in 1896 was <b>interdependence</b> — so the plan's dependency graph is a
+      first-class figure, not a footnote. Tasks are quiet nodes layered by depth; dependencies are hairline edges;
+      <b>the critical path is the one accent spine</b> — zicato's champion-spine idiom pointed at scheduling.
+      Status is earned per node (✓ done, ● running on the spine, ○ pending); a task <b>dropped at a replan stays
+      as a dashed ghost</b> with its severed edge — the DAG remembers the seam. Pairs with 07 strata (same tasks,
+      time-axis vs dependency-axis).
+    </p>
+    <div class="figwrap" id="fig-dag"></div>
+    <div class="legend">
+      <span><span class="ln" style="border-color:var(--accent)"></span>critical path</span>
+      <span><span class="ln" style="border-color:var(--ink-faint)"></span>dependency</span>
+      <span style="color:var(--good)">✓ done</span><span style="color:var(--accent)">● running</span>
+      <span style="color:var(--ink-faint)">○ pending</span><span style="color:var(--bad)">✕ dropped at replan (ghost)</span>
+    </div>
+  </div>
+</section>
+
+<section class="study">
+  <h2>Which of these earn promotion</h2>
+  <p class="lede">
+    Build order, if these graduate to the console: <b>02 seismograph</b> (the product thesis in one mark) →
+    <b>07 strata + 08 replan slope + 14 plan DAG</b> (the data already sits in <code>planHistoryStore</code>) →
+    <b>10 delegation score</b> (the Gantt already draws transfer edges; this is its summary form) →
+    <b>01 fingerprint</b> (the dessert — session picker, fleet cards, and the brand made data).
+    03/05 ride inside existing panels; 06/11 are session-summary surfaces; 04/12/13 are overlays on figures
+    that already exist.
+  </p>
+</section>
+
+</main>
+
+<footer class="study">
+  harmonograf figure-grammar study · every mark token-only &amp; fit-to-width · status earns color, identity never does ·
+  part of the <a href="index.html">zicato-language UI study</a> · companion: <a href="brand.html">brand &amp; logo study</a>
+</footer>
+
+<script>
+/* ===== theme picker (study-standard) ===== */
+window.THEME_IDS = ['monokai','solarized-dark','solarized-light','google-light','google-dark',
+  'lunaria-light','lunaria-eclipse','belafonte-day','belafonte-night','paper','zenburn',
+  'selenized-black','relaxed','espresso','dracula','ubuntu'];
+const THEME_SWATCHES = {
+  'monokai':['#1e1f1c','#272822','#f8f8f2','#a6e22e','#f92672','#66d9ef'],
+  'solarized-dark':['#04222B','#0A2D38','#93A1A1','#8BB80E','#E0483C','#2AA198'],
+  'solarized-light':['#FDF6E3','#FBF1D6','#586E75','#6B9B0B','#DC322F','#268BD2'],
+  'google-light':['#FFFFFF','#F4F4F4','#474A4E','#34A853','#EA4335','#1B9CB8'],
+  'google-dark':['#202124','#2C2D30','#FFFFFF','#34A853','#EA4335','#24C1E0'],
+  'lunaria-light':['#EBE4E1','#E2DCD9','#363434','#497D46','#783C1F','#3778A9'],
+  'lunaria-eclipse':['#323F46','#3B484F','#DFE2ED','#BEDBC1','#BA9088','#C8429F'],
+  'belafonte-day':['#D5CCBA','#CCC3B2','#34292D','#6E6A4E','#BE100E','#426A79'],
+  'belafonte-night':['#20111B','#271821','#D5CCBA','#A6A07A','#D6403E','#6F8E97'],
+  'paper':['#F2EEDE','#E6E2D3','#1A1A1A','#216609','#CC3E28','#1E6FCC'],
+  'zenburn':['#3A3A3A','#424241','#DCDCCC','#8FB28F','#CC9393','#8CD0D3'],
+  'selenized-black':['#181818','#202020','#DEDEDE','#83C746','#FF5E56','#56D8C9'],
+  'relaxed':['#353A44','#3D424B','#F7F7F7','#A0AC77','#BC5653','#7EAAC7'],
+  'espresso':['#323232','#3A3A3A','#FFFFFF','#A5C261','#D25252','#6C99BB'],
+  'dracula':['#282A36','#343746','#F8F8F2','#50FA7B','#FF5555','#BD93F9'],
+  'ubuntu':['#300A24','#3D1530','#EEEEEC','#8AE234','#CC0000','#34E2E2'],
+};
+const THEME_LABELS = {'monokai':'Monokai','solarized-dark':'Solarized Dark','solarized-light':'Solarized Light',
+  'google-light':'Google Light','google-dark':'Google Dark','lunaria-light':'Lunaria Light','lunaria-eclipse':'Lunaria Eclipse',
+  'belafonte-day':'Belafonte Day','belafonte-night':'Belafonte Night','paper':'Paper','zenburn':'Zenburn',
+  'selenized-black':'Selenized Black','relaxed':'Relaxed','espresso':'Espresso','dracula':'Dracula','ubuntu':'Ubuntu'};
+const THEME_KEY = 'hgraf-study-theme';
+function swatchStrip(id, sm){ const t = THEME_SWATCHES[id] || [];
+  return `<span class="dt-swatch-strip${sm?' dt-swatch-strip-sm':''}">`+t.map(c=>`<span class="dt-swatch" style="background:${c}"></span>`).join('')+`</span>`; }
+function currentTheme(){ return document.documentElement.getAttribute('data-theme') || 'monokai'; }
+function applyTheme(id){ document.documentElement.setAttribute('data-theme', id);
+  try { localStorage.setItem(THEME_KEY, id); } catch(e){}
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker); }
+function buildPicker(host){ const cur = currentTheme();
+  host.innerHTML = `<div class="dt-cd"><button class="dt-cd-trigger" aria-haspopup="listbox" aria-expanded="false">${swatchStrip(cur,true)}<span class="dt-cd-name">${THEME_LABELS[cur]}</span><span class="dt-cd-caret" aria-hidden="true">▾</span></button><div class="dt-cd-list" role="listbox" aria-label="theme">${window.THEME_IDS.map(id=>`<div class="dt-cd-option" role="option" data-id="${id}" aria-selected="${id===cur}">${swatchStrip(id)}<span class="dt-cd-name">${THEME_LABELS[id]}</span></div>`).join('')}</div></div>`;
+  const cd = host.querySelector('.dt-cd'), trig = host.querySelector('.dt-cd-trigger');
+  trig.addEventListener('click', e=>{ e.stopPropagation(); const open = cd.classList.toggle('dt-cd-open'); trig.setAttribute('aria-expanded', open); });
+  host.querySelectorAll('.dt-cd-option').forEach(o=> o.addEventListener('click', ()=>{ applyTheme(o.dataset.id); cd.classList.remove('dt-cd-open'); })); }
+document.addEventListener('click', ()=> document.querySelectorAll('.dt-cd-open').forEach(c=>c.classList.remove('dt-cd-open')));
+(function initTheme(){ let saved=null; try { saved=localStorage.getItem(THEME_KEY); } catch(e){}
+  const P=new URLSearchParams(location.search), fromUrl=P.get('theme');
+  const id=(fromUrl&&window.THEME_IDS.includes(fromUrl))?fromUrl:(saved&&window.THEME_IDS.includes(saved))?saved:'monokai';
+  document.documentElement.setAttribute('data-theme', id); })();
+
+/* ===== shared helpers ===== */
+function lcg(seed){ let s=seed>>>0; return ()=>((s=(s*1664525+1013904223)>>>0)/4294967296); }
+function P(pts){ return 'M'+pts.map(p=>p[0].toFixed(2)+','+p[1].toFixed(2)).join(' L'); }
+function lerpKeys(keys, t){ // keys: [[t,v],...] sorted
+  if(t<=keys[0][0]) return keys[0][1];
+  for(let i=1;i<keys.length;i++){ if(t<=keys[i][0]){ const [t0,v0]=keys[i-1], [t1,v1]=keys[i];
+    return v0+(v1-v0)*(t-t0)/(t1-t0); } }
+  return keys[keys.length-1][1];
+}
+const KIND = k => `var(--hg-kind-${k})`;
+
+/* ===== 01 fingerprints ===== */
+function fingerprint(o){ const n=o.n||900, T=o.T||30, pts=[];
+  const Amod = o.Amod || (()=>1);
+  for(let i=0;i<=n;i++){ const t=T*i/n, m=Amod(t,T);
+    pts.push([32 + 24*m*Math.exp(-(o.d||0)*t)*Math.sin(o.fx*t+(o.px||0)),
+              32 + 24*m*Math.exp(-(o.d||0)*t)*Math.sin(o.fy*t)]); }
+  const end=pts[pts.length-1];
+  return `<svg width="96" height="96" viewBox="0 0 64 64" role="img" aria-label="session fingerprint — ${o.label}">
+    <path d="${P(pts)}" fill="none" stroke="currentColor" stroke-width="0.9" opacity=".75"/>
+    <circle cx="${end[0].toFixed(1)}" cy="${end[1].toFixed(1)}" r="2.2" fill="var(--${o.dot})"/></svg>`;
+}
+function mountFP(){
+  const cells = [
+    { svg: fingerprint({fx:1.0, fy:1.0, px:Math.PI/2, d:.02, label:'aligned', dot:'good'}), name:'aligned', sub:'1:1, in phase', pill:'done', ptxt:'✓ done' },
+    { svg: fingerprint({fx:3.0, fy:2.02, px:Math.PI/2, d:.025, label:'harmonic', dot:'good'}), name:'harmonic', sub:'3:2 chord', pill:'done', ptxt:'✓ done' },
+    { svg: fingerprint({fx:2.41, fy:1.53, px:.6, d:.011, T:42, label:'drifty', dot:'accent'}), name:'drifty', sub:'detuned, precessing', pill:'live', ptxt:'● live' },
+    { svg: fingerprint({fx:3.0, fy:2.03, px:Math.PI/2, d:.013, label:'corrected', dot:'accent',
+        Amod:(t)=> t<13 ? 1 : (t<16 ? 1-(t-13)/3*.55 : .45)}), name:'corrected', sub:'tightens at the intervention', pill:'live', ptxt:'● live' },
+    { svg: fingerprint({fx:2.6, fy:1.7, px:.3, d:-.012, T:26, label:'diverging', dot:'bad',
+        Amod:(t,T)=> .3 + .55*t/T }), name:'diverging', sub:'amplitude growing', pill:'fail', ptxt:'✕ failed' },
+  ];
+  document.getElementById('fig-fp').innerHTML = cells.map(c =>
+    `<div class="fp-cell">${c.svg}${c.name}<br><span style="color:var(--ink-faint);font-size:9px">${c.sub}</span><br><span class="fp-pill ${c.pill}">${c.ptxt}</span></div>`).join('');
+}
+
+/* ===== 02 seismograph ===== */
+function mountSeismo(){
+  const W=880, rowH=58, padL=78, padR=16, lanes=[
+    { id:'coder', keys:[[0,1],[6,2],[10,3],[13,11],[15,14],[17,6],[22,3],[26,2],[30,4],[33,12],[35,15],[38,7],[44,3],[50,2]],
+      ticks:[[15,'refine'],[35,'nudge']] },
+    { id:'reviewer', keys:[[0,1],[10,2],[20,3],[26,9],[29,10],[31,4],[40,2],[50,1.5]], ticks:[[29,'nudge']] },
+    { id:'planner', keys:[[0,.5],[12,1.5],[25,1],[38,2],[50,1]], ticks:[] },
+  ];
+  const H = lanes.length*rowH + 26, X=t=>padL+(W-padL-padR)*t/50, TOL=8;
+  let g = `<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="drift seismograph — per-agent judge drift around the on-plan rule">`;
+  for(let i=0;i<=5;i++){ const gx=X(i*10);
+    g+=`<line class="hg-gantt-grid" x1="${gx}" y1="6" x2="${gx}" y2="${H-18}"/><text class="gm-axis" x="${gx-6}" y="${H-6}">${i*10}s</text>`; }
+  lanes.forEach((ln,li)=>{
+    const base = 14 + li*rowH + rowH - 18, rnd = lcg(40+li), yOf = v => base - v*2.5;
+    g+=`<text class="gm-label" x="8" y="${base-14}">${ln.id}</text>`;
+    g+=`<rect class="gm-tol" x="${X(0)}" y="${yOf(TOL)}" width="${X(50)-X(0)}" height="${yOf(0)-yOf(TOL)}"/>`;
+    g+=`<line class="gm-onplan" x1="${X(0)}" y1="${base}" x2="${X(50)}" y2="${base}"/>`;
+    const pts=[]; for(let i=0;i<=300;i++){ const t=50*i/300;
+      const v = Math.max(0, lerpKeys(ln.keys,t) + Math.sin(t*2.3+li)*0.5 + (rnd()-0.5)*0.9);
+      pts.push([X(t), yOf(v), v, t]); }
+    // excursion fills above tolerance
+    let seg=null; const segs=[];
+    pts.forEach(p=>{ if(p[2]>TOL){ if(!seg) seg=[]; seg.push(p); } else if(seg){ segs.push(seg); seg=null; } });
+    if(seg) segs.push(seg);
+    segs.forEach(s=>{ const poly=s.map(p=>p[0].toFixed(1)+','+p[1].toFixed(1)).join(' ')
+        +' '+s[s.length-1][0].toFixed(1)+','+yOf(TOL).toFixed(1)+' '+s[0][0].toFixed(1)+','+yOf(TOL).toFixed(1);
+      g+=`<polygon class="gm-excursion" points="${poly}"/>`; });
+    g+=`<path class="gm-trace" d="${P(pts)}"/>`;
+    ln.ticks.forEach(([t,kind])=>{ const tx=X(t);
+      g+=`<line class="gm-tick" x1="${tx}" y1="${base-rowH+24}" x2="${tx}" y2="${base+4}"><title>intervention · ${kind} @ ${t}s</title></line>`;
+      g+=`<text class="gm-tick-label" x="${tx+3}" y="${base-rowH+30}">${kind}</text>`; });
+  });
+  const nx=X(50);
+  g+=`<line class="hg-gantt-now" x1="${nx}" y1="6" x2="${nx}" y2="${H-18}"/><circle class="hg-gantt-now-cap" cx="${nx}" cy="6" r="2.5"/>`;
+  g+=`</svg>`;
+  document.getElementById('fig-seismo').innerHTML=g;
+}
+
+/* ===== 03 heartbeat strip ===== */
+function mountHeart(){
+  const W=880, H=64, padL=78, X=t=>padL+(W-padL-16)*t/50, rnd=lcg(7);
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="judge heartbeat strip">`;
+  g+=`<text class="gm-label" x="8" y="30">coder</text>`;
+  g+=`<line class="gm-onplan" x1="${X(0)}" y1="40" x2="${X(50)}" y2="40"/>`;
+  const events=[]; for(let i=0;i<38;i++){ const t=1+i*1.28+rnd()*0.5;
+    let k='ok'; if(i===8||i===9||i===21||i===22||i===23) k='warn'; if(i===27) k='crit';
+    events.push([t,k]); }
+  events.forEach(([t,k])=>{ const x=X(t);
+    if(k==='ok')   g+=`<circle cx="${x}" cy="26" r="1.6" fill="var(--hg-gf-judge-on-task)" opacity=".75"><title>on-task</title></circle>`;
+    if(k==='warn') g+=`<text x="${x-3.5}" y="30" font-size="9" fill="var(--caution)"><title>warning</title>▲</text>`;
+    if(k==='crit') g+=`<text x="${x-3.5}" y="30" font-size="10" fill="var(--bad)" font-weight="700"><title>critical</title>✕</text>`; });
+  for(let i=0;i<=5;i++){ g+=`<text class="gm-axis" x="${X(i*10)-6}" y="${H-8}">${i*10}s</text>`; }
+  g+=`</svg>`;
+  document.getElementById('fig-heart').innerHTML=g;
+}
+
+/* ===== 04 intervention ladder ===== */
+function ladderFig(dots, label){
+  const W=430, H=150, padL=72, X=t=>padL+(W-padL-14)*t/50;
+  const RUNGS=['nudge','refine','replan','escalate'], rungY=i=>118-i*30;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="intervention ladder — ${label}">`;
+  RUNGS.forEach((r,i)=>{ const y=rungY(i);
+    g+=`<line x1="${padL}" y1="${y}" x2="${W-14}" y2="${y}" stroke="var(--rule)" stroke-width="1"/>`;
+    g+=`<text class="gm-faint" x="8" y="${y+3}">${r}</text>`; });
+  if(dots.length>1){ const step=dots.map((d,i)=>(i?'L':'M')+X(d[0]).toFixed(1)+','+rungY(d[1]).toFixed(1)).join(' ');
+    g+=`<path d="${step}" fill="none" stroke="var(--ink-faint)" stroke-width="0.8" stroke-dasharray="2 3" opacity=".7"/>`; }
+  dots.forEach(d=>{ const y=rungY(d[1]), cls = d[1]===3?'var(--bad)':'var(--ink-soft)';
+    g+=`<circle cx="${X(d[0])}" cy="${y}" r="3.4" fill="${cls}"><title>${RUNGS[d[1]]} @ ${d[0]}s</title></circle>`; });
+  g+=`</svg>`; return g;
+}
+function mountLadders(){
+  document.getElementById('fig-lad-a').innerHTML = ladderFig([[8,0],[19,0],[31,0],[42,1]], 'healthy');
+  document.getElementById('fig-lad-b').innerHTML = ladderFig([[6,0],[12,0],[18,1],[26,1],[33,2],[44,3]], 'escalating');
+}
+
+/* ===== 05 correction slopegraphs ===== */
+function mountSlopes(){
+  const cases=[ ['nudge',12,4], ['refine',14,3], ['nudge',9,8], ['replan',16,5], ['nudge',6,9], ['refine',11,11] ];
+  document.getElementById('fig-slopes').innerHTML = cases.map(([k,b,a])=>{
+    const W=96,H=78, y=v=>64-v*3.2, dir = a<b-1 ? 'good' : (a>b+1 ? 'bad' : 'flat');
+    return `<div class="sm-cell"><svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" role="img" aria-label="correction: ${k}, drift ${b} to ${a}">
+      <line x1="26" y1="10" x2="26" y2="66" stroke="var(--rule-soft)"/><line x1="70" y1="10" x2="70" y2="66" stroke="var(--rule-soft)"/>
+      <line class="gm-ln-${dir}" x1="26" y1="${y(b)}" x2="70" y2="${y(a)}" stroke-width="1.6"/>
+      <circle cx="26" cy="${y(b)}" r="2.4" fill="var(--ink-soft)"/><circle class="gm-${dir}" cx="70" cy="${y(a)}" r="2.6"/>
+      <text class="gm-axis" x="20" y="${y(b)-5}">${b}</text><text class="gm-axis" x="65" y="${y(a)-5}">${a}</text>
+      <text class="gm-faint" x="22" y="${H-2}">before · after</text></svg>${k}</div>`; }).join('');
+}
+
+/* ===== 06 drift sankey ===== */
+function mountSankey(){
+  const W=880, H=240, SC=4.4, NW=8;
+  const kinds=[['goal-drift',9],['tool-misuse',7],['loop',5],['scope-creep',4]];
+  const ints=[['nudge',12],['refine',8],['replan',5]];
+  const outs=[['resolved',18,'good'],['recurred',7,'bad']];
+  const f1={ 'goal-drift':[['nudge',4],['refine',3],['replan',2]], 'tool-misuse':[['nudge',5],['refine',2]],
+             'loop':[['nudge',2],['refine',2],['replan',1]], 'scope-creep':[['nudge',1],['refine',1],['replan',2]] };
+  const f2={ 'nudge':[['resolved',9],['recurred',3]], 'refine':[['resolved',6],['recurred',2]], 'replan':[['resolved',3],['recurred',2]] };
+  function layout(col, x){ let y=18; const m={};
+    col.forEach(([id,n])=>{ m[id]={x, y, h:n*SC, used:0}; y+=n*SC+14; }); return m; }
+  const A=layout(kinds,90), B=layout(ints,430), C=layout(outs,760);
+  function ribbon(a,b,n){ const h=n*SC, x0=a.x+NW, y0=a.y+a.used, x1=b.x, y1=b.y+b.used; a.used+=h; b.used+=h;
+    const c=(x0+x1)/2;
+    return `<path class="gm-ribbon" d="M${x0},${y0} C${c},${y0} ${c},${y1} ${x1},${y1} L${x1},${y1+h} C${c},${y1+h} ${c},${y0+h} ${x0},${y0+h} Z"><title>${n} runs</title></path>`; }
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="drift sankey: kind to intervention to outcome">`;
+  kinds.forEach(([id])=>{ f1[id].forEach(([to,n])=>{ g+=ribbon(A[id], B[to], n); }); });
+  // reset usage on B for outgoing side
+  Object.values(B).forEach(b=>b.usedOut=0);
+  ints.forEach(([id])=>{ f2[id].forEach(([to,n])=>{ const b=B[id], c=C[to], h=n*SC;
+    const x0=b.x+NW, y0=b.y+b.usedOut, x1=c.x, y1=c.y+c.used; b.usedOut+=h; c.used+=h; const cm=(x0+x1)/2;
+    g+=`<path class="gm-ribbon" d="M${x0},${y0} C${cm},${y0} ${cm},${y1} ${x1},${y1} L${x1},${y1+h} C${cm},${y1+h} ${cm},${y0+h} ${x0},${y0+h} Z"><title>${n} runs</title></path>`; }); });
+  function nodes(m, col, side, colorBy){ col.forEach(c=>{ const id=c[0], nd=m[id];
+    const fill = colorBy && c[2] ? `var(--${c[2]})` : 'var(--ink-soft)';
+    g+=`<rect x="${nd.x}" y="${nd.y}" width="${NW}" height="${nd.h}" rx="2" fill="${fill}" fill-opacity=".8"/>`;
+    const tx = side==='l' ? nd.x-6 : nd.x+NW+6, anchor = side==='l' ? 'end' : 'start';
+    g+=`<text class="gm-label" x="${tx}" y="${nd.y+nd.h/2+3}" text-anchor="${anchor}">${id} <tspan class="gm-faint tnum">${c[1]}</tspan></text>`; }); }
+  nodes(A,kinds,'l'); nodes(B,ints,'r'); nodes(C,outs,'r',true);
+  g+=`<text class="gm-faint" x="90" y="${H-6}">drift kind</text><text class="gm-faint" x="430" y="${H-6}">intervention</text><text class="gm-faint" x="700" y="${H-6}">outcome</text></svg>`;
+  document.getElementById('fig-sankey').innerHTML=g;
+}
+
+/* ===== 07 plan strata ===== */
+function mountStrata(){
+  const W=880, rowH=52, tasks={T1:0,T2:1,T3:2,T4:3,T5:4,T6:5,T7:6};
+  const tx=i=>96+i*110, BW=84, BH=15;
+  const strata=[ // newest first (top)
+    { v:'v3 · live', has:['T1','T2','T4','T6','T7'], added:['T7'], live:true },
+    { v:'v2', has:['T1','T2','T4','T5','T6'], added:['T6'], seam:'replan · goal-drift' },
+    { v:'v1', has:['T1','T2','T3','T4','T5'], added:[], seam:'replan · scope-creep' },
+  ];
+  const H=strata.length*rowH+30;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="plan strata — three revisions as sediment">`;
+  // column ghosts
+  Object.entries(tasks).forEach(([t,i])=>{ g+=`<text class="gm-faint" x="${tx(i)+BW/2-8}" y="12">${t}</text>`; });
+  strata.forEach((s,si)=>{ const y0=22+si*rowH, cy=y0+rowH/2;
+    g+=`<text class="gm-label" x="8" y="${cy+4}" ${s.live?'fill="var(--accent)"':''}>${s.v}</text>`;
+    if(s.live) g+=`<line class="gm-spine" x1="78" y1="${y0+4}" x2="78" y2="${y0+rowH-8}"/>`;
+    s.has.forEach(t=>{ const x=tx(tasks[t]);
+      const op = s.live ? .8 : (.45 - si*.08);
+      g+=`<rect x="${x}" y="${cy-BH/2}" width="${BW}" height="${BH}" rx="3" fill="var(--ink-soft)" fill-opacity="${op.toFixed(2)}"><title>${t} in ${s.v}</title></rect>`;
+      if(s.added.includes(t)) g+=`<text x="${x-11}" y="${cy+4}" font-size="10" fill="var(--accent)">○</text>`; });
+    // dropped: in this stratum but not in the one above (newer)
+    if(si>0){ const newer=strata[si-1];
+      s.has.filter(t=>!newer.has.includes(t)).forEach(t=>{ const x=tx(tasks[t]);
+        g+=`<text x="${x+BW+4}" y="${cy+4}" font-size="10" fill="var(--bad)">✕</text>`; }); }
+    if(s.seam){ const sy=y0-3;
+      g+=`<line class="gm-seam" x1="78" y1="${sy}" x2="${W-180}" y2="${sy}"/>`;
+      g+=`<text class="gm-tick-label" x="${W-172}" y="${sy+3}">${s.seam}</text>`; }
+  });
+  g+=`</svg>`;
+  document.getElementById('fig-strata').innerHTML=g;
+}
+
+/* ===== 08 replan slopegraph ===== */
+function mountReplan(){
+  const W=540, H=210, xL=140, xR=400;
+  const v2=['design-api','impl-core','wire-cli','write-docs','add-tests'];
+  const v3=['impl-core','design-api','wire-cli','add-tests','polish-ux'];
+  const yAt=i=>34+i*36;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="replan slopegraph v2 to v3">`;
+  g+=`<text class="gm-faint" x="${xL-14}" y="14" text-anchor="end">plan v2</text><text class="gm-faint" x="${xR+14}" y="14">plan v3 · live</text>`;
+  v2.forEach((t,i)=>{ const y=yAt(i), j=v3.indexOf(t);
+    g+=`<text class="gm-label" x="${xL-14}" y="${y+3}" text-anchor="end">${t}</text>`;
+    if(j<0){ // dropped
+      g+=`<line class="gm-ln-bad" x1="${xL}" y1="${y}" x2="${(xL+xR)/2-26}" y2="${y}" stroke-width="1.4" opacity=".8"/>`;
+      g+=`<text x="${(xL+xR)/2-20}" y="${y+3.5}" font-size="10" fill="var(--bad)">✕ dropped</text>`; return; }
+    const y2=yAt(j), cls = j===i ? 'gm-ln-flat' : '';
+    g+=`<line class="${cls}" x1="${xL}" y1="${y}" x2="${xR}" y2="${y2}" stroke="${j===i?'var(--flat, var(--ink-faint))':'var(--ink-soft)'}" stroke-width="1.4"/>`; });
+  v3.forEach((t,j)=>{ const y=yAt(j);
+    g+=`<text class="gm-label" x="${xR+14}" y="${y+3}">${t}</text>`;
+    if(!v2.includes(t)){
+      g+=`<line x1="${(xL+xR)/2+34}" y1="${y}" x2="${xR}" y2="${y}" stroke="var(--accent)" stroke-width="1.4" stroke-dasharray="4 3"/>`;
+      g+=`<text x="${(xL+xR)/2-2}" y="${y+3.5}" font-size="10" fill="var(--accent)">○ new</text>`; } });
+  g+=`</svg>`;
+  document.getElementById('fig-replan').innerHTML=g;
+}
+
+/* ===== 09 plan reel ===== */
+function mountReel(){
+  const W=880, H=104, xs=[120,340,560,780], rem=[12,9,5,2],
+    trig=['', 'scope-creep', 'goal-drift', 'tool-misuse'];
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="plan reel — remaining work across revisions">`;
+  g+=`<line class="gm-spine" x1="${xs[0]}" y1="56" x2="${xs[3]}" y2="56"/>`;
+  xs.forEach((x,i)=>{
+    if(i>0){ g+=`<text class="gm-tick-label" x="${(xs[i-1]+x)/2-26}" y="34">↯ ${trig[i]}</text>`; }
+    g+=`<circle cx="${x}" cy="56" r="${i===3?6:4.5}" fill="${i===3?'var(--accent)':'var(--panel)'}" stroke="${i===3?'var(--accent)':'var(--ink-soft)'}" stroke-width="1.5"/>`;
+    g+=`<text class="gm-label" x="${x-10}" y="${78}">v${i}</text>`;
+    g+=`<text class="gm-axis" x="${x-22}" y="${94}">${rem[i]} tasks left</text>`;
+    if(i>0){ const drop=rem[i-1]-rem[i];
+      g+=`<text class="gm-good" x="${(xs[i-1]+x)/2-12}" y="${50}" font-size="9.5">−${drop}</text>`; } });
+  g+=`</svg>`;
+  document.getElementById('fig-reel').innerHTML=g;
+}
+
+/* ===== 10 delegation score ===== */
+function mountScore(){
+  const W=880, H=210, padL=96, X=t=>padL+(W-padL-20)*t;
+  const yP=44, yC=96, yT=158;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="delegation score — fork, run beneath, rejoin">`;
+  [['planner',yP],['coder',yC],['coder ▸ tests',yT]].forEach(([n,y])=>{
+    g+=`<text class="gm-label" x="8" y="${y+4}" ${n.includes('▸')?'opacity=".7"':''}>${n}</text>`;
+    g+=`<line class="hg-gantt-lane-sep" x1="${padL}" y1="${y}" x2="${W-20}" y2="${y}" opacity=".4"/>`; });
+  // planner + coder activity
+  g+=`<rect x="${X(.02)}" y="${yP-6}" width="${X(.2)-X(.02)}" height="12" rx="3" fill="${KIND('llm-call')}" fill-opacity=".55"><title>planner · llm_call</title></rect>`;
+  g+=`<rect x="${X(.26)}" y="${yC-6}" width="${X(.42)-X(.26)}" height="12" rx="3" fill="${KIND('llm-call')}" fill-opacity=".55"><title>coder · llm_call</title></rect>`;
+  g+=`<rect x="${X(.80)}" y="${yC-6}" width="${X(.95)-X(.80)}" height="12" rx="3" fill="${KIND('llm-call')}" fill-opacity=".55" stroke="var(--accent)" stroke-width="2"><title>coder · llm_call · running</title></rect>`;
+  // transfer arc planner→coder
+  g+=`<path class="hg-gantt-edge is-transfer" d="M${X(.21)},${yP+8} C ${X(.23)},${yP+30} ${X(.23)},${yC-28} ${X(.25)},${yC-8}"><title>transfer planner → coder</title></path>`;
+  g+=`<text x="${X(.215)}" y="${(yP+yC)/2+2}" font-size="9" fill="${KIND('transfer')}">⇄</text>`;
+  // delegation: fork at .42, child band .44→.74 (heavy: 38k tokens), rejoin at .76
+  const bh=18; // band height ∝ tokens
+  g+=`<path d="M${X(.42)},${yC+6} C ${X(.43)},${yC+34} ${X(.43)},${yT-26} ${X(.44)},${yT-bh/2}" fill="none" stroke="var(--ink-faint)" stroke-width="1.1"/>`;
+  g+=`<rect x="${X(.44)}" y="${yT-bh/2}" width="${X(.74)-X(.44)}" height="${bh}" rx="3" fill="${KIND('tool-call')}" fill-opacity=".5"><title>delegated: run test suite · 38k tokens</title></rect>`;
+  g+=`<path d="M${X(.74)},${yT-bh/2} C ${X(.75)},${yT-30} ${X(.75)},${yC+30} ${X(.76)},${yC+7}" fill="none" stroke="var(--ink-faint)" stroke-width="1.1"/>`;
+  g+=`<text x="${X(.762)}" y="${yC+24}" font-size="11" fill="var(--good)">✓</text>`;
+  g+=`<text class="gm-faint" x="${X(.46)}" y="${yT+22}">38k tok · band height ∝ cost</text>`;
+  // a pending (planned) delegation — dashed ghost
+  g+=`<rect x="${X(.84)}" y="${yT-6}" width="${X(.97)-X(.84)}" height="12" rx="3" class="hg-gantt-bar is-planned"><title>planned: lint pass</title></rect>`;
+  const nx=X(.95);
+  g+=`<line class="hg-gantt-now" x1="${nx}" y1="14" x2="${nx}" y2="${H-26}"/><circle class="hg-gantt-now-cap" cx="${nx}" cy="14" r="2.5"/>`;
+  g+=`</svg>`;
+  document.getElementById('fig-score').innerHTML=g;
+}
+
+/* ===== 11 transfer chord — DIRECTIONAL =====
+   Agents sit on a semicircle. Direction is encoded three redundant ways:
+   (1) each agent's arc sector splits into an OUTBOUND half (solid, source
+   colour) and an INBOUND half (hollow); (2) each ribbon is an ASYMMETRIC
+   teardrop — pinched at the source, broad at the target — so it visibly
+   flows toward the receiver; (3) a source→target hue plus a small arrowhead
+   landing on the target arc. */
+function chordSVG(o){
+  const W=o.W||560, H=o.H||230, cx=W/2, cyA=o.cyA||(H-26), R=o.R||(W*0.30);
+  const agents=o.agents, flows=o.flows; // flows: [srcIdx, dstIdx, count]
+  const n=agents.length, SECTOR=Math.PI/(n)*0.74; // angular half-width of each sector
+  // angle of agent i along the upper semicircle (left→right)
+  const ang=i=> Math.PI - Math.PI*i/(n-1);
+  const onArc=(th,r)=>[cx+r*Math.cos(th), cyA-r*Math.sin(th)];
+  const aColor=i=> `var(--hg-agent-${i+1})`;
+  // tally outbound / inbound load per agent so we can pack endpoints along the sector
+  const outN=agents.map(()=>0), inN=agents.map(()=>0);
+  flows.forEach(([a,b,c])=>{ outN[a]+=c; inN[b]+=c; });
+  const outUsed=agents.map(()=>0), inUsed=agents.map(()=>0);
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="directional transfer chord — who initiates and who receives">`;
+  // arc sectors: outbound half (leading edge, solid) + inbound half (trailing edge, hollow)
+  agents.forEach((a,i)=>{ const th=ang(i);
+    // outbound occupies [th, th-SECTOR/?]; we render two short concentric arc strokes.
+    const oA=th+SECTOR/2, oB=th+0.04, iA=th-0.04, iB=th-SECTOR/2;
+    const arcStroke=(thA,thB,r,attrs)=>{ const [xA,yA]=onArc(thA,r), [xB,yB]=onArc(thB,r);
+      const large=0; const sweep= thA>thB?1:0;
+      return `<path d="M${xA.toFixed(1)},${yA.toFixed(1)} A${r},${r} 0 ${large} ${sweep} ${xB.toFixed(1)},${yB.toFixed(1)}" fill="none" ${attrs}/>`; };
+    if(outN[i]) g+=arcStroke(oA,oB,R, `stroke="${aColor(i)}" stroke-width="5" stroke-linecap="round" opacity=".9"`);
+    if(inN[i])  g+=arcStroke(iA,iB,R, `stroke="${aColor(i)}" stroke-width="5" stroke-linecap="round" opacity=".9" stroke-dasharray="1.5 2.4"`);
+  });
+  // ribbons: asymmetric teardrop, src→dst hue gradient, arrowhead on the target
+  flows.forEach(([a,b,c],fi)=>{ const ths=ang(a), thd=ang(b);
+    // source endpoint packed in OUTBOUND half; target endpoint packed in INBOUND half
+    const sFrac=(outUsed[a]+c/2)/Math.max(outN[a],1); outUsed[a]+=c;
+    const dFrac=(inUsed[b]+c/2)/Math.max(inN[b],1);  inUsed[b]+=c;
+    const sTh=ths+0.06+ (SECTOR/2-0.06)*sFrac;       // along the outbound half
+    const dTh=thd-0.06- (SECTOR/2-0.06)*dFrac;       // along the inbound half
+    const wS=1.6, wT=Math.max(5, c*1.9);             // pinched at source, broad at target
+    const [sx,sy]=onArc(sTh,R-4), [dx,dy]=onArc(dTh,R-9); // target inset so the arrowhead sits on the arc
+    // tangent at each end spreads the ribbon edges along the arc
+    const tS=[Math.sin(sTh),Math.cos(sTh)], tD=[Math.sin(dTh),Math.cos(dTh)];
+    const s1=[sx+tS[0]*wS/2, sy+tS[1]*wS/2], s2=[sx-tS[0]*wS/2, sy-tS[1]*wS/2];
+    const t1=[dx+tD[0]*wT/2, dy+tD[1]*wT/2], t2=[dx-tD[0]*wT/2, dy-tD[1]*wT/2];
+    // a single shared control point near the centre so the teardrop body bends inward
+    const mid=[(sx+dx)/2 + (cx-(sx+dx)/2)*0.62, (sy+dy)/2 + ((cyA-34)-(sy+dy)/2)*0.5];
+    const gid=`chgrad${fi}`;
+    g+=`<defs><linearGradient id="${gid}" x1="${sx.toFixed(1)}" y1="${sy.toFixed(1)}" x2="${dx.toFixed(1)}" y2="${dy.toFixed(1)}" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="${aColor(a)}" stop-opacity=".35"/><stop offset="1" stop-color="${aColor(b)}" stop-opacity=".95"/></linearGradient></defs>`;
+    g+=`<path fill="url(#${gid})" stroke="none"
+      d="M${s1[0].toFixed(1)},${s1[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${t1[0].toFixed(1)},${t1[1].toFixed(1)}
+         L${t2[0].toFixed(1)},${t2[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${s2[0].toFixed(1)},${s2[1].toFixed(1)} Z">
+      <title>${agents[a]} → ${agents[b]} · ${c} transfers (${agents[a]} initiates)</title></path>`;
+    // arrowhead landing on the target arc, pointing outward at the receiver
+    const outward=[Math.cos(dTh),-Math.sin(dTh)]; // unit vector from centre outward at dst
+    const tip=onArc(dTh,R-1);
+    const base=[tip[0]-outward[0]*8, tip[1]-outward[1]*8];
+    g+=`<path d="M${(base[0]+tD[0]*4).toFixed(1)},${(base[1]+tD[1]*4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(base[0]-tD[0]*4).toFixed(1)},${(base[1]-tD[1]*4).toFixed(1)} Z" fill="${aColor(b)}"/>`;
+  });
+  // nodes + labels
+  agents.forEach((a,i)=>{ const th=ang(i), [x,y]=onArc(th,R);
+    g+=`<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3" fill="${aColor(i)}"/>`;
+    const lr=R+16, [lx,ly]=onArc(th,lr);
+    const anchor = lx<cx-10?'end':(lx>cx+10?'start':'middle');
+    g+=`<text class="gm-label" x="${lx.toFixed(1)}" y="${(ly+ (ly<40?-2:4)).toFixed(1)}" text-anchor="${anchor}">${a}</text>`; });
+  g+=`</svg>`;
+  return g;
+}
+function mountChord(){
+  document.getElementById('fig-chord').innerHTML = chordSVG({
+    W:560, H:230,
+    agents:['planner','coder','reviewer','tester','goldfive'],
+    flows:[[0,1,6],[0,2,3],[1,3,4],[1,2,2],[4,0,2]] });
+}
+
+/* ===== 12 conductor's marks ===== */
+function mountSteer(){
+  const W=880, H=140, padL=96, X=t=>padL+(W-padL-20)*t, yL=46, yM=104;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="conductor's marks — operator steering in the margin">`;
+  g+=`<text class="gm-label" x="8" y="${yL+4}">coder</text>`;
+  g+=`<text class="gm-faint" x="8" y="${yM+4}">operator</text>`;
+  g+=`<line class="hg-gantt-lane-sep" x1="${padL}" y1="${yM-14}" x2="${W-20}" y2="${yM-14}" opacity=".5"/>`;
+  // lane: work → waiting → work → gate → running
+  g+=`<rect x="${X(.02)}" y="${yL-6}" width="${X(.28)-X(.02)}" height="12" rx="3" fill="${KIND('llm-call')}" fill-opacity=".55"/>`;
+  g+=`<rect x="${X(.28)}" y="${yL-6}" width="${X(.42)-X(.28)}" height="12" rx="3" fill="${KIND('wait-for-human')}" fill-opacity=".30" stroke="${KIND('wait-for-human')}" stroke-dasharray="3 2" stroke-width="1"><title>waiting for human · 14s</title></rect>`;
+  g+=`<rect x="${X(.42)}" y="${yL-6}" width="${X(.60)-X(.42)}" height="12" rx="3" fill="${KIND('tool-call')}" fill-opacity=".55"/>`;
+  g+=`<rect x="${X(.64)}" y="${yL-6}" width="${X(.86)-X(.64)}" height="12" rx="3" fill="${KIND('llm-call')}" fill-opacity=".55" stroke="var(--accent)" stroke-width="2"><title>running</title></rect>`;
+  // gate at .62
+  g+=`<circle class="gm-gate" cx="${X(.62)}" cy="${yL}" r="6"><title>approval gate</title></circle>`;
+  g+=`<text x="${X(.62)-3.5}" y="${yL+3.5}" font-size="9" fill="var(--good)">✓</text>`;
+  g+=`<text class="gm-faint" x="${X(.595)}" y="${yL-14}">gate</text>`;
+  // margin marks
+  g+=`<text x="${X(.28)-4}" y="${yM+4}" font-size="11" fill="${KIND('wait-for-human')}"><title>paused for human @ 28%</title>◷</text>`;
+  g+=`<line class="gm-tick" x1="${X(.42)}" y1="${yM-9}" x2="${X(.42)}" y2="${yM+5}" stroke="var(--accent)"/>`;
+  g+=`<text class="gm-faint" x="${X(.435)}" y="${yM+4}">“prefer the streaming api” — steer</text>`;
+  g+=`<text x="${X(.62)-4}" y="${yM+4}" font-size="10" fill="var(--good)"><title>approved @ 62%</title>✓</text>`;
+  const nx=X(.86);
+  g+=`<line class="hg-gantt-now" x1="${nx}" y1="16" x2="${nx}" y2="${yM-20}"/><circle class="hg-gantt-now-cap" cx="${nx}" cy="16" r="2.5"/>`;
+  g+=`</svg>`;
+  document.getElementById('fig-steer').innerHTML=g;
+}
+
+/* ===== 13 context tide ===== */
+function mountTide(){
+  const W=880, H=120, padL=96, X=t=>padL+(W-padL-20)*t, base=96, top=22;
+  const keys=[[0,.12],[.18,.34],[.34,.58],[.48,.78],[.55,.80],[.555,.34],[.7,.52],[.85,.68],[1,.72]];
+  const yOf=v=>base-(base-top)*v;
+  const pts=[]; for(let i=0;i<=400;i++){ const t=i/400; pts.push([X(t), yOf(lerpKeys(keys,t)), lerpKeys(keys,t), t]); }
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="context tide — window occupancy with a compaction relief seam">`;
+  g+=`<text class="gm-label" x="8" y="${(base+top)/2}">coder ctx</text>`;
+  g+=`<line class="gm-onplan" x1="${X(0)}" y1="${top}" x2="${X(1)}" y2="${top}"/><text class="gm-faint" x="${X(0)}" y="${top-6}">window limit</text>`;
+  // base area
+  g+=`<path d="${P(pts)} L${X(1)},${base} L${X(0)},${base} Z" fill="var(--accent)" fill-opacity=".10"/>`;
+  g+=`<path d="${P(pts)}" fill="none" stroke="var(--accent)" stroke-width="1" opacity=".6"/>`;
+  // caution overlay where v > .72
+  let seg=null; const segs=[];
+  pts.forEach(p=>{ if(p[2]>.72){ if(!seg) seg=[]; seg.push(p); } else if(seg){ segs.push(seg); seg=null; } });
+  if(seg) segs.push(seg);
+  segs.forEach(s=>{ const lim=yOf(.72);
+    const poly=s.map(p=>p[0].toFixed(1)+','+p[1].toFixed(1)).join(' ')+` ${s[s.length-1][0].toFixed(1)},${lim} ${s[0][0].toFixed(1)},${lim}`;
+    g+=`<polygon points="${poly}" fill="var(--caution)" fill-opacity=".30"/>`; });
+  // compaction seam
+  const sx=X(.553);
+  g+=`<line class="gm-seam" x1="${sx}" y1="${top-2}" x2="${sx}" y2="${base+4}"/>`;
+  g+=`<text class="gm-faint" x="${sx+5}" y="${base-44}">compaction · −46%</text>`;
+  for(let i=0;i<=4;i++){ g+=`<text class="gm-axis" x="${X(i/4)-6}" y="${H-6}">${i*25}%</text>`; }
+  g+=`</svg>`;
+  document.getElementById('fig-tide').innerHTML=g;
+}
+
+/* ===== 14 plan DAG ===== */
+function mountDag(){
+  const W=880, H=200;
+  const NODES = {
+    'design-api': {x:90,  y:96,  st:'done'},
+    'impl-core':  {x:310, y:96,  st:'done'},
+    'wire-cli':   {x:530, y:56,  st:'running'},
+    'run-suite':  {x:530, y:136, st:'done'},
+    'polish-ux':  {x:750, y:96,  st:'pending'},
+    'write-docs': {x:310, y:170, st:'ghost'},
+  };
+  const EDGES = [ ['design-api','impl-core',1], ['impl-core','wire-cli',1], ['impl-core','run-suite',0],
+                  ['wire-cli','polish-ux',1], ['run-suite','polish-ux',0], ['design-api','write-docs','ghost'] ];
+  const BW=128, BH=26;
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="plan dependency DAG with the critical path as the accent spine">`;
+  EDGES.forEach(([a,b,crit])=>{ const A=NODES[a], B=NODES[b];
+    const x0=A.x+BW/2, y0=A.y, x1=B.x-BW/2, y1=B.y, c=(x0+x1)/2;
+    const stroke = crit===1 ? 'var(--accent)' : 'var(--ink-faint)';
+    const extra = crit==='ghost' ? ` stroke-dasharray="3 4" opacity=".45"` : crit===1 ? ` stroke-width="2"` : ` stroke-width="1" opacity=".6"`;
+    g+=`<path d="M${x0},${y0} C ${c},${y0} ${c},${y1} ${x1},${y1}" fill="none" stroke="${stroke}"${extra} vector-effect="non-scaling-stroke"><title>${a} → ${b}${crit===1?' · critical path':crit==='ghost'?' · severed at replan v2':''}</title></path>`; });
+  Object.entries(NODES).forEach(([id,n])=>{
+    const ghost = n.st==='ghost';
+    const stroke = n.st==='done' ? 'var(--good)' : n.st==='running' ? 'var(--accent)' : ghost ? 'var(--rule)' : 'var(--ink-faint)';
+    const glyph = n.st==='done' ? ['✓','var(--good)'] : n.st==='running' ? ['●','var(--accent)'] : ghost ? ['✕','var(--bad)'] : ['○','var(--ink-faint)'];
+    g+=`<rect x="${n.x-BW/2}" y="${n.y-BH/2}" width="${BW}" height="${BH}" rx="4" fill="var(--panel)" stroke="${stroke}" stroke-width="${n.st==='running'?2:1.2}"${ghost?` stroke-dasharray="4 3" opacity=".55"`:''} tabindex="0" vector-effect="non-scaling-stroke"><title>${id} · ${ghost?'dropped at replan v2':n.st}</title></rect>`;
+    g+=`<text x="${n.x-BW/2+10}" y="${n.y+3.5}" font-size="10.5" fill="${ghost?'var(--ink-faint)':'var(--ink-soft)'}"${ghost?` opacity=".7" text-decoration="line-through"`:''}>${id}</text>`;
+    g+=`<text x="${n.x+BW/2-17}" y="${n.y+4}" font-size="10" fill="${glyph[1]}">${glyph[0]}</text>`; });
+  g+=`<text class="gm-faint" x="12" y="${H-10}">layers = dependency depth · the accent spine = the critical path · ghost = dropped at a replan</text>`;
+  g+=`</svg>`;
+  document.getElementById('fig-dag').innerHTML=g;
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker);
+  mountFP(); mountSeismo(); mountHeart(); mountLadders(); mountSlopes(); mountSankey();
+  mountStrata(); mountReplan(); mountReel(); mountScore(); mountChord(); mountSteer(); mountTide(); mountDag();
+});
+</script>
+<script>window.__EMBED_CFG__ = { optSel: '[data-opt]', bareHide: ['h2', '.rationale', '.legend', '.ba-tag'] };</script>
+<script src="_embed.js"></script>
+</body>
+</html>

--- a/docs/design/zicato-ui-study/grammar.html
+++ b/docs/design/zicato-ui-study/grammar.html
@@ -211,16 +211,16 @@
       Agents on an arc, transfer counts as chords, width ∝ frequency, quiet agent-ramp hues. A plain chord hides the
       one thing the operator most needs — <b>who initiates vs. who receives</b> — so this one is <b>directional three
       ways at once</b>: (1) each agent's sector is split into an <b>outbound half</b> (solid, source side) and an
-      <b>inbound half</b> (hollow tick, target side); (2) every ribbon is an <b>asymmetric teardrop</b> — pinched at
-      the source, broad at the target — so the chord visibly <i>flows</i> toward whom it reaches; (3) it carries the
-      <b>source→target hue</b> and ends in a small arrowhead on the target arc. A coordinator-and-spokes system fans
+      <b>inbound half</b> (hollow tick, target side); (2) every chord is a <b>thin line</b> whose hue <b>fades from a
+      faint source to a bright target</b>, so it visibly <i>flows</i> toward whom it reaches; (3) and it ends in a
+      small arrowhead on the target arc. A coordinator-and-spokes system fans
       <i>out</i> from one sector; <b>if it looks like a web, something's off</b>. The session-summary topology check.
     </p>
     <div class="figwrap" id="fig-chord"></div>
     <div class="legend">
       <span><span class="sw" style="background:var(--hg-agent-1);opacity:.8"></span>outbound (source) half</span>
       <span><span class="sw" style="background:var(--panel);border:1px solid var(--rule)"></span>inbound (target) half</span>
-      <span>pinched ▸ source · broad ▸ target · ▸ arrowhead at the receiver</span>
+      <span>faint ▸ source · bright ▸ target · ▸ arrowhead at the receiver</span>
     </div>
   </div>
 </section>
@@ -621,8 +621,8 @@ function chordSVG(o){
     const arcStroke=(thA,thB,r,attrs)=>{ const [xA,yA]=onArc(thA,r), [xB,yB]=onArc(thB,r);
       const large=0; const sweep= thA>thB?1:0;
       return `<path d="M${xA.toFixed(1)},${yA.toFixed(1)} A${r},${r} 0 ${large} ${sweep} ${xB.toFixed(1)},${yB.toFixed(1)}" fill="none" ${attrs}/>`; };
-    if(outN[i]) g+=arcStroke(oA,oB,R, `stroke="${aColor(i)}" stroke-width="5" stroke-linecap="round" opacity=".9"`);
-    if(inN[i])  g+=arcStroke(iA,iB,R, `stroke="${aColor(i)}" stroke-width="5" stroke-linecap="round" opacity=".9" stroke-dasharray="1.5 2.4"`);
+    if(outN[i]) g+=arcStroke(oA,oB,R, `stroke="${aColor(i)}" stroke-width="4.5" stroke-linecap="round" vector-effect="non-scaling-stroke" opacity=".9"`);
+    if(inN[i])  g+=arcStroke(iA,iB,R, `stroke="${aColor(i)}" stroke-width="4.5" stroke-linecap="round" vector-effect="non-scaling-stroke" opacity=".9" stroke-dasharray="1.5 2.4"`);
   });
   // ribbons: asymmetric teardrop, src→dst hue gradient, arrowhead on the target
   flows.forEach(([a,b,c],fi)=>{ const ths=ang(a), thd=ang(b);
@@ -631,26 +631,25 @@ function chordSVG(o){
     const dFrac=(inUsed[b]+c/2)/Math.max(inN[b],1);  inUsed[b]+=c;
     const sTh=ths+0.06+ (SECTOR/2-0.06)*sFrac;       // along the outbound half
     const dTh=thd-0.06- (SECTOR/2-0.06)*dFrac;       // along the inbound half
-    const wS=1.6, wT=Math.max(5, c*1.9);             // pinched at source, broad at target
-    const [sx,sy]=onArc(sTh,R-4), [dx,dy]=onArc(dTh,R-9); // target inset so the arrowhead sits on the arc
-    // tangent at each end spreads the ribbon edges along the arc
-    const tS=[Math.sin(sTh),Math.cos(sTh)], tD=[Math.sin(dTh),Math.cos(dTh)];
-    const s1=[sx+tS[0]*wS/2, sy+tS[1]*wS/2], s2=[sx-tS[0]*wS/2, sy-tS[1]*wS/2];
-    const t1=[dx+tD[0]*wT/2, dy+tD[1]*wT/2], t2=[dx-tD[0]*wT/2, dy-tD[1]*wT/2];
-    // a single shared control point near the centre so the teardrop body bends inward
+    // ribbon = a THIN stroked curve, not a fat filled teardrop: width is a
+    // restrained √count, hard-capped and non-scaling so it stays a crisp
+    // hairline. Direction reads from the gradient (faint source → bright
+    // target), the solid/dashed arc split and the arrowhead.
+    const w=Math.min(4, 0.9+Math.sqrt(c)*1.1);
+    const [sx,sy]=onArc(sTh,R-4), [dx,dy]=onArc(dTh,R-6); // target inset so the arrowhead sits on the arc
+    const tD=[Math.sin(dTh),Math.cos(dTh)];
+    // a single shared control point near the centre so the chord bends inward
     const mid=[(sx+dx)/2 + (cx-(sx+dx)/2)*0.62, (sy+dy)/2 + ((cyA-34)-(sy+dy)/2)*0.5];
     const gid=`chgrad${fi}`;
     g+=`<defs><linearGradient id="${gid}" x1="${sx.toFixed(1)}" y1="${sy.toFixed(1)}" x2="${dx.toFixed(1)}" y2="${dy.toFixed(1)}" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="${aColor(a)}" stop-opacity=".35"/><stop offset="1" stop-color="${aColor(b)}" stop-opacity=".95"/></linearGradient></defs>`;
-    g+=`<path fill="url(#${gid})" stroke="none"
-      d="M${s1[0].toFixed(1)},${s1[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${t1[0].toFixed(1)},${t1[1].toFixed(1)}
-         L${t2[0].toFixed(1)},${t2[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${s2[0].toFixed(1)},${s2[1].toFixed(1)} Z">
+      <stop offset="0" stop-color="${aColor(a)}" stop-opacity=".45"/><stop offset="1" stop-color="${aColor(b)}" stop-opacity=".95"/></linearGradient></defs>`;
+    g+=`<path fill="none" stroke="url(#${gid})" stroke-width="${w.toFixed(2)}" stroke-linecap="round" vector-effect="non-scaling-stroke"
+      d="M${sx.toFixed(1)},${sy.toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${dx.toFixed(1)},${dy.toFixed(1)}">
       <title>${agents[a]} → ${agents[b]} · ${c} transfers (${agents[a]} initiates)</title></path>`;
-    // arrowhead landing on the target arc, pointing outward at the receiver
+    // a small SOLID arrowhead tipping the chord onto the target arc
     const outward=[Math.cos(dTh),-Math.sin(dTh)]; // unit vector from centre outward at dst
-    const tip=onArc(dTh,R-1);
-    const base=[tip[0]-outward[0]*8, tip[1]-outward[1]*8];
-    g+=`<path d="M${(base[0]+tD[0]*4).toFixed(1)},${(base[1]+tD[1]*4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(base[0]-tD[0]*4).toFixed(1)},${(base[1]-tD[1]*4).toFixed(1)} Z" fill="${aColor(b)}"/>`;
+    const tip=[dx+outward[0]*4, dy+outward[1]*4];
+    g+=`<path d="M${(dx+tD[0]*1.4).toFixed(1)},${(dy+tD[1]*1.4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(dx-tD[0]*1.4).toFixed(1)},${(dy-tD[1]*1.4).toFixed(1)} Z" fill="${aColor(b)}" stroke="none"/>`;
   });
   // nodes + labels
   agents.forEach((a,i)=>{ const th=ang(i), [x,y]=onArc(th,R);

--- a/docs/design/zicato-ui-study/index.html
+++ b/docs/design/zicato-ui-study/index.html
@@ -127,10 +127,11 @@
       </a>
       <a class="surface-card compose" href="compose.html">
         <div class="sc-name">compose <span class="sc-arrow">→</span></div>
-        <div class="sc-desc"><b>The full console, interactive.</b> Three whole-UI proposals — A·observatory (rail-switched
-          hero views + inspector), B·score (sequence-first with a gantt minimap and drift margin), C·mission control
-          (fingerprint fleet) — with clickable spans, ⌘K session switching, and the grammar figures composed in.
-          Opens from file://, no server needed.</div>
+        <div class="sc-desc"><b>The full console, interactive.</b> The gantt stands alone as the hero view; one
+          coalesced instruments view leads with the plan — the reel sits above the DAG and <b>drives</b> it (click a
+          revision; the DAG redraws that version, added in accent, dropped ghosted) — then sequence, the projectable
+          topology chord, and one time-track stack: the drift seismograph with the judge heartbeat folded in, over a
+          time-aligned intervention ladder. Sessions switch only through the ⌘K fingerprint picker; spans → inspector.</div>
       </a>
     </div>
   </section>

--- a/docs/design/zicato-ui-study/index.html
+++ b/docs/design/zicato-ui-study/index.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="monokai">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>harmonograf × zicato — UI study</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="_tokens.css">
+<link rel="stylesheet" href="_study.css">
+<style>
+  .hero-thesis { border:1px solid var(--rule); border-left:3px solid var(--accent); border-radius:0 var(--r-panel) var(--r-panel) 0;
+    background:var(--panel); padding:18px 20px; margin:18px 0 26px; }
+  .hero-thesis p { margin:0 0 10px; font-size:13.5px; color:var(--ink); max-width:92ch; }
+  .hero-thesis p:last-child { margin-bottom:0; }
+  .hero-thesis b { color:var(--accent); }
+  .axes { display:grid; grid-template-columns:1fr 1fr; gap:14px; margin:14px 0 0; }
+  @media (max-width:760px){ .axes { grid-template-columns:1fr; } }
+  .axis { border:1px dashed var(--rule); border-radius:var(--r-panel); padding:12px 14px; background:var(--panel-2); }
+  .axis h4 { margin:0 0 8px; font-size:11px; text-transform:uppercase; letter-spacing:.1em; color:var(--ink-faint); }
+  .axis .row { display:flex; align-items:center; gap:8px; font-size:11.5px; color:var(--ink-soft); margin:5px 0; }
+  .axis .sw { width:16px; height:11px; border-radius:2px; flex:none; }
+  .axis .mk { width:18px; height:13px; border-radius:2px; flex:none; display:inline-flex; align-items:center; justify-content:center; font-size:10px; }
+  .cards { display:grid; grid-template-columns:repeat(auto-fit, minmax(260px,1fr)); gap:14px; margin:8px 0 0; }
+  a.surface-card { display:block; border:1px solid var(--rule); border-radius:var(--r-card); background:var(--panel);
+    padding:16px 18px; text-decoration:none; transition:border-color .12s, transform .12s; }
+  a.surface-card:hover { border-color:var(--accent); transform:translateY(-1px); text-decoration:none; }
+  a.surface-card .sc-name { font-size:14px; font-weight:700; color:var(--ink); display:flex; align-items:baseline; gap:8px; }
+  a.surface-card .sc-arrow { color:var(--accent); margin-left:auto; }
+  a.surface-card .sc-desc { font-size:11.5px; color:var(--ink-soft); margin-top:6px; line-height:1.5; }
+  a.surface-card.compose { border-style:dashed; }
+  .themewall { display:grid; grid-template-columns:repeat(auto-fill, minmax(150px,1fr)); gap:8px; margin-top:8px; }
+  .twcell { border:1px solid var(--rule); border-radius:var(--r-panel); overflow:hidden; cursor:pointer; background:var(--panel); }
+  .twcell .tw-strip { display:flex; height:26px; }
+  .twcell .tw-strip span { flex:1; }
+  .twcell .tw-name { font-size:10px; color:var(--ink-soft); padding:4px 7px; display:flex; justify-content:space-between; }
+  .twcell.active { border-color:var(--accent); }
+  .twcell.active .tw-name { color:var(--accent); }
+</style>
+</head>
+<body>
+<header class="study">
+  <span class="brand-row"><span data-brand-mark="24"></span><span data-brand-wordmark></span></span>
+  <h1>harmonograf — a UI study in the zicato design language</h1>
+  <span class="spacer"></span>
+  <span class="theme-pick-label">theme</span>
+  <span data-theme-picker></span>
+</header>
+
+<main class="study">
+  <p class="lede" style="margin-top:22px">
+    harmonograf is a multi-agent coordination console — a Gantt-forward instrument for watching many agents, 9 span kinds
+    and goldfive's steering unfold over wall-clock. This study redraws it in <b>zicato's design language</b>: Tufte
+    data-ink line-art, a calm mono ground, theme-adaptive by pure CSS swap. It is a <b>design artifact</b> — standalone
+    HTML/CSS/JS, no build step, opens from <code>file://</code> — theme-switchable across all 16 Console palettes.
+  </p>
+
+  <section class="study">
+    <h2>The thesis — a full categorical palette, sourced from terminal ANSI</h2>
+    <div class="hero-thesis">
+      <p>zicato spends exactly <b>one green accent</b> on a neutral ground — perfect for a binary promote/reject surface.
+        harmonograf is a <b>categorical instrument</b>: it needs many distinguishable hues at once. So this study
+        <b>keeps the full categorical palette</b> — but sources every categorical hue from the active theme's
+        <b>terminal ANSI palette</b> (the Gogh scheme each zicato theme derives from). Switch the theme: the whole
+        categorical encoding re-skins, ANSI and all.</p>
+      <p>That keeps harmonograf's elegant <b>2-axis encoding</b> intact while honoring zicato's "earned by direction"
+        rule. KIND is an identity hue; STATUS is a treatment. good / bad / accent appear <b>only</b> for status — so a
+        span is never red for what it is, only when it failed.</p>
+      <div class="axes">
+        <div class="axis">
+          <h4>KIND = hue (ANSI slot)</h4>
+          <div class="row"><span class="sw" style="background:var(--hg-kind-llm-call);opacity:.6"></span> LLM_CALL — blue</div>
+          <div class="row"><span class="sw" style="background:var(--hg-kind-tool-call);opacity:.6"></span> TOOL_CALL — cyan</div>
+          <div class="row"><span class="sw" style="background:var(--hg-kind-user-message);opacity:.6"></span> USER_MESSAGE — green</div>
+          <div class="row"><span class="sw" style="background:var(--hg-kind-transfer);opacity:.6"></span> TRANSFER — yellow</div>
+          <div class="row"><span class="sw" style="background:var(--hg-kind-wait-for-human);opacity:.6"></span> WAIT_FOR_HUMAN — magenta</div>
+        </div>
+        <div class="axis">
+          <h4>STATUS = treatment (role)</h4>
+          <div class="row"><span class="mk" style="border:2px solid var(--accent)"></span> RUNNING — accent + breathe (now)</div>
+          <div class="row"><span class="mk" style="background:var(--bad);color:var(--paper)">✕</span> FAILED — bad + glyph</div>
+          <div class="row"><span class="mk" style="background:var(--good)"></span> COMPLETED ok — good</div>
+          <div class="row"><span class="mk" style="background:var(--hg-kind-tool-call);opacity:.32"></span> PENDING — faint (neutral, not red)</div>
+          <div class="row"><span class="mk" style="background:var(--ink-faint);opacity:.4"></span> CANCELLED — hatch</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="study">
+    <h2>The surfaces</h2>
+    <div class="cards">
+      <a class="surface-card" href="shell.html">
+        <div class="sc-name">shell <span class="sc-arrow">→</span></div>
+        <div class="sc-desc">The chrome: AppBar → console topbar (the harmonograf α mark + plain-letter wordmark, breadcrumbs,
+          status / RUN pill), NavRail, CurrentTaskStrip, TransportBar, inspector Drawer. Before/after per element.</div>
+      </a>
+      <a class="surface-card" href="gantt.html">
+        <div class="sc-name">gantt <span class="sc-arrow">→</span></div>
+        <div class="sc-desc"><b>The hero.</b> The execution timeline in line-art: categorical kind hues, status treatments,
+          the accent now-cursor, agent lifelines, context band. Both the SVG and canvas options.</div>
+      </a>
+      <a class="surface-card" href="sequence.html">
+        <div class="sc-name">sequence <span class="sc-arrow">→</span></div>
+        <div class="sc-desc"><b>How the agents talk to one another.</b> The agent-interaction sequence diagram
+          (lifelines down, time down, each message a directional connector) paired with the directional transfer
+          chord for topology; the horizontal score is the Gantt-companion alternative. Lifelines stay neutral;
+          messages carry the kind hue; direction is explicit.</div>
+      </a>
+      <a class="surface-card" href="figures.html">
+        <div class="sc-name">figures <span class="sc-arrow">→</span></div>
+        <div class="sc-desc">The component catalogue: OrchestrationTimeline, TaskStages, LiveActivity
+          (<code>.dn-board-table</code>), Interventions (goldfive steering), the ⌘K SessionPicker.</div>
+      </a>
+      <a class="surface-card" href="brand.html">
+        <div class="sc-name">brand <span class="sc-arrow">→</span></div>
+        <div class="sc-desc"><b>harmonograf's own mark.</b> A logo study for the standalone console — the double namesake
+          (Adamiecki's 1896 harmonogram × the Victorian harmonograph), four line-art marks generated live from the
+          damped-oscillator equations, wordmark, favicon cuts, the accent question.</div>
+      </a>
+      <a class="surface-card" href="grammar.html">
+        <div class="sc-name">grammar <span class="sc-arrow">→</span></div>
+        <div class="sc-desc"><b>Fourteen new figures.</b> Drift seismograph, intervention ladder, correction slopegraphs,
+          drift sankey, plan strata, replan slopegraph, plan DAG (critical path as the spine), delegation score,
+          transfer chord, conductor's marks, context tide, the harmonograph session fingerprint.</div>
+      </a>
+      <a class="surface-card compose" href="compose.html">
+        <div class="sc-name">compose <span class="sc-arrow">→</span></div>
+        <div class="sc-desc"><b>The full console, interactive.</b> Three whole-UI proposals — A·observatory (rail-switched
+          hero views + inspector), B·score (sequence-first with a gantt minimap and drift margin), C·mission control
+          (fingerprint fleet) — with clickable spans, ⌘K session switching, and the grammar figures composed in.
+          Opens from file://, no server needed.</div>
+      </a>
+    </div>
+  </section>
+
+  <section class="study">
+    <h2>Sixteen themes — the re-skin</h2>
+    <p class="rationale">Every mark on every page reads <code>--v2-*</code> roles + <code>--ansi-*</code> categorical from
+      <code>_tokens.css</code>. Click any palette to set it across the whole study (persists). The strip is
+      <em>ground · panel · ink · good · bad · accent</em>.</p>
+    <div class="themewall" id="themewall"></div>
+  </section>
+</main>
+
+<footer class="study">
+  harmonograf UI study · the bar is zicato's own <code>tournament-viz-study</code> · token-only colour · fit-to-width ·
+  reduced-motion-aware · verified in <code>paper</code> + <code>monokai</code>. Foundation &amp; decisions:
+  <a href="STYLE-GUIDE.md">STYLE-GUIDE.md</a> · palette: <a href="_refs/gogh-palettes.json">gogh-palettes.json</a>.
+</footer>
+
+<!-- shared chrome -->
+<script>
+window.THEME_IDS = ['monokai','solarized-dark','solarized-light','google-light','google-dark',
+  'lunaria-light','lunaria-eclipse','belafonte-day','belafonte-night','paper','zenburn',
+  'selenized-black','relaxed','espresso','dracula','ubuntu'];
+const THEME_SWATCHES = {
+  'monokai':['#1e1f1c','#272822','#f8f8f2','#a6e22e','#f92672','#66d9ef'],
+  'solarized-dark':['#04222B','#0A2D38','#93A1A1','#8BB80E','#E0483C','#2AA198'],
+  'solarized-light':['#FDF6E3','#FBF1D6','#586E75','#6B9B0B','#DC322F','#268BD2'],
+  'google-light':['#FFFFFF','#F4F4F4','#474A4E','#34A853','#EA4335','#1B9CB8'],
+  'google-dark':['#202124','#2C2D30','#FFFFFF','#34A853','#EA4335','#24C1E0'],
+  'lunaria-light':['#EBE4E1','#E2DCD9','#363434','#497D46','#783C1F','#3778A9'],
+  'lunaria-eclipse':['#323F46','#3B484F','#DFE2ED','#BEDBC1','#BA9088','#C8429F'],
+  'belafonte-day':['#D5CCBA','#CCC3B2','#34292D','#6E6A4E','#BE100E','#426A79'],
+  'belafonte-night':['#20111B','#271821','#D5CCBA','#A6A07A','#D6403E','#6F8E97'],
+  'paper':['#F2EEDE','#E6E2D3','#1A1A1A','#216609','#CC3E28','#1E6FCC'],
+  'zenburn':['#3A3A3A','#424241','#DCDCCC','#8FB28F','#CC9393','#8CD0D3'],
+  'selenized-black':['#181818','#202020','#DEDEDE','#83C746','#FF5E56','#56D8C9'],
+  'relaxed':['#353A44','#3D424B','#F7F7F7','#A0AC77','#BC5653','#7EAAC7'],
+  'espresso':['#323232','#3A3A3A','#FFFFFF','#A5C261','#D25252','#6C99BB'],
+  'dracula':['#282A36','#343746','#F8F8F2','#50FA7B','#FF5555','#BD93F9'],
+  'ubuntu':['#300A24','#3D1530','#EEEEEC','#8AE234','#CC0000','#34E2E2'],
+};
+const THEME_LABELS = {'monokai':'Monokai','solarized-dark':'Solarized Dark','solarized-light':'Solarized Light',
+  'google-light':'Google Light','google-dark':'Google Dark','lunaria-light':'Lunaria Light','lunaria-eclipse':'Lunaria Eclipse',
+  'belafonte-day':'Belafonte Day','belafonte-night':'Belafonte Night','paper':'Paper','zenburn':'Zenburn',
+  'selenized-black':'Selenized Black','relaxed':'Relaxed','espresso':'Espresso','dracula':'Dracula','ubuntu':'Ubuntu'};
+const THEME_KEY = 'hgraf-study-theme';
+let themeListeners = []; function onThemeChange(fn){ themeListeners.push(fn); }
+function swatchStrip(id, sm){ const t = THEME_SWATCHES[id] || [];
+  return `<span class="dt-swatch-strip${sm?' dt-swatch-strip-sm':''}">`+t.map(c=>`<span class="dt-swatch" style="background:${c}"></span>`).join('')+`</span>`; }
+function currentTheme(){ return document.documentElement.getAttribute('data-theme') || 'monokai'; }
+function applyTheme(id){ document.documentElement.setAttribute('data-theme', id);
+  try { localStorage.setItem(THEME_KEY, id); } catch(e){}
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker);
+  themeListeners.forEach(fn=>{ try{fn();}catch(e){} }); }
+function buildPicker(host){ const cur = currentTheme();
+  host.innerHTML = `<div class="dt-cd"><button class="dt-cd-trigger" aria-haspopup="listbox" aria-expanded="false">${swatchStrip(cur,true)}<span class="dt-cd-name">${THEME_LABELS[cur]}</span><span class="dt-cd-caret" aria-hidden="true">▾</span></button><div class="dt-cd-list" role="listbox" aria-label="theme">${window.THEME_IDS.map(id=>`<div class="dt-cd-option" role="option" data-id="${id}" aria-selected="${id===cur}">${swatchStrip(id)}<span class="dt-cd-name">${THEME_LABELS[id]}</span></div>`).join('')}</div></div>`;
+  const cd = host.querySelector('.dt-cd'), trig = host.querySelector('.dt-cd-trigger');
+  trig.addEventListener('click', e=>{ e.stopPropagation(); const open = cd.classList.toggle('dt-cd-open'); trig.setAttribute('aria-expanded', open); });
+  host.querySelectorAll('.dt-cd-option').forEach(o=> o.addEventListener('click', ()=>{ applyTheme(o.dataset.id); cd.classList.remove('dt-cd-open'); })); }
+document.addEventListener('click', ()=> document.querySelectorAll('.dt-cd-open').forEach(c=>c.classList.remove('dt-cd-open')));
+(function initTheme(){ let saved=null; try { saved=localStorage.getItem(THEME_KEY); } catch(e){}
+  const P=new URLSearchParams(location.search), fromUrl=P.get('theme');
+  const id=(fromUrl&&window.THEME_IDS.includes(fromUrl))?fromUrl:(saved&&window.THEME_IDS.includes(saved))?saved:'monokai';
+  document.documentElement.setAttribute('data-theme', id); })();
+/* harmonograf brand — the Option-D alpha: one period of the 2:3 Lissajous,
+   MIRRORED about the vertical axis (x = cx − A·cos2t, y = cy + B·sin3t) so the
+   knot reads as a lowercase α — still a Lissajous, loop left, tails right.
+   Stroke currentColor; the one dot rides the lower-right tail tip: the pen at
+   rest. ONE ALPHA PER LOCKUP: beside this mark the wordmark is PLAIN LETTERS
+   (the glyph already carries the α and the dot); only a STANDALONE wordmark
+   spells the "a" of graf with the drawn α. */
+function hgAlphaPath(cx, cy, A, B){ const pts=[];
+  for(let i=0;i<=240;i++){ const t=2*Math.PI*i/240;
+    pts.push((cx - A*Math.cos(2*t)).toFixed(2)+','+(cy + B*Math.sin(3*t)).toFixed(2)); }
+  return 'M'+pts.join(' L')+' Z'; }
+function hgBrandMarkSVG(h){ return `<svg class="hg-brand-mark" style="height:${h||24}px" viewBox="0 0 48 48" role="img" aria-label="harmonograf" focusable="false"><path d="${hgAlphaPath(24,24,19,15)}" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/><circle cx="43" cy="39" r="3.2" fill="var(--hgraf-brand, #5EA3EC)"/></svg>`; }
+function hgWordmarkSVG(){ const T='harmonograf', X0=1, ADV=9.6, BASE=15; const W=X0*2+T.length*ADV;
+  return `<svg class="hg-brand-name" viewBox="0 0 ${W} 18" role="img" aria-label="harmonograf" focusable="false"><text x="${X0}" y="${BASE}" font-family="var(--brand-mono)" font-size="15" font-weight="700" textLength="${T.length*ADV}" lengthAdjust="spacing" fill="currentColor" xml:space="preserve">${T}</text></svg>`; }
+function mountBrand(){ document.querySelectorAll('[data-brand-mark]').forEach(n=>{ n.innerHTML=hgBrandMarkSVG(+n.dataset.brandMark||24); });
+  document.querySelectorAll('[data-brand-wordmark]').forEach(n=>{ n.innerHTML=hgWordmarkSVG(); }); }
+
+function buildThemewall(){
+  const host=document.getElementById('themewall'); if(!host) return;
+  const cur=currentTheme();
+  host.innerHTML = window.THEME_IDS.map(id=>{
+    const t=THEME_SWATCHES[id];
+    return `<div class="twcell${id===cur?' active':''}" data-id="${id}" role="button" tabindex="0" aria-label="${THEME_LABELS[id]}">
+      <div class="tw-strip">${t.map(c=>`<span style="background:${c}"></span>`).join('')}</div>
+      <div class="tw-name"><span>${THEME_LABELS[id]}</span><span>${id===cur?'●':''}</span></div>
+    </div>`;
+  }).join('');
+  host.querySelectorAll('.twcell').forEach(c=>{
+    c.addEventListener('click', ()=>applyTheme(c.dataset.id));
+    c.addEventListener('keydown', e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); applyTheme(c.dataset.id); } });
+  });
+}
+onThemeChange(buildThemewall);
+window.addEventListener('DOMContentLoaded', ()=>{
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker);
+  mountBrand(); buildThemewall();
+});
+</script>
+</body>
+</html>

--- a/docs/design/zicato-ui-study/sequence.html
+++ b/docs/design/zicato-ui-study/sequence.html
@@ -74,8 +74,8 @@
     <p class="rationale">
       <b>One vertical lifeline per agent, time flowing down</b> — the canonical sequence-diagram orientation, so it
       reads as one at a glance. Every message is a <b>horizontal connector</b> from the sender's lifeline to the
-      receiver's, with a <b>solid arrowhead at the receiving end</b> (a synchronous call) or a <b>dashed return</b>
-      (a result/reply), the label riding above in the KIND hue — dashed TRANSFER yellow for hand-offs, user green,
+      receiver's, ending in a <b>small solid arrowhead</b> at the receiver — a <b>solid connector</b> for a synchronous
+      call, a <b>dashed return</b> for a result/reply, the label riding above in the KIND hue — dashed TRANSFER yellow for hand-offs, user green,
       agent-message bright-green. <b>Activations</b> hug each lifeline as kind-hue bars (the agent is busy). The
       tester delegation <b>opens a child lifeline, runs beneath, and returns ✓</b>. The reviewer's approval is a
       <b>gate</b> (○ deciding). The failed check is the only red. It paginates vertically like a transcript, which
@@ -91,8 +91,8 @@
         <div class="ba-frame" id="fig-chord"></div>
         <p class="sq-lbl" style="margin:8px 2px 0;line-height:1.5">
           The transfer chord, made directional: each agent's arc splits into a solid <b>outbound</b> half and a
-          dashed <b>inbound</b> half; every ribbon is pinched at its source and broad at its target, carries the
-          source→target hue, and lands an arrowhead on the receiver. A coordinator-and-spokes run fans out from one
+          dashed <b>inbound</b> half; every chord is a thin line that fades from a faint source to a bright target
+          and lands an arrowhead on the receiver. A coordinator-and-spokes run fans out from one
           sector; a web means everyone is talking to everyone. <b>Built to scale:</b> ribbon width grows with
           <b>√count and caps</b>, so a chatty pair can never flood the figure — and the chord is <b>interactive</b>:
           hover an agent to <b>project</b> its conversations (everything else fades to a whisper, counts appear on
@@ -120,7 +120,7 @@
     <p class="rationale">
       The same trace laid <b>horizontally</b>, sharing the Gantt's time axis exactly. Agents are horizontal
       <b>staves</b>; work sits ON the staff as quiet kind-hue activations; messages are thin vertical connectors with
-      open arrowheads. Its strength is being the Gantt's connective tissue — drop it over the same axis and the two
+      small solid arrowheads. Its strength is being the Gantt's connective tissue — drop it over the same axis and the two
       views scrub together — but as a <i>sequence</i> diagram it is weaker: vertical message connectors between five
       closely-stacked staves are cramped, and it reads as an execution overlay more than a conversation. Keep it as
       the Gantt-companion lane; <b>the vertical sequence diagram above is the view</b> for reading the interaction.
@@ -273,10 +273,8 @@ function mountUML(){
    connector in the KIND hue. Activations hug each lifeline. The delegation
    opens a child lifeline that runs beneath the parent and returns. */
 function arrowHead(x, y, dir, color, open){ // dir: +1 head points right, -1 left
-  const b = open
-    ? `<path d="M${x-9*dir},${y-4.5} L${x},${y} L${x-9*dir},${y+4.5}" fill="none" stroke="${color}" stroke-width="1.4" vector-effect="non-scaling-stroke"/>`
-    : `<path d="M${x-9*dir},${y-4.5} L${x},${y} L${x-9*dir},${y+4.5} Z" fill="${color}"/>`;
-  return b;
+  // a small SOLID arrowhead; the SOLID-vs-DASHED connector carries call/return
+  return `<path d="M${x-6*dir},${y-2.4} L${x},${y} L${x-6*dir},${y+2.4} Z" fill="${color}" stroke="none"/>`;
 }
 function mountStaff(){
   const W=760, padT=58, H=520;
@@ -358,31 +356,32 @@ function chordSVG(o){
     const oA=th+SECTOR/2, oB=th+0.05, iA=th-0.05, iB=th-SECTOR/2;
     const arcStroke=(thA,thB,r,attrs)=>{ const [xA,yA]=onArc(thA,r), [xB,yB]=onArc(thB,r);
       return `<path data-agent="${a}" d="M${xA.toFixed(1)},${yA.toFixed(1)} A${r},${r} 0 0 ${thA>thB?1:0} ${xB.toFixed(1)},${yB.toFixed(1)}" fill="none" ${attrs}/>`; };
-    if(outN[i]) g+=arcStroke(oA,oB,R, `stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9"`);
-    if(inN[i])  g+=arcStroke(iA,iB,R, `stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9" stroke-dasharray="1.5 2.4"`);
+    if(outN[i]) g+=arcStroke(oA,oB,R, `stroke="${aColor(a)}" stroke-width="4.5" stroke-linecap="round" vector-effect="non-scaling-stroke" opacity=".9"`);
+    if(inN[i])  g+=arcStroke(iA,iB,R, `stroke="${aColor(a)}" stroke-width="4.5" stroke-linecap="round" vector-effect="non-scaling-stroke" opacity=".9" stroke-dasharray="1.5 2.4"`);
   });
   let counts='';
   flows.forEach(([a,b,c],fi)=>{ const ths=ang(a), thd=ang(b);
     const sFrac=(outUsed[a]+c/2)/Math.max(outN[a],1); outUsed[a]+=c;
     const dFrac=(inUsed[b]+c/2)/Math.max(inN[b],1);  inUsed[b]+=c;
     const sTh=ths+0.07+(SECTOR/2-0.07)*sFrac, dTh=thd-0.07-(SECTOR/2-0.07)*dFrac;
-    // √count with a hard cap: heavy traffic thickens slowly and can never flood
-    const wS=1.6, wT=Math.min(15, 4+Math.sqrt(c)*3.4);
-    const [sx,sy]=onArc(sTh,R-4), [dx,dy]=onArc(dTh,R-9);
-    const tS=[Math.sin(sTh),Math.cos(sTh)], tD=[Math.sin(dTh),Math.cos(dTh)];
-    const s1=[sx+tS[0]*wS/2, sy+tS[1]*wS/2], s2=[sx-tS[0]*wS/2, sy-tS[1]*wS/2];
-    const t1=[dx+tD[0]*wT/2, dy+tD[1]*wT/2], t2=[dx-tD[0]*wT/2, dy-tD[1]*wT/2];
+    // ribbon = a THIN stroked curve, not a fat filled teardrop: width is a
+    // restrained √count, hard-capped, and non-scaling so it stays a crisp
+    // hairline at any container width. Direction still reads from the gradient
+    // (faint source → bright target), the solid/dashed arc split and the
+    // arrowhead — the swelling teardrop was a redundant fourth cue.
+    const w=Math.min(4, 0.9+Math.sqrt(c)*1.1);
+    const [sx,sy]=onArc(sTh,R-4), [dx,dy]=onArc(dTh,R-6);
+    const tD=[Math.sin(dTh),Math.cos(dTh)];
     const mid=[(sx+dx)/2 + (cx-(sx+dx)/2)*0.62, (sy+dy)/2 + ((cyA-34)-(sy+dy)/2)*0.5];
     const gid=`sqchg${fi}`, FT=`data-f="${agents[a]}" data-t="${agents[b]}"`;
     g+=`<defs><linearGradient id="${gid}" x1="${sx.toFixed(1)}" y1="${sy.toFixed(1)}" x2="${dx.toFixed(1)}" y2="${dy.toFixed(1)}" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="${aColor(agents[a])}" stop-opacity=".32"/><stop offset="1" stop-color="${aColor(agents[b])}" stop-opacity=".95"/></linearGradient></defs>`;
-    g+=`<path data-ribbon="1" ${FT} fill="url(#${gid})" stroke="none"
-      d="M${s1[0].toFixed(1)},${s1[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${t1[0].toFixed(1)},${t1[1].toFixed(1)}
-         L${t2[0].toFixed(1)},${t2[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${s2[0].toFixed(1)},${s2[1].toFixed(1)} Z">
+      <stop offset="0" stop-color="${aColor(agents[a])}" stop-opacity=".45"/><stop offset="1" stop-color="${aColor(agents[b])}" stop-opacity=".95"/></linearGradient></defs>`;
+    g+=`<path data-ribbon="1" ${FT} fill="none" stroke="url(#${gid})" stroke-width="${w.toFixed(2)}" stroke-linecap="round" vector-effect="non-scaling-stroke"
+      d="M${sx.toFixed(1)},${sy.toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${dx.toFixed(1)},${dy.toFixed(1)}">
       <title>${agents[a]} → ${agents[b]} · ${c} transfers (${agents[a]} initiates)</title></path>`;
-    const outward=[Math.cos(dTh),-Math.sin(dTh)], tip=onArc(dTh,R-1);
-    const base=[tip[0]-outward[0]*8, tip[1]-outward[1]*8];
-    g+=`<path data-ahead="1" ${FT} d="M${(base[0]+tD[0]*4).toFixed(1)},${(base[1]+tD[1]*4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(base[0]-tD[0]*4).toFixed(1)},${(base[1]-tD[1]*4).toFixed(1)} Z" fill="${aColor(agents[b])}"/>`;
+    const outward=[Math.cos(dTh),-Math.sin(dTh)], tip=[dx+outward[0]*4, dy+outward[1]*4];
+    // a small SOLID arrowhead tipping the chord onto the receiver
+    g+=`<path data-ahead="1" ${FT} d="M${(dx+tD[0]*1.4).toFixed(1)},${(dy+tD[1]*1.4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(dx-tD[0]*1.4).toFixed(1)},${(dy-tD[1]*1.4).toFixed(1)} Z" fill="${aColor(agents[b])}" stroke="none"/>`;
     counts+=`<text class="tch-count" data-count="1" ${FT} x="${mid[0].toFixed(1)}" y="${(mid[1]+3).toFixed(1)}" text-anchor="middle">${c}×</text>`;
   });
   agents.forEach((a,i)=>{ const th=ang(i), [x,y]=onArc(th,R);
@@ -442,7 +441,7 @@ function mountScore(){
     if(st==='awaiting') g+=`<text x="${x0+w+3}" y="${y+3.5}" font-size="10" fill="${KIND('wait-for-human')}">◷</text>`; });
   function arrow(x, y0, y1, color, dash, lbl){ const d=y1>y0?1:-1, bend=14*d;
     let s=`<path class="sq-msg" d="M${x},${y0+7*d} C ${x+3},${y0+bend} ${x+3},${y1-bend} ${x},${y1-8*d}" stroke="${color}"${dash?` stroke-dasharray="4 3"`:''}><title>${lbl}</title></path>`;
-    s+=`<path class="sq-head" d="M${x-3.5},${y1-9.5*d} L${x},${y1-2*d} L${x+3.5},${y1-9.5*d}" stroke="${color}" stroke-width="1.2" fill="none" vector-effect="non-scaling-stroke"/>`;
+    s+=`<path class="sq-head" d="M${x-2.4},${y1-7*d} L${x},${y1-2*d} L${x+2.4},${y1-7*d} Z" stroke="none" fill="${color}"/>`;
     return s; }
   MSGS.forEach(([t,f,o,k,lbl])=>{ const x=X(t);
     if(k==='delegate'||k==='result') return;

--- a/docs/design/zicato-ui-study/sequence.html
+++ b/docs/design/zicato-ui-study/sequence.html
@@ -1,0 +1,433 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="monokai">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>harmonograf — sequence: how the agents talk to one another</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="_tokens.css">
+<link rel="stylesheet" href="_study.css">
+<style>
+  .sq-act { fill-opacity: .55; transition: fill-opacity .1s; }
+  .sq-act:hover { fill-opacity: 1; }
+  .sq-staff { stroke: var(--rule); stroke-width: 1; vector-effect: non-scaling-stroke; }
+  .sq-life { stroke: var(--rule); stroke-width: 1.1; stroke-dasharray: 1 4; vector-effect: non-scaling-stroke; }
+  .sq-msg { fill: none; stroke-width: 1.4; vector-effect: non-scaling-stroke; }
+  .sq-msg-return { stroke-dasharray: 4 3; }
+  .sq-name { fill: var(--ink); font-size: 10.5px; font-weight: 500; }
+  .sq-axis { fill: var(--ink-faint); font-size: 9px; font-variant-numeric: tabular-nums; }
+  .sq-lbl { fill: var(--ink-soft); font-size: 9px; }
+  .sq-chip { fill: var(--panel); stroke: var(--rule); }
+  .gm-ribbon { fill: var(--ink); fill-opacity: .14; }
+  .uml * { vector-effect: non-scaling-stroke; }
+  .uml .box { fill: var(--panel); stroke: var(--ink-soft); stroke-width: 1.2; }
+  .uml .frame { fill: none; stroke: var(--ink-soft); stroke-width: 1.2; }
+  .uml text { fill: var(--ink-soft); font-size: 10px; }
+  .uml .life { stroke: var(--ink-soft); stroke-width: 1; stroke-dasharray: 5 4; }
+  .uml .arrow { stroke: var(--ink-soft); stroke-width: 1.2; fill: none; }
+  .uml .ahead { fill: var(--ink-soft); }
+  .uml .act { fill: var(--rule-soft); stroke: var(--ink-soft); stroke-width: 1; }
+  .two-up { display: grid; grid-template-columns: minmax(0,1.55fr) minmax(0,1fr); gap: 18px; align-items: start; }
+  @media (max-width: 980px){ .two-up { grid-template-columns: 1fr; } }
+  .two-up h3 { font-size: 10px; text-transform: uppercase; letter-spacing: .12em; color: var(--ink-faint);
+    margin: 0 0 6px; font-weight: 600; }
+</style>
+</head>
+<body>
+
+<header class="study">
+  <span class="brand-row"><span data-brand-mark="22"></span><span data-brand-wordmark></span></span>
+  <h1>sequence — how the agents talk to one another</h1>
+  <span class="spacer"></span>
+  <span class="theme-pick-label">theme</span>
+  <span data-theme-picker></span>
+</header>
+
+<main class="study">
+
+<section class="study">
+  <h2>Premise</h2>
+  <p class="lede">
+    This view answers one question: <b>who said what to whom, and when</b> — the agent-interaction picture, not
+    the execution overlay. The classic answer is a sequence diagram: one <b>lifeline per agent</b>, <b>time flowing
+    down</b>, each message a horizontal connector from sender to receiver with a clear arrowhead. We keep that
+    grammar — it is the right one — but Tufte it into the zicato language. The rules: <b>lifelines are identity and
+    stay neutral</b> (a hairline, a quiet name chip — identity never earns color); <b>messages carry the KIND hue</b>
+    (transfer yellow, user green, agent-message bright-green); <b>activations are quiet kind-hue bars</b> on the
+    lifeline; a delegation <b>opens a sub-lifeline, runs beneath, and returns</b> with its verdict; the accent
+    appears only at <i>now</i>. Paired with it, the <b>directional transfer chord</b> summarises the same
+    conversation as a topology — who initiates, who receives — so the time-ordered diagram and the shape of the
+    communication agree.
+  </p>
+</section>
+
+<section class="study" data-surface>
+  <h2>The sequence diagram <span style="float:right;font-size:9.5px;letter-spacing:.12em;color:var(--accent)">RECOMMENDED</span></h2>
+  <div class="surface">
+    <p class="rationale">
+      <b>One vertical lifeline per agent, time flowing down</b> — the canonical sequence-diagram orientation, so it
+      reads as one at a glance. Every message is a <b>horizontal connector</b> from the sender's lifeline to the
+      receiver's, with a <b>solid arrowhead at the receiving end</b> (a synchronous call) or a <b>dashed return</b>
+      (a result/reply), the label riding above in the KIND hue — dashed TRANSFER yellow for hand-offs, user green,
+      agent-message bright-green. <b>Activations</b> hug each lifeline as kind-hue bars (the agent is busy). The
+      tester delegation <b>opens a child lifeline, runs beneath, and returns ✓</b>. The reviewer's approval is a
+      <b>gate</b> (○ deciding). The failed check is the only red. It paginates vertically like a transcript, which
+      is exactly how an operator deep-reads a long exchange.
+    </p>
+    <div class="two-up">
+      <div>
+        <h3>time-ordered — who said what to whom, when</h3>
+        <div class="ba-frame" id="fig-staff"></div>
+      </div>
+      <div>
+        <h3>topology — who initiates, who receives</h3>
+        <div class="ba-frame" id="fig-chord"></div>
+        <p class="sq-lbl" style="margin:8px 2px 0;line-height:1.5">
+          The transfer chord, made directional: each agent's arc splits into a solid <b>outbound</b> half and a
+          dashed <b>inbound</b> half; every ribbon is pinched at its source and broad at its target, carries the
+          source→target hue, and lands an arrowhead on the receiver. A coordinator-and-spokes run fans out from one
+          sector; a web means everyone is talking to everyone.
+        </p>
+      </div>
+    </div>
+    <div class="legend">
+      <span><span class="ln" style="border-color:var(--hg-kind-transfer);border-top-style:dashed"></span>transfer (hand-off)</span>
+      <span><span class="ln" style="border-color:var(--hg-kind-user-message)"></span>user → agent</span>
+      <span><span class="ln" style="border-color:var(--hg-kind-agent-message)"></span>agent message</span>
+      <span><span class="ln" style="border-color:var(--ink-faint);border-top-style:dashed"></span>return / result</span>
+      <span><span class="sw" style="background:var(--hg-kind-llm-call);opacity:.6"></span>llm activation</span>
+      <span><span class="sw" style="background:var(--hg-kind-tool-call);opacity:.6"></span>tool activation</span>
+      <span>○ gate</span><span style="color:var(--bad)">✕ failed</span>
+      <span><span class="ln" style="border-color:var(--accent)"></span>now</span>
+    </div>
+  </div>
+</section>
+
+<section class="study" data-surface>
+  <h2>Alternative — the score (time runs right, like the Gantt)</h2>
+  <div class="surface">
+    <p class="rationale">
+      The same trace laid <b>horizontally</b>, sharing the Gantt's time axis exactly. Agents are horizontal
+      <b>staves</b>; work sits ON the staff as quiet kind-hue activations; messages are thin vertical connectors with
+      open arrowheads. Its strength is being the Gantt's connective tissue — drop it over the same axis and the two
+      views scrub together — but as a <i>sequence</i> diagram it is weaker: vertical message connectors between five
+      closely-stacked staves are cramped, and it reads as an execution overlay more than a conversation. Keep it as
+      the Gantt-companion lane; <b>the vertical sequence diagram above is the view</b> for reading the interaction.
+    </p>
+    <div class="ba-frame" id="fig-score"></div>
+    <div class="legend">
+      <span><span class="ln" style="border-color:var(--hg-kind-transfer);border-top-style:dashed"></span>transfer</span>
+      <span><span class="ln" style="border-color:var(--hg-kind-user-message)"></span>user → agent</span>
+      <span><span class="ln" style="border-color:var(--hg-kind-agent-message)"></span>agent message</span>
+      <span><span class="sw" style="background:var(--hg-kind-llm-call);opacity:.6"></span>llm activation</span>
+      <span><span class="sw" style="background:var(--hg-kind-tool-call);opacity:.6"></span>tool activation</span>
+      <span>○ gate</span><span style="color:var(--bad)">✕ failed</span>
+      <span><span class="ln" style="border-color:var(--accent)"></span>now</span>
+    </div>
+  </div>
+</section>
+
+<section class="study" data-surface>
+  <h2>Before — the inherited frame</h2>
+  <div class="surface">
+    <p class="rationale">
+      The textbook UML sequence diagram has the right <i>orientation</i> — lifelines down, messages across — but
+      spends every mark on <b>structure</b>: actor boxes, a heavy lifeline grid, filled arrowheads, activation
+      rectangles, an <code>alt</code> frame. None of it encodes kind, status, or cost. The recommended view keeps
+      its grammar and drops the chartjunk.
+    </p>
+    <div class="ba-frame before" style="max-width:680px;margin:0 auto"><div id="fig-uml"></div></div>
+  </div>
+</section>
+
+</main>
+
+<footer class="study">
+  harmonograf sequence study · lifelines neutral, messages carry kind, direction is explicit, the accent only at now ·
+  part of the <a href="index.html">UI study</a> · companions: <a href="gantt.html">gantt</a> ·
+  <a href="grammar.html">figure grammar</a> · <a href="compose.html">the composed console</a>
+</footer>
+
+<script>
+/* ===== theme picker (study-standard) ===== */
+window.THEME_IDS = ['monokai','solarized-dark','solarized-light','google-light','google-dark',
+  'lunaria-light','lunaria-eclipse','belafonte-day','belafonte-night','paper','zenburn',
+  'selenized-black','relaxed','espresso','dracula','ubuntu'];
+const THEME_SWATCHES = {
+  'monokai':['#1e1f1c','#272822','#f8f8f2','#a6e22e','#f92672','#66d9ef'],
+  'solarized-dark':['#04222B','#0A2D38','#93A1A1','#8BB80E','#E0483C','#2AA198'],
+  'solarized-light':['#FDF6E3','#FBF1D6','#586E75','#6B9B0B','#DC322F','#268BD2'],
+  'google-light':['#FFFFFF','#F4F4F4','#474A4E','#34A853','#EA4335','#1B9CB8'],
+  'google-dark':['#202124','#2C2D30','#FFFFFF','#34A853','#EA4335','#24C1E0'],
+  'lunaria-light':['#EBE4E1','#E2DCD9','#363434','#497D46','#783C1F','#3778A9'],
+  'lunaria-eclipse':['#323F46','#3B484F','#DFE2ED','#BEDBC1','#BA9088','#C8429F'],
+  'belafonte-day':['#D5CCBA','#CCC3B2','#34292D','#6E6A4E','#BE100E','#426A79'],
+  'belafonte-night':['#20111B','#271821','#D5CCBA','#A6A07A','#D6403E','#6F8E97'],
+  'paper':['#F2EEDE','#E6E2D3','#1A1A1A','#216609','#CC3E28','#1E6FCC'],
+  'zenburn':['#3A3A3A','#424241','#DCDCCC','#8FB28F','#CC9393','#8CD0D3'],
+  'selenized-black':['#181818','#202020','#DEDEDE','#83C746','#FF5E56','#56D8C9'],
+  'relaxed':['#353A44','#3D424B','#F7F7F7','#A0AC77','#BC5653','#7EAAC7'],
+  'espresso':['#323232','#3A3A3A','#FFFFFF','#A5C261','#D25252','#6C99BB'],
+  'dracula':['#282A36','#343746','#F8F8F2','#50FA7B','#FF5555','#BD93F9'],
+  'ubuntu':['#300A24','#3D1530','#EEEEEC','#8AE234','#CC0000','#34E2E2'],
+};
+const THEME_LABELS = {'monokai':'Monokai','solarized-dark':'Solarized Dark','solarized-light':'Solarized Light',
+  'google-light':'Google Light','google-dark':'Google Dark','lunaria-light':'Lunaria Light','lunaria-eclipse':'Lunaria Eclipse',
+  'belafonte-day':'Belafonte Day','belafonte-night':'Belafonte Night','paper':'Paper','zenburn':'Zenburn',
+  'selenized-black':'Selenized Black','relaxed':'Relaxed','espresso':'Espresso','dracula':'Dracula','ubuntu':'Ubuntu'};
+const THEME_KEY = 'hgraf-study-theme';
+function swatchStrip(id, sm){ const t = THEME_SWATCHES[id] || [];
+  return `<span class="dt-swatch-strip${sm?' dt-swatch-strip-sm':''}">`+t.map(c=>`<span class="dt-swatch" style="background:${c}"></span>`).join('')+`</span>`; }
+function currentTheme(){ return document.documentElement.getAttribute('data-theme') || 'monokai'; }
+function applyTheme(id){ document.documentElement.setAttribute('data-theme', id);
+  try { localStorage.setItem(THEME_KEY, id); } catch(e){}
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker); }
+function buildPicker(host){ const cur = currentTheme();
+  host.innerHTML = `<div class="dt-cd"><button class="dt-cd-trigger" aria-haspopup="listbox" aria-expanded="false">${swatchStrip(cur,true)}<span class="dt-cd-name">${THEME_LABELS[cur]}</span><span class="dt-cd-caret" aria-hidden="true">▾</span></button><div class="dt-cd-list" role="listbox" aria-label="theme">${window.THEME_IDS.map(id=>`<div class="dt-cd-option" role="option" data-id="${id}" aria-selected="${id===cur}">${swatchStrip(id)}<span class="dt-cd-name">${THEME_LABELS[id]}</span></div>`).join('')}</div></div>`;
+  const cd = host.querySelector('.dt-cd'), trig = host.querySelector('.dt-cd-trigger');
+  trig.addEventListener('click', e=>{ e.stopPropagation(); const open = cd.classList.toggle('dt-cd-open'); trig.setAttribute('aria-expanded', open); });
+  host.querySelectorAll('.dt-cd-option').forEach(o=> o.addEventListener('click', ()=>{ applyTheme(o.dataset.id); cd.classList.remove('dt-cd-open'); })); }
+document.addEventListener('click', ()=> document.querySelectorAll('.dt-cd-open').forEach(c=>c.classList.remove('dt-cd-open')));
+(function initTheme(){ let saved=null; try { saved=localStorage.getItem(THEME_KEY); } catch(e){}
+  const P=new URLSearchParams(location.search), fromUrl=P.get('theme');
+  const id=(fromUrl&&window.THEME_IDS.includes(fromUrl))?fromUrl:(saved&&window.THEME_IDS.includes(saved))?saved:'monokai';
+  document.documentElement.setAttribute('data-theme', id); })();
+
+/* harmonograf brand — the Option-D alpha: one period of the 2:3 Lissajous,
+   MIRRORED about the vertical axis (x = cx − A·cos2t, y = cy + B·sin3t) so the
+   knot reads as a lowercase α — still a Lissajous, loop left, tails right.
+   Stroke currentColor; the one dot rides the lower-right tail tip: the pen at
+   rest. ONE ALPHA PER LOCKUP: beside this mark the wordmark is PLAIN LETTERS
+   (the glyph already carries the α and the dot); only a STANDALONE wordmark
+   spells the "a" of graf with the drawn α. */
+function hgAlphaPath(cx, cy, A, B){ const pts=[];
+  for(let i=0;i<=240;i++){ const t=2*Math.PI*i/240;
+    pts.push((cx - A*Math.cos(2*t)).toFixed(2)+','+(cy + B*Math.sin(3*t)).toFixed(2)); }
+  return 'M'+pts.join(' L')+' Z'; }
+function hgBrandMarkSVG(h){ return `<svg class="hg-brand-mark" style="height:${h||24}px" viewBox="0 0 48 48" role="img" aria-label="harmonograf" focusable="false"><path d="${hgAlphaPath(24,24,19,15)}" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/><circle cx="43" cy="39" r="3.2" fill="var(--hgraf-brand, #5EA3EC)"/></svg>`; }
+function hgWordmarkSVG(){ const T='harmonograf', X0=1, ADV=9.6, BASE=15; const W=X0*2+T.length*ADV;
+  return `<svg class="hg-brand-name" viewBox="0 0 ${W} 18" role="img" aria-label="harmonograf" focusable="false"><text x="${X0}" y="${BASE}" font-family="var(--brand-mono)" font-size="15" font-weight="700" textLength="${T.length*ADV}" lengthAdjust="spacing" fill="currentColor" xml:space="preserve">${T}</text></svg>`; }
+function mountBrand(){ document.querySelectorAll('[data-brand-mark]').forEach(n=>{ n.innerHTML=hgBrandMarkSVG(+n.dataset.brandMark||24); });
+  document.querySelectorAll('[data-brand-wordmark]').forEach(n=>{ n.innerHTML=hgWordmarkSVG(); }); }
+
+/* ===== the shared trace ===== */
+const KIND = k => `var(--hg-kind-${k})`;
+const AGENTS = ['user','planner','coder','tester','reviewer'];
+const ACTS = [ // activations: [agent, kind, t0, t1, label, status]
+  ['planner','llm-call',3,14,'draft plan v1'],
+  ['coder','llm-call',18,30,'implement core'],
+  ['coder','tool-call',30,38,'edit 12 files'],
+  ['coder','tool-call',38,44,'tsc --noEmit','failed'],
+  ['coder','llm-call',44,54,'fix types'],
+  ['tester','tool-call',56,68,'run suite · 38k tok'],
+  ['reviewer','llm-call',72,76,'review diff'],
+  ['reviewer','wait-for-human',76,80,'approve api change','awaiting'],
+];
+const MSGS = [ // [t, from, to, kind, label]
+  [2,'user','planner','user-message','refactor checkout → streaming'],
+  [16,'planner','coder','transfer','transfer · plan v1'],
+  [54,'coder','tester','delegate','delegate · run test suite'],
+  [68,'tester','coder','result','✓ 214 passed'],
+  [70,'coder','reviewer','transfer','transfer · diff ready'],
+  [76,'reviewer','user','agent-message','approval requested'],
+];
+const NOW = 80, T1 = 96;
+/* topology: directed transfer counts over the whole trace, [srcIdx,dstIdx,count] */
+const CHORD_AGENTS = ['user','planner','coder','tester','reviewer'];
+const CHORD_FLOWS = [[0,1,1],[1,2,3],[2,3,2],[3,2,2],[2,4,2],[4,0,1]];
+
+/* ===== before: the UML frame ===== */
+function mountUML(){
+  const W=640, H=320, X={user:80,planner:215,coder:350,tester:485,reviewer:600}, yT=t=>56+(t/T1)*230;
+  let g=`<svg class="fig uml" viewBox="0 0 ${W} ${H}" role="img" aria-label="classic UML sequence diagram">`;
+  AGENTS.forEach(a=>{ const x=X[a];
+    g+=`<rect class="box" x="${x-34}" y="10" width="68" height="24" rx="2"/><text x="${x}" y="26" text-anchor="middle">${a}</text>`;
+    g+=`<line class="life" x1="${x}" y1="34" x2="${x}" y2="${H-12}"/>`; });
+  ACTS.slice(0,6).forEach(([a,k,t0,t1])=>{ const x=X[a];
+    g+=`<rect class="act" x="${x-5}" y="${yT(t0)}" width="10" height="${Math.max(8,yT(t1)-yT(t0))}"/>`; });
+  MSGS.forEach(([t,f,o,,lbl])=>{ const y=yT(t), x0=X[f], x1=X[o], d=x1>x0?1:-1;
+    g+=`<line class="arrow" x1="${x0}" y1="${y}" x2="${x1-7*d}" y2="${y}"/>`;
+    g+=`<path class="ahead" d="M${x1-8*d},${y-4} L${x1},${y} L${x1-8*d},${y+4} Z"/>`;
+    g+=`<text x="${(x0+x1)/2}" y="${y-5}" text-anchor="middle">${lbl}</text>`; });
+  g+=`<rect class="frame" x="300" y="${yT(38)-8}" width="110" height="${yT(54)-yT(38)+10}"/>`;
+  g+=`<rect class="box" x="300" y="${yT(38)-8}" width="34" height="13"/><text x="317" y="${yT(38)+3}" text-anchor="middle" font-size="8">alt</text>`;
+  g+=`</svg>`;
+  document.getElementById('fig-uml').innerHTML=g;
+}
+
+/* ===== RECOMMENDED: the vertical sequence diagram =====
+   One lifeline per agent, time DOWN. Each message is a horizontal connector
+   from the sender's lifeline to the receiver's, with a SOLID arrowhead at the
+   receiving end (a call) or a DASHED return (a result). Labels ride above each
+   connector in the KIND hue. Activations hug each lifeline. The delegation
+   opens a child lifeline that runs beneath the parent and returns. */
+function arrowHead(x, y, dir, color, open){ // dir: +1 head points right, -1 left
+  const b = open
+    ? `<path d="M${x-9*dir},${y-4.5} L${x},${y} L${x-9*dir},${y+4.5}" fill="none" stroke="${color}" stroke-width="1.4" vector-effect="non-scaling-stroke"/>`
+    : `<path d="M${x-9*dir},${y-4.5} L${x},${y} L${x-9*dir},${y+4.5} Z" fill="${color}"/>`;
+  return b;
+}
+function mountStaff(){
+  const W=760, padT=58, H=520;
+  // agent columns; the tester column hosts the delegated child lifeline
+  const X={user:96, planner:236, coder:392, tester:548, reviewer:684};
+  const yT=t=>padT+(t/T1)*(H-padT-30);
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="agent-interaction sequence diagram — lifelines down, messages across">`;
+  // time axis (left)
+  for(let i=0;i<=8;i++){ const y=yT(i*12);
+    g+=`<line class="hg-gantt-grid" x1="58" y1="${y}" x2="${W-14}" y2="${y}" opacity=".5"/><text class="sq-axis" x="30" y="${y+3}">${i*12}s</text>`; }
+  // lifelines + agent header chips
+  AGENTS.forEach(a=>{ const x=X[a];
+    const aColor = a==='user' ? 'var(--hg-agent-user)' : `var(--hg-agent-${['planner','coder','tester','reviewer'].indexOf(a)+1})`;
+    g+=`<line class="sq-life" x1="${x}" y1="32" x2="${x}" y2="${H-16}" stroke="${aColor}" opacity=".8"/>`;
+    g+=`<rect class="sq-chip" x="${x-36}" y="12" width="72" height="20" rx="4" stroke="${aColor}"/>`;
+    g+=`<text class="sq-name" x="${x}" y="${25.5}" text-anchor="middle">${a}</text>`; });
+  // delegated child lifeline (coder ▸ tester) — opens at t0, closes at t1
+  const dg={t0:54, t1:68}, childX = X.tester; // child rides the tester column as a thicker activation
+  // activations on each lifeline
+  ACTS.forEach(([a,k,t0,t1,lbl,st])=>{ const x=X[a], y0=yT(t0), h=Math.max(7,yT(t1)-y0);
+    const fill = st==='failed' ? 'var(--bad)' : st==='awaiting' ? KIND('wait-for-human') : KIND(k);
+    const extra = st==='awaiting' ? ` stroke="${KIND('wait-for-human')}" stroke-dasharray="3 2" stroke-width="1"` : '';
+    g+=`<rect class="sq-act" x="${x-4}" y="${y0}" width="8" height="${h}" rx="2.5" fill="${fill}" fill-opacity="${st==='awaiting'?.4:st==='failed'?.85:.6}"${extra} tabindex="0"><title>${a} · ${lbl}${st?' · '+st:''} · ${t0}–${t1}s</title></rect>`;
+    if(st==='failed') g+=`<text x="${x+9}" y="${y0+h/2+3}" font-size="9" fill="var(--bad)">✕ tsc --noEmit</text>`; });
+  // (the reviewer's AWAITING_HUMAN is the gate below — labelled once, there)
+  // messages: horizontal connectors with a clear arrowhead + label above.
+  // Sequence-diagram layout: a message's y comes from its time, but consecutive
+  // messages are kept at least MINGAP apart (real diagrams give each message its
+  // own row) so a near-coincident call+return never overprints. A "leader" tick
+  // ties the row back to the true time on the axis when it was nudged.
+  const MINGAP=26; let prevY=-1e9;
+  MSGS.forEach(([t,f,o,k,lbl])=>{ const yTrue=yT(t);
+    let y=Math.max(yTrue, prevY+MINGAP); prevY=y;
+    const x0=X[f], x1=X[o], dir=x1>x0?1:-1;
+    const isReturn = k==='result';
+    const color = k==='transfer' ? KIND('transfer') : k==='user-message' ? KIND('user-message')
+      : k==='delegate' ? 'var(--ink-soft)' : isReturn ? 'var(--ink-faint)' : KIND('agent-message');
+    const dash = k==='transfer' ? ` stroke-dasharray="5 3"` : '';
+    const cls = `sq-msg${isReturn?' sq-msg-return':''}`;
+    // line stops short of the receiver lifeline so the arrowhead sits cleanly on it
+    g+=`<line class="${cls}" x1="${x0+4*dir}" y1="${y}" x2="${x1-9*dir}" y2="${y}" stroke="${color}"${dash}><title>${f} → ${o} · ${lbl} · ${t}s</title></line>`;
+    g+=arrowHead(x1-1*dir, y, dir, color, isReturn);
+    // label rides above each connector, hugging the sender end so even stacked
+    // rows read left-to-right without overprint.
+    const lx = x0 + 18*dir, anchor = dir>0?'start':'end';
+    g+=`<text class="sq-lbl" x="${lx}" y="${y-5}" text-anchor="${anchor}" fill="${color}">${lbl}</text>`; });
+  // delegation: child activation band on the tester lifeline + "open"/"return" framing
+  const cb0=yT(dg.t0), cb1=yT(dg.t1);
+  g+=`<rect x="${childX-6}" y="${cb0}" width="12" height="${cb1-cb0}" rx="3" fill="${KIND('tool-call')}" fill-opacity=".5" stroke="var(--ink-faint)" stroke-width="1"><title>delegated child · run test suite · 38k tok</title></rect>`;
+  g+=`<text class="sq-lbl" x="${childX+11}" y="${(cb0+cb1)/2}" fill="var(--ink-faint)">38k tok</text>`;
+  // approval gate on the reviewer lifeline at NOW
+  g+=`<circle cx="${X.reviewer}" cy="${yT(80)}" r="6" fill="none" stroke="var(--ink-soft)" stroke-width="1.5"><title>approval gate · deciding…</title></circle>`;
+  g+=`<text class="sq-lbl" x="${X.reviewer-8}" y="${yT(80)+18}" text-anchor="end">gate · deciding…</text>`;
+  // now
+  const ny=yT(NOW);
+  g+=`<line class="hg-gantt-now" x1="58" y1="${ny}" x2="${W-14}" y2="${ny}"/>`;
+  g+=`<text class="hg-gantt-now-label" x="62" y="${ny-5}">now ${NOW}s</text>`;
+  g+=`</svg>`;
+  document.getElementById('fig-staff').innerHTML=g;
+}
+
+/* ===== the directional transfer chord (topology summary) =====
+   Direction is encoded three redundant ways: (1) each agent's arc sector splits
+   into a solid OUTBOUND half and a dashed INBOUND half; (2) each ribbon is an
+   asymmetric teardrop — pinched at the source, broad at the target; (3) a
+   source→target hue plus an arrowhead landing on the target arc. */
+function chordSVG(o){
+  const W=o.W||360, H=o.H||300, cx=W/2, cyA=o.cyA||(H-30), R=o.R||(W*0.34);
+  const agents=o.agents, flows=o.flows, n=agents.length, SECTOR=Math.PI/n*0.74;
+  const ang=i=> Math.PI - Math.PI*i/(n-1);
+  const onArc=(th,r)=>[cx+r*Math.cos(th), cyA-r*Math.sin(th)];
+  const aColor=a=> a==='user' ? 'var(--hg-agent-user)' : a==='goldfive' ? 'var(--hg-agent-goldfive)'
+    : `var(--hg-agent-${['planner','coder','tester','reviewer'].indexOf(a)+1})`;
+  const outN=agents.map(()=>0), inN=agents.map(()=>0);
+  flows.forEach(([a,b,c])=>{ outN[a]+=c; inN[b]+=c; });
+  const outUsed=agents.map(()=>0), inUsed=agents.map(()=>0);
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="directional transfer chord — who initiates and who receives">`;
+  agents.forEach((a,i)=>{ const th=ang(i);
+    const oA=th+SECTOR/2, oB=th+0.05, iA=th-0.05, iB=th-SECTOR/2;
+    const arcStroke=(thA,thB,r,attrs)=>{ const [xA,yA]=onArc(thA,r), [xB,yB]=onArc(thB,r);
+      return `<path d="M${xA.toFixed(1)},${yA.toFixed(1)} A${r},${r} 0 0 ${thA>thB?1:0} ${xB.toFixed(1)},${yB.toFixed(1)}" fill="none" ${attrs}/>`; };
+    if(outN[i]) g+=arcStroke(oA,oB,R, `stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9"`);
+    if(inN[i])  g+=arcStroke(iA,iB,R, `stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9" stroke-dasharray="1.5 2.4"`);
+  });
+  flows.forEach(([a,b,c],fi)=>{ const ths=ang(a), thd=ang(b);
+    const sFrac=(outUsed[a]+c/2)/Math.max(outN[a],1); outUsed[a]+=c;
+    const dFrac=(inUsed[b]+c/2)/Math.max(inN[b],1);  inUsed[b]+=c;
+    const sTh=ths+0.07+(SECTOR/2-0.07)*sFrac, dTh=thd-0.07-(SECTOR/2-0.07)*dFrac;
+    const wS=1.6, wT=Math.max(5, c*2.4);
+    const [sx,sy]=onArc(sTh,R-4), [dx,dy]=onArc(dTh,R-9);
+    const tS=[Math.sin(sTh),Math.cos(sTh)], tD=[Math.sin(dTh),Math.cos(dTh)];
+    const s1=[sx+tS[0]*wS/2, sy+tS[1]*wS/2], s2=[sx-tS[0]*wS/2, sy-tS[1]*wS/2];
+    const t1=[dx+tD[0]*wT/2, dy+tD[1]*wT/2], t2=[dx-tD[0]*wT/2, dy-tD[1]*wT/2];
+    const mid=[(sx+dx)/2 + (cx-(sx+dx)/2)*0.62, (sy+dy)/2 + ((cyA-34)-(sy+dy)/2)*0.5];
+    const gid=`sqchg${fi}`;
+    g+=`<defs><linearGradient id="${gid}" x1="${sx.toFixed(1)}" y1="${sy.toFixed(1)}" x2="${dx.toFixed(1)}" y2="${dy.toFixed(1)}" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="${aColor(a)}" stop-opacity=".32"/><stop offset="1" stop-color="${aColor(b)}" stop-opacity=".95"/></linearGradient></defs>`;
+    g+=`<path fill="url(#${gid})" stroke="none"
+      d="M${s1[0].toFixed(1)},${s1[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${t1[0].toFixed(1)},${t1[1].toFixed(1)}
+         L${t2[0].toFixed(1)},${t2[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${s2[0].toFixed(1)},${s2[1].toFixed(1)} Z">
+      <title>${agents[a]} → ${agents[b]} · ${c} transfers (${agents[a]} initiates)</title></path>`;
+    const outward=[Math.cos(dTh),-Math.sin(dTh)], tip=onArc(dTh,R-1);
+    const base=[tip[0]-outward[0]*8, tip[1]-outward[1]*8];
+    g+=`<path d="M${(base[0]+tD[0]*4).toFixed(1)},${(base[1]+tD[1]*4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(base[0]-tD[0]*4).toFixed(1)},${(base[1]-tD[1]*4).toFixed(1)} Z" fill="${aColor(b)}"/>`;
+  });
+  agents.forEach((a,i)=>{ const th=ang(i), [x,y]=onArc(th,R);
+    g+=`<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3" fill="${aColor(a)}"/>`;
+    const [lx,ly]=onArc(th,R+15), anchor= lx<cx-10?'end':(lx>cx+10?'start':'middle');
+    g+=`<text class="sq-lbl" x="${lx.toFixed(1)}" y="${(ly+(ly<40?-2:4)).toFixed(1)}" text-anchor="${anchor}" fill="var(--ink)">${a}</text>`; });
+  g+=`</svg>`; return g;
+}
+function mountChord(){
+  document.getElementById('fig-chord').innerHTML = chordSVG({
+    W:360, H:300, agents:CHORD_AGENTS, flows:CHORD_FLOWS });
+}
+
+/* ===== Alternative: the score (horizontal) ===== */
+function mountScore(){
+  const W=960, H=270, padL=86, X=t=>padL+(W-padL-18)*t/T1;
+  const Y={user:34,planner:78,coder:128,tester:182,reviewer:232};
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="sequence as a horizontal score">`;
+  for(let i=0;i<=8;i++){ const gx=X(i*12);
+    g+=`<line class="hg-gantt-grid" x1="${gx}" y1="14" x2="${gx}" y2="${H-22}"/><text class="sq-axis" x="${gx-6}" y="${H-8}">${i*12}s</text>`; }
+  AGENTS.forEach(a=>{ const y=Y[a];
+    g+=`<text class="sq-name" x="8" y="${y+3}">${a}</text>`;
+    g+=`<line class="sq-staff" x1="${padL}" y1="${y}" x2="${W-18}" y2="${y}" opacity=".55"/>`; });
+  ACTS.forEach(([a,k,t0,t1,lbl,st])=>{ const y=Y[a], x0=X(t0), w=Math.max(5,X(t1)-x0);
+    const extra = st==='failed' ? `` : st==='awaiting' ? ` stroke="${KIND('wait-for-human')}" stroke-dasharray="3 2" stroke-width="1"` : ``;
+    const fill = st==='failed' ? 'var(--bad)' : st==='awaiting' ? KIND('wait-for-human') : KIND(k);
+    const fo = st==='awaiting' ? .3 : st==='failed' ? .8 : .55;
+    g+=`<rect class="sq-act" x="${x0}" y="${y-6}" width="${w}" height="12" rx="3" fill="${fill}" fill-opacity="${fo}"${extra} tabindex="0"><title>${a} · ${lbl}${st?' · '+st:''} · ${t0}–${t1}s</title></rect>`;
+    if(st==='failed') g+=`<text x="${x0+w-11}" y="${y-9}" font-size="9" fill="var(--bad)">✕</text>`;
+    if(st==='awaiting') g+=`<text x="${x0+w+3}" y="${y+3.5}" font-size="10" fill="${KIND('wait-for-human')}">◷</text>`; });
+  function arrow(x, y0, y1, color, dash, lbl){ const d=y1>y0?1:-1, bend=14*d;
+    let s=`<path class="sq-msg" d="M${x},${y0+7*d} C ${x+3},${y0+bend} ${x+3},${y1-bend} ${x},${y1-8*d}" stroke="${color}"${dash?` stroke-dasharray="4 3"`:''}><title>${lbl}</title></path>`;
+    s+=`<path class="sq-head" d="M${x-3.5},${y1-9.5*d} L${x},${y1-2*d} L${x+3.5},${y1-9.5*d}" stroke="${color}" stroke-width="1.2" fill="none" vector-effect="non-scaling-stroke"/>`;
+    return s; }
+  MSGS.forEach(([t,f,o,k,lbl])=>{ const x=X(t);
+    if(k==='delegate'||k==='result') return;
+    const color = k==='transfer' ? KIND('transfer') : k==='user-message' ? KIND('user-message') : KIND('agent-message');
+    g+=arrow(x, Y[f], Y[o], color, k==='transfer', `${f} → ${o} · ${lbl}`);
+    g+=`<text class="sq-lbl" x="${x+5}" y="${(Y[f]+Y[o])/2+3}" fill="${color}">${k==='transfer'?'⇄':''} ${lbl}</text>`; });
+  g+=`<path class="sq-msg" d="M${X(54)},${Y.coder+7} C ${X(55)},${Y.coder+26} ${X(55)},${Y.tester-24} ${X(56)},${Y.tester-8}" stroke="var(--ink-faint)"><title>delegate · run test suite</title></path>`;
+  g+=`<path class="sq-msg" d="M${X(68)},${Y.tester-8} C ${X(69)},${Y.tester-24} ${X(69)},${Y.coder+26} ${X(70)},${Y.coder+7}" stroke="var(--ink-faint)"><title>rejoin · ✓ 214 passed</title></path>`;
+  g+=`<text x="${X(70)+2}" y="${Y.coder+22}" font-size="10" fill="var(--good)">✓</text>`;
+  g+=`<circle cx="${X(80)}" cy="${Y.reviewer}" r="5.5" fill="none" stroke="var(--ink-soft)" stroke-width="1.4"><title>approval gate · deciding…</title></circle>`;
+  g+=`<text class="sq-lbl" x="${X(80)-12}" y="${Y.reviewer+17}">gate · deciding…</text>`;
+  const nx=X(NOW);
+  g+=`<line class="hg-gantt-now" x1="${nx}" y1="12" x2="${nx}" y2="${H-22}"/><circle class="hg-gantt-now-cap" cx="${nx}" cy="12" r="2.5"/>`;
+  g+=`<text class="hg-gantt-now-label" x="${nx+5}" y="20">now ${NOW}s</text>`;
+  g+=`</svg>`;
+  document.getElementById('fig-score').innerHTML=g;
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker);
+  mountBrand(); mountUML(); mountStaff(); mountChord(); mountScore();
+});
+</script>
+<script>window.__EMBED_CFG__ = { optSel: '[data-surface]', bareHide: ['h2', '.rationale', '.legend'] };</script>
+<script src="_embed.js"></script>
+</body>
+</html>

--- a/docs/design/zicato-ui-study/sequence.html
+++ b/docs/design/zicato-ui-study/sequence.html
@@ -21,6 +21,11 @@
   .sq-lbl { fill: var(--ink-soft); font-size: 9px; }
   .sq-chip { fill: var(--panel); stroke: var(--rule); }
   .gm-ribbon { fill: var(--ink); fill-opacity: .14; }
+  /* chord interactivity: hover/click an agent to PROJECT its conversations */
+  .topo-chord g[data-agent] { cursor: pointer; }
+  .topo-chord [data-ribbon], .topo-chord [data-ahead], .topo-chord [data-agent] { transition: opacity .15s ease; }
+  .tch-count { fill: var(--ink); font-size: 9px; font-variant-numeric: tabular-nums; pointer-events: none;
+    paint-order: stroke; stroke: var(--paper); stroke-width: 3px; opacity: 0; transition: opacity .15s ease; }
   .uml * { vector-effect: non-scaling-stroke; }
   .uml .box { fill: var(--panel); stroke: var(--ink-soft); stroke-width: 1.2; }
   .uml .frame { fill: none; stroke: var(--ink-soft); stroke-width: 1.2; }
@@ -88,7 +93,11 @@
           The transfer chord, made directional: each agent's arc splits into a solid <b>outbound</b> half and a
           dashed <b>inbound</b> half; every ribbon is pinched at its source and broad at its target, carries the
           source→target hue, and lands an arrowhead on the receiver. A coordinator-and-spokes run fans out from one
-          sector; a web means everyone is talking to everyone.
+          sector; a web means everyone is talking to everyone. <b>Built to scale:</b> ribbon width grows with
+          <b>√count and caps</b>, so a chatty pair can never flood the figure — and the chord is <b>interactive</b>:
+          hover an agent to <b>project</b> its conversations (everything else fades to a whisper, counts appear on
+          the survivors), click to pin the projection, click empty space to clear. On a 12-agent web, projection is
+          how the figure stays readable.
         </p>
       </div>
     </div>
@@ -344,44 +353,74 @@ function chordSVG(o){
   const outN=agents.map(()=>0), inN=agents.map(()=>0);
   flows.forEach(([a,b,c])=>{ outN[a]+=c; inN[b]+=c; });
   const outUsed=agents.map(()=>0), inUsed=agents.map(()=>0);
-  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="directional transfer chord — who initiates and who receives">`;
+  let g=`<svg class="fig topo-chord" viewBox="0 0 ${W} ${H}" role="img" aria-label="directional transfer chord — who initiates and who receives">`;
   agents.forEach((a,i)=>{ const th=ang(i);
     const oA=th+SECTOR/2, oB=th+0.05, iA=th-0.05, iB=th-SECTOR/2;
     const arcStroke=(thA,thB,r,attrs)=>{ const [xA,yA]=onArc(thA,r), [xB,yB]=onArc(thB,r);
-      return `<path d="M${xA.toFixed(1)},${yA.toFixed(1)} A${r},${r} 0 0 ${thA>thB?1:0} ${xB.toFixed(1)},${yB.toFixed(1)}" fill="none" ${attrs}/>`; };
+      return `<path data-agent="${a}" d="M${xA.toFixed(1)},${yA.toFixed(1)} A${r},${r} 0 0 ${thA>thB?1:0} ${xB.toFixed(1)},${yB.toFixed(1)}" fill="none" ${attrs}/>`; };
     if(outN[i]) g+=arcStroke(oA,oB,R, `stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9"`);
     if(inN[i])  g+=arcStroke(iA,iB,R, `stroke="${aColor(a)}" stroke-width="5" stroke-linecap="round" opacity=".9" stroke-dasharray="1.5 2.4"`);
   });
+  let counts='';
   flows.forEach(([a,b,c],fi)=>{ const ths=ang(a), thd=ang(b);
     const sFrac=(outUsed[a]+c/2)/Math.max(outN[a],1); outUsed[a]+=c;
     const dFrac=(inUsed[b]+c/2)/Math.max(inN[b],1);  inUsed[b]+=c;
     const sTh=ths+0.07+(SECTOR/2-0.07)*sFrac, dTh=thd-0.07-(SECTOR/2-0.07)*dFrac;
-    const wS=1.6, wT=Math.max(5, c*2.4);
+    // √count with a hard cap: heavy traffic thickens slowly and can never flood
+    const wS=1.6, wT=Math.min(15, 4+Math.sqrt(c)*3.4);
     const [sx,sy]=onArc(sTh,R-4), [dx,dy]=onArc(dTh,R-9);
     const tS=[Math.sin(sTh),Math.cos(sTh)], tD=[Math.sin(dTh),Math.cos(dTh)];
     const s1=[sx+tS[0]*wS/2, sy+tS[1]*wS/2], s2=[sx-tS[0]*wS/2, sy-tS[1]*wS/2];
     const t1=[dx+tD[0]*wT/2, dy+tD[1]*wT/2], t2=[dx-tD[0]*wT/2, dy-tD[1]*wT/2];
     const mid=[(sx+dx)/2 + (cx-(sx+dx)/2)*0.62, (sy+dy)/2 + ((cyA-34)-(sy+dy)/2)*0.5];
-    const gid=`sqchg${fi}`;
+    const gid=`sqchg${fi}`, FT=`data-f="${agents[a]}" data-t="${agents[b]}"`;
     g+=`<defs><linearGradient id="${gid}" x1="${sx.toFixed(1)}" y1="${sy.toFixed(1)}" x2="${dx.toFixed(1)}" y2="${dy.toFixed(1)}" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="${aColor(a)}" stop-opacity=".32"/><stop offset="1" stop-color="${aColor(b)}" stop-opacity=".95"/></linearGradient></defs>`;
-    g+=`<path fill="url(#${gid})" stroke="none"
+      <stop offset="0" stop-color="${aColor(agents[a])}" stop-opacity=".32"/><stop offset="1" stop-color="${aColor(agents[b])}" stop-opacity=".95"/></linearGradient></defs>`;
+    g+=`<path data-ribbon="1" ${FT} fill="url(#${gid})" stroke="none"
       d="M${s1[0].toFixed(1)},${s1[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${t1[0].toFixed(1)},${t1[1].toFixed(1)}
          L${t2[0].toFixed(1)},${t2[1].toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(1)} ${s2[0].toFixed(1)},${s2[1].toFixed(1)} Z">
       <title>${agents[a]} → ${agents[b]} · ${c} transfers (${agents[a]} initiates)</title></path>`;
     const outward=[Math.cos(dTh),-Math.sin(dTh)], tip=onArc(dTh,R-1);
     const base=[tip[0]-outward[0]*8, tip[1]-outward[1]*8];
-    g+=`<path d="M${(base[0]+tD[0]*4).toFixed(1)},${(base[1]+tD[1]*4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(base[0]-tD[0]*4).toFixed(1)},${(base[1]-tD[1]*4).toFixed(1)} Z" fill="${aColor(b)}"/>`;
+    g+=`<path data-ahead="1" ${FT} d="M${(base[0]+tD[0]*4).toFixed(1)},${(base[1]+tD[1]*4).toFixed(1)} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(base[0]-tD[0]*4).toFixed(1)},${(base[1]-tD[1]*4).toFixed(1)} Z" fill="${aColor(agents[b])}"/>`;
+    counts+=`<text class="tch-count" data-count="1" ${FT} x="${mid[0].toFixed(1)}" y="${(mid[1]+3).toFixed(1)}" text-anchor="middle">${c}×</text>`;
   });
   agents.forEach((a,i)=>{ const th=ang(i), [x,y]=onArc(th,R);
-    g+=`<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3" fill="${aColor(a)}"/>`;
     const [lx,ly]=onArc(th,R+15), anchor= lx<cx-10?'end':(lx>cx+10?'start':'middle');
-    g+=`<text class="sq-lbl" x="${lx.toFixed(1)}" y="${(ly+(ly<40?-2:4)).toFixed(1)}" text-anchor="${anchor}" fill="var(--ink)">${a}</text>`; });
-  g+=`</svg>`; return g;
+    g+=`<g data-agent="${a}" tabindex="0" role="button" aria-label="project ${a}'s conversations">
+      <circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="12" fill="transparent" stroke="none"/>
+      <circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3" fill="${aColor(a)}"/>
+      <text class="sq-lbl" x="${lx.toFixed(1)}" y="${(ly+(ly<40?-2:4)).toFixed(1)}" text-anchor="${anchor}" fill="var(--ink)">${a}</text></g>`; });
+  g+=counts+`</svg>`; return g;
+}
+/* hover an agent → project (dim everything not involving it); click → pin */
+function wireChord(scope){
+  scope.querySelectorAll('svg.topo-chord').forEach(svg=>{
+    let pinned=null;
+    const apply=f=>{
+      svg.querySelectorAll('[data-ribbon],[data-ahead]').forEach(p=>{
+        p.style.opacity = (!f || p.dataset.f===f || p.dataset.t===f) ? '' : .05; });
+      svg.querySelectorAll('[data-count]').forEach(tx=>{
+        tx.style.opacity = (f && (tx.dataset.f===f || tx.dataset.t===f)) ? 1 : ''; });
+      svg.querySelectorAll('[data-agent]').forEach(n=>{
+        n.style.opacity = (!f || n.dataset.agent===f) ? '' : .3; });
+    };
+    svg.querySelectorAll('g[data-agent]').forEach(h=>{
+      h.addEventListener('mouseenter',()=>{ if(!pinned) apply(h.dataset.agent); });
+      h.addEventListener('mouseleave',()=>{ if(!pinned) apply(null); });
+      h.addEventListener('click',e=>{ e.stopPropagation();
+        pinned = pinned===h.dataset.agent ? null : h.dataset.agent; apply(pinned); });
+      h.addEventListener('keydown',e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); h.click(); } });
+    });
+    svg.addEventListener('click',()=>{ if(pinned){ pinned=null; apply(null); } });
+    const want=new URLSearchParams(location.search).get('chord');
+    if(want && svg.querySelector(`g[data-agent="${want}"]`)){ pinned=want; apply(want); }
+  });
 }
 function mountChord(){
   document.getElementById('fig-chord').innerHTML = chordSVG({
     W:360, H:300, agents:CHORD_AGENTS, flows:CHORD_FLOWS });
+  wireChord(document.getElementById('fig-chord'));
 }
 
 /* ===== Alternative: the score (horizontal) ===== */

--- a/docs/design/zicato-ui-study/shell.html
+++ b/docs/design/zicato-ui-study/shell.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="monokai">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>harmonograf × zicato — shell (chrome) study</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="_tokens.css">
+<link rel="stylesheet" href="_study.css">
+<style>
+  /* ---- BEFORE-state MD3 replica. The ONLY hardcoded hex on this page; these
+       are harmonograf's OWN current MD3 dark values (from frontend/src/index.css
+       + theme/themes.ts dark), reproduced so the "before" reads true. They are
+       NOT study tokens and are scoped to .md3 so they can never leak. ---- */
+  .md3 {
+    --m-surface:#10131a; --m-surf-c:#1c1f26; --m-surf-ch:#262931; --m-surf-chh:#31333c;
+    --m-on:#e2e2e9; --m-on-var:#c3c6cf; --m-outline:#8d9199; --m-outline-v:#43474e;
+    --m-primary:#a8c8ff; --m-primary-c:#00468a; --m-on-primary-c:#d6e3ff;
+    --m-secondary-c:#005227; --m-on-secondary-c:#9bf8bb; --m-error:#ffb4ab;
+    --m-tertiary:#e8c84c;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    background: var(--m-surface); color: var(--m-on); font-size: 14px;
+    border-radius: 4px; overflow: hidden;
+  }
+  .md3 .b-appbar { display:flex; align-items:center; gap:8px; padding:0 12px; height:48px;
+    background:var(--m-surf-c); border-bottom:1px solid var(--m-outline-v); }
+  .md3 .b-appbar .b-title { font-weight:600; }
+  .md3 .b-session { background:var(--m-surf-ch); border:1px solid var(--m-outline-v);
+    padding:4px 12px; border-radius:4px; font-size:13px; }
+  .md3 .b-icon { background:transparent; border:none; padding:6px 8px; border-radius:4px; color:inherit; font-size:17px; cursor:pointer; }
+  .md3 .b-spacer { flex:1; }
+  .md3 .b-strip { display:flex; align-items:center; gap:10px; padding:4px 14px; min-height:26px;
+    background:var(--m-surf-c); border-bottom:1px solid var(--m-outline-v); font-size:12px; }
+  .md3 .b-strip-label { opacity:.55; text-transform:uppercase; font-size:10px; letter-spacing:.06em; }
+  .md3 .b-strip-agent { background:var(--m-surf-ch); color:var(--m-on-var); padding:1px 8px;
+    border-radius:999px; font-size:11px; font-family:ui-monospace,monospace; }
+  .md3 .b-chip { padding:1px 8px; border-radius:999px; font-size:10px; font-weight:600;
+    text-transform:uppercase; letter-spacing:.04em; }
+  .md3 .b-chip-run { background:rgba(120,220,150,.18); color:#78dc96; animation:b-pulse 1.8s ease-in-out infinite; }
+  @keyframes b-pulse { 0%,100%{opacity:1;} 50%{opacity:.55;} }
+  .md3 .b-rail { display:flex; flex-direction:column; gap:4px; padding:12px 8px; width:72px;
+    background:var(--m-surf-c); border-right:1px solid var(--m-outline-v); }
+  .md3 .b-rail-item { display:flex; flex-direction:column; align-items:center; gap:2px; padding:8px 4px;
+    border:none; background:transparent; border-radius:8px; color:var(--m-on-var); font-size:11px; cursor:pointer; }
+  .md3 .b-rail-item.sel { background:var(--m-secondary-c); color:var(--m-on-secondary-c); }
+  .md3 .b-rail-icon { font-size:20px; }
+  .md3 .b-transport { display:flex; align-items:center; gap:8px; padding:0 12px; height:44px;
+    background:var(--m-surf-c); border-top:1px solid var(--m-outline-v); }
+  .md3 .b-tbtn { background:var(--m-surf-ch); border:1px solid var(--m-outline-v); padding:4px 10px;
+    border-radius:4px; color:inherit; font-size:12px; cursor:pointer; }
+  .md3 .b-live { display:flex; align-items:center; gap:5px; font-family:ui-monospace,monospace;
+    font-size:11px; font-weight:700; letter-spacing:.06em; color:var(--m-primary); }
+  .md3 .b-live-dot { width:7px; height:7px; border-radius:999px; background:var(--m-primary);
+    box-shadow:0 0 6px var(--m-primary); animation:b-live 1.6s ease-in-out infinite; }
+  @keyframes b-live { 0%,100%{opacity:1;} 50%{opacity:.35;} }
+  .md3 .b-clock { font-family:ui-monospace,monospace; font-size:12px; opacity:.8; }
+  .md3 .b-tspacer { flex:1; }
+  .md3 .b-return { background:#3a3000; border:1px solid var(--m-tertiary); color:var(--m-tertiary);
+    font-weight:600; font-size:11px; padding:3px 9px; border-radius:4px; cursor:pointer; }
+  .md3 .b-drawer { width:320px; background:var(--m-surf-c); border-left:1px solid var(--m-outline-v); }
+  .md3 .b-drawer-head { padding:12px 16px; border-bottom:1px solid var(--m-outline-v); display:flex; gap:8px; align-items:center; }
+  .md3 .b-drawer-title { font-weight:600; flex:1; }
+  .md3 .b-drawer-tabs { display:flex; gap:4px; padding:0 8px; border-bottom:1px solid var(--m-outline-v); }
+  .md3 .b-drawer-tabs button { background:transparent; border:none; border-bottom:2px solid transparent;
+    padding:10px 12px; color:var(--m-on-var); font-size:12px; cursor:pointer; }
+  .md3 .b-drawer-tabs button.sel { color:var(--m-primary); border-bottom-color:var(--m-primary); }
+  .md3 .b-drawer-body { padding:12px 16px; font-size:12px; }
+  .md3 .b-attrs { display:grid; grid-template-columns:max-content 1fr; gap:4px 12px; }
+  .md3 .b-attrs dt { color:var(--m-on-var); }
+  .md3 .b-attrs dd { margin:0; font-family:ui-monospace,monospace; }
+  .md3 .b-code { display:block; background:var(--m-surf-chh); padding:8px 10px; border-radius:4px;
+    font-family:ui-monospace,monospace; font-size:11px; white-space:pre-wrap; margin-top:8px; }
+
+  /* a compact frame used for the assembled / after shells */
+  .shell-shot { border:1px solid var(--rule); border-radius:var(--r-panel); overflow:hidden; }
+  .after-shell { display:grid; grid-template-columns:62px 1fr 300px; grid-template-rows:auto auto 200px auto;
+    grid-template-areas: "top top top" "strip strip strip" "rail main drawer" "rail transport drawer";
+    background:var(--paper); min-height:0; }
+  .after-shell .hg-topbar { grid-area:top; }
+  .after-shell .hg-strip { grid-area:strip; }
+  .after-shell .hg-rail { grid-area:rail; }
+  .after-shell .as-main { grid-area:main; padding:14px 18px; min-width:0; overflow:hidden; }
+  .after-shell .hg-transport { grid-area:transport; }
+  .after-shell .hg-drawer { grid-area:drawer; }
+  .as-main-fig { margin-top:8px; }
+  .micro { font-size:10.5px; color:var(--ink-faint); }
+</style>
+</head>
+<body>
+<header class="study">
+  <span class="brand-row"><span data-brand-mark="22"></span><span data-brand-wordmark></span></span>
+  <h1>shell — chrome restyled in the zicato design language</h1>
+  <span class="spacer"></span>
+  <span class="legend-inline">accent reserved · <b>now / live / selected</b> only</span>
+  <span class="theme-pick-label">theme</span>
+  <span data-theme-picker></span>
+</header>
+
+<main class="study">
+  <p class="lede" style="margin-top:22px">
+    harmonograf's chrome today is <b>Material Design 3</b>: <code>--md-sys-color-*</code> tokens, a system-ui sans,
+    elevation containers with drop shadows, a blue primary, and several <code>animation:…infinite</code> pulses.
+    This study redraws every chrome surface in <b>zicato's language</b> — one calm <code>--paper</code> ground with a
+    single <code>--panel</code> lift, hairline <code>--rule</code> separators instead of elevation, an all-mono voice,
+    and <code>--accent</code> <b>reserved</b> for now / live / selected. Switch the theme above: the whole shell
+    re-skins across all 16 Console palettes with no re-render.
+  </p>
+
+  <!-- ===== assembled AFTER shell ===== -->
+  <section class="study" data-surface>
+    <h2>The assembled console — after</h2>
+    <p class="rationale">
+      AppBar → <b>topbar</b> (the harmonograf brand — the Lissajous-α mark, dot at its tail, beside the plain-letter wordmark — breadcrumbs,
+      typeface switch, scale pill, status / RUN pill) · NavRail · CurrentTaskStrip · TransportBar (LIVE pill + clock)
+      · inspector Drawer (tabs · attrs · code). One ground, one lift, hairlines, mono, accent reserved.
+    </p>
+    <div class="shell-shot">
+      <div class="after-shell">
+        <header class="hg-topbar">
+          <span class="hg-brand"><span data-brand-mark="22"></span><span data-brand-wordmark></span></span>
+          <nav class="hg-crumbs"><a class="hg-crumb" href="#">sessions</a><span class="hg-crumb-sep">›</span><span class="hg-crumb-current">checkout-refactor</span></nav>
+          <span class="hg-topbar-spacer"></span>
+          <span class="hg-typeswitch"><button aria-pressed="true">mono</button><button>serif</button><button>display</button></span>
+          <span class="hg-scale-pill">⊟ <span class="tnum">100%</span> ⟲</span>
+          <span class="hg-status is-connected is-running">
+            <span class="hg-status-dot"></span><span>live</span>
+            <span class="hg-run-badge"><span class="hg-run-pulse" aria-hidden="true"></span><span class="hg-run-label">running</span><span>· <span class="tnum">3</span> agents</span></span>
+          </span>
+        </header>
+        <div class="hg-strip">
+          <span class="hg-strip-label">task</span>
+          <span class="hg-strip-title">Refactor the checkout flow to use the new pricing service</span>
+          <span class="dn-pill accent">running</span>
+          <span class="hg-strip-agent">planner</span>
+          <span class="micro">· tool: <code>read_file</code></span>
+        </div>
+        <nav class="hg-rail">
+          <button class="hg-rail-item" aria-selected="true"><span class="hg-rail-icon">▤</span><span>gantt</span></button>
+          <button class="hg-rail-item"><span class="hg-rail-icon">◷</span><span>activity</span></button>
+          <button class="hg-rail-item"><span class="hg-rail-icon">✎</span><span>notes</span></button>
+          <button class="hg-rail-item"><span class="hg-rail-icon">⚙</span><span>settings</span></button>
+        </nav>
+        <div class="as-main">
+          <div class="micro">execution gantt</div>
+          <div class="as-main-fig" id="mini-gantt"></div>
+        </div>
+        <aside class="hg-drawer">
+          <div class="hg-drawer-header"><span class="hg-drawer-title">tool_call · read_file</span><span class="dn-pill accent">running</span></div>
+          <div class="hg-drawer-tabs"><button aria-selected="true">attrs</button><button>payload</button><button>links</button></div>
+          <div class="hg-drawer-body">
+            <dl class="hg-attrs">
+              <dt>agent</dt><dd>planner</dd>
+              <dt>kind</dt><dd>TOOL_CALL</dd>
+              <dt>started</dt><dd class="tnum">00:00:12.480</dd>
+              <dt>path</dt><dd>src/pricing/service.ts</dd>
+            </dl>
+            <code class="hg-drawer-code"><span class="hg-j-punct">{</span> <span class="hg-j-key">"lines"</span><span class="hg-j-punct">:</span> <span class="hg-j-num">420</span><span class="hg-j-punct">,</span> <span class="hg-j-key">"ok"</span><span class="hg-j-punct">:</span> <span class="hg-j-bool">true</span> <span class="hg-j-punct">}</span></code>
+          </div>
+        </aside>
+        <div class="hg-transport">
+          <div class="hg-transport-group">
+            <button class="hg-transport-btn">⏮</button>
+            <button class="hg-transport-btn">◀</button>
+            <button class="hg-transport-btn">▶</button>
+            <button class="hg-transport-btn">⏭</button>
+          </div>
+          <span class="hg-transport-divider"></span>
+          <span class="hg-live-badge"><span class="hg-live-dot"></span>LIVE</span>
+          <span class="hg-clock tnum">00:00:14.320</span>
+          <span class="hg-transport-spacer"></span>
+          <span class="micro">zoom</span>
+          <button class="hg-transport-btn">−</button><button class="hg-transport-btn">+</button>
+        </div>
+      </div>
+    </div>
+    <div class="legend">
+      <span><span class="sw" style="background:var(--accent)"></span> accent — now / live / selected</span>
+      <span><span class="sw" style="background:var(--good)"></span> good — connected</span>
+      <span><span class="sw" style="background:var(--rule)"></span> rule — hairline separators (no elevation)</span>
+      <span><span class="sw" style="background:var(--panel)"></span> panel — the one lift</span>
+    </div>
+  </section>
+
+  <!-- ===== topbar before/after ===== -->
+  <section class="study" data-surface>
+    <h2>AppBar → topbar</h2>
+    <p class="rationale">
+      The MD3 AppBar is a flat container with a sans title and a surface-tinted session button. The console topbar
+      leads with the <b>harmonograf lockup</b> — the mirrored-Lissajous α mark beside plain-letter <code>harmonograf</code> (one alpha per lockup; see <a href="brand.html">the brand study</a>),
+      then mono breadcrumbs, the typeface switch and scale pill, and a status pill whose <b>RUN badge pulses the one
+      accent</b> — the chrome's only keyframe (gated under <code>prefers-reduced-motion</code>).
+    </p>
+    <div class="ba-grid">
+      <div class="ba-cell">
+        <p class="ba-tag">before · MD3</p>
+        <div class="ba-frame before"><div class="md3"><div class="b-appbar">
+          <button class="b-icon">☰</button><span class="b-title">harmonograf</span>
+          <button class="b-session">checkout-refactor ▾</button><span class="b-spacer"></span>
+          <button class="b-icon">◷</button><button class="b-icon">⚙</button><button class="b-icon">◑</button>
+        </div></div></div>
+      </div>
+      <div class="ba-cell">
+        <p class="ba-tag after">after · zicato</p>
+        <div class="ba-frame"><div style="background:var(--paper)"><header class="hg-topbar">
+          <span class="hg-brand"><span data-brand-mark="22"></span><span data-brand-wordmark></span></span>
+          <nav class="hg-crumbs"><a class="hg-crumb" href="#">sessions</a><span class="hg-crumb-sep">›</span><span class="hg-crumb-current">checkout-refactor</span></nav>
+          <span class="hg-topbar-spacer"></span>
+          <span class="hg-typeswitch"><button aria-pressed="true">mono</button><button>serif</button></span>
+          <span class="hg-status is-connected is-running"><span class="hg-status-dot"></span><span>live</span>
+            <span class="hg-run-badge"><span class="hg-run-pulse" aria-hidden="true"></span><span class="hg-run-label">running</span></span></span>
+        </header></div></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== rail + strip before/after ===== -->
+  <section class="study" data-surface>
+    <h2>NavRail &amp; CurrentTaskStrip</h2>
+    <p class="rationale">
+      MD3 marks the selected rail item with a <code>secondary-container</code> fill (green pill) and animates the
+      running task chip with an <code>infinite</code> opacity pulse. In-language: the selected item is a quiet
+      <code>color-mix(--accent 14%, --panel)</code> tint with accent text; the strip's running state is a mono
+      <b>outline-first accent pill</b> — <b>not red</b> (an in-flight task is neutral, never a failure).
+    </p>
+    <div class="ba-grid">
+      <div class="ba-cell">
+        <p class="ba-tag">before · MD3</p>
+        <div class="ba-frame before"><div class="md3" style="display:flex">
+          <nav class="b-rail">
+            <button class="b-rail-item sel"><span class="b-rail-icon">▤</span><span>gantt</span></button>
+            <button class="b-rail-item"><span class="b-rail-icon">◷</span><span>activity</span></button>
+            <button class="b-rail-item"><span class="b-rail-icon">⚙</span><span>settings</span></button>
+          </nav>
+          <div style="flex:1"><div class="b-strip">
+            <span class="b-strip-label">task</span><span style="flex:0 1 auto;overflow:hidden;text-overflow:ellipsis">Refactor checkout flow</span>
+            <span class="b-chip b-chip-run">running</span><span class="b-strip-agent">planner</span>
+          </div></div>
+        </div></div>
+      </div>
+      <div class="ba-cell">
+        <p class="ba-tag after">after · zicato</p>
+        <div class="ba-frame"><div style="display:flex;background:var(--paper)">
+          <nav class="hg-rail">
+            <button class="hg-rail-item" aria-selected="true"><span class="hg-rail-icon">▤</span><span>gantt</span></button>
+            <button class="hg-rail-item"><span class="hg-rail-icon">◷</span><span>activity</span></button>
+            <button class="hg-rail-item"><span class="hg-rail-icon">⚙</span><span>settings</span></button>
+          </nav>
+          <div style="flex:1"><div class="hg-strip">
+            <span class="hg-strip-label">task</span><span class="hg-strip-title">Refactor checkout flow</span>
+            <span class="dn-pill accent">running</span><span class="hg-strip-agent">planner</span>
+          </div></div>
+        </div></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== transport before/after ===== -->
+  <section class="study" data-surface>
+    <h2>TransportBar</h2>
+    <p class="rationale">
+      Transport controls become mono outline-first buttons (fill the accent only on hover). The LIVE badge keeps a
+      single pulsing dot — re-pointed from the MD3 blue primary to <code>--accent</code> — and the clock uses
+      <code>tabular-nums</code> so digits never jitter. The "return to live" affordance, an MD3 amber container, maps
+      to a <code>--caution</code> outline.
+    </p>
+    <div class="ba-grid">
+      <div class="ba-cell">
+        <p class="ba-tag">before · MD3</p>
+        <div class="ba-frame before"><div class="md3"><div class="b-transport">
+          <button class="b-tbtn">⏮</button><button class="b-tbtn">▶</button><button class="b-tbtn">⏭</button>
+          <span class="b-live"><span class="b-live-dot"></span>LIVE</span><span class="b-clock">00:00:14.32</span>
+          <span class="b-tspacer"></span><button class="b-return">⟲ return to live</button>
+        </div></div></div>
+      </div>
+      <div class="ba-cell">
+        <p class="ba-tag after">after · zicato</p>
+        <div class="ba-frame"><div style="background:var(--paper)"><div class="hg-transport">
+          <button class="hg-transport-btn">⏮</button><button class="hg-transport-btn">▶</button><button class="hg-transport-btn">⏭</button>
+          <span class="hg-transport-divider"></span>
+          <span class="hg-live-badge"><span class="hg-live-dot"></span>LIVE</span><span class="hg-clock tnum">00:00:14.320</span>
+          <span class="hg-transport-spacer"></span><button class="hg-transport-btn" style="border-color:var(--caution);color:var(--caution)">⟲ return to live</button>
+        </div></div></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== drawer before/after ===== -->
+  <section class="study" data-surface>
+    <h2>Inspector Drawer</h2>
+    <p class="rationale">
+      The drawer keeps its tabbed shape but loses the elevated <code>surface-container-highest</code> code block in
+      favor of a hairline-framed <code>--panel-2</code> pre. Tabs underline in <code>--accent</code> when active; the
+      JSON tint reads from tokens (<code>--good</code> strings, <code>--caution</code> numbers, <code>--bad</code>
+      booleans, <code>--accent</code> keys) so it re-skins with the theme instead of shipping fixed syntax colors.
+    </p>
+    <div class="ba-grid">
+      <div class="ba-cell">
+        <p class="ba-tag">before · MD3</p>
+        <div class="ba-frame before"><div class="md3"><div class="b-drawer" style="width:auto">
+          <div class="b-drawer-head"><span class="b-drawer-title">tool_call · read_file</span></div>
+          <div class="b-drawer-tabs"><button class="sel">attrs</button><button>payload</button><button>links</button></div>
+          <div class="b-drawer-body">
+            <dl class="b-attrs"><dt>agent</dt><dd>planner</dd><dt>kind</dt><dd>TOOL_CALL</dd><dt>path</dt><dd>service.ts</dd></dl>
+            <code class="b-code">{ "lines": 420, "ok": true }</code>
+          </div>
+        </div></div></div>
+      </div>
+      <div class="ba-cell">
+        <p class="ba-tag after">after · zicato</p>
+        <div class="ba-frame"><div style="background:var(--paper)"><aside class="hg-drawer" style="height:auto">
+          <div class="hg-drawer-header"><span class="hg-drawer-title">tool_call · read_file</span><span class="dn-pill accent">running</span></div>
+          <div class="hg-drawer-tabs"><button aria-selected="true">attrs</button><button>payload</button><button>links</button></div>
+          <div class="hg-drawer-body">
+            <dl class="hg-attrs"><dt>agent</dt><dd>planner</dd><dt>kind</dt><dd>TOOL_CALL</dd><dt>path</dt><dd>service.ts</dd></dl>
+            <code class="hg-drawer-code"><span class="hg-j-punct">{</span> <span class="hg-j-key">"lines"</span><span class="hg-j-punct">:</span> <span class="hg-j-num">420</span><span class="hg-j-punct">,</span> <span class="hg-j-key">"ok"</span><span class="hg-j-punct">:</span> <span class="hg-j-bool">true</span> <span class="hg-j-punct">}</span></code>
+          </div>
+        </aside></div></div>
+      </div>
+    </div>
+    <div class="legend">
+      <span><span class="sw" style="background:var(--accent)"></span> keys · active tab</span>
+      <span><span class="sw" style="background:var(--good)"></span> strings</span>
+      <span><span class="sw" style="background:var(--caution)"></span> numbers</span>
+      <span><span class="sw" style="background:var(--bad)"></span> booleans</span>
+    </div>
+  </section>
+</main>
+
+<footer class="study">
+  harmonograf UI study · <b>shell</b> · standalone, theme-switchable across 16 Console palettes · token-only colour
+  (the only hex is the scoped <code>.md3</code> before-replica) · verify in <code>paper</code> + <code>monokai</code>.
+</footer>
+
+<!-- shared chrome (theme picker + brand mark) -->
+<script>
+window.THEME_IDS = ['monokai','solarized-dark','solarized-light','google-light','google-dark',
+  'lunaria-light','lunaria-eclipse','belafonte-day','belafonte-night','paper','zenburn',
+  'selenized-black','relaxed','espresso','dracula','ubuntu'];
+const THEME_SWATCHES = {
+  'monokai':['#1e1f1c','#272822','#f8f8f2','#a6e22e','#f92672','#66d9ef'],
+  'solarized-dark':['#04222B','#0A2D38','#93A1A1','#8BB80E','#E0483C','#2AA198'],
+  'solarized-light':['#FDF6E3','#FBF1D6','#586E75','#6B9B0B','#DC322F','#268BD2'],
+  'google-light':['#FFFFFF','#F4F4F4','#474A4E','#34A853','#EA4335','#1B9CB8'],
+  'google-dark':['#202124','#2C2D30','#FFFFFF','#34A853','#EA4335','#24C1E0'],
+  'lunaria-light':['#EBE4E1','#E2DCD9','#363434','#497D46','#783C1F','#3778A9'],
+  'lunaria-eclipse':['#323F46','#3B484F','#DFE2ED','#BEDBC1','#BA9088','#C8429F'],
+  'belafonte-day':['#D5CCBA','#CCC3B2','#34292D','#6E6A4E','#BE100E','#426A79'],
+  'belafonte-night':['#20111B','#271821','#D5CCBA','#A6A07A','#D6403E','#6F8E97'],
+  'paper':['#F2EEDE','#E6E2D3','#1A1A1A','#216609','#CC3E28','#1E6FCC'],
+  'zenburn':['#3A3A3A','#424241','#DCDCCC','#8FB28F','#CC9393','#8CD0D3'],
+  'selenized-black':['#181818','#202020','#DEDEDE','#83C746','#FF5E56','#56D8C9'],
+  'relaxed':['#353A44','#3D424B','#F7F7F7','#A0AC77','#BC5653','#7EAAC7'],
+  'espresso':['#323232','#3A3A3A','#FFFFFF','#A5C261','#D25252','#6C99BB'],
+  'dracula':['#282A36','#343746','#F8F8F2','#50FA7B','#FF5555','#BD93F9'],
+  'ubuntu':['#300A24','#3D1530','#EEEEEC','#8AE234','#CC0000','#34E2E2'],
+};
+const THEME_LABELS = {'monokai':'Monokai','solarized-dark':'Solarized Dark','solarized-light':'Solarized Light',
+  'google-light':'Google Light','google-dark':'Google Dark','lunaria-light':'Lunaria Light','lunaria-eclipse':'Lunaria Eclipse',
+  'belafonte-day':'Belafonte Day','belafonte-night':'Belafonte Night','paper':'Paper','zenburn':'Zenburn',
+  'selenized-black':'Selenized Black','relaxed':'Relaxed','espresso':'Espresso','dracula':'Dracula','ubuntu':'Ubuntu'};
+const THEME_KEY = 'hgraf-study-theme';
+function swatchStrip(id, sm){ const t = THEME_SWATCHES[id] || [];
+  return `<span class="dt-swatch-strip${sm?' dt-swatch-strip-sm':''}">`+t.map(c=>`<span class="dt-swatch" style="background:${c}"></span>`).join('')+`</span>`; }
+function currentTheme(){ return document.documentElement.getAttribute('data-theme') || 'monokai'; }
+function applyTheme(id){ document.documentElement.setAttribute('data-theme', id);
+  try { localStorage.setItem(THEME_KEY, id); } catch(e){}
+  document.querySelectorAll('[data-theme-picker]').forEach(buildPicker); }
+function buildPicker(host){ const cur = currentTheme();
+  host.innerHTML = `<div class="dt-cd"><button class="dt-cd-trigger" aria-haspopup="listbox" aria-expanded="false">${swatchStrip(cur,true)}<span class="dt-cd-name">${THEME_LABELS[cur]}</span><span class="dt-cd-caret" aria-hidden="true">▾</span></button><div class="dt-cd-list" role="listbox" aria-label="theme">${window.THEME_IDS.map(id=>`<div class="dt-cd-option" role="option" data-id="${id}" aria-selected="${id===cur}">${swatchStrip(id)}<span class="dt-cd-name">${THEME_LABELS[id]}</span></div>`).join('')}</div></div>`;
+  const cd = host.querySelector('.dt-cd'), trig = host.querySelector('.dt-cd-trigger');
+  trig.addEventListener('click', e=>{ e.stopPropagation(); const open = cd.classList.toggle('dt-cd-open'); trig.setAttribute('aria-expanded', open); });
+  host.querySelectorAll('.dt-cd-option').forEach(o=> o.addEventListener('click', ()=>{ applyTheme(o.dataset.id); cd.classList.remove('dt-cd-open'); })); }
+document.addEventListener('click', ()=> document.querySelectorAll('.dt-cd-open').forEach(c=>c.classList.remove('dt-cd-open')));
+(function initTheme(){ let saved=null; try { saved=localStorage.getItem(THEME_KEY); } catch(e){}
+  const P=new URLSearchParams(location.search), fromUrl=P.get('theme');
+  const id=(fromUrl&&window.THEME_IDS.includes(fromUrl))?fromUrl:(saved&&window.THEME_IDS.includes(saved))?saved:'monokai';
+  document.documentElement.setAttribute('data-theme', id); })();
+/* harmonograf brand — the Option-D alpha: one period of the 2:3 Lissajous,
+   MIRRORED about the vertical axis (x = cx − A·cos2t, y = cy + B·sin3t) so the
+   knot reads as a lowercase α — still a Lissajous, loop left, tails right.
+   Stroke currentColor; the one dot rides the lower-right tail tip: the pen at
+   rest. ONE ALPHA PER LOCKUP: beside this mark the wordmark is PLAIN LETTERS
+   (the glyph already carries the α and the dot); only a STANDALONE wordmark
+   spells the "a" of graf with the drawn α. */
+function hgAlphaPath(cx, cy, A, B){ const pts=[];
+  for(let i=0;i<=240;i++){ const t=2*Math.PI*i/240;
+    pts.push((cx - A*Math.cos(2*t)).toFixed(2)+','+(cy + B*Math.sin(3*t)).toFixed(2)); }
+  return 'M'+pts.join(' L')+' Z'; }
+function hgBrandMarkSVG(h){ return `<svg class="hg-brand-mark" style="height:${h||24}px" viewBox="0 0 48 48" role="img" aria-label="harmonograf" focusable="false"><path d="${hgAlphaPath(24,24,19,15)}" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/><circle cx="43" cy="39" r="3.2" fill="var(--hgraf-brand, #5EA3EC)"/></svg>`; }
+function hgWordmarkSVG(){ const T='harmonograf', X0=1, ADV=9.6, BASE=15; const W=X0*2+T.length*ADV;
+  return `<svg class="hg-brand-name" viewBox="0 0 ${W} 18" role="img" aria-label="harmonograf" focusable="false"><text x="${X0}" y="${BASE}" font-family="var(--brand-mono)" font-size="15" font-weight="700" textLength="${T.length*ADV}" lengthAdjust="spacing" fill="currentColor" xml:space="preserve">${T}</text></svg>`; }
+function mountBrand(){ document.querySelectorAll('[data-brand-mark]').forEach(n=>{ n.innerHTML=hgBrandMarkSVG(+n.dataset.brandMark||24); });
+  document.querySelectorAll('[data-brand-wordmark]').forEach(n=>{ n.innerHTML=hgWordmarkSVG(); }); }
+window.addEventListener('DOMContentLoaded', ()=>{ document.querySelectorAll('[data-theme-picker]').forEach(buildPicker); mountBrand(); mountMiniGantt(); });
+
+/* a tiny line-art gantt for the assembled-shell main pane (in-language preview) */
+function mountMiniGantt(){
+  const host = document.getElementById('mini-gantt'); if(!host) return;
+  const W=560, H=120, padL=66, padR=10, top=8, rowH=22;
+  const lanes=[
+    {label:'planner', bars:[['invocation',0,.95]]},
+    {label:'coder',   bars:[['llm-call',.12,.34],['tool-call',.36,.52],['llm-call',.55,.78,'running']]},
+    {label:'reviewer',bars:[['transfer',.52,.58],['agent-message',.60,.74]]},
+    {label:'goldfive', bars:[['custom',.30,.42]]},
+  ];
+  const x=f=>padL+f*(W-padL-padR);
+  let g=`<svg class="fig" viewBox="0 0 ${W} ${H}" role="img" aria-label="execution gantt preview">`;
+  for(let i=0;i<=4;i++){ const gx=padL+i/4*(W-padL-padR);
+    g+=`<line class="hg-gantt-grid" x1="${gx}" y1="${top}" x2="${gx}" y2="${top+lanes.length*rowH}"/>`; }
+  lanes.forEach((ln,i)=>{ const cy=top+i*rowH+rowH/2;
+    g+=`<text class="hg-gantt-lane-label" x="6" y="${cy+3}">${ln.label}</text>`;
+    ln.bars.forEach(b=>{ const [kind,a,bb,st]=b; const w=Math.max(4,x(bb)-x(a));
+      const cls='hg-gantt-bar is-'+kind+(st==='running'?' is-running':'');
+      g+=`<rect class="${cls}" x="${x(a)}" y="${cy-6}" width="${w}" height="12" rx="3" fill="var(--hg-kind-${kind})"/>`; }); });
+  const nx=x(.78);
+  g+=`<line class="hg-gantt-now" x1="${nx}" y1="${top-2}" x2="${nx}" y2="${top+lanes.length*rowH+2}"/>`;
+  g+=`<circle class="hg-gantt-now-cap" cx="${nx}" cy="${top-2}" r="2.5"/>`;
+  g+=`</svg>`;
+  host.innerHTML=g;
+}
+</script>
+<script>window.__EMBED_CFG__ = { optSel: '[data-surface]', bareHide: ['h2', '.rationale', '.legend', '.ba-tag'] };</script>
+<script src="_embed.js"></script>
+</body>
+</html>

--- a/docs/zicato-frontend-port.md
+++ b/docs/zicato-frontend-port.md
@@ -1,0 +1,303 @@
+# Zicato console — frontend port: state & resume guide
+
+**Last updated:** 2026-06-13 · **Branch:** `design/sequence-compose-parity` · **Status:** ⚠️ **first cut — builds & passes CI, NOT yet verified against real data. Do not consider production-ready.**
+
+This document is the single place to resume work on porting the **zicato-language UI
+study** into the real React frontend as a parallel, toggle-able console. It covers
+what exists, what's verified vs. not, how to run it for real, the architecture, and a
+file-level map with code pointers.
+
+---
+
+## 1. TL;DR
+
+harmonograf's production console (`frontend/`) is a React + TypeScript + Vite app built
+on `@material/web` (MD3), `zustand`, and connectrpc. A separate **design study** in
+`docs/design/zicato-ui-study/` redraws that console in "zicato's design language"
+(Tufte/line-art, monospace-forward, single-accent-on-calm-ground, theme-switchable).
+
+This work **ports that study into the real app as a second, parallel console** that the
+user can toggle to/from the MD3 one:
+
+- A new `uiMode: 'md3' | 'zicato'` flag (persisted, **default `md3`**) branches the app
+  at the top level. Production behaviour is unchanged until a user opts in.
+- The zicato console is a full parallel component tree under
+  `frontend/src/components/zicato/`, reading **real session data** (the same RPC
+  hooks/zustand stores the MD3 console uses) through a dedicated **adapter** that maps the
+  live session model into the study's render inputs.
+- All six study figures were ported to React: hero **gantt**, topology **chord**, drift +
+  judge **seismograph**, intervention **ladder**, **plan** reel→DAG, vertical **sequence**
+  diagram, and the session **fingerprint**.
+
+It compiles, lints, the full test suite is green (740/740), and both consoles mount in a
+headless browser. **It has not been rendered against a live session** — that is the
+critical, not-yet-done verification step (see §3 and §8).
+
+---
+
+## 2. Status at a glance
+
+| Area | State |
+| --- | --- |
+| `pnpm build` (`tsc -b && vite build`) | ✅ passes |
+| `pnpm lint` (eslint) | ✅ clean |
+| `pnpm test` (vitest) | ✅ 740/740 (incl. 6 zicato smoke tests) |
+| Empty-state mount (headless chrome, no server) | ✅ both consoles render, no crash, toggle present |
+| **Render against a live session (real data)** | ❌ **never done** — the adapter mappings + every figure are unexercised against real RPC data |
+| Interactive QA (span→inspector, chord hover/pin, reel→DAG, ⌘K, theme switch, toggle round-trip) | ❌ not exercised with content |
+| Committed to git | ✅ (on `design/sequence-compose-parity`; not merged) |
+| Affects the live MD3 UI | ❌ no — gated behind a default-off toggle |
+
+The 6 smoke tests (`frontend/src/__tests__/components/zicato.smoke.test.tsx`) assert the
+console **renders against an empty store without throwing** and that token/agent mappers
+are correct. They are a scaffold gate, **not** a correctness check of the figures.
+
+---
+
+## 3. How to run it for real (the most important next step)
+
+The figures have only ever been seen empty. To validate them you need a **live session**.
+Two paths:
+
+### A. Full stack (server serves the built SPA)
+
+```bash
+# 1. build the console into the server's static dir
+make console                      # → harmonograf_server/_console (or frontend/dist)
+
+# 2. run the server (serves gRPC-Web + the console SPA on the web port)
+make server-run                   # or: python -m harmonograf_server  (see server/harmonograf_server/cli.py)
+
+# 3. drive an orchestration to produce a live session
+ls examples/                      # → standalone_observability
+#    run the example so spans/plans/drift stream into a session
+
+# 4. open the served console in a browser, then flip to zicato:
+#    AppBar ⧉ button (top-right), OR set localStorage 'harmonograf.uiMode'='zicato'
+```
+
+### B. Vite dev server pointed at a running backend
+
+```bash
+make server-run                                          # backend on its web port (e.g. 127.0.0.1:17532)
+VITE_HARMONOGRAF_API=http://127.0.0.1:17532 make frontend-dev   # vite dev w/ HMR
+# transport.ts resolves: window.__HARMONOGRAF_API__ → VITE_HARMONOGRAF_API → compiled default
+```
+
+Then, **in either case**, walk every figure against real data and fix what's wrong:
+gantt spans/lanes/now-line/transfers, chord projection, seismograph drift + judge beats,
+ladder, plan reel→DAG, sequence diagram, fingerprint, span→inspector, ⌘K session switch,
+and all 16 zicato themes. The adapter (`adapter.ts`) is where most real-data bugs will be.
+
+> The toggle persists in `localStorage['harmonograf.uiMode']`. To force the zicato console
+> for a screenshot without clicking, seed that key before the bundle loads.
+
+---
+
+## 4. Architecture
+
+### 4.1 The toggle (md3 ↔ zicato)
+
+The whole feature hangs off one persisted store flag; nothing else about the MD3 app changes.
+
+- **Store** — `frontend/src/state/uiStore.ts`
+  - `UI_MODE_KEY = 'harmonograf.uiMode'` (L83), `ZICATO_THEME_KEY = 'harmonograf.zicatoTheme'` (L84)
+  - `uiMode` / `setUiMode` / `toggleUiMode` in the `UiState` interface (L367–369), plus `zicatoTheme` (L370+)
+  - Initial values + reducers: `uiMode: readUiMode()` (L536), `setUiMode`/`toggleUiMode` (L538–547), `zicatoTheme: readZicatoTheme()` (L548). Persistence uses the file's existing per-key `read*`/`write*` helper pattern. **Default is `md3`.**
+- **Branch** — `frontend/src/App.tsx` L48–51: `const uiMode = useUiStore(s => s.uiMode)`; `#/stress` is checked first (dev route unaffected), then `uiMode === 'zicato' → <ZicatoConsole/>`, else `<Shell/>`. The session deep-link hook stays **above** the branch so links work in both consoles.
+- **Toggle controls (both directions):**
+  - MD3 → zicato: `frontend/src/components/shell/AppBar.tsx` L73–81 — `⧉` icon button, `onClick={() => setUiMode('zicato')}`, `data-testid="ui-mode-toggle"`.
+  - zicato → MD3: `ZicatoConsole.tsx` topbar — `data-testid="ui-mode-toggle-z"` (L205), wired via `onToMd3={() => setUiMode('md3')}` (L523).
+
+### 4.2 The console shell
+
+`frontend/src/components/zicato/ZicatoConsole.tsx` (538 lines) ports `compose.html`'s
+`appHybrid` shell. The top-level component is `ZicatoConsole()` (L508):
+
+```
+<div className="zk-root" data-zicato-theme={zicatoTheme}>      // L520 — theme scoped here
+  <SessionsSyncer/>                                            // session list poll (reused from MD3)
+  <ZicatoTopbar z onToMd3/>            // brand · session crumb (⌘K) · status · theme picker · ⧉→md3
+  <ZicatoStrip z/>                     // goal + live/done/failed pill
+  <div className="zk-app-body">
+    <ZicatoRail view onView/>          // rail: 'gantt' | 'instruments'
+    <main className="zk-main">{ view==='gantt' ? <GanttViewZ/> : <InstrumentsViewZ/> }</main>
+    <ZicatoInspector/>                 // docked span/session drawer
+  </div>
+  <ZicatoTransport/>                   // transport bar (live clock)
+  <SessionPicker/>                     // ⌘K picker — REUSED from MD3
+</div>
+```
+
+Sub-components in the same file: `ZicatoThemePicker` (L110), `ZicatoTopbar` (L163),
+`statusPill` (L215), `ZicatoStrip` (L221), `ZicatoRail` + `ZicatoView` type (L247/L249),
+`ZicatoTransport` (L279), `ZicatoInspector` (L387). View selection is **local React state**
+(`useState<ZicatoView>('gantt')`, L518) — not in the store. `useSessionWatch(sessionId)`
+(L516) keeps one stream alive for all sub-views; `useGlobalShortcuts()` (L509) is owned here.
+
+### 4.3 Data flow — the adapter (the linchpin)
+
+`frontend/src/components/zicato/adapter.ts` (1147 lines) is the boundary between the real
+session model and the study's render inputs. **All real-data correctness lives here.**
+
+- **Public hook:** `useZicatoSession(sessionId): ZSession` (L1012). It:
+  - gets the live store via `getSessionStore(sessionId)`;
+  - is **reactive**: subscribes to every registry (`spans`, `agents`, `tasks`, `drifts`,
+    `delegations`, `contextSeries`) plus a 1s timer, snapshotting `Date.now()` in a reducer
+    (not render) so the play-head/`now` advances (L1020–1041);
+  - pulls goal/title from `useSessionsStore`, annotations from `useAnnotationStore`, plan
+    inputs from `usePlanHistory` / `useCumulativePlan` / `useSupersedesMap`, and
+    `trajectorySelectedPlanId` / `selectedRevision` from `useUiStore`;
+  - returns `EMPTY_SESSION` when there's no store, or a graceful partial when the session
+    has no spans/agents yet (L1062–1067) — **figures must never crash on empty/loading.**
+- **Output type:** `ZSession` (L191) — `{ id, goal, status, T, now, agents[], spans[], transfers[], delegation, edges[], judges, ticks, ladder, ctx, plan, fp, empty }`.
+- **Fallback:** `EMPTY_SESSION` (L239, `empty: true`, all arrays empty, `T: 30`, `now: 0`).
+- **Builders** (each maps a slice of `SessionStore`): `buildAgents` (L373), `buildSpans`
+  (L419), `buildTransfers` (L450), `buildDelegation` (L465), `buildEdges` (L496, derives
+  transfer/delegation/return edges — same algo as MD3 GraphView), `buildJudges` (L623),
+  `buildTicks` (L642), `buildLadder` (L664), `buildCtx` (L703), `buildPlan` (L735),
+  `deriveFingerprint` (L947), `deriveStatus` (after L1147).
+- **Encoding mappers:** `toKindToken` (L285, `LLM_CALL→'llm-call'` …), `toStatusToken`
+  (L311, `AWAITING_HUMAN→'awaiting'` …), `gfClassForSpan` (L335), `colorVar` (L994,
+  agent → `--hg-agent-*` token), `severityToValue` (L269, goldfive drift severity → value).
+
+`svgUtils.ts` (140 lines) holds the shared render helpers ported from the study:
+`KIND` (L13), `gfVar` (L16), `statusFill` (L26), `lerpKeys` (L36), `lcg` (L55, seeded RNG),
+`timeScale` (L65, the shared `padL/padR/X` so the seismograph + heartbeat + ladder share an
+axis), `uniqueId` (L83), `hgAlphaPath` (L97, the brand α-Lissajous), `judgeBeats` (L122,
+**derives the judge heartbeat from the drift** so the marks sit over the excursions).
+
+### 4.4 The figures (one component per study renderer)
+
+| Component | File:line | Ports study renderer | Props |
+| --- | --- | --- | --- |
+| `GanttZ` | `GanttZ.tsx:32` | `ganttSVG` | `{ z, selectedSpanId, onSpanSelect }` |
+| `ChordZ` | `ChordZ.tsx:38` | `topoChordSVG` | `{ z, W=300 }` |
+| `SeismographZ` | `SeismographZ.tsx:51` | `seismoSVG` | `{ z, W=940, axis }` |
+| `JudgeHeartbeatZ` | `SeismographZ.tsx:272` | `heartSVG` | `{ z, W=940 }` |
+| `LadderZ` | `LadderZ.tsx:25` | `ladderSVG` | `{ z, W=940 }` |
+| `PlanZ` | `PlanZ.tsx:33` | `reelSVG` + `dagSVG` (reel drives DAG) | `{ z }` |
+| `SequenceZ` | `SequenceZ.tsx:150` | `seqDiagramSVG` | `{ z, W=520, H=380 }` |
+| `FingerprintZ` | `FingerprintZ.tsx:59` | `fpSVG` | `{ fp, status, id, size }` |
+| `BrandMark` / `Wordmark` | `Brand.tsx:10/34` | brand block | — |
+
+The two rail views compose them:
+- `GanttViewZ.tsx:13` — `<GanttZ/>` (wired to `selectedSpanId`/`selectSpan` from the store) + `<JudgeHeartbeatZ/>`.
+- `InstrumentsViewZ.tsx:25` — session head (`FingerprintZ`) → `<PlanZ/>` → panes-2 (`SequenceZ` | `ChordZ`) → the coordinated time-track stack (`SeismographZ` over `LadderZ`).
+
+### 4.5 Theming
+
+The zicato console has its **own** palette, independent of MD3:
+- `zicatoTheme` in `uiStore` (16 study themes), applied via `data-zicato-theme` on `.zk-root`
+  (`ZicatoConsole.tsx:520`) — it **never touches** the MD3 `<html data-theme>`, so there is
+  no MD3 regression. Theme id list: `ZICATO_THEME_IDS` (`ZicatoConsole.tsx:41`).
+- Tokens: `frontend/src/components/zicato/zicato-tokens.css` (715 lines — the per-theme role
+  tokens `--paper/--panel/--ink/--good/--bad/--accent/--caution`, the `--ansi-*` ramp, and
+  the categorical `--hg-kind-*` / `--hg-agent-*` / `--hg-gf-*` / `--hgraf-brand` tokens).
+- Component CSS: `frontend/src/components/zicato/zicato.css` (1041 lines).
+- Both are imported at the top of `ZicatoConsole.tsx` (L15–16).
+
+---
+
+## 5. File map
+
+```
+frontend/src/
+  App.tsx                         ← uiMode branch (L48–51)
+  state/uiStore.ts                ← uiMode + zicatoTheme (keys L83-84, type L367, init L536-548)
+  components/shell/AppBar.tsx     ← ⧉ toggle to zicato (L73-81)
+  components/zicato/
+    ZicatoConsole.tsx   538  shell: topbar/strip/rail/main/inspector/transport/picker
+    adapter.ts         1147  real session → ZSession (useZicatoSession L1012); ALL data mapping
+    svgUtils.ts         140  shared render helpers (timeScale, judgeBeats, hgAlphaPath, …)
+    GanttZ.tsx          393  hero gantt
+    ChordZ.tsx          347  topology chord (thin gradient strokes, projection)
+    SeismographZ.tsx    314  drift + judge seismograph (+ JudgeHeartbeatZ)
+    LadderZ.tsx         128  intervention ladder (time-locked to the seismograph)
+    PlanZ.tsx           413  plan reel → DAG
+    SequenceZ.tsx       366  vertical sequence diagram
+    FingerprintZ.tsx    119  session fingerprint identicon
+    Brand.tsx            63  α mark + wordmark
+    GanttViewZ.tsx       30  rail view: gantt
+    InstrumentsViewZ.tsx 79  rail view: instruments
+    zicato-tokens.css   715  per-theme token contract
+    zicato.css         1041  component CSS
+  __tests__/components/zicato.smoke.test.tsx   the scaffold gate (6 tests)
+```
+
+---
+
+## 6. The design study (visual source of truth)
+
+`docs/design/zicato-ui-study/` is the standalone, theme-switchable HTML/CSS/vanilla-JS
+study the components port from. When a figure looks wrong, compare against the study —
+the React components were written to match it 1:1. Key files:
+
+- `compose.html` — the interactive composed console (the React shell + views mirror it).
+- `grammar.html` — the figure catalogue (chord, seismograph, ladder, plan DAG, fingerprint, …).
+- `sequence.html` — the sequence diagram + chord.
+- `_tokens.css` / `_study.css` — the token contract the React `zicato-tokens.css`/`zicato.css` port.
+- `STYLE-GUIDE.md`, `BRIEF.md`, `README.md`.
+
+**Encoding rules (preserved in the port):** KIND = categorical/ANSI hue, STATUS = treatment
+(running → accent + breathe, failed → `--bad` + ✕, pending → faint, planned → dashed,
+awaiting → wait-for-human dash). `good`/`bad`/`accent` are earned by status, never identity.
+
+**Recent study refinements** (also in this branch): arrowheads are **small solid triangles**;
+chords are **thin gradient strokes** (width `min(4, 0.9+√count·1.1)`, non-scaling) rather than
+filled teardrops; gantt transfer/delegation edges connect **span-end → span-start** with a
+landing arrowhead; the judge heartbeat is **derived from the drift** so its marks line up
+with the seismograph.
+
+---
+
+## 7. Side fix included on this branch — TrajectoryView header
+
+While integrating, two **pre-existing** failures in
+`frontend/src/__tests__/components/TrajectoryView.headerMath.test.tsx` were resolved (MD3
+code, unrelated to zicato). Root cause: PR #195 added a `"Plan N · "` header prefix (for a
+*merged-trajectory* model) + tests; PR #196 (newest) shipped the **plan picker**, which
+scopes the view model to one plan and shows plan identity via chips — **superseding** the
+prefix — but left #195's 2 prefix-tests stale. Fix: the header stays a plain `"rev N of M"`
+(`planPrefix = ''` in `TrajectoryView.tsx`, ~L533), and the 2 stale tests were updated to
+assert no-prefix while keeping their rev-math coverage. If the prefix is actually wanted,
+that's the opposite call (un-scope the plan list for the header **and** flip
+`TrajectoryView.planPicker.test.tsx`'s no-prefix assertion).
+
+---
+
+## 8. Known issues, risks & TODO (for whoever resumes)
+
+1. **Verify against real data (blocking).** Nothing here has rendered a real session. Expect
+   adapter bugs first: field mappings, time scale (`T`/`now`), edge derivation, plan
+   reel→DAG, judge drift/beats. Start at `adapter.ts` builders (§4.3).
+2. **Interactions unverified:** span → `ZicatoInspector`, chord hover/pin projection,
+   reel→DAG drive, ⌘K session switch (`SessionPicker` is reused), theme switching across all
+   16 zicato themes, and the toggle round-trip (only the button presence is asserted).
+3. **No visual regression / a11y / cross-browser** pass yet.
+4. **Bundle size:** `vite build` warns the single chunk is >500 kB (~785 kB raw / ~229 kB
+   gzip). Pre-existing (heavy deps: MD3, `shiki`, protobuf). Advisory only. If load time
+   matters, code-split: lazy-load `shiki` and the zicato console behind the toggle
+   (`React.lazy` on the `App.tsx` branch).
+5. **Not merged.** Lives on `design/sequence-compose-parity`.
+
+---
+
+## 9. Commands
+
+```bash
+# from frontend/
+pnpm build      # tsc -b && vite build
+pnpm lint       # eslint .
+pnpm test       # vitest run (740 tests)
+pnpm dev        # vite dev (set VITE_HARMONOGRAF_API to point at a backend)
+
+# from repo root (Makefile)
+make console        # build the SPA into the server static dir
+make server-run     # run the server (serves gRPC-Web + the console)
+make frontend-dev   # vite dev
+make test           # all suites
+```
+
+Related memory/notes: `docs/design/zicato-ui-study/` (the study), and the project's design
+intent. The toggle is intentionally default-off; keep it that way until §3/§8 are done.

--- a/examples/standalone_observability/replan_scenario.py
+++ b/examples/standalone_observability/replan_scenario.py
@@ -1,0 +1,495 @@
+"""Standalone replan scenario: emit a plan + multiple revisions to harmonograf.
+
+This exercises harmonograf's *plan-revision visualization* — the plan reel
+and the plan DAG — by driving a single plan id through four revisions so the
+console has real evolution to render: tasks that get ADDED, tasks that get
+DROPPED (ghosted), tasks that get SUPERSEDED, and the replan-trigger seams
+(reason / kind / severity) between each revision.
+
+WHY THIS IS STANDALONE
+----------------------
+Post the goldfive migration (issue #2/#4) harmonograf_client is an
+observability-only library: plans, tasks, and drift now live in goldfive and
+ride to the server inside a ``TelemetryUp.goldfive_event`` variant. Crucially,
+*nothing requires the goldfive orchestration machinery (Runner / planner /
+LLM) to PRODUCE those events*. We build the ``goldfive.v1.Event`` protos by
+hand — a ``PlanSubmitted`` for rev0 and a ``PlanRevised`` for each subsequent
+revision — and push them through the same ``Client.emit_goldfive_event`` path
+the ``HarmonografSink`` uses. The result is fully deterministic: no LLM, no
+network beyond the harmonograf gRPC stream, identical every run.
+
+The goldfive proto stubs come in via the ``orchestration`` extra (the
+``goldfive`` package grafts ``goldfive.v1`` onto its namespace), but we only
+import the generated message classes — we never instantiate a Runner.
+
+WHAT LANDS ON THE SERVER
+------------------------
+Each emitted event is correlated to this client's session by setting
+``event.session_id`` (and the matching Hello session via the Client). The
+server's ingest path (``_on_plan_submitted`` / ``_on_plan_revised`` in
+``server/harmonograf_server/ingest.py``) upserts each into the
+``task_plan_revisions`` table keyed on ``(plan_id, revision_index)``. After
+this script runs, that table has FOUR rows for one ``plan_id`` — exactly the
+shape the reel diffs across.
+
+Required per the ingest contract:
+  * ``event.run_id``        — non-empty, else the event is dropped wholesale.
+  * ``plan.id``             — non-empty, the storage primary key; SAME across
+                              all four revisions so they form one lineage.
+  * ``plan.revision_index`` — 0,1,2,3 monotonic; drives reel ordering.
+  * ``event.session_id``    — routes the event to this run's session.
+
+THE SCENARIO (one plan, four revisions)
+---------------------------------------
+  rev0  PlanSubmitted   {research, draft, review}
+                        reason "initial plan install"  (no drift metadata)
+  rev1  PlanRevised     + gather-sources               (added before draft)
+                        kind NEW_WORK_DISCOVERED / INFO   "scope creep"
+  rev2  PlanRevised     draft -> draft-v2 (REPLACE-supersedes),
+                        DROP review, + fact-check
+                        kind PLAN_DIVERGENCE / WARNING    "goal drift"
+  rev3  PlanRevised     mark every surviving task COMPLETED
+                        kind UNSPECIFIED / INFO           "run wrap-up"
+
+Run:
+    export HARMONOGRAF_SERVER=127.0.0.1:7531
+    uv run --extra orchestration python \\
+        examples/standalone_observability/replan_scenario.py
+
+Environment:
+    HARMONOGRAF_SERVER  (default 127.0.0.1:7531)
+
+Contrast with ``with_orchestration.py``, which produces the same kind of
+events the *real* way (a goldfive Runner with a StaticPlanner). This file is
+the deterministic, LLM-free shortcut for stress-testing the revision UI.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+# Importing goldfive grafts ``goldfive.v1`` onto the package namespace so the
+# generated proto stubs resolve. We pull ONLY message classes from it — no
+# Runner, no planner, no orchestration. ``goldfive.pb`` triggers the graft.
+import goldfive  # noqa: F401  (import for namespace side effect)
+import goldfive.pb  # noqa: F401  (extends goldfive.__path__ to the pb subtree)
+from goldfive.v1 import events_pb2, types_pb2
+from google.protobuf import timestamp_pb2
+
+from harmonograf_client import Client
+
+# Plan id is stable across every revision — the four rows in
+# task_plan_revisions share this id and differ only by revision_index.
+PLAN_ID = "replan-demo"
+PLANNER_AGENT = "planner"
+WORKER_AGENT = "worker"
+
+
+def _now_ts(offset_s: float = 0.0) -> timestamp_pb2.Timestamp:
+    """A protobuf Timestamp at wall-clock now + offset (seconds)."""
+    ts = timestamp_pb2.Timestamp()
+    ts.FromNanoseconds(int((time.time() + offset_s) * 1_000_000_000))
+    return ts
+
+
+def _task(
+    task_id: str,
+    title: str,
+    *,
+    status: int = types_pb2.TASK_STATUS_PENDING,
+    assignee: str = WORKER_AGENT,
+    supersedes: str = "",
+    supersedes_kind: int = types_pb2.SUPERSESSION_KIND_UNSPECIFIED,
+    description: str = "",
+) -> types_pb2.Task:
+    """Build a goldfive ``Task`` proto with sane defaults."""
+    return types_pb2.Task(
+        id=task_id,
+        title=title,
+        description=description,
+        assignee_agent_id=assignee,
+        status=status,
+        supersedes=supersedes,
+        supersedes_kind=supersedes_kind,
+    )
+
+
+def _edge(from_id: str, to_id: str) -> types_pb2.TaskEdge:
+    return types_pb2.TaskEdge(from_task_id=from_id, to_task_id=to_id)
+
+
+def _plan(
+    *,
+    run_id: str,
+    revision_index: int,
+    tasks: list[types_pb2.Task],
+    edges: list[types_pb2.TaskEdge],
+    summary: str,
+    revision_reason: str = "",
+    revision_kind: int = types_pb2.DRIFT_KIND_UNSPECIFIED,
+    revision_severity: int = types_pb2.DRIFT_SEVERITY_UNSPECIFIED,
+    trigger_event_id: str = "",
+    created_offset_s: float = 0.0,
+) -> types_pb2.Plan:
+    """Build a goldfive ``Plan`` proto for one revision of PLAN_ID."""
+    return types_pb2.Plan(
+        id=PLAN_ID,
+        run_id=run_id,
+        goal_ids=["g-research-summary"],
+        summary=summary,
+        tasks=tasks,
+        edges=edges,
+        revision_reason=revision_reason,
+        revision_kind=revision_kind,
+        revision_severity=revision_severity,
+        revision_index=revision_index,
+        created_at=_now_ts(created_offset_s),
+        revision_trigger_event_id=trigger_event_id,
+    )
+
+
+def _event(
+    *,
+    run_id: str,
+    session_id: str,
+    sequence: int,
+    payload_field: str,
+    payload_msg,  # PlanSubmitted | PlanRevised
+    emitted_offset_s: float = 0.0,
+) -> events_pb2.Event:
+    """Wrap a plan payload in the goldfive ``Event`` envelope.
+
+    ``run_id`` + ``session_id`` are set on the envelope so the harmonograf
+    ingest path persists the row under THIS run's session (see module
+    docstring — both are part of the persistence contract).
+    """
+    evt = events_pb2.Event(
+        event_id=str(uuid.uuid4()),
+        run_id=run_id,
+        sequence=sequence,
+        session_id=session_id,
+        emitted_at=_now_ts(emitted_offset_s),
+    )
+    getattr(evt, payload_field).CopyFrom(payload_msg)
+    return evt
+
+
+# ---------------------------------------------------------------------------
+# The four revisions
+# ---------------------------------------------------------------------------
+
+
+def rev0_submitted(run_id: str) -> types_pb2.Plan:
+    """rev0 — the initial plan the planner installs. {research, draft, review}."""
+    tasks = [
+        _task("research", "Gather research notes", status=types_pb2.TASK_STATUS_PENDING),
+        _task("draft", "Draft the summary", status=types_pb2.TASK_STATUS_PENDING),
+        _task("review", "Review the draft", status=types_pb2.TASK_STATUS_PENDING),
+    ]
+    edges = [_edge("research", "draft"), _edge("draft", "review")]
+    return _plan(
+        run_id=run_id,
+        revision_index=0,
+        tasks=tasks,
+        edges=edges,
+        summary="Research, draft, review a short summary.",
+        revision_reason="initial plan install",
+        created_offset_s=0.0,
+    )
+
+
+def rev1_add_gather_sources(run_id: str, trigger_event_id: str) -> types_pb2.Plan:
+    """rev1 — ADD gather-sources before draft. Scope creep (NEW_WORK_DISCOVERED)."""
+    tasks = [
+        # research has started running by now
+        _task("research", "Gather research notes", status=types_pb2.TASK_STATUS_RUNNING),
+        _task(
+            "gather-sources",
+            "Gather primary sources",
+            status=types_pb2.TASK_STATUS_PENDING,
+            description="Discovered we need cited sources before drafting.",
+        ),
+        _task("draft", "Draft the summary", status=types_pb2.TASK_STATUS_PENDING),
+        _task("review", "Review the draft", status=types_pb2.TASK_STATUS_PENDING),
+    ]
+    edges = [
+        _edge("research", "gather-sources"),
+        _edge("gather-sources", "draft"),
+        _edge("draft", "review"),
+    ]
+    return _plan(
+        run_id=run_id,
+        revision_index=1,
+        tasks=tasks,
+        edges=edges,
+        summary="Research, gather sources, draft, review.",
+        revision_reason="reviewer asked for cited sources; adding a sourcing step",
+        revision_kind=types_pb2.DRIFT_KIND_NEW_WORK_DISCOVERED,
+        revision_severity=types_pb2.DRIFT_SEVERITY_INFO,
+        trigger_event_id=trigger_event_id,
+        created_offset_s=0.5,
+    )
+
+
+def rev2_supersede_and_drop(run_id: str, trigger_event_id: str) -> types_pb2.Plan:
+    """rev2 — SUPERSEDE draft->draft-v2, DROP review, ADD fact-check.
+
+    Goal drift (PLAN_DIVERGENCE / WARNING): the deliverable shape changed, so
+    the old draft is replaced and a verification step replaces plain review.
+    """
+    tasks = [
+        _task("research", "Gather research notes", status=types_pb2.TASK_STATUS_COMPLETED),
+        _task("gather-sources", "Gather primary sources", status=types_pb2.TASK_STATUS_COMPLETED),
+        # old draft kept as a CANCELLED ghost that the new task supersedes
+        _task("draft", "Draft the summary", status=types_pb2.TASK_STATUS_CANCELLED),
+        _task(
+            "draft-v2",
+            "Draft the summary (sourced rewrite)",
+            status=types_pb2.TASK_STATUS_RUNNING,
+            supersedes="draft",
+            supersedes_kind=types_pb2.SUPERSESSION_KIND_REPLACE,
+            description="Rewrite the draft to weave in the gathered sources.",
+        ),
+        _task(
+            "fact-check",
+            "Fact-check claims against sources",
+            status=types_pb2.TASK_STATUS_PENDING,
+            description="Replaces a plain read-through with a sourced verification.",
+        ),
+        # NOTE: 'review' is intentionally ABSENT -> dropped/ghost in the reel.
+    ]
+    edges = [
+        _edge("research", "gather-sources"),
+        _edge("gather-sources", "draft-v2"),
+        _edge("draft-v2", "fact-check"),
+    ]
+    return _plan(
+        run_id=run_id,
+        revision_index=2,
+        tasks=tasks,
+        edges=edges,
+        summary="Research, sources, sourced draft, fact-check.",
+        revision_reason="deliverable shifted to a sourced brief; rewriting draft and replacing review with fact-check",
+        revision_kind=types_pb2.DRIFT_KIND_PLAN_DIVERGENCE,
+        revision_severity=types_pb2.DRIFT_SEVERITY_WARNING,
+        trigger_event_id=trigger_event_id,
+        created_offset_s=1.0,
+    )
+
+
+def rev3_mark_done(run_id: str, trigger_event_id: str) -> types_pb2.Plan:
+    """rev3 — terminal sweep: mark every surviving task COMPLETED."""
+    tasks = [
+        _task("research", "Gather research notes", status=types_pb2.TASK_STATUS_COMPLETED),
+        _task("gather-sources", "Gather primary sources", status=types_pb2.TASK_STATUS_COMPLETED),
+        _task("draft", "Draft the summary", status=types_pb2.TASK_STATUS_CANCELLED),
+        _task(
+            "draft-v2",
+            "Draft the summary (sourced rewrite)",
+            status=types_pb2.TASK_STATUS_COMPLETED,
+            supersedes="draft",
+            supersedes_kind=types_pb2.SUPERSESSION_KIND_REPLACE,
+        ),
+        _task("fact-check", "Fact-check claims against sources", status=types_pb2.TASK_STATUS_COMPLETED),
+    ]
+    edges = [
+        _edge("research", "gather-sources"),
+        _edge("gather-sources", "draft-v2"),
+        _edge("draft-v2", "fact-check"),
+    ]
+    return _plan(
+        run_id=run_id,
+        revision_index=3,
+        tasks=tasks,
+        edges=edges,
+        summary="All work complete.",
+        revision_reason="run wrap-up: all surviving tasks complete",
+        revision_kind=types_pb2.DRIFT_KIND_UNSPECIFIED,
+        revision_severity=types_pb2.DRIFT_SEVERITY_INFO,
+        trigger_event_id=trigger_event_id,
+        created_offset_s=1.5,
+    )
+
+
+def _diff(
+    *,
+    added: list[str],
+    removed: list[str],
+    modified: list[str],
+    added_edges: list[types_pb2.TaskEdge] | None = None,
+    removed_edges: list[types_pb2.TaskEdge] | None = None,
+) -> events_pb2.PlanRevisionDiff:
+    """Build the advisory cross-revision diff carried on PlanRevised."""
+    return events_pb2.PlanRevisionDiff(
+        added_task_ids=added,
+        removed_task_ids=removed,
+        modified_task_ids=modified,
+        added_edges=added_edges or [],
+        removed_edges=removed_edges or [],
+    )
+
+
+def _wait_for_session(client: Client, timeout_s: float = 10.0) -> str:
+    """Block until the server assigns this client a session id (via Welcome).
+
+    The Hello -> Welcome handshake happens on the transport thread; the
+    server-assigned id is what every plan event must carry so the rows land
+    under the right session. Falls back to the client-local id if the server
+    never assigns one in time (still valid — the server uses it verbatim).
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        sid = client.session_id
+        if sid:
+            return sid
+        time.sleep(0.05)
+    return client.session_id
+
+
+def main() -> None:
+    server = os.environ.get("HARMONOGRAF_SERVER", "127.0.0.1:7531")
+    # run_id ties the four events together as one goldfive "run". A fresh uuid
+    # per process keeps reruns from colliding on the audit log.
+    run_id = f"replan-run-{uuid.uuid4().hex[:12]}"
+
+    client = Client(
+        name="replan-scenario",
+        framework="CUSTOM",
+        server_addr=server,
+        session_title="Replan scenario (4 revisions)",
+    )
+    try:
+        # Emit one INVOCATION span first so the Hello lands and the server
+        # assigns + persists a session row the plan revisions can FK to.
+        from harmonograf_client import SpanKind, SpanStatus
+
+        invocation = client.emit_span_start(
+            kind=SpanKind.INVOCATION,
+            name="replan_scenario",
+            attributes={"scenario": "replan", "revisions": 4},
+        )
+
+        session_id = _wait_for_session(client)
+        print(f"session_id={session_id}")
+        print(f"run_id={run_id}")
+        print(f"plan_id={PLAN_ID}")
+
+        # Synthesize a distinct trigger event id per revision so the
+        # intervention/trigger seams are unique (mirrors a real DriftDetected.id).
+        trig_r1 = f"trigger-{uuid.uuid4().hex[:8]}"
+        trig_r2 = f"trigger-{uuid.uuid4().hex[:8]}"
+        trig_r3 = f"trigger-{uuid.uuid4().hex[:8]}"
+
+        # --- rev0: PlanSubmitted -------------------------------------------
+        e0 = _event(
+            run_id=run_id,
+            session_id=session_id,
+            sequence=0,
+            payload_field="plan_submitted",
+            payload_msg=events_pb2.PlanSubmitted(plan=rev0_submitted(run_id)),
+            emitted_offset_s=0.0,
+        )
+        client.emit_goldfive_event(e0)
+
+        # --- rev1: add gather-sources --------------------------------------
+        p1 = rev1_add_gather_sources(run_id, trig_r1)
+        e1 = _event(
+            run_id=run_id,
+            session_id=session_id,
+            sequence=1,
+            payload_field="plan_revised",
+            payload_msg=events_pb2.PlanRevised(
+                plan=p1,
+                drift_kind=p1.revision_kind,
+                severity=p1.revision_severity,
+                reason=p1.revision_reason,
+                revision_index=1,
+                trigger_event_id=trig_r1,
+                diff=_diff(
+                    added=["gather-sources"],
+                    removed=[],
+                    modified=["research"],
+                    added_edges=[_edge("research", "gather-sources"), _edge("gather-sources", "draft")],
+                    removed_edges=[_edge("research", "draft")],
+                ),
+                refine_input_summary="rev0 {research(running), draft, review}; reviewer wants citations",
+                refine_output_summary="rev1 adds gather-sources before draft",
+            ),
+            emitted_offset_s=0.5,
+        )
+        client.emit_goldfive_event(e1)
+
+        # --- rev2: supersede draft, drop review, add fact-check ------------
+        p2 = rev2_supersede_and_drop(run_id, trig_r2)
+        e2 = _event(
+            run_id=run_id,
+            session_id=session_id,
+            sequence=2,
+            payload_field="plan_revised",
+            payload_msg=events_pb2.PlanRevised(
+                plan=p2,
+                drift_kind=p2.revision_kind,
+                severity=p2.revision_severity,
+                reason=p2.revision_reason,
+                revision_index=2,
+                trigger_event_id=trig_r2,
+                diff=_diff(
+                    added=["draft-v2", "fact-check"],
+                    removed=["review"],
+                    modified=["draft", "research", "gather-sources"],
+                    added_edges=[_edge("gather-sources", "draft-v2"), _edge("draft-v2", "fact-check")],
+                    removed_edges=[_edge("gather-sources", "draft"), _edge("draft", "review")],
+                ),
+                refine_input_summary="rev1 {…, draft, review}; deliverable became a sourced brief",
+                refine_output_summary="rev2 supersedes draft->draft-v2, drops review, adds fact-check",
+            ),
+            emitted_offset_s=1.0,
+        )
+        client.emit_goldfive_event(e2)
+
+        # --- rev3: terminal sweep ------------------------------------------
+        p3 = rev3_mark_done(run_id, trig_r3)
+        e3 = _event(
+            run_id=run_id,
+            session_id=session_id,
+            sequence=3,
+            payload_field="plan_revised",
+            payload_msg=events_pb2.PlanRevised(
+                plan=p3,
+                drift_kind=p3.revision_kind,
+                severity=p3.revision_severity,
+                reason=p3.revision_reason,
+                revision_index=3,
+                trigger_event_id=trig_r3,
+                diff=_diff(
+                    added=[],
+                    removed=[],
+                    modified=["draft-v2", "fact-check"],
+                ),
+                refine_input_summary="rev2 work finishing; sweep to terminal",
+                refine_output_summary="rev3 marks all surviving tasks completed",
+            ),
+            emitted_offset_s=1.5,
+        )
+        client.emit_goldfive_event(e3)
+
+        # Close out the invocation span so the session reads as finished.
+        client.emit_span_end(invocation, status=SpanStatus.COMPLETED)
+
+        print("emitted revisions: 4 (rev0 submitted + rev1 + rev2 + rev3)")
+        print("  rev0  initial plan install            {research, draft, review}")
+        print("  rev1  new_work_discovered / info      + gather-sources")
+        print("  rev2  plan_divergence / warning       draft->draft-v2, drop review, + fact-check")
+        print("  rev3  (unspecified) / info            mark all completed")
+    finally:
+        # Flush generously — the four goldfive events plus the span pair must
+        # drain before the transport shuts down.
+        client.shutdown(flush_timeout=8.0)
+
+    print(f"DONE. session_id={session_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Shell } from './components/shell/Shell';
 import { StressPage } from './gantt/StressPage';
 import { useUiStore } from './state/uiStore';
-import { useSessionsStore } from './state/sessionsStore';
 import { sessionIdFromHash } from './lib/sessionRoute';
 
 // Minimal hash router. The stress harness is dev-only and intentionally not
@@ -18,28 +17,28 @@ function useHashRoute(): string {
 }
 
 // Reads a `#/session/<id>` deep link and selects that session in the UI store.
-// Runs on the initial hash and on every hashchange. Because the deep-linked id
-// may not have arrived from ListSessions yet (sessions still loading), it
-// records the desired id and (re)applies the selection whenever the sessions
-// list changes — selecting the session as soon as it appears. Setting
-// currentSessionId here also pre-empts SessionsSyncer's newest-session
-// auto-select, so a deep link opens straight into its trace.
+// Applies each distinct deep-link target exactly once — on the initial hash and
+// again whenever the hash changes to a new session. The selection is eager: the
+// id need not have arrived from ListSessions yet (WatchSession/ListSessions will
+// populate it), and setting currentSessionId here also pre-empts SessionsSyncer's
+// newest-first auto-select, so a deep link opens straight into its trace.
+//
+// Crucially this does NOT re-fire on every sessions poll: doing so would yank the
+// user back to the deep-linked session ~every 5s after they navigate away via the
+// picker (which updates the store, not the hash), trapping them on that session.
 function useSessionDeepLink(hash: string): void {
   const setCurrentSession = useUiStore((s) => s.setCurrentSession);
-  const sessions = useSessionsStore((s) => s.sessions);
-
   const wantedId = sessionIdFromHash(hash);
+  const appliedId = useRef<string | null>(null);
 
   useEffect(() => {
     if (!wantedId) return;
-    // Already selected — nothing to do.
-    const current = useUiStore.getState().currentSessionId;
-    if (current === wantedId) return;
-    // If the session is known, select it now. If not, select it eagerly
-    // anyway: WatchSession/ListSessions will populate it, and this still
-    // blocks SessionsSyncer's newest-first auto-select from racing ahead.
+    // Apply this target once; let a later manual selection (picker) stick.
+    if (appliedId.current === wantedId) return;
+    appliedId.current = wantedId;
+    if (useUiStore.getState().currentSessionId === wantedId) return;
     setCurrentSession(wantedId);
-  }, [wantedId, sessions, setCurrentSession]);
+  }, [wantedId, setCurrentSession]);
 }
 
 export default function App() {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Shell } from './components/shell/Shell';
 import { StressPage } from './gantt/StressPage';
+import { ZicatoConsole } from './components/zicato/ZicatoConsole';
 import { useUiStore } from './state/uiStore';
 import { sessionIdFromHash } from './lib/sessionRoute';
 
@@ -43,7 +44,9 @@ function useSessionDeepLink(hash: string): void {
 
 export default function App() {
   const hash = useHashRoute();
-  useSessionDeepLink(hash);
-  if (hash.startsWith('#/stress')) return <StressPage />;
+  useSessionDeepLink(hash); // keep ABOVE the branch — deep links select in both consoles
+  const uiMode = useUiStore((s) => s.uiMode);
+  if (hash.startsWith('#/stress')) return <StressPage />; // dev route unaffected
+  if (uiMode === 'zicato') return <ZicatoConsole />;
   return <Shell />;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Shell } from './components/shell/Shell';
 import { StressPage } from './gantt/StressPage';
+import { useUiStore } from './state/uiStore';
+import { useSessionsStore } from './state/sessionsStore';
+import { sessionIdFromHash } from './lib/sessionRoute';
 
 // Minimal hash router. The stress harness is dev-only and intentionally not
 // linked anywhere user-facing. Visit /#/stress to open it.
@@ -14,8 +17,34 @@ function useHashRoute(): string {
   return hash;
 }
 
+// Reads a `#/session/<id>` deep link and selects that session in the UI store.
+// Runs on the initial hash and on every hashchange. Because the deep-linked id
+// may not have arrived from ListSessions yet (sessions still loading), it
+// records the desired id and (re)applies the selection whenever the sessions
+// list changes — selecting the session as soon as it appears. Setting
+// currentSessionId here also pre-empts SessionsSyncer's newest-session
+// auto-select, so a deep link opens straight into its trace.
+function useSessionDeepLink(hash: string): void {
+  const setCurrentSession = useUiStore((s) => s.setCurrentSession);
+  const sessions = useSessionsStore((s) => s.sessions);
+
+  const wantedId = sessionIdFromHash(hash);
+
+  useEffect(() => {
+    if (!wantedId) return;
+    // Already selected — nothing to do.
+    const current = useUiStore.getState().currentSessionId;
+    if (current === wantedId) return;
+    // If the session is known, select it now. If not, select it eagerly
+    // anyway: WatchSession/ListSessions will populate it, and this still
+    // blocks SessionsSyncer's newest-first auto-select from racing ahead.
+    setCurrentSession(wantedId);
+  }, [wantedId, sessions, setCurrentSession]);
+}
+
 export default function App() {
   const hash = useHashRoute();
+  useSessionDeepLink(hash);
   if (hash.startsWith('#/stress')) return <StressPage />;
   return <Shell />;
 }

--- a/frontend/src/__tests__/components/GanttZ.zoom.test.tsx
+++ b/frontend/src/__tests__/components/GanttZ.zoom.test.tsx
@@ -1,0 +1,60 @@
+// Regression: the zicato gantt zoom/pan viewport actually changes the rendered
+// window. Clicking + (zoom in) must move a span's x; fit must restore it.
+// Pure render test (no RPC/browser) so it can't be fooled by a stale dist.
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GanttViewZ } from '../../components/zicato/GanttViewZ';
+import { EMPTY_SESSION, type ZSession } from '../../components/zicato/adapter';
+
+function mkSession(): ZSession {
+  return {
+    ...EMPTY_SESSION,
+    id: 'zoom-test',
+    T: 100,
+    now: 100,
+    empty: false,
+    agents: [{ id: 'a', label: 'coder', ordinal: 1, synthetic: null }],
+    // t0=30,t1=50 stays inside the +-zoom window [20,80] so the bar is visible
+    // before AND after, and its x must shift.
+    spans: [
+      {
+        id: 's1',
+        agent: 'a',
+        kind: 'llm-call',
+        status: 'completed',
+        gf: null,
+        t0: 30,
+        t1: 50,
+        label: 'work',
+        hasReasoning: false,
+        reasoning: null,
+      },
+    ],
+  };
+}
+
+const barX = (): string | null =>
+  (document.querySelector('[data-span="s1"]') as SVGRectElement | null)?.getAttribute('x') ?? null;
+
+describe('zicato gantt zoom viewport', () => {
+  it('zoom in (+) shifts a span; fit restores it', () => {
+    render(<GanttViewZ z={mkSession()} />);
+    const x0 = barX();
+    expect(x0).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText('zoom in'));
+    const x1 = barX();
+    expect(x1).not.toBe(x0); // the visible window narrowed → the bar moved
+
+    fireEvent.click(screen.getByLabelText('fit to range'));
+    expect(barX()).toBe(x0); // back to the full range
+  });
+
+  it('fit is disabled at the full range and enabled once zoomed', () => {
+    render(<GanttViewZ z={mkSession()} />);
+    expect(screen.getByLabelText('fit to range')).toBeDisabled();
+    fireEvent.click(screen.getByLabelText('zoom in'));
+    expect(screen.getByLabelText('fit to range')).not.toBeDisabled();
+  });
+});

--- a/frontend/src/__tests__/components/TrajectoryView.headerMath.test.tsx
+++ b/frontend/src/__tests__/components/TrajectoryView.headerMath.test.tsx
@@ -146,26 +146,25 @@ describe('<TrajectoryView /> header "rev N of M" math', () => {
     expect(headerHint()).toBe('rev 2 of 2');
   });
 
-  it('uses revisionIndex (not length-1) when the rev numbering has a gap (R0 + R2, no R1)', () => {
-    // Goldfive planners can mint a fresh plan_id mid-stream, leaving the
-    // rev sequence non-contiguous when the trajectory merges both plans.
-    // The header denominator must reflect the highest revisionIndex
-    // observed, not `vm.revs.length - 1`.
+  it('reads the highest revisionIndex (not array position) for a plan that starts at a non-zero rev', () => {
+    // A goldfive planner can mint a fresh plan_id mid-stream that begins at a
+    // non-zero revisionIndex (here p2 jumps straight to rev 2). The default
+    // selection is the latest plan (p2), and the header denominator must come
+    // from its revisionIndex (2), not the scoped vm.revs length-1 (0).
     //
-    // Multi-plan note (Item 4 of UX cleanup batch): two distinct plan
-    // ids (p1, p2) means the header now prefixes the rev label with
-    // "Plan {N} · " so operators can see which plan the current rev
-    // belongs to (the H1 plan picker lands the picker UI on top of this
-    // label). The numerator/denominator math is unchanged.
+    // Multi-plan identity is conveyed by the plan-picker chip-bar (see
+    // TrajectoryView.planPicker test), NOT a header prefix: an earlier
+    // "Plan {N} · " prefix (#195, written for a merged-trajectory model) was
+    // superseded when the picker (#196) landed and scoped the view model to a
+    // single selected plan. So the header stays a plain "rev N of M".
     mockStore.tasks.upsertPlan(mkPlan('p1', [mkTask('t1')], 0));
     mockStore.tasks.upsertPlan(
       mkPlan('p2', [mkTask('t1'), mkTask('t2')], 2, 'user steer', 'user_steer'),
     );
     render(<TrajectoryView />);
-    // vm.revs.length === 2, but max revisionIndex === 2 → "rev 2 of 2",
-    // not the buggy "rev 1 of 1". Multi-plan prefix surfaces "Plan 2"
-    // because the latest rev belongs to the second distinct plan id.
-    expect(headerHint()).toBe('Plan 2 · rev 2 of 2');
+    // Selected = latest = p2, revisionIndex 2 → "rev 2 of 2" (not "rev 2 of 0").
+    expect(headerHint()).toBe('rev 2 of 2');
+    expect(headerHint()).not.toContain('Plan');
   });
 
   it('switches between "no plan yet" and a "rev N of M" hint as plans land', () => {
@@ -194,10 +193,11 @@ describe('<TrajectoryView /> header "rev N of M" math', () => {
     expect(headerHint()).not.toContain('Plan');
   });
 
-  it('prefixes "Plan N · " when multiple plan ids are present (Item 4)', () => {
-    // Three distinct plan ids → header surfaces the index of the plan
-    // the current rev belongs to, so an operator viewing rev 2 can tell
-    // which plan they're scoped to ahead of the H1 plan picker landing.
+  it('keeps a plain "rev N of M" header on multi-plan sessions (plan identity comes from the picker chips)', () => {
+    // Three distinct plan ids → the plan-picker chip-bar (see
+    // TrajectoryView.planPicker test) shows which plan is selected, so the
+    // header does NOT duplicate that with a "Plan N · " prefix. The earlier
+    // prefix (#195) was superseded when the picker (#196) landed.
     mockStore.tasks.upsertPlan(mkPlan('p1', [mkTask('t1')], 0));
     mockStore.tasks.upsertPlan(
       mkPlan('p2', [mkTask('t1'), mkTask('t2')], 1, 'split', 'plan_divergence'),
@@ -206,7 +206,8 @@ describe('<TrajectoryView /> header "rev N of M" math', () => {
       mkPlan('p3', [mkTask('t1'), mkTask('t2'), mkTask('t3')], 2, 'next', 'goldfive'),
     );
     render(<TrajectoryView />);
-    // Latest rev belongs to the third distinct plan id → "Plan 3".
-    expect(headerHint()).toBe('Plan 3 · rev 2 of 2');
+    // Latest = p3, revisionIndex 2 → "rev 2 of 2", no "Plan 3 · " prefix.
+    expect(headerHint()).toBe('rev 2 of 2');
+    expect(headerHint()).not.toContain('Plan');
   });
 });

--- a/frontend/src/__tests__/components/zicato.smoke.test.tsx
+++ b/frontend/src/__tests__/components/zicato.smoke.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SessionStore } from '../../gantt/index';
+
+// Keep the smoke test hermetic: no real RPC, no global key handlers, no
+// session-list poll. The console must render against an empty store without
+// throwing — that is the scaffold gate.
+const emptyStore = new SessionStore();
+
+vi.mock('../../rpc/hooks', () => ({
+  useSessionWatch: () => ({
+    store: emptyStore,
+    connected: false,
+    initialBurstComplete: false,
+    error: null,
+    sessionStatus: 'UNKNOWN',
+    lastEventAtMs: 0,
+  }),
+  getSessionStore: () => undefined,
+  useSendControl: () => async () => {},
+}));
+vi.mock('../../rpc/SessionsSyncer', () => ({ SessionsSyncer: () => null }));
+vi.mock('../../components/SessionPicker/SessionPicker', () => ({
+  SessionPicker: () => null,
+}));
+vi.mock('../../lib/shortcuts', () => ({ useGlobalShortcuts: () => {} }));
+
+import { ZicatoConsole } from '../../components/zicato/ZicatoConsole';
+import {
+  EMPTY_SESSION,
+  toKindToken,
+  toStatusToken,
+  colorVar,
+  type ZAgent,
+} from '../../components/zicato/adapter';
+
+describe('zicato console scaffold', () => {
+  it('renders ZicatoConsole against an empty store without throwing', () => {
+    render(<ZicatoConsole />);
+    expect(screen.getByTestId('zicato-console')).toBeTruthy();
+  });
+
+  it('mounts the md3 toggle so the user can switch back', () => {
+    render(<ZicatoConsole />);
+    expect(screen.getByTestId('ui-mode-toggle-z')).toBeTruthy();
+  });
+
+  it('renders both rail views (gantt + instruments)', () => {
+    render(<ZicatoConsole />);
+    // Two rail items, each labelled by its view name.
+    expect(screen.getByText('gantt')).toBeTruthy();
+    expect(screen.getByText('instruments')).toBeTruthy();
+  });
+
+  it('exposes a safe EMPTY_SESSION shape (empty arrays, empty:true)', () => {
+    expect(EMPTY_SESSION.empty).toBe(true);
+    expect(EMPTY_SESSION.spans).toEqual([]);
+    expect(EMPTY_SESSION.agents).toEqual([]);
+    expect(EMPTY_SESSION.edges).toEqual([]);
+    expect(EMPTY_SESSION.transfers).toEqual([]);
+    expect(EMPTY_SESSION.ladder).toEqual([]);
+    expect(EMPTY_SESSION.ctx).toEqual([]);
+    expect(EMPTY_SESSION.judges).toEqual({});
+    expect(EMPTY_SESSION.ticks).toEqual({});
+    expect(EMPTY_SESSION.plan.planId).toBeNull();
+    expect(EMPTY_SESSION.delegation).toBeNull();
+    expect(EMPTY_SESSION.T).toBe(30);
+    expect(EMPTY_SESSION.now).toBe(0);
+  });
+
+  it('normalizes kind + status tokens', () => {
+    expect(toKindToken('LLM_CALL')).toBe('llm-call');
+    expect(toKindToken('WAIT_FOR_HUMAN')).toBe('wait-for-human');
+    expect(toStatusToken('AWAITING_HUMAN')).toBe('awaiting');
+    expect(toStatusToken('RUNNING')).toBe('running');
+  });
+
+  it('maps agents to the --hg-agent-* token ramp', () => {
+    const a: ZAgent = { id: 'c:coder', label: 'coder', ordinal: 1, synthetic: null };
+    const user: ZAgent = { id: '__user__', label: 'user', ordinal: 0, synthetic: 'user' };
+    const gf: ZAgent = {
+      id: '__goldfive__',
+      label: 'goldfive',
+      ordinal: 0,
+      synthetic: 'goldfive',
+    };
+    expect(colorVar(a)).toBe('var(--hg-agent-1)');
+    expect(colorVar(user)).toBe('var(--hg-agent-user)');
+    expect(colorVar(gf)).toBe('var(--hg-agent-goldfive)');
+  });
+});

--- a/frontend/src/__tests__/components/zicato.smoke.test.tsx
+++ b/frontend/src/__tests__/components/zicato.smoke.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { SessionStore } from '../../gantt/index';
+import type { Span } from '../../gantt/types';
 
 // Keep the smoke test hermetic: no real RPC, no global key handlers, no
 // session-list poll. The console must render against an empty store without
@@ -31,8 +32,11 @@ import {
   toKindToken,
   toStatusToken,
   colorVar,
+  buildSpans,
+  buildSteers,
   type ZAgent,
 } from '../../components/zicato/adapter';
+import { steerColor } from '../../components/zicato/svgUtils';
 
 describe('zicato console scaffold', () => {
   it('renders ZicatoConsole against an empty store without throwing', () => {
@@ -87,5 +91,209 @@ describe('zicato console scaffold', () => {
     expect(colorVar(a)).toBe('var(--hg-agent-1)');
     expect(colorVar(user)).toBe('var(--hg-agent-user)');
     expect(colorVar(gf)).toBe('var(--hg-agent-goldfive)');
+  });
+});
+
+// ── reasoning + steering adapter logic (TRAJECTORY features) ─────────────────
+
+function mkSpan(over: Partial<Span> & Pick<Span, 'id' | 'agentId'>): Span {
+  return {
+    sessionId: 's',
+    parentSpanId: null,
+    kind: 'LLM_CALL',
+    status: 'COMPLETED',
+    name: over.name ?? over.id,
+    startMs: 0,
+    endMs: 1000,
+    links: [],
+    attributes: {},
+    payloadRefs: [],
+    error: null,
+    lane: -1,
+    replaced: false,
+    ...over,
+  };
+}
+
+describe('zicato adapter — reasoning detection (🧠)', () => {
+  it('marks a span with llm.reasoning as hasReasoning + carries the text', () => {
+    const store = new SessionStore();
+    store.spans.append(
+      mkSpan({
+        id: 'sp-reason',
+        agentId: 'c:coder',
+        attributes: {
+          'llm.reasoning': { kind: 'string', value: 'I will read the file first.' },
+        },
+      }),
+    );
+    const spans = buildSpans(store, [], 2);
+    const sp = spans.find((s) => s.id === 'sp-reason')!;
+    expect(sp.hasReasoning).toBe(true);
+    expect(sp.reasoning).toBe('I will read the file first.');
+  });
+
+  it('honours the has_reasoning flag even when the text rides a payload ref', () => {
+    const store = new SessionStore();
+    store.spans.append(
+      mkSpan({
+        id: 'sp-flag',
+        agentId: 'c:coder',
+        attributes: { has_reasoning: { kind: 'bool', value: true } },
+      }),
+    );
+    const sp = buildSpans(store, [], 2).find((s) => s.id === 'sp-flag')!;
+    expect(sp.hasReasoning).toBe(true);
+    // No inline text → null (the drawer renders the payload-ref fallback).
+    expect(sp.reasoning).toBeNull();
+  });
+
+  it('prefers the INVOCATION reasoning_trail aggregate over a single call', () => {
+    const store = new SessionStore();
+    store.spans.append(
+      mkSpan({
+        id: 'sp-trail',
+        agentId: 'c:coder',
+        kind: 'INVOCATION',
+        attributes: {
+          'llm.reasoning': { kind: 'string', value: 'one call' },
+          'llm.reasoning_trail': {
+            kind: 'string',
+            value: '[LLM call 1] one call\n[LLM call 2] two call',
+          },
+        },
+      }),
+    );
+    const sp = buildSpans(store, [], 2).find((s) => s.id === 'sp-trail')!;
+    expect(sp.hasReasoning).toBe(true);
+    expect(sp.reasoning).toContain('[LLM call 2]');
+  });
+
+  it('leaves ordinary spans without reasoning', () => {
+    const store = new SessionStore();
+    store.spans.append(mkSpan({ id: 'sp-plain', agentId: 'c:coder' }));
+    const sp = buildSpans(store, [], 2).find((s) => s.id === 'sp-plain')!;
+    expect(sp.hasReasoning).toBe(false);
+    expect(sp.reasoning).toBeNull();
+  });
+});
+
+describe('zicato adapter — steering derivation (correction → target)', () => {
+  it('derives a steer from a refine attempt pointing at the steered agent', () => {
+    const store = new SessionStore();
+    // A refine the orchestrator emitted in response to a drift, steering coder.
+    store.refineAttempts.append({
+      runId: 'r1',
+      attemptId: 'att-1',
+      driftId: 'drift-1',
+      triggerKind: 'off_topic',
+      triggerSeverity: 'warning',
+      taskId: 't2',
+      agentId: 'c:coder',
+      recordedAtMs: 5000,
+    });
+    const steers = buildSteers(store, []);
+    expect(steers).toHaveLength(1);
+    expect(steers[0].to).toBe('c:coder');
+    expect(steers[0].t).toBe(5); // ms → seconds
+    expect(steers[0].kind).toBe('off_topic');
+    expect(steers[0].severity).toBe('warning');
+    expect(steers[0].taskId).toBe('t2');
+  });
+
+  it('resolves the target from the refine span target_agent_id when a revision matches', () => {
+    const store = new SessionStore();
+    // History: rev 1 triggered by drift-1.
+    const history = [
+      {
+        revision: 1,
+        kind: 'off_topic',
+        reason: 'pulled back on task',
+        triggerEventId: 'drift-1',
+        // plan + record fields the adapter does not read in buildSteers:
+      } as unknown as Parameters<typeof buildSteers>[1][number],
+    ];
+    // refine span carries the authoritative target agent for refine.index 1.
+    store.spans.append(
+      mkSpan({
+        id: 'refine-1',
+        agentId: '__goldfive__',
+        kind: 'CUSTOM',
+        name: 'refine: off_topic',
+        attributes: {
+          'refine.index': { kind: 'string', value: '1' },
+          'refine.target_agent_id': { kind: 'string', value: 'c:reviewer' },
+        },
+      }),
+    );
+    store.refineAttempts.append({
+      runId: 'r1',
+      attemptId: 'att-1',
+      driftId: 'drift-1',
+      triggerKind: 'off_topic',
+      triggerSeverity: 'warning',
+      taskId: '',
+      agentId: 'c:coder', // attempt's own agent — overridden by the span target
+      recordedAtMs: 5000,
+    });
+    const steers = buildSteers(store, history);
+    expect(steers).toHaveLength(1);
+    // refine span's target_agent_id wins over the attempt's agentId.
+    expect(steers[0].to).toBe('c:reviewer');
+    expect(steers[0].revision).toBe(1);
+    expect(steers[0].reason).toBe('pulled back on task');
+  });
+
+  it('falls back to drift→revision when no refine attempts were recorded', () => {
+    const store = new SessionStore();
+    store.drifts.append({
+      kind: 'looping_reasoning',
+      severity: 'critical',
+      detail: 'repeated calls',
+      taskId: 't1',
+      agentId: 'c:coder',
+      recordedAtMs: 8000,
+      annotationId: '',
+      driftId: 'drift-9',
+    });
+    const history = [
+      {
+        revision: 2,
+        kind: 'looping_reasoning',
+        reason: 'broke the loop',
+        triggerEventId: 'drift-9',
+      } as unknown as Parameters<typeof buildSteers>[1][number],
+    ];
+    const steers = buildSteers(store, history);
+    expect(steers).toHaveLength(1);
+    expect(steers[0].to).toBe('c:coder');
+    expect(steers[0].severity).toBe('critical');
+    expect(steers[0].revision).toBe(2);
+  });
+
+  it('drops a steer with no resolvable, non-goldfive target', () => {
+    const store = new SessionStore();
+    // Drift with no plan revision (no history match) and no refine attempts →
+    // nothing to point at.
+    store.drifts.append({
+      kind: 'off_topic',
+      severity: 'info',
+      detail: '',
+      taskId: '',
+      agentId: '',
+      recordedAtMs: 3000,
+      annotationId: '',
+      driftId: 'drift-x',
+    });
+    expect(buildSteers(store, [])).toEqual([]);
+  });
+});
+
+describe('zicato — steering arrow hue by severity', () => {
+  it('maps severity → correction token', () => {
+    expect(steerColor({ severity: 'critical' })).toBe('var(--bad)');
+    expect(steerColor({ severity: 'warning' })).toBe('var(--caution)');
+    expect(steerColor({ severity: 'info' })).toBe('var(--hg-gf-refine)');
+    expect(steerColor({ severity: '' })).toBe('var(--hg-gf-refine)');
   });
 });

--- a/frontend/src/__tests__/rpc/sessionDeepLink.test.tsx
+++ b/frontend/src/__tests__/rpc/sessionDeepLink.test.tsx
@@ -79,6 +79,33 @@ describe('App #/session/<id> deep link', () => {
     expect(useUiStore.getState().currentSessionId).toBe('sess-late');
   });
 
+  it('does not bounce back to the deep link after a manual selection', () => {
+    // Regression: the effect must apply the deep link once, not re-fire on
+    // every ListSessions poll. Otherwise a user who deep-links to sess-a and
+    // then picks sess-b (which updates the store, not the hash) gets dragged
+    // back to sess-a on the next poll.
+    setHash('#/session/sess-a');
+    const { rerender } = render(<App />);
+    expect(useUiStore.getState().currentSessionId).toBe('sess-a');
+
+    // User picks another session via the picker.
+    act(() => {
+      useUiStore.getState().setCurrentSession('sess-b');
+    });
+
+    // A ListSessions poll lands (new sessions array) and App re-renders.
+    act(() => {
+      useSessionsStore.setState({
+        sessions: [{ id: 'sess-a' } as RpcSession, { id: 'sess-b' } as RpcSession],
+        loading: false,
+        error: null,
+      });
+    });
+    rerender(<App />);
+
+    expect(useUiStore.getState().currentSessionId).toBe('sess-b');
+  });
+
   it('does not select anything for the default route', () => {
     setHash('#/');
     render(<App />);

--- a/frontend/src/__tests__/rpc/sessionDeepLink.test.tsx
+++ b/frontend/src/__tests__/rpc/sessionDeepLink.test.tsx
@@ -1,0 +1,87 @@
+// Coverage for the `#/session/<id>` deep-link routing added to App.tsx:
+//   * sessionIdFromHash parses the hash form (and rejects others),
+//   * mounting App with a `#/session/<id>` hash selects that session in the
+//     UI store — even before the session has arrived from ListSessions, and
+//     re-applies once the sessions list updates.
+//
+// Shell + StressPage are mocked to inert markers so the test exercises only
+// the routing/selection logic without pulling in the whole UI tree.
+
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sessionIdFromHash } from '../../lib/sessionRoute';
+import { useUiStore } from '../../state/uiStore';
+import { useSessionsStore } from '../../state/sessionsStore';
+import type { RpcSession } from '../../state/sessionsStore';
+
+// Inert stand-ins — App's routing only needs to mount *something*.
+vi.mock('../../components/shell/Shell', () => ({
+  Shell: () => <div data-testid="shell" />,
+}));
+vi.mock('../../gantt/StressPage', () => ({
+  StressPage: () => <div data-testid="stress" />,
+}));
+
+import App from '../../App';
+
+function setHash(hash: string): void {
+  window.location.hash = hash;
+}
+
+beforeEach(() => {
+  useUiStore.setState({ currentSessionId: null });
+  useSessionsStore.setState({ sessions: [], loading: false, error: null });
+});
+
+afterEach(() => {
+  setHash('');
+});
+
+describe('sessionIdFromHash', () => {
+  it('parses #/session/<id>', () => {
+    expect(sessionIdFromHash('#/session/abc-123')).toBe('abc-123');
+    expect(sessionIdFromHash('#/session/abc-123/')).toBe('abc-123');
+  });
+
+  it('url-decodes the id', () => {
+    expect(sessionIdFromHash('#/session/run%2F42')).toBe('run/42');
+  });
+
+  it('returns null for non-session hashes', () => {
+    expect(sessionIdFromHash('#/')).toBeNull();
+    expect(sessionIdFromHash('#/stress')).toBeNull();
+    expect(sessionIdFromHash('#/session/')).toBeNull();
+    expect(sessionIdFromHash('')).toBeNull();
+  });
+});
+
+describe('App #/session/<id> deep link', () => {
+  it('selects the deep-linked session on mount, even before it loads', () => {
+    setHash('#/session/sess-xyz');
+    render(<App />);
+    // Selected eagerly so SessionsSyncer's newest-first auto-select can't race.
+    expect(useUiStore.getState().currentSessionId).toBe('sess-xyz');
+  });
+
+  it('keeps the deep-linked selection once the session appears in the list', () => {
+    setHash('#/session/sess-late');
+    render(<App />);
+    expect(useUiStore.getState().currentSessionId).toBe('sess-late');
+
+    act(() => {
+      useSessionsStore.setState({
+        sessions: [{ id: 'sess-late' } as RpcSession],
+        loading: false,
+        error: null,
+      });
+    });
+    expect(useUiStore.getState().currentSessionId).toBe('sess-late');
+  });
+
+  it('does not select anything for the default route', () => {
+    setHash('#/');
+    render(<App />);
+    expect(useUiStore.getState().currentSessionId).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/rpc/transport.test.ts
+++ b/frontend/src/__tests__/rpc/transport.test.ts
@@ -1,0 +1,33 @@
+// Coverage for transport.apiBaseUrl()'s resolution precedence:
+//   1. window.__HARMONOGRAF_API__ (runtime, injected by the serving server)
+//   2. VITE_HARMONOGRAF_API (build-time env var)
+//   3. the compiled-in default.
+//
+// The runtime global is the new path that lets a single built bundle work
+// behind any host/port without a rebuild (see static_site.py).
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { apiBaseUrl } from '../../rpc/transport';
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:7532';
+
+afterEach(() => {
+  delete window.__HARMONOGRAF_API__;
+});
+
+describe('apiBaseUrl', () => {
+  it('prefers the runtime window.__HARMONOGRAF_API__ global', () => {
+    window.__HARMONOGRAF_API__ = 'http://example.test:9000';
+    expect(apiBaseUrl()).toBe('http://example.test:9000');
+  });
+
+  it('ignores an empty runtime global and falls through', () => {
+    window.__HARMONOGRAF_API__ = '';
+    // No VITE env set in the test runner, so this lands on the default.
+    expect(apiBaseUrl()).toBe(DEFAULT_BASE_URL);
+  });
+
+  it('falls back to the compiled-in default when nothing is configured', () => {
+    expect(apiBaseUrl()).toBe(DEFAULT_BASE_URL);
+  });
+});

--- a/frontend/src/components/shell/AppBar.tsx
+++ b/frontend/src/components/shell/AppBar.tsx
@@ -24,6 +24,7 @@ export function AppBar() {
   const toggleRail = useUiStore((s) => s.toggleNavRail);
   const setNavSection = useUiStore((s) => s.setNavSection);
   const toggleLegend = useUiStore((s) => s.toggleLegend);
+  const setUiMode = useUiStore((s) => s.setUiMode);
   const sessionId = useUiStore((s) => s.currentSessionId);
   const rpcSessions = useSessionsStore((s) => s.sessions);
   const rpcError = useSessionsStore((s) => s.error);
@@ -69,6 +70,15 @@ export function AppBar() {
         ⌘K
       </span>
       <div className="hg-appbar__spacer" />
+      <button
+        className="hg-appbar__icon-btn"
+        onClick={() => setUiMode('zicato')}
+        aria-label="Switch to zicato console"
+        title="zicato console"
+        data-testid="ui-mode-toggle"
+      >
+        ⧉
+      </button>
       <button
         className="hg-appbar__icon-btn hg-appbar__attention-badge"
         data-count={attention}

--- a/frontend/src/components/shell/views/TrajectoryView.tsx
+++ b/frontend/src/components/shell/views/TrajectoryView.tsx
@@ -530,30 +530,14 @@ export function TrajectoryView() {
   const currentRevisionIndex = currentRev?.revisionIndex ?? revIdx;
   const compareRevisionIndex =
     compareRev?.revisionIndex ?? compareRevIdx ?? null;
-  // Multi-plan awareness for the header (Item 4 of UX cleanup batch).
-  // Compute the distinct plan_ids spanned by ``vm.revs`` — when the
-  // session contains more than one we prefix the rev label with "Plan
-  // {N}" so operators can tell which plan the current revision belongs
-  // to. Plans are numbered by first appearance in the time-sorted rev
-  // list; this composes naturally with the H1 plan picker landing in a
-  // sibling PR (the picker selects a plan and the header reflects which
-  // plan is selected). Single-plan sessions retain the unchanged
-  // "rev N of M" label.
-  const distinctPlanIds: string[] = [];
-  const planIdSeen = new Set<string>();
-  for (const rev of vm.revs) {
-    if (!planIdSeen.has(rev.id)) {
-      planIdSeen.add(rev.id);
-      distinctPlanIds.push(rev.id);
-    }
-  }
-  const multiPlan = distinctPlanIds.length > 1;
-  const currentPlanIndex = currentRev
-    ? distinctPlanIds.indexOf(currentRev.id) + 1
-    : 0;
-  const planPrefix = multiPlan && currentPlanIndex > 0
-    ? `Plan ${currentPlanIndex} · `
-    : '';
+  // Multi-plan identity in the header is conveyed by the plan-picker
+  // chip-bar (rendered for multi-plan sessions — see TrajectoryView.planPicker
+  // test): the selected chip shows which of the session's plans the trajectory
+  // is scoped to, and ``vm`` is scoped to that plan (see buildViewModel above).
+  // An earlier "Plan {N} · " header prefix (#195, written for a merged-trajectory
+  // model) was superseded when the picker (#196) landed — the chips make a
+  // header prefix redundant — so the header stays a plain "rev N of M".
+  const planPrefix = '';
   // Only produce diff marks when the user has explicitly pinned a compare
   // rev — otherwise every task would be flagged "added" against a null prev.
   const marks =

--- a/frontend/src/components/zicato/Brand.tsx
+++ b/frontend/src/components/zicato/Brand.tsx
@@ -1,0 +1,63 @@
+// Brand.tsx — the harmonograf brand lockup for the zicato topbar (+ reuse in the
+// ⌘K picker). JSX port of compose.html 149-157. Pure — no session data.
+//
+//   <BrandMark height={20} />   the α-mark (one period of a 2:3 Lissajous,
+//                               mirrored about the vertical axis → lowercase α)
+//   <Wordmark />                plain mono "harmonograf"
+
+import { hgAlphaPath } from './svgUtils';
+
+export function BrandMark({ height = 24 }: { height?: number }) {
+  return (
+    <svg
+      className="hg-brand-mark"
+      style={{ height: `${height}px` }}
+      viewBox="0 0 48 48"
+      role="img"
+      aria-label="harmonograf"
+      focusable="false"
+    >
+      <path
+        d={hgAlphaPath(24, 24, 19, 15)}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* the one dot rides the lower-right tail tip — the pen at rest. */}
+      <circle cx={43} cy={39} r={3.2} fill="var(--hgraf-brand, #5EA3EC)" />
+    </svg>
+  );
+}
+
+export function Wordmark() {
+  const T = 'harmonograf';
+  const X0 = 1;
+  const ADV = 9.6;
+  const BASE = 15;
+  const W = X0 * 2 + T.length * ADV;
+  return (
+    <svg
+      className="hg-brand-name"
+      viewBox={`0 0 ${W} 18`}
+      role="img"
+      aria-label="harmonograf"
+      focusable="false"
+    >
+      <text
+        x={X0}
+        y={BASE}
+        fontFamily="var(--brand-mono)"
+        fontSize={15}
+        fontWeight={700}
+        textLength={T.length * ADV}
+        lengthAdjust="spacing"
+        fill="currentColor"
+        xmlSpace="preserve"
+      >
+        {T}
+      </text>
+    </svg>
+  );
+}

--- a/frontend/src/components/zicato/ChordZ.tsx
+++ b/frontend/src/components/zicato/ChordZ.tsx
@@ -1,0 +1,347 @@
+// ChordZ.tsx — directional transfer chord on an upper semicircle.
+//
+// Ported from compose.html topoChordSVG (368-419) + wireChord (422-443).
+// Agents sit on an upper-semicircle arc; each gets two concentric arc sectors
+// (outbound SOLID 4.5px non-scaling cap / inbound DASHED). Every directional
+// flow is a THIN gradient-stroked quadratic curve (width min(4, 0.9+√count*1.1),
+// non-scaling) running faint-source → bright-target, tipped by a SMALL SOLID
+// triangle arrowhead at the receiver. Hover (or click-to-pin) an agent to
+// PROJECT its conversations: everything not touching that agent dims, and the
+// count labels for the focused agent's flows appear.
+//
+// Encoding: agent hue (colorVar → --hg-agent-*) drives arcs/ribbons/arrowheads;
+// token-only colors. Gradient <defs> ids are unique per instance via uniqueId.
+//
+// SIGNATURE IS FROZEN — do not change the props.
+
+import { useState, type ReactElement } from 'react';
+import type { ZSession, ZAgent } from './adapter';
+import { colorVar, uniqueId } from './svgUtils';
+
+export interface ChordZProps {
+  z: ZSession;
+  W?: number;
+}
+
+// One tallied directional flow between two displayed-agent indices.
+interface Flow {
+  a: number; // source index into displayed `agents`
+  b: number; // target index into displayed `agents`
+  c: number; // count
+}
+
+// Max agents to seat on the semicircle before it gets unreadable. Counts are
+// tallied across ALL agents but only flows between seated agents are drawn —
+// matching the study, which silently drops flows whose endpoints aren't shown.
+const MAX_ARC_AGENTS = 8;
+
+export function ChordZ({ z, W = 300 }: ChordZProps) {
+  // Focus agent for projection: a pinned agent wins over the hovered one.
+  const [pinned, setPinned] = useState<string | null>(null);
+  const [hovered, setHovered] = useState<string | null>(null);
+  const focus = pinned ?? hovered;
+
+  const H = Math.round(W * 0.82);
+
+  // Seat the first MAX_ARC_AGENTS lanes (adapter already orders join-time,
+  // synthetics included). Empty/loading → arcs-only placeholder, no crash.
+  const agents: ZAgent[] = z.agents.slice(0, MAX_ARC_AGENTS);
+  const n = agents.length;
+
+  if (n === 0) {
+    return (
+      <svg
+        className="fig topo-chord"
+        viewBox={`0 0 ${W} ${H}`}
+        role="img"
+        aria-label={`directional transfer chord — no agents yet · ${z.id}`}
+      >
+        <text x={W / 2} y={H / 2} textAnchor="middle" className="gm-faint">
+          no agents yet
+        </text>
+      </svg>
+    );
+  }
+
+  const idById = new Map<string, number>();
+  agents.forEach((a, i) => idById.set(a.id, i));
+  const idx = (id: string): number =>
+    idById.has(id) ? (idById.get(id) as number) : -1;
+
+  // Tally directional counts (study `bump`): user-message → its agent;
+  // transfers from→to; delegation both ways; agent-message → user.
+  const counts = new Map<string, number>();
+  const bump = (fromIdx: number, toIdx: number): void => {
+    if (fromIdx < 0 || toIdx < 0 || fromIdx === toIdx) return;
+    const k = `${fromIdx}>${toIdx}`;
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  };
+  const userAgent = agents.find((a) => a.synthetic === 'user');
+  const userIdx = userAgent ? idx(userAgent.id) : -1;
+
+  const um = z.spans.find((x) => x.kind === 'user-message');
+  if (um && userIdx >= 0) bump(userIdx, idx(um.agent));
+  for (const tr of z.transfers) bump(idx(tr.from), idx(tr.to));
+  if (z.delegation) {
+    bump(idx(z.delegation.from), idx(z.delegation.to));
+    bump(idx(z.delegation.to), idx(z.delegation.from));
+  }
+  const am = z.spans.find((x) => x.kind === 'agent-message');
+  if (am && userIdx >= 0) bump(idx(am.agent), userIdx);
+
+  const flows: Flow[] = [...counts.entries()].map(([k, c]) => {
+    const [a, b] = k.split('>').map(Number);
+    return { a, b, c };
+  });
+
+  // Geometry (study constants).
+  const cx = W / 2;
+  const cyA = H - 26;
+  const R = W * 0.34;
+  const SECTOR = (Math.PI / n) * 0.74;
+  // Even spread across the upper semicircle; single agent sits at the apex.
+  const ang = (i: number): number => (n === 1 ? Math.PI / 2 : Math.PI - (Math.PI * i) / (n - 1));
+  const onArc = (th: number, r: number): [number, number] => [
+    cx + r * Math.cos(th),
+    cyA - r * Math.sin(th),
+  ];
+
+  // Per-agent outbound/inbound totals (to distribute ribbon anchor angles).
+  const outN = agents.map(() => 0);
+  const inN = agents.map(() => 0);
+  for (const f of flows) {
+    outN[f.a] += f.c;
+    inN[f.b] += f.c;
+  }
+
+  // Projection opacity: dim everything not involving the focused agent.
+  // (port wireChord) — focus is an agent id; flows carry source/target ids.
+  const ribbonOpacity = (fromId: string, toId: string): number | undefined =>
+    !focus || fromId === focus || toId === focus ? undefined : 0.05;
+  const countOpacity = (fromId: string, toId: string): number | undefined =>
+    focus && (fromId === focus || toId === focus) ? 1 : undefined;
+  const agentOpacity = (agentId: string): number | undefined =>
+    !focus || agentId === focus ? undefined : 0.3;
+
+  // ── arc sectors (outbound solid / inbound dashed) ──────────────────────────
+  const arcNodes = agents.map((a, i) => {
+    const th = ang(i);
+    const oA = th + SECTOR / 2;
+    const oB = th + 0.05;
+    const iA = th - 0.05;
+    const iB = th - SECTOR / 2;
+    const arcPath = (thA: number, thB: number): string => {
+      const [xA, yA] = onArc(thA, R);
+      const [xB, yB] = onArc(thB, R);
+      return `M${xA.toFixed(1)},${yA.toFixed(1)} A${R},${R} 0 0 ${
+        thA > thB ? 1 : 0
+      } ${xB.toFixed(1)},${yB.toFixed(1)}`;
+    };
+    const col = colorVar(a);
+    const op = agentOpacity(a.id);
+    return (
+      <g key={`arc-${a.id}`}>
+        {outN[i] > 0 && (
+          <path
+            data-agent={a.id}
+            d={arcPath(oA, oB)}
+            fill="none"
+            stroke={col}
+            strokeWidth={4.5}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+            opacity={op ?? 0.9}
+          />
+        )}
+        {inN[i] > 0 && (
+          <path
+            data-agent={a.id}
+            d={arcPath(iA, iB)}
+            fill="none"
+            stroke={col}
+            strokeWidth={4.5}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+            strokeDasharray="1.5 2.4"
+            opacity={op ?? 0.9}
+          />
+        )}
+      </g>
+    );
+  });
+
+  // ── ribbons + arrowheads + count labels ────────────────────────────────────
+  const outUsed = agents.map(() => 0);
+  const inUsed = agents.map(() => 0);
+  const ribbonNodes: ReactElement[] = [];
+  const countNodes: ReactElement[] = [];
+
+  flows.forEach((flow, fi) => {
+    const { a, b, c } = flow;
+    const ths = ang(a);
+    const thd = ang(b);
+    // Spread multiple flows across each agent's sector so they fan out.
+    const sF = (outUsed[a] + c / 2) / Math.max(outN[a], 1);
+    outUsed[a] += c;
+    const dF = (inUsed[b] + c / 2) / Math.max(inN[b], 1);
+    inUsed[b] += c;
+    const sTh = ths + 0.07 + (SECTOR / 2 - 0.07) * sF;
+    const dTh = thd - 0.07 - (SECTOR / 2 - 0.07) * dF;
+
+    // THIN stroked ribbon: restrained √count, hard-capped, non-scaling.
+    const w = Math.min(4, 0.9 + Math.sqrt(c) * 1.1);
+    const [sx, sy] = onArc(sTh, R - 4);
+    const [dx, dy] = onArc(dTh, R - 6);
+    const tD: [number, number] = [Math.sin(dTh), Math.cos(dTh)];
+    const mid: [number, number] = [
+      (sx + dx) / 2 + (cx - (sx + dx) / 2) * 0.62,
+      (sy + dy) / 2 + (cyA - 34 - (sy + dy) / 2) * 0.5,
+    ];
+    const gid = uniqueId(`tch-${z.id}-${fi}`);
+
+    const fromAgent = agents[a];
+    const toAgent = agents[b];
+    const fromId = fromAgent.id;
+    const toId = toAgent.id;
+    const fromCol = colorVar(fromAgent);
+    const toCol = colorVar(toAgent);
+    const ribbonOp = ribbonOpacity(fromId, toId);
+
+    // small SOLID arrowhead tipping the chord onto the receiver
+    const outward: [number, number] = [Math.cos(dTh), -Math.sin(dTh)];
+    const tip: [number, number] = [dx + outward[0] * 4, dy + outward[1] * 4];
+
+    ribbonNodes.push(
+      <g key={`flow-${fi}`}>
+        <defs>
+          <linearGradient
+            id={gid}
+            x1={sx.toFixed(1)}
+            y1={sy.toFixed(1)}
+            x2={dx.toFixed(1)}
+            y2={dy.toFixed(1)}
+            gradientUnits="userSpaceOnUse"
+          >
+            <stop offset="0" stopColor={fromCol} stopOpacity={0.45} />
+            <stop offset="1" stopColor={toCol} stopOpacity={0.95} />
+          </linearGradient>
+        </defs>
+        <path
+          data-ribbon="1"
+          data-f={fromId}
+          data-t={toId}
+          fill="none"
+          stroke={`url(#${gid})`}
+          strokeWidth={Number(w.toFixed(2))}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+          d={`M${sx.toFixed(1)},${sy.toFixed(1)} Q${mid[0].toFixed(1)},${mid[1].toFixed(
+            1,
+          )} ${dx.toFixed(1)},${dy.toFixed(1)}`}
+          opacity={ribbonOp}
+        >
+          <title>{`${fromAgent.label} → ${toAgent.label} · ${c} (${fromAgent.label} initiates)`}</title>
+        </path>
+        <path
+          data-ahead="1"
+          data-f={fromId}
+          data-t={toId}
+          d={`M${(dx + tD[0] * 1.4).toFixed(1)},${(dy + tD[1] * 1.4).toFixed(
+            1,
+          )} L${tip[0].toFixed(1)},${tip[1].toFixed(1)} L${(dx - tD[0] * 1.4).toFixed(
+            1,
+          )},${(dy - tD[1] * 1.4).toFixed(1)} Z`}
+          fill={toCol}
+          stroke="none"
+          opacity={ribbonOp}
+        />
+      </g>,
+    );
+
+    countNodes.push(
+      <text
+        key={`count-${fi}`}
+        className="tch-count"
+        data-count="1"
+        data-f={fromId}
+        data-t={toId}
+        x={mid[0].toFixed(1)}
+        y={(mid[1] + 3).toFixed(1)}
+        textAnchor="middle"
+        opacity={countOpacity(fromId, toId)}
+      >
+        {c}×
+      </text>,
+    );
+  });
+
+  // ── agent nodes (hover→project / click→pin) ────────────────────────────────
+  const togglePin = (id: string): void =>
+    setPinned((prev) => (prev === id ? null : id));
+
+  const agentNodes = agents.map((a, i) => {
+    const th = ang(i);
+    const [x, y] = onArc(th, R);
+    const [lx, ly] = onArc(th, R + 14);
+    const anc = lx < cx - 10 ? 'end' : lx > cx + 10 ? 'start' : 'middle';
+    return (
+      <g
+        key={`agent-${a.id}`}
+        data-agent={a.id}
+        tabIndex={0}
+        role="button"
+        aria-label={`project ${a.label}'s conversations`}
+        opacity={agentOpacity(a.id)}
+        onMouseEnter={() => {
+          if (!pinned) setHovered(a.id);
+        }}
+        onMouseLeave={() => {
+          if (!pinned) setHovered(null);
+        }}
+        onClick={(e) => {
+          e.stopPropagation();
+          togglePin(a.id);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            togglePin(a.id);
+          }
+        }}
+      >
+        <circle cx={x.toFixed(1)} cy={y.toFixed(1)} r={12} fill="transparent" stroke="none" />
+        <circle cx={x.toFixed(1)} cy={y.toFixed(1)} r={3} fill={colorVar(a)} />
+        <text
+          className="sq-lbl"
+          x={lx.toFixed(1)}
+          y={(ly + (ly < 36 ? -2 : 4)).toFixed(1)}
+          textAnchor={anc}
+          fill="var(--ink)"
+        >
+          {a.label}
+        </text>
+      </g>
+    );
+  });
+
+  return (
+    <svg
+      className="fig topo-chord"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label={`directional transfer chord — who initiates and who receives · ${z.id}`}
+      onClick={() => {
+        // Click on empty SVG ground clears a pin (study svg-level handler).
+        if (pinned) {
+          setPinned(null);
+          setHovered(null);
+        }
+      }}
+    >
+      {arcNodes}
+      {ribbonNodes}
+      {agentNodes}
+      {countNodes}
+    </svg>
+  );
+}

--- a/frontend/src/components/zicato/Fig.tsx
+++ b/frontend/src/components/zicato/Fig.tsx
@@ -9,7 +9,9 @@
 
 import { useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from 'react';
 
-export function useMeasuredWidth(
+// Local (not exported): keeping Fig.tsx exporting only the <Fig> component keeps
+// React Fast Refresh happy (react-refresh/only-export-components).
+function useMeasuredWidth(
   fallback: number,
 ): [RefObject<HTMLDivElement | null>, number] {
   const ref = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/zicato/Fig.tsx
+++ b/frontend/src/components/zicato/Fig.tsx
@@ -1,0 +1,45 @@
+// Fig — render a figure at its container's TRUE pixel width.
+//
+// The zicato figures draw into a fixed viewBox (e.g. `0 0 940 H`) with the SVG
+// at `width:100%`. On a wide pane that upscales the whole drawing — text, bars,
+// strokes — by container/viewBox (≈2× at 1800px), so "everything looks too
+// large". Measuring the container and passing that width as the viewBox width
+// keeps 1 viewBox unit = 1 CSS px, so labels/strokes render at their intended
+// size at any width (the figure still fills the pane horizontally).
+
+import { useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from 'react';
+
+export function useMeasuredWidth(
+  fallback: number,
+): [RefObject<HTMLDivElement | null>, number] {
+  const ref = useRef<HTMLDivElement>(null);
+  const [w, setW] = useState(fallback);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    // jsdom (tests) and very old browsers lack ResizeObserver — fall back to the
+    // provided width so the figure still renders (and the smoke test passes).
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver((entries) => {
+      const cw = entries[0]?.contentRect.width ?? 0;
+      if (cw > 0) setW(Math.round(cw));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  return [ref, w];
+}
+
+export function Fig({
+  fallback = 940,
+  children,
+}: {
+  fallback?: number;
+  children: (w: number) => ReactNode;
+}) {
+  const [ref, w] = useMeasuredWidth(fallback);
+  return (
+    <div ref={ref} style={{ width: '100%' }}>
+      {children(w)}
+    </div>
+  );
+}

--- a/frontend/src/components/zicato/FingerprintZ.tsx
+++ b/frontend/src/components/zicato/FingerprintZ.tsx
@@ -1,0 +1,119 @@
+// FingerprintZ.tsx — the damped Lissajous session "fingerprint".
+//
+// Port of compose.html `fpSVG` (256-266). A damped Lissajous identicon of the
+// session: x = plan progress, y = drift. A tight harmonic knot reads as
+// on-plan; a loose scribble reads as drifting; an outward sweep (grow) reads as
+// diverging scope. The end DOT is the only status-earned mark — `--bad` failed
+// / `--good` done / `--accent` live — so the encoding holds: KIND/identity is
+// the calm currentColor line, STATUS is the single treatment dot.
+//
+// Reused at sizes 30 (⌘K picker rows), 58 (session header), 72 (drawer). The
+// geometry is computed in the fixed 0 0 64 64 viewBox and fit-to-`size`.
+//
+// SIGNATURE IS FROZEN — do not change the props.
+
+import { useMemo } from 'react';
+import type { ZFingerprint, ZSessionStatus } from './adapter';
+
+export interface FingerprintZProps {
+  fp: ZFingerprint;
+  status: ZSessionStatus;
+  id: string;
+  size: number;
+}
+
+const N = 800; // sample count (study fpSVG)
+
+/**
+ * Build the damped-Lissajous path `d` from the fingerprint params. Pure +
+ * deterministic — same params always yield the same curve. Mirrors the study's
+ * `T = o.T || 30` guard so a zero/absent duration can never divide by zero.
+ */
+function fingerprintPath(fp: ZFingerprint): string {
+  const T = fp.T || 30;
+  const d = fp.d || 0;
+  const px = fp.px || 0;
+  const pts: string[] = [];
+  for (let i = 0; i <= N; i++) {
+    const t = (T * i) / N;
+    // m = amplitude modulation. grow → slow outward sweep (divergence);
+    // corrAt → a one-time correction kink that damps the amplitude to .45;
+    // otherwise a steady 1 (the body just rides the exponential damping `d`).
+    const m = fp.grow
+      ? 0.3 + (0.55 * t) / T
+      : fp.corrAt != null
+        ? t < fp.corrAt
+          ? 1
+          : t < fp.corrAt + 3
+            ? 1 - ((t - fp.corrAt) / 3) * 0.55
+            : 0.45
+        : 1;
+    const amp = 24 * m * Math.exp(-d * t);
+    const x = 32 + amp * Math.sin(fp.fx * t + px);
+    const y = 32 + amp * Math.sin(fp.fy * t);
+    pts.push(`${x.toFixed(1)},${y.toFixed(1)}`);
+  }
+  return `M${pts.join(' L')}`;
+}
+
+export function FingerprintZ({ fp, status, id, size }: FingerprintZProps) {
+  // Memoise the 800-point path on the params (FingerprintZ is rendered in
+  // every ⌘K picker row, so recomputing per keystroke would be wasteful).
+  const { d, end } = useMemo(() => {
+    const path = fingerprintPath(fp);
+    const T = fp.T || 30;
+    const damp = fp.d || 0;
+    const px = fp.px || 0;
+    // End point = the last sample (i = N). Recompute it directly rather than
+    // re-parsing the path string.
+    const t = T;
+    const m = fp.grow
+      ? 0.3 + (0.55 * t) / T
+      : fp.corrAt != null
+        ? t < fp.corrAt
+          ? 1
+          : t < fp.corrAt + 3
+            ? 1 - ((t - fp.corrAt) / 3) * 0.55
+            : 0.45
+        : 1;
+    const amp = 24 * m * Math.exp(-damp * t);
+    return {
+      d: path,
+      end: {
+        x: 32 + amp * Math.sin(fp.fx * t + px),
+        y: 32 + amp * Math.sin(fp.fy * t),
+      },
+    };
+  }, [fp]);
+
+  // STATUS = treatment: the single status-earned colour, only on the end dot.
+  const dot =
+    status === 'failed'
+      ? 'var(--bad)'
+      : status === 'done'
+        ? 'var(--good)'
+        : 'var(--accent)';
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      role="img"
+      aria-label={`fingerprint ${id}`}
+      focusable="false"
+    >
+      {/* The identity line — calm, single currentColor hairline. Non-scaling so
+          the 0.9px stroke stays a hairline at size 30 as well as 72. */}
+      <path
+        d={d}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={0.9}
+        opacity={0.7}
+        vectorEffect="non-scaling-stroke"
+      />
+      <circle cx={end.x.toFixed(1)} cy={end.y.toFixed(1)} r={2.4} fill={dot} />
+    </svg>
+  );
+}

--- a/frontend/src/components/zicato/FloatingDrawerZ.tsx
+++ b/frontend/src/components/zicato/FloatingDrawerZ.tsx
@@ -1,0 +1,271 @@
+// FloatingDrawerZ.tsx — the zicato floating detail drawer. A port of the MD3
+// TrajectoryFloatingDrawer (focus-trap + Esc + backdrop + 200ms slide) restyled
+// in the zicato language (Tufte line-art, token-only colours, monospace). It
+// overlays the main area rather than reserving a right column, and surfaces the
+// two kinds of detail this work adds:
+//
+//   * REASONING — the 🧠 chain-of-thought of a selected span, rendered verbatim
+//                 (extractThinkingText output from the adapter's ZSpan).
+//   * STEERING  — a goldfive correction: what triggered it (drift kind +
+//                 severity), what it decided (reason), and the agent/task it
+//                 steered (the ZSteer the user clicked on the Gantt arrow).
+//
+// It is mounted INSIDE the .zk-root subtree (ZicatoConsole) so it inherits the
+// scoped theme and never touches the MD3 console. When `open=false` the drawer
+// unmounts entirely.
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import type { ZSession, ZSpan, ZSteer } from './adapter';
+import { steerColor } from './svgUtils';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function collectFocusable(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+export interface FloatingDrawerZProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+  /** Width override in px. Default 360 (matches the zicato chrome scale). */
+  width?: number;
+  testId?: string;
+}
+
+/**
+ * The bare floating drawer chrome: backdrop + sliding panel + focus trap. The
+ * body content (reasoning / steering) is passed as children so callers compose
+ * exactly what they need.
+ */
+export function FloatingDrawerZ(props: FloatingDrawerZProps): ReactElement | null {
+  const { open, onClose, title, children, width = 360, testId } = props;
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const autoTitleId = useId();
+  const titleId = title ? `${autoTitleId}-title` : undefined;
+
+  // Restore focus on close (WCAG 2.4.3) and move focus into the drawer on open.
+  useEffect(() => {
+    if (!open) return;
+    previousFocusRef.current =
+      (document.activeElement as HTMLElement | null) ?? null;
+    const drawer = drawerRef.current;
+    if (drawer) {
+      const focusables = collectFocusable(drawer);
+      (focusables[0] ?? drawer).focus();
+    }
+    return () => {
+      const prev = previousFocusRef.current;
+      if (prev && typeof prev.focus === 'function') prev.focus();
+      previousFocusRef.current = null;
+    };
+  }, [open]);
+
+  // Esc closes; Tab / Shift-Tab wrap within the drawer.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const drawer = drawerRef.current;
+      if (!drawer) return;
+      const focusables = collectFocusable(drawer);
+      if (focusables.length === 0) {
+        e.preventDefault();
+        drawer.focus();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || !drawer.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [open, onClose]);
+
+  const onBackdropClick = useCallback(
+    (e: ReactMouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        className="zk-fdrawer-backdrop"
+        data-testid={testId ? `${testId}-backdrop` : 'zk-fdrawer-backdrop'}
+        onClick={onBackdropClick}
+        aria-hidden="true"
+      />
+      <div
+        ref={drawerRef}
+        className="zk-fdrawer"
+        data-testid={testId ?? 'zk-fdrawer'}
+        data-open="true"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        style={{ width: `${width}px` }}
+      >
+        <header className="zk-fdrawer-head">
+          <h3 id={titleId} className="zk-fdrawer-title">
+            {title ?? 'detail'}
+          </h3>
+          <button
+            type="button"
+            className="zk-fdrawer-close"
+            onClick={onClose}
+            aria-label="Close"
+            data-testid={testId ? `${testId}-close` : 'zk-fdrawer-close'}
+          >
+            ×
+          </button>
+        </header>
+        <div className="zk-fdrawer-body">{children}</div>
+      </div>
+    </>
+  );
+}
+
+// ── detail bodies ────────────────────────────────────────────────────────────
+
+/** Resolve a lane label from an agent id (falls back to the id itself). */
+function labelOf(z: ZSession, agentId: string): string {
+  return z.agents.find((a) => a.id === agentId)?.label ?? agentId;
+}
+
+export interface ReasoningDetailBodyProps {
+  span: ZSpan;
+  z: ZSession;
+}
+
+/**
+ * The reasoning detail: agent / span identity + the verbatim 🧠 chain-of-thought
+ * (ZSpan.reasoning). Degrades to a placeholder line when the span carries the
+ * has_reasoning flag but no decoded text (large reasoning rides a payload_ref
+ * the zicato console does not fetch).
+ */
+export function ReasoningDetailBody(
+  props: ReasoningDetailBodyProps,
+): ReactElement {
+  const { span, z } = props;
+  return (
+    <div data-testid="zk-reasoning-detail">
+      <div className="zk-detail-kicker">
+        <span className="zk-reasoning-glyph" aria-hidden="true">
+          🧠
+        </span>
+        reasoning · {labelOf(z, span.agent)}
+      </div>
+      <section className="zk-detail-section">
+        <h4>span</h4>
+        <div className="zk-detail-target">{span.label}</div>
+      </section>
+      <section className="zk-detail-section">
+        <div className="zk-reasoning-head">
+          <h4>chain of thought</h4>
+        </div>
+        {span.reasoning ? (
+          <pre className="zk-reasoning" data-testid="zk-reasoning-text">
+            {span.reasoning}
+          </pre>
+        ) : (
+          <div className="zk-reasoning-empty">
+            This span carries reasoning, but the full text was not captured
+            inline (it lives in a payload reference).
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export interface SteeringDetailBodyZProps {
+  steer: ZSteer;
+  z: ZSession;
+}
+
+/**
+ * The steering detail: the three questions the MD3 SteeringDetailPanel answers,
+ * in the zicato language —
+ *   Trigger  — drift kind + severity that goldfive observed.
+ *   Steering — the reason / decision text goldfive published.
+ *   Target   — the agent (+ task) the correction steered.
+ */
+export function SteeringDetailBodyZ(
+  props: SteeringDetailBodyZProps,
+): ReactElement {
+  const { steer, z } = props;
+  const sevTone = steerColor(steer);
+  return (
+    <div data-testid="zk-steering-detail">
+      <div className="zk-detail-kicker" style={{ color: sevTone }}>
+        goldfive steer{steer.revision > 0 ? ` · rev ${steer.revision}` : ''}
+      </div>
+      <section className="zk-detail-section" data-testid="zk-steering-trigger">
+        <h4>trigger</h4>
+        <div className="zk-detail-target">
+          {steer.kind || 'drift'}
+          {steer.severity ? ` (${steer.severity})` : ''}
+        </div>
+      </section>
+      <section className="zk-detail-section" data-testid="zk-steering-steering">
+        <h4>steering</h4>
+        <div className="zk-detail-target">
+          {steer.reason || '(no reason recorded)'}
+        </div>
+      </section>
+      <section className="zk-detail-section" data-testid="zk-steering-target">
+        <h4>target</h4>
+        <div className="zk-detail-target" data-testid="zk-steering-target-agent">
+          <span className="zk-detail-target-label">agent</span>
+          {labelOf(z, steer.to)}
+        </div>
+        {steer.taskId && (
+          <div
+            className="zk-detail-target"
+            data-testid="zk-steering-target-task"
+            style={{ marginTop: 4 }}
+          >
+            <span className="zk-detail-target-label">task</span>
+            <code>{steer.taskId}</code>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/zicato/GanttViewZ.tsx
+++ b/frontend/src/components/zicato/GanttViewZ.tsx
@@ -3,6 +3,7 @@
 
 import { useUiStore } from '../../state/uiStore';
 import type { ZSession } from './adapter';
+import { Fig } from './Fig';
 import { GanttZ } from './GanttZ';
 import { JudgeHeartbeatZ } from './SeismographZ';
 
@@ -17,14 +18,19 @@ export function GanttViewZ({ z }: GanttViewZProps) {
     <>
       <h3>execution — gantt</h3>
       <div className="gantt-click">
-        <GanttZ
-          z={z}
-          selectedSpanId={selectedSpanId}
-          onSpanSelect={(id) => selectSpan(id)}
-        />
+        <Fig>
+          {(w) => (
+            <GanttZ
+              z={z}
+              W={w}
+              selectedSpanId={selectedSpanId}
+              onSpanSelect={(id) => selectSpan(id)}
+            />
+          )}
+        </Fig>
       </div>
       <h3>judge heartbeat</h3>
-      <JudgeHeartbeatZ z={z} />
+      <Fig>{(w) => <JudgeHeartbeatZ z={z} W={w} />}</Fig>
     </>
   );
 }

--- a/frontend/src/components/zicato/GanttViewZ.tsx
+++ b/frontend/src/components/zicato/GanttViewZ.tsx
@@ -1,11 +1,20 @@
 // GanttViewZ.tsx — the hero rail view: the gantt stands alone, full size, with
 // the judge heartbeat underneath. (compose.html mainHybrid gantt branch 714-717.)
+//
+// It owns the zoom/pan VIEWPORT state for the hero gantt: a null view means
+// "fit" (the full [0, T] range, identical to the pre-zoom behaviour); a non-null
+// view is the visible time window. The header carries a − / + / fit toolbar, the
+// GanttZ takes wheel-zoom + drag-pan, and a full-range MinimapZ beneath both
+// shows where the window sits and seeks on click/drag.
 
+import { useState } from 'react';
 import { useUiStore } from '../../state/uiStore';
 import type { ZSession } from './adapter';
 import { Fig } from './Fig';
 import { GanttZ } from './GanttZ';
+import { MinimapZ } from './MinimapZ';
 import { JudgeHeartbeatZ } from './SeismographZ';
+import { fitView, isFit, zoomView, type GanttView } from './ganttViewport';
 
 export interface GanttViewZProps {
   z: ZSession;
@@ -14,21 +23,64 @@ export interface GanttViewZProps {
 export function GanttViewZ({ z }: GanttViewZProps) {
   const selectedSpanId = useUiStore((s) => s.selectedSpanId);
   const selectSpan = useUiStore((s) => s.selectSpan);
+
+  // Viewport state: null = fit (full range). The effective window `eff` is what
+  // every child reads; with view===null it is the full [0, T] so the gantt
+  // renders exactly as it did before zoom existed.
+  const [view, setView] = useState<GanttView | null>(null);
+  const T = z.T > 0 ? z.T : 30;
+  const eff = view ?? fitView(T);
+  const atFit = isFit(eff, T);
+  const center = (eff.t0 + eff.t1) / 2;
+
   return (
     <>
-      <h3>execution — gantt</h3>
+      <div className="zk-gantt-head">
+        <h3>execution — gantt</h3>
+        <div className="zk-zoom" role="group" aria-label="gantt zoom">
+          <button
+            type="button"
+            aria-label="zoom out"
+            title="zoom out"
+            onClick={() => setView(zoomView(eff, 1 / 0.6, center, T))}
+          >
+            −
+          </button>
+          <button
+            type="button"
+            aria-label="zoom in"
+            title="zoom in"
+            onClick={() => setView(zoomView(eff, 0.6, center, T))}
+          >
+            +
+          </button>
+          <button
+            type="button"
+            aria-label="fit to range"
+            title="fit to full range"
+            aria-pressed={atFit}
+            disabled={atFit}
+            onClick={() => setView(null)}
+          >
+            fit
+          </button>
+        </div>
+      </div>
       <div className="gantt-click">
         <Fig>
           {(w) => (
             <GanttZ
               z={z}
               W={w}
+              view={eff}
+              onViewChange={setView}
               selectedSpanId={selectedSpanId}
               onSpanSelect={(id) => selectSpan(id)}
             />
           )}
         </Fig>
       </div>
+      <Fig>{(w) => <MinimapZ z={z} view={eff} onViewChange={setView} W={w} />}</Fig>
       <h3>judge heartbeat</h3>
       <Fig>{(w) => <JudgeHeartbeatZ z={z} W={w} />}</Fig>
     </>

--- a/frontend/src/components/zicato/GanttViewZ.tsx
+++ b/frontend/src/components/zicato/GanttViewZ.tsx
@@ -1,0 +1,30 @@
+// GanttViewZ.tsx — the hero rail view: the gantt stands alone, full size, with
+// the judge heartbeat underneath. (compose.html mainHybrid gantt branch 714-717.)
+
+import { useUiStore } from '../../state/uiStore';
+import type { ZSession } from './adapter';
+import { GanttZ } from './GanttZ';
+import { JudgeHeartbeatZ } from './SeismographZ';
+
+export interface GanttViewZProps {
+  z: ZSession;
+}
+
+export function GanttViewZ({ z }: GanttViewZProps) {
+  const selectedSpanId = useUiStore((s) => s.selectedSpanId);
+  const selectSpan = useUiStore((s) => s.selectSpan);
+  return (
+    <>
+      <h3>execution — gantt</h3>
+      <div className="gantt-click">
+        <GanttZ
+          z={z}
+          selectedSpanId={selectedSpanId}
+          onSpanSelect={(id) => selectSpan(id)}
+        />
+      </div>
+      <h3>judge heartbeat</h3>
+      <JudgeHeartbeatZ z={z} />
+    </>
+  );
+}

--- a/frontend/src/components/zicato/GanttZ.tsx
+++ b/frontend/src/components/zicato/GanttZ.tsx
@@ -47,12 +47,55 @@ export function GanttZ({
 
   // Lanes: mini drops the goldfive lane. Lane order = adapter join-time order.
   const agents = mini ? z.agents.filter((a) => a.synthetic !== 'goldfive') : z.agents;
-  const H = agents.length * rowH + (mini ? 10 : 30);
   const X = (t: number): number => padL + ((W - padL - PAD_R) * t) / T;
 
-  // Per-agent center-y, keyed by agent id. (Study keys Y by name; here by id.)
+  // ── span stacking (MD3 packLanes) ───────────────────────────────────────────
+  // Greedy interval packing: each agent's concurrent spans get distinct sub-
+  // lanes instead of overlapping; the agent's row then grows to fit its lanes.
+  const GAP = 3;
+  const subPitch = bh + GAP;
+  const ROWPAD = mini ? 4 : 10;
+  const laneOf = new Map<string, number>();
+  const laneCount = new Map<string, number>();
+  agents.forEach((a) => {
+    const spans = z.spans
+      .filter((s) => s.agent === a.id)
+      .sort((p, q) => p.t0 - q.t0 || p.t1 - q.t1);
+    const laneEnds: number[] = [];
+    for (const s of spans) {
+      let lane = laneEnds.findIndex((end) => end <= s.t0);
+      if (lane === -1) {
+        lane = laneEnds.length;
+        laneEnds.push(0);
+      }
+      laneEnds[lane] = s.t1;
+      laneOf.set(s.id, lane);
+    }
+    laneCount.set(a.id, Math.max(1, laneEnds.length));
+  });
+
+  // Variable per-agent row geometry; Y keeps the row CENTER (edges/ctx/label).
+  const rowTop = new Map<string, number>();
+  const rowHt = new Map<string, number>();
   const Y = new Map<string, number>();
-  agents.forEach((a, i) => Y.set(a.id, (mini ? 5 : 12) + i * rowH + rowH / 2));
+  let acc = mini ? 5 : 10;
+  agents.forEach((a) => {
+    const h = Math.max(rowH, laneCount.get(a.id)! * subPitch - GAP + ROWPAD);
+    rowTop.set(a.id, acc);
+    rowHt.set(a.id, h);
+    Y.set(a.id, acc + h / 2);
+    acc += h;
+  });
+  const H = acc + (mini ? 5 : 24);
+
+  // y-top of a span's bar within its agent row (centers the lane block).
+  const spanYTop = (sp: ZSpan): number => {
+    const top = rowTop.get(sp.agent);
+    if (top == null) return 0;
+    const blockH = laneCount.get(sp.agent)! * subPitch - GAP;
+    const padTop = (rowHt.get(sp.agent)! - blockH) / 2;
+    return top + padTop + (laneOf.get(sp.id) ?? 0) * subPitch;
+  };
 
   // Empty/loading: render the grid + axis frame so the view never collapses.
   // (The adapter never returns null; an empty session has no agents/spans.)
@@ -116,9 +159,9 @@ export function GanttZ({
             <line
               className="hg-gantt-lane-sep"
               x1={padL}
-              y1={y + rowH / 2 - 2}
+              y1={rowTop.get(a.id)! + rowHt.get(a.id)! - 1}
               x2={W - PAD_R}
-              y2={y + rowH / 2 - 2}
+              y2={rowTop.get(a.id)! + rowHt.get(a.id)! - 1}
               opacity={0.35}
             />
           </g>
@@ -134,8 +177,8 @@ export function GanttZ({
 
       {/* span bars + failed/awaiting glyphs */}
       {z.spans.map((sp) => {
-        const y = Y.get(sp.agent);
-        if (y == null) return null;
+        if (!rowTop.has(sp.agent)) return null;
+        const yTop = spanYTop(sp);
         const x0 = X(sp.t0);
         const w = Math.max(4, X(sp.t1) - x0);
         const fill = statusFill(sp); // failed→--bad, gf→gfVar, else KIND(kind)
@@ -164,7 +207,7 @@ export function GanttZ({
               className={cls}
               data-span={sp.id}
               x={x0}
-              y={y - bh / 2}
+              y={yTop}
               width={w}
               height={bh}
               rx={3}
@@ -188,12 +231,12 @@ export function GanttZ({
               </title>
             </rect>
             {!mini && sp.status === 'failed' && (
-              <text className="hg-gantt-glyph-fail" x={x0 + w - 11} y={y - bh / 2 - 2}>
+              <text className="hg-gantt-glyph-fail" x={x0 + w - 11} y={yTop - 2}>
                 ✕
               </text>
             )}
             {!mini && sp.status === 'awaiting' && (
-              <text className="hg-gantt-glyph-wait" x={x0 + w + 3} y={y + 3.5}>
+              <text className="hg-gantt-glyph-wait" x={x0 + w + 3} y={yTop + bh / 2 + 3.5}>
                 ◷
               </text>
             )}

--- a/frontend/src/components/zicato/GanttZ.tsx
+++ b/frontend/src/components/zicato/GanttZ.tsx
@@ -13,8 +13,9 @@
 import { useEffect, useRef, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react';
 import { useUiStore } from '../../state/uiStore';
 import type { ZSession, ZSpan } from './adapter';
-import { KIND, statusFill, uniqueId } from './svgUtils';
+import { KIND, statusFill, steerColor, uniqueId } from './svgUtils';
 import { fitView, panView, zoomView, type GanttView } from './ganttViewport';
+import { useSteerSelect } from './steerContext';
 
 export interface GanttZProps {
   z: ZSession;
@@ -48,6 +49,9 @@ export function GanttZ({
 }: GanttZProps) {
   // Default selection handler: open the existing inspector drawer.
   const select = onSpanSelect ?? ((id: string) => useUiStore.getState().selectSpan(id));
+  // Steer-arrow click → the console floating drawer (no-op when GanttZ is
+  // rendered outside the console's SteerSelectContext provider, e.g. in tests).
+  const onSteerSelect = useSteerSelect();
 
   // ── layout ─────────────────────────────────────────────────────────────────
   const rowH = compact ? 24 : 30;
@@ -358,6 +362,11 @@ export function GanttZ({
                 ◷
               </text>
             )}
+            {!mini && sp.hasReasoning && (
+              <text className="hg-gantt-glyph-reason" x={x0 + 1} y={yTop - 1.5}>
+                🧠
+              </text>
+            )}
           </g>
         );
       })}
@@ -372,6 +381,44 @@ export function GanttZ({
           spanStart={spanStart}
         />
       )}
+
+      {/* goldfive STEERING corrections: an arrow from the goldfive lane up to the
+          steered agent at the correction time, coloured by severity; click → the
+          floating drawer. Clipped + window-aware like the other time content. */}
+      {!mini &&
+        z.steers.map((st, i) => {
+          const y0 = Y.get(st.from);
+          const y1 = Y.get(st.to);
+          if (y0 == null || y1 == null || st.t < eff.t0 || st.t > eff.t1) return null;
+          const x = X(st.t);
+          const col = steerColor(st);
+          const vs = Math.sign(y1 - y0) || 1;
+          const ya = y0 + vs * 5;
+          const yb = y1 - vs * 5;
+          const mid = ((ya + yb) / 2).toFixed(1);
+          return (
+            <g
+              key={`steer-${i}`}
+              style={{ cursor: 'pointer' }}
+              onClick={() => onSteerSelect(st)}
+            >
+              <path
+                className="hg-gantt-edge is-steer"
+                style={{ stroke: col }}
+                d={`M${x.toFixed(1)},${ya.toFixed(1)} C ${(x + 6).toFixed(1)},${mid} ${(x - 6).toFixed(1)},${mid} ${x.toFixed(1)},${yb.toFixed(1)}`}
+              />
+              <path
+                d={`M${(x - 2.5).toFixed(1)},${(yb - 3 * vs).toFixed(1)} L${x.toFixed(1)},${yb.toFixed(1)} L${(x + 2.5).toFixed(1)},${(yb - 3 * vs).toFixed(1)} Z`}
+                fill={col}
+                stroke="none"
+                opacity={0.92}
+              />
+              <title>
+                {`steer · ${st.kind || 'refine'} → ${a_label(z, st.to)}${st.reason ? ` · ${st.reason}` : ''}`}
+              </title>
+            </g>
+          );
+        })}
 
       {/* now-cursor accent line + cap + label — only when the play-head (clamped
           to the session end T) falls inside the visible window. */}

--- a/frontend/src/components/zicato/GanttZ.tsx
+++ b/frontend/src/components/zicato/GanttZ.tsx
@@ -10,10 +10,11 @@
 // viewBox width = container px (responsive, via <Fig>) so the drawing never
 // upscales; non-scaling strokes.
 
-import { type ReactNode } from 'react';
+import { useEffect, useRef, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react';
 import { useUiStore } from '../../state/uiStore';
 import type { ZSession, ZSpan } from './adapter';
-import { KIND, statusFill } from './svgUtils';
+import { KIND, statusFill, uniqueId } from './svgUtils';
+import { fitView, panView, zoomView, type GanttView } from './ganttViewport';
 
 export interface GanttZProps {
   z: ZSession;
@@ -25,9 +26,15 @@ export interface GanttZProps {
   selectedSpanId?: string | null;
   /** default → useUiStore.getState().selectSpan */
   onSpanSelect?: (spanId: string) => void;
+  /** Visible time window in seconds. Default = fitView(T) → renders as today. */
+  view?: GanttView;
+  /** When set, wheel zooms toward the cursor + pointer-drag pans (else static). */
+  onViewChange?: (v: GanttView) => void;
 }
 
 const PAD_R = 14;
+/** A pointer move under this many px from press is a click (selects), not a drag. */
+const DRAG_THRESHOLD = 4;
 
 export function GanttZ({
   z,
@@ -36,6 +43,8 @@ export function GanttZ({
   mini = false,
   selectedSpanId = null,
   onSpanSelect,
+  view,
+  onViewChange,
 }: GanttZProps) {
   // Default selection handler: open the existing inspector drawer.
   const select = onSpanSelect ?? ((id: string) => useUiStore.getState().selectSpan(id));
@@ -46,9 +55,16 @@ export function GanttZ({
   const bh = mini ? 6 : 12;
   const T = z.T > 0 ? z.T : 30;
 
+  // The visible window. Default = the full range, so with no `view` prop the
+  // figure renders identically to today (X collapses to padL + frac*plotW * t/T).
+  const eff = view ?? fitView(T);
+  const vSpan = eff.t1 - eff.t0 > 0 ? eff.t1 - eff.t0 : T;
+  const plotW = W - padL - PAD_R;
+
   // Lanes: mini drops the goldfive lane. Lane order = adapter join-time order.
   const agents = mini ? z.agents.filter((a) => a.synthetic !== 'goldfive') : z.agents;
-  const X = (t: number): number => padL + ((W - padL - PAD_R) * t) / T;
+  // Time → x over the VISIBLE window. With eff = fitView(T) this is the original.
+  const X = (t: number): number => padL + (plotW * (t - eff.t0)) / vSpan;
 
   // ── span stacking (MD3 packLanes) ───────────────────────────────────────────
   // Greedy interval packing: each agent's concurrent spans get distinct sub-
@@ -126,28 +142,126 @@ export function GanttZ({
     return best;
   };
 
+  // ── interactions: wheel-zoom-toward-cursor + drag-to-pan ─────────────────────
+  // Only active when onViewChange is wired. A drag past DRAG_THRESHOLD suppresses
+  // the trailing span-click so selection still works on a plain click. The svg
+  // ref + getBoundingClientRect map clientX → svg-x → time over the live window.
+  const svgRef = useRef<SVGSVGElement>(null);
+  const interactive = !mini && !!onViewChange;
+  const dragRef = useRef<{
+    startX: number;
+    moved: boolean;
+    view: GanttView;
+  } | null>(null);
+
+  // Wheel-zoom toward the cursor. Attached as a NON-PASSIVE native listener (a
+  // React onWheel is passive in React 19 → preventDefault would no-op + warn), so
+  // the page never scrolls while zooming. The effect re-registers when the view /
+  // handler changes so the closure always reads the current window.
+  useEffect(() => {
+    const el = svgRef.current;
+    if (!el || !interactive || !onViewChange) return;
+    const handler = (e: WheelEvent): void => {
+      e.preventDefault();
+      const rect = el.getBoundingClientRect();
+      if (rect.width <= 0) return;
+      const svgX = ((e.clientX - rect.left) / rect.width) * W;
+      const focusT = eff.t0 + ((svgX - padL) / plotW) * vSpan;
+      // deltaY > 0 (scroll down) → zoom OUT; deltaY < 0 → zoom IN.
+      const factor = e.deltaY > 0 ? 1 / 0.85 : 0.85;
+      onViewChange(zoomView(eff, factor, focusT, T));
+    };
+    el.addEventListener('wheel', handler, { passive: false });
+    return () => el.removeEventListener('wheel', handler);
+  }, [interactive, onViewChange, eff, vSpan, plotW, padL, W, T]);
+
+  const onPointerDown = (e: ReactPointerEvent<SVGSVGElement>): void => {
+    if (!onViewChange || e.button !== 0) return;
+    dragRef.current = { startX: e.clientX, moved: false, view: eff };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e: ReactPointerEvent<SVGSVGElement>): void => {
+    const d = dragRef.current;
+    if (!d || !onViewChange) return;
+    const rect = svgRef.current?.getBoundingClientRect();
+    if (!rect || rect.width <= 0) return;
+    const dxPx = e.clientX - d.startX;
+    if (!d.moved && Math.abs(dxPx) < DRAG_THRESHOLD) return;
+    d.moved = true;
+    // Pan from the drag-start view: dt = -(dxPx in svg units) → window seconds.
+    const dxSvg = (dxPx / rect.width) * W;
+    const dt = -(dxSvg / plotW) * vSpan;
+    onViewChange(panView(d.view, dt, T));
+  };
+
+  const onPointerUp = (e: ReactPointerEvent<SVGSVGElement>): void => {
+    const d = dragRef.current;
+    if (d) {
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        /* capture may already be released */
+      }
+    }
+    // Keep `moved` readable through the trailing click (cleared on next press).
+  };
+
+  // A span click is swallowed when the gesture was a drag (movement past thresh).
+  const selectSpanGuarded = (id: string): void => {
+    if (dragRef.current?.moved) {
+      dragRef.current = null;
+      return;
+    }
+    dragRef.current = null;
+    select(id);
+  };
+
+  // Unique clip id so the time-varying content can't spill into the lane gutter.
+  const clipId = uniqueId(`gantt-${z.id}-${W}-${H}`);
+
   return (
     <svg
+      ref={svgRef}
       className="fig"
       viewBox={`0 0 ${W} ${H}`}
       role="img"
       aria-label={`execution gantt — ${z.id || 'session'}`}
+      style={interactive ? { touchAction: 'none', cursor: 'grab' } : undefined}
+      onPointerDown={interactive ? onPointerDown : undefined}
+      onPointerMove={interactive ? onPointerMove : undefined}
+      onPointerUp={interactive ? onPointerUp : undefined}
+      onPointerCancel={interactive ? onPointerUp : undefined}
     >
-      {/* vertical gridlines + Ns axis labels (non-mini) */}
-      {!mini &&
-        Array.from({ length: 9 }, (_, i) => {
-          const gx = X((T * i) / 8);
-          return (
-            <g key={`grid-${i}`}>
-              <line className="hg-gantt-grid" x1={gx} y1={6} x2={gx} y2={H - 22} />
-              <text className="gm-axis hg-gantt-axis" x={gx - 7} y={H - 8}>
-                {Math.round((T * i) / 8)}s
-              </text>
-            </g>
-          );
-        })}
+      {/* Clip the time-varying content to the plot rect so a zoomed window
+          never draws over the left lane-label gutter. */}
+      <defs>
+        <clipPath id={clipId}>
+          <rect x={padL} y={0} width={Math.max(0, W - PAD_R - padL)} height={H} />
+        </clipPath>
+      </defs>
+      {/* vertical gridlines + Ns axis labels (non-mini). Lines span the visible
+          window so they stay aligned under zoom; clipped to the plot rect.
+          Labels sit BELOW the plot (y=H-8) and are clipped too — that gutter is
+          inside the clip x-range. */}
+      {!mini && (
+        <g clipPath={`url(#${clipId})`}>
+          {Array.from({ length: 9 }, (_, i) => {
+            const t = eff.t0 + (vSpan * i) / 8;
+            const gx = X(t);
+            return (
+              <g key={`grid-${i}`}>
+                <line className="hg-gantt-grid" x1={gx} y1={6} x2={gx} y2={H - 22} />
+                <text className="gm-axis hg-gantt-axis" x={gx - 7} y={H - 8}>
+                  {Math.round(t)}s
+                </text>
+              </g>
+            );
+          })}
+        </g>
+      )}
 
-      {/* lane labels + separators */}
+      {/* lane labels + separators — UNclipped (the left gutter + full-width sep). */}
       {agents.map((a) => {
         const y = Y.get(a.id)!;
         return (
@@ -169,6 +283,9 @@ export function GanttZ({
         );
       })}
 
+      {/* ── time-varying content: clipped to the plot rect so a zoomed window
+          never spills into the lane-label gutter. ─────────────────────────── */}
+      <g clipPath={`url(#${clipId})`}>
       {/* context-window utilisation curve */}
       {ctxPath && (
         <path className="hg-gantt-ctxband-line" d={ctxPath}>
@@ -201,7 +318,7 @@ export function GanttZ({
                 strokeWidth: 1.2,
               }
             : {};
-        const onActivate = (): void => select(sp.id);
+        const onActivate = (): void => selectSpanGuarded(sp.id);
         return (
           <g key={sp.id}>
             <rect
@@ -256,8 +373,12 @@ export function GanttZ({
         />
       )}
 
-      {/* now-cursor accent line + cap + label */}
-      <NowCursor X={X} now={z.now} T={T} H={H} mini={mini} />
+      {/* now-cursor accent line + cap + label — only when the play-head (clamped
+          to the session end T) falls inside the visible window. */}
+      {Math.min(z.now, T) >= eff.t0 && Math.min(z.now, T) <= eff.t1 && (
+        <NowCursor X={X} now={Math.min(z.now, T)} H={H} mini={mini} />
+      )}
+      </g>
     </svg>
   );
 }
@@ -390,14 +511,14 @@ function Edge({ x0, y0, x1, y1, cls, col, tip }: EdgeProps) {
 
 interface NowCursorProps {
   X: (t: number) => number;
+  /** the play-head time, already clamped to the session end. */
   now: number;
-  T: number;
   H: number;
   mini: boolean;
 }
 
-function NowCursor({ X, now, T, H, mini }: NowCursorProps) {
-  const nx = X(Math.min(now, T));
+function NowCursor({ X, now, H, mini }: NowCursorProps) {
+  const nx = X(now);
   return (
     <>
       <line

--- a/frontend/src/components/zicato/GanttZ.tsx
+++ b/frontend/src/components/zicato/GanttZ.tsx
@@ -1,0 +1,393 @@
+// GanttZ.tsx — the hero lane-per-agent Gantt. (compose.html ganttSVG 267-312 +
+// edge/arrowhead 78-81/296-299.) Lanes per agent; spans positioned by time,
+// colored by KIND with STATUS treatment; now-cursor accent line; transfer +
+// delegation edges as span-end→span-start S-curves with SMALL SOLID arrowheads.
+// Clickable spans → inspector (onSpanSelect → useUiStore.selectSpan).
+//
+// KIND = hue (--hg-kind-*), STATUS = treatment (running→accent+breathe via
+// .is-running, failed→--bad+✕, awaiting→wait-for-human dashed stroke+◷,
+// planned→dashed). goldfive spans → --hg-gf-*. THIN line-art, token-only colors,
+// fit-to-width viewBox + non-scaling strokes.
+//
+// SIGNATURE IS FROZEN — do not change the props.
+
+import { type ReactNode } from 'react';
+import { useUiStore } from '../../state/uiStore';
+import type { ZSession, ZSpan } from './adapter';
+import { KIND, statusFill } from './svgUtils';
+
+export interface GanttZProps {
+  z: ZSession;
+  /** mini drops the goldfive lane/axis/labels and uses bh=6. */
+  compact?: boolean;
+  mini?: boolean;
+  selectedSpanId?: string | null;
+  /** default → useUiStore.getState().selectSpan */
+  onSpanSelect?: (spanId: string) => void;
+}
+
+const W = 940;
+const PAD_R = 14;
+
+export function GanttZ({
+  z,
+  compact = false,
+  mini = false,
+  selectedSpanId = null,
+  onSpanSelect,
+}: GanttZProps) {
+  // Default selection handler: open the existing inspector drawer.
+  const select = onSpanSelect ?? ((id: string) => useUiStore.getState().selectSpan(id));
+
+  // ── layout ─────────────────────────────────────────────────────────────────
+  const rowH = compact ? 24 : 30;
+  const padL = mini ? 8 : 76;
+  const bh = mini ? 6 : 12;
+  const T = z.T > 0 ? z.T : 30;
+
+  // Lanes: mini drops the goldfive lane. Lane order = adapter join-time order.
+  const agents = mini ? z.agents.filter((a) => a.synthetic !== 'goldfive') : z.agents;
+  const H = agents.length * rowH + (mini ? 10 : 30);
+  const X = (t: number): number => padL + ((W - padL - PAD_R) * t) / T;
+
+  // Per-agent center-y, keyed by agent id. (Study keys Y by name; here by id.)
+  const Y = new Map<string, number>();
+  agents.forEach((a, i) => Y.set(a.id, (mini ? 5 : 12) + i * rowH + rowH / 2));
+
+  // Empty/loading: render the grid + axis frame so the view never collapses.
+  // (The adapter never returns null; an empty session has no agents/spans.)
+
+  // ── context curve (busiest lane, study draws it on the `coder` row) ──────────
+  // The adapter's z.ctx is the busiest non-synthetic agent's utilisation; place
+  // it on the first non-synthetic lane present (study: coder).
+  const ctxLane = agents.find((a) => a.synthetic === null);
+  let ctxPath: string | null = null;
+  if (!mini && !compact && z.ctx.length > 0 && ctxLane) {
+    const cy = Y.get(ctxLane.id)! + rowH / 2 - 3;
+    let d = `M${X(0)},${cy}`;
+    for (const [t, v] of z.ctx) {
+      if (t <= T) d += ` L${X(t).toFixed(1)},${(cy - v * 9).toFixed(1)}`;
+    }
+    ctxPath = d;
+  }
+
+  // ── edges (transfer + delegation), anchored bar-end → receiver bar-start ─────
+  // spanStart: the receiver's next span starting at/after t (study 295).
+  const spanStart = (agentId: string, t: number): ZSpan | null => {
+    let best: ZSpan | null = null;
+    for (const sp of z.spans) {
+      if (sp.agent !== agentId || !Y.has(sp.agent)) continue;
+      if (sp.t0 >= t - 3 && (!best || sp.t0 < best.t0)) best = sp;
+    }
+    return best;
+  };
+
+  return (
+    <svg
+      className="fig"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label={`execution gantt — ${z.id || 'session'}`}
+    >
+      {/* vertical gridlines + Ns axis labels (non-mini) */}
+      {!mini &&
+        Array.from({ length: 9 }, (_, i) => {
+          const gx = X((T * i) / 8);
+          return (
+            <g key={`grid-${i}`}>
+              <line className="hg-gantt-grid" x1={gx} y1={6} x2={gx} y2={H - 22} />
+              <text className="gm-axis hg-gantt-axis" x={gx - 7} y={H - 8}>
+                {Math.round((T * i) / 8)}s
+              </text>
+            </g>
+          );
+        })}
+
+      {/* lane labels + separators */}
+      {agents.map((a) => {
+        const y = Y.get(a.id)!;
+        return (
+          <g key={`lane-${a.id}`}>
+            {!mini && (
+              <text className="hg-gantt-lane-label" x={6} y={y + 3}>
+                {a.label}
+              </text>
+            )}
+            <line
+              className="hg-gantt-lane-sep"
+              x1={padL}
+              y1={y + rowH / 2 - 2}
+              x2={W - PAD_R}
+              y2={y + rowH / 2 - 2}
+              opacity={0.35}
+            />
+          </g>
+        );
+      })}
+
+      {/* context-window utilisation curve */}
+      {ctxPath && (
+        <path className="hg-gantt-ctxband-line" d={ctxPath}>
+          <title>context window utilisation</title>
+        </path>
+      )}
+
+      {/* span bars + failed/awaiting glyphs */}
+      {z.spans.map((sp) => {
+        const y = Y.get(sp.agent);
+        if (y == null) return null;
+        const x0 = X(sp.t0);
+        const w = Math.max(4, X(sp.t1) - x0);
+        const fill = statusFill(sp); // failed→--bad, gf→gfVar, else KIND(kind)
+        const isPlanned = sp.status === 'planned';
+        const cls =
+          `hg-gantt-bar is-${sp.kind}` +
+          (sp.status === 'running' ? ' is-running' : '') +
+          (sp.status === 'planned' ? ' is-planned' : '') +
+          (sp.status === 'failed' ? ' is-failed' : '') +
+          (sp.status === 'pending' ? ' is-pending' : '') +
+          (sp.status === 'cancelled' ? ' is-cancelled' : '') +
+          (selectedSpanId === sp.id ? ' is-selected' : '');
+        // awaiting → wait-for-human magenta dashed stroke (study inline attrs).
+        const awaitingProps =
+          sp.status === 'awaiting'
+            ? {
+                stroke: KIND('wait-for-human'),
+                strokeDasharray: '3 2',
+                strokeWidth: 1.2,
+              }
+            : {};
+        const onActivate = (): void => select(sp.id);
+        return (
+          <g key={sp.id}>
+            <rect
+              className={cls}
+              data-span={sp.id}
+              x={x0}
+              y={y - bh / 2}
+              width={w}
+              height={bh}
+              rx={3}
+              // planned bars are CSS-driven (rule-soft fill); others get KIND fill.
+              {...(isPlanned ? {} : { fill })}
+              {...awaitingProps}
+              tabIndex={mini ? -1 : 0}
+              role="button"
+              aria-label={`${a_label(z, sp.agent)} · ${sp.label} · ${sp.status}`}
+              onClick={onActivate}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onActivate();
+                }
+              }}
+            >
+              <title>
+                {a_label(z, sp.agent)} · {sp.label} · {fmt(sp.t0)}–{fmt(sp.t1)}s ·{' '}
+                {sp.status}
+              </title>
+            </rect>
+            {!mini && sp.status === 'failed' && (
+              <text className="hg-gantt-glyph-fail" x={x0 + w - 11} y={y - bh / 2 - 2}>
+                ✕
+              </text>
+            )}
+            {!mini && sp.status === 'awaiting' && (
+              <text className="hg-gantt-glyph-wait" x={x0 + w + 3} y={y + 3.5}>
+                ◷
+              </text>
+            )}
+          </g>
+        );
+      })}
+
+      {/* transfer + delegation edges with SMALL SOLID arrowheads */}
+      {!mini && (
+        <Edges
+          z={z}
+          X={X}
+          Y={Y}
+          T={T}
+          spanStart={spanStart}
+        />
+      )}
+
+      {/* now-cursor accent line + cap + label */}
+      <NowCursor X={X} now={z.now} T={T} H={H} mini={mini} />
+    </svg>
+  );
+}
+
+// ── edges ──────────────────────────────────────────────────────────────────
+
+interface EdgesProps {
+  z: ZSession;
+  X: (t: number) => number;
+  Y: Map<string, number>;
+  T: number;
+  spanStart: (agentId: string, t: number) => ZSpan | null;
+}
+
+/**
+ * Transfer + delegation edges. Each edge is a smooth cubic-bezier S anchored on
+ * the source bar edge → the receiver's next span start, with a SMALL SOLID
+ * triangle arrowhead landing on the receiver. (compose.html 296-307.) The
+ * arrowhead is intentionally classless so its presentation attributes hold.
+ */
+function Edges({ z, X, Y, T, spanStart }: EdgesProps) {
+  const parts: ReactNode[] = [];
+
+  // Transfers (z.transfers, derived in the adapter from the edge set).
+  z.transfers.forEach((tr, i) => {
+    const y0 = Y.get(tr.from);
+    const y1 = Y.get(tr.to);
+    if (y0 == null || y1 == null || tr.t > T) return;
+    const dst = spanStart(tr.to, tr.t);
+    parts.push(
+      <Edge
+        key={`tr-${i}`}
+        x0={X(tr.t)}
+        y0={y0}
+        x1={X(dst ? dst.t0 : tr.t)}
+        y1={y1}
+        cls=" is-transfer"
+        col="var(--hg-kind-transfer)"
+        tip={`transfer ${labelOf(z, tr.from)} → ${labelOf(z, tr.to)} · ${fmt(tr.t)}s`}
+      />,
+    );
+  });
+
+  // A single delegation block (out + rejoin), if present.
+  const d = z.delegation;
+  if (d) {
+    const yFrom = Y.get(d.from);
+    const yTo = Y.get(d.to);
+    const out = spanStart(d.to, d.t0);
+    if (yFrom != null && yTo != null && out && d.t0 < T) {
+      parts.push(
+        <Edge
+          key="dlg-out"
+          x0={X(d.t0)}
+          y0={yFrom}
+          x1={X(out.t0)}
+          y1={yTo}
+          cls=""
+          col="var(--ink-soft)"
+          tip={`delegate → ${labelOf(z, d.to)}${d.tokens != null ? ` · ${d.tokens} tok` : ''}`}
+        />,
+        <Edge
+          key="dlg-rejoin"
+          x0={X(Math.min(out.t1, T))}
+          y0={yTo}
+          x1={X(Math.min(d.t1, T))}
+          y1={yFrom}
+          cls=""
+          col="var(--ink-soft)"
+          tip={`rejoin${d.verdict ? ` · ${d.verdict}` : ''}`}
+        />,
+      );
+      parts.push(
+        <text
+          key="dlg-ok"
+          x={X(Math.min(d.t1, T)) + 3}
+          y={yFrom + 16}
+          fontSize={9}
+          fill="var(--good)"
+        >
+          ✓
+        </text>,
+      );
+    }
+  }
+
+  return <>{parts}</>;
+}
+
+interface EdgeProps {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+  cls: string;
+  col: string;
+  tip: string;
+}
+
+/** One S-curve edge + its small solid arrowhead. (compose.html 296-299.) */
+function Edge({ x0, y0, x1, y1, cls, col, tip }: EdgeProps) {
+  const vs = Math.sign(y1 - y0) || 1;
+  const ya = y0 + vs * 5;
+  const yb = y1 - vs * 5;
+  const dx = Math.max(10, Math.abs(x1 - x0) * 0.5);
+  const ad = x1 >= x0 ? 1 : -1;
+  return (
+    <>
+      <path
+        className={`hg-gantt-edge${cls}`}
+        d={`M${x0.toFixed(1)},${ya.toFixed(1)} C ${(x0 + dx).toFixed(1)},${ya.toFixed(
+          1,
+        )} ${(x1 - dx).toFixed(1)},${yb.toFixed(1)} ${x1.toFixed(1)},${yb.toFixed(1)}`}
+      >
+        <title>{tip}</title>
+      </path>
+      <path
+        d={`M${(x1 - 3 * ad).toFixed(1)},${(yb - 1.4).toFixed(1)} L${x1.toFixed(
+          1,
+        )},${yb.toFixed(1)} L${(x1 - 3 * ad).toFixed(1)},${(yb + 1.4).toFixed(1)} Z`}
+        fill={col}
+        stroke="none"
+        opacity={0.85}
+      />
+    </>
+  );
+}
+
+// ── now cursor ───────────────────────────────────────────────────────────────
+
+interface NowCursorProps {
+  X: (t: number) => number;
+  now: number;
+  T: number;
+  H: number;
+  mini: boolean;
+}
+
+function NowCursor({ X, now, T, H, mini }: NowCursorProps) {
+  const nx = X(Math.min(now, T));
+  return (
+    <>
+      <line
+        className="hg-gantt-now"
+        x1={nx}
+        y1={4}
+        x2={nx}
+        y2={H - (mini ? 6 : 22)}
+      />
+      {!mini && (
+        <>
+          <circle className="hg-gantt-now-cap" cx={nx} cy={4} r={2.5} />
+          <text className="hg-gantt-now-label" x={nx + 5} y={11}>
+            now {fmt(now)}s
+          </text>
+        </>
+      )}
+    </>
+  );
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Trim trailing `.0` so the tooltip reads like the study (`16s`, not `16.0s`). */
+function fmt(t: number): string {
+  return Number.isInteger(t) ? String(t) : t.toFixed(1);
+}
+
+/** Resolve a lane label from an agent id (falls back to the id itself). */
+function labelOf(z: ZSession, agentId: string): string {
+  return z.agents.find((a) => a.id === agentId)?.label ?? agentId;
+}
+
+/** Alias kept for the span aria-label call site (readability). */
+function a_label(z: ZSession, agentId: string): string {
+  return labelOf(z, agentId);
+}

--- a/frontend/src/components/zicato/GanttZ.tsx
+++ b/frontend/src/components/zicato/GanttZ.tsx
@@ -7,9 +7,8 @@
 // KIND = hue (--hg-kind-*), STATUS = treatment (running→accent+breathe via
 // .is-running, failed→--bad+✕, awaiting→wait-for-human dashed stroke+◷,
 // planned→dashed). goldfive spans → --hg-gf-*. THIN line-art, token-only colors,
-// fit-to-width viewBox + non-scaling strokes.
-//
-// SIGNATURE IS FROZEN — do not change the props.
+// viewBox width = container px (responsive, via <Fig>) so the drawing never
+// upscales; non-scaling strokes.
 
 import { type ReactNode } from 'react';
 import { useUiStore } from '../../state/uiStore';
@@ -18,6 +17,8 @@ import { KIND, statusFill } from './svgUtils';
 
 export interface GanttZProps {
   z: ZSession;
+  /** viewBox width in px (pass the measured container width from <Fig>). */
+  W?: number;
   /** mini drops the goldfive lane/axis/labels and uses bh=6. */
   compact?: boolean;
   mini?: boolean;
@@ -26,11 +27,11 @@ export interface GanttZProps {
   onSpanSelect?: (spanId: string) => void;
 }
 
-const W = 940;
 const PAD_R = 14;
 
 export function GanttZ({
   z,
+  W = 940,
   compact = false,
   mini = false,
   selectedSpanId = null,

--- a/frontend/src/components/zicato/InstrumentsViewZ.tsx
+++ b/frontend/src/components/zicato/InstrumentsViewZ.tsx
@@ -1,0 +1,79 @@
+// InstrumentsViewZ.tsx — everything that is NOT the gantt, coalesced into one
+// mission-control scroll: THE PLAN LEADS (reel → DAG), then conversation +
+// topology side-by-side, then ONE coordinated time-track stack (drift+judge
+// seismograph over the time-aligned intervention ladder).
+// (compose.html mainHybrid instruments branch 718-735.)
+
+import type { ZSession } from './adapter';
+import { FingerprintZ } from './FingerprintZ';
+import { PlanZ } from './PlanZ';
+import { SequenceZ } from './SequenceZ';
+import { ChordZ } from './ChordZ';
+import { SeismographZ } from './SeismographZ';
+import { LadderZ } from './LadderZ';
+
+export interface InstrumentsViewZProps {
+  z: ZSession;
+}
+
+function statusLabel(z: ZSession): string {
+  if (z.status === 'live') return 'live';
+  if (z.status === 'done') return '✓ done';
+  return '✕ failed';
+}
+
+export function InstrumentsViewZ({ z }: InstrumentsViewZProps) {
+  return (
+    <>
+      <div className="zk-sess-head">
+        <FingerprintZ fp={z.fp} status={z.status} id={z.id} size={58} />
+        <div>
+          <div className="zk-sess-title">{z.id || 'session'}</div>
+          <div style={{ fontSize: 11, color: 'var(--ink-faint)' }}>{z.goal}</div>
+        </div>
+        <span style={{ flex: 1 }} />
+        <span className="zk-sess-stats">
+          <span
+            className={`dn-pill ${
+              z.status === 'live' ? 'accent' : z.status === 'done' ? 'good' : 'bad'
+            }`}
+          >
+            {statusLabel(z)}
+          </span>
+          <span className="dn-pill flat tnum">{z.spans.length} spans</span>
+          <span className="dn-pill flat tnum">{Math.round(z.now)}s</span>
+        </span>
+      </div>
+
+      <PlanZ z={z} />
+
+      <div className="zk-panes-2">
+        <div className="gantt-click">
+          <h3>sequence — who said what to whom, when</h3>
+          <SequenceZ z={z} W={520} H={380} />
+        </div>
+        <div>
+          <h3>topology — who initiates, who receives</h3>
+          <ChordZ z={z} W={300} />
+          <p
+            className="zk-prop-note"
+            style={{ margin: '6px 2px 0', lineHeight: 1.5 }}
+          >
+            hover an agent to <b>project</b> its conversations (click to pin · click
+            away to clear) · ribbon width grows with √count and caps, so heavy
+            traffic can never flood the figure
+          </p>
+        </div>
+      </div>
+
+      <h3>drift seismograph + judge heartbeat — one instrument, one time axis</h3>
+      <div className="track-stack">
+        <SeismographZ z={z} W={940} axis={false} />
+        <div className="track-sub">
+          interventions, time-aligned beneath the drift above ↓
+        </div>
+        <LadderZ z={z} W={940} />
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/zicato/InstrumentsViewZ.tsx
+++ b/frontend/src/components/zicato/InstrumentsViewZ.tsx
@@ -5,6 +5,7 @@
 // (compose.html mainHybrid instruments branch 718-735.)
 
 import type { ZSession } from './adapter';
+import { Fig } from './Fig';
 import { FingerprintZ } from './FingerprintZ';
 import { PlanZ } from './PlanZ';
 import { SequenceZ } from './SequenceZ';
@@ -45,16 +46,16 @@ export function InstrumentsViewZ({ z }: InstrumentsViewZProps) {
         </span>
       </div>
 
-      <PlanZ z={z} />
+      <Fig>{(w) => <PlanZ z={z} W={w} />}</Fig>
 
       <div className="zk-panes-2">
         <div className="gantt-click">
           <h3>sequence — who said what to whom, when</h3>
-          <SequenceZ z={z} W={520} H={380} />
+          <Fig fallback={520}>{(w) => <SequenceZ z={z} W={w} H={380} />}</Fig>
         </div>
         <div>
           <h3>topology — who initiates, who receives</h3>
-          <ChordZ z={z} W={300} />
+          <Fig fallback={300}>{(w) => <ChordZ z={z} W={Math.min(w, 460)} />}</Fig>
           <p
             className="zk-prop-note"
             style={{ margin: '6px 2px 0', lineHeight: 1.5 }}
@@ -68,11 +69,11 @@ export function InstrumentsViewZ({ z }: InstrumentsViewZProps) {
 
       <h3>drift seismograph + judge heartbeat — one instrument, one time axis</h3>
       <div className="track-stack">
-        <SeismographZ z={z} W={940} axis={false} />
+        <Fig>{(w) => <SeismographZ z={z} W={w} axis={false} />}</Fig>
         <div className="track-sub">
           interventions, time-aligned beneath the drift above ↓
         </div>
-        <LadderZ z={z} W={940} />
+        <Fig>{(w) => <LadderZ z={z} W={w} />}</Fig>
       </div>
     </>
   );

--- a/frontend/src/components/zicato/LadderZ.tsx
+++ b/frontend/src/components/zicato/LadderZ.tsx
@@ -1,0 +1,128 @@
+// LadderZ.tsx — the intervention ladder, time-LOCKED to SeismographZ (same z + W
+// → identical timeScale padL/padR/X, and the SAME 4-gridline domain), so a
+// rung-dot at time t sits directly beneath the drift reading at t in the
+// seismograph stacked above it.
+//
+// Ported from compose.html ladderSVG (520-535). 4 rungs nudge/refine/replan/
+// escalate (rungY(i)=96-i*25); a dashed connector path through z.ladder; dots
+// --bad on the escalate rung (3) else --ink-soft. Empty z.ladder → italic
+// "never left the ground" empty state.
+//
+// SIGNATURE IS FROZEN — do not change the props.
+
+import { type ReactNode } from 'react';
+import { timeScale } from './svgUtils';
+import type { ZSession } from './adapter';
+
+export interface LadderZProps {
+  z: ZSession;
+  W?: number;
+}
+
+const RUNGS = ['nudge', 'refine', 'replan', 'escalate'] as const;
+const rungY = (i: number): number => 96 - i * 25;
+
+export function LadderZ({ z, W = 940 }: LadderZProps) {
+  const H = 124;
+  const { padL, padR, X } = timeScale(z.T, W);
+  const dots = z.ladder;
+
+  // Shared x-domain gridlines — match the seismograph's 4-division grid so the
+  // ladder reads on the same time axis. Top of grid stops just above rung 3.
+  const gridLines: ReactNode[] = [];
+  const axisLabels: ReactNode[] = [];
+  for (let i = 0; i <= 4; i++) {
+    const gx = X((z.T * i) / 4);
+    gridLines.push(
+      <line
+        key={`g${i}`}
+        className="hg-gantt-grid"
+        x1={gx}
+        y1={2}
+        x2={gx}
+        y2={rungY(3) - 6}
+        opacity={0.5}
+      />,
+    );
+    axisLabels.push(
+      <text key={`gl${i}`} className="gm-axis" x={gx - 7} y={H - 4}>
+        {Math.round((z.T * i) / 4)}s
+      </text>,
+    );
+  }
+
+  // The four rung baselines + their left-hand labels.
+  const rungs: ReactNode[] = [];
+  RUNGS.forEach((r, i) => {
+    const y = rungY(i);
+    rungs.push(
+      <line
+        key={`r${i}`}
+        x1={padL}
+        y1={y}
+        x2={W - padR}
+        y2={y}
+        stroke="var(--rule)"
+        strokeWidth={1}
+        vectorEffect="non-scaling-stroke"
+      />,
+      <text key={`rl${i}`} className="gm-faint" x={8} y={y + 3}>
+        {r}
+      </text>,
+    );
+  });
+
+  // The dashed connector through the intervention dots (only when >1 reading).
+  const connector =
+    dots.length > 1 ? (
+      <path
+        d={dots
+          .map(([t, rung], i) => `${i ? 'L' : 'M'}${X(t).toFixed(1)},${rungY(rung).toFixed(1)}`)
+          .join(' ')}
+        fill="none"
+        stroke="var(--ink-faint)"
+        strokeWidth={0.8}
+        strokeDasharray="2 3"
+        opacity={0.7}
+        vectorEffect="non-scaling-stroke"
+      />
+    ) : null;
+
+  // The dots themselves: --bad on the escalate rung (3), else --ink-soft.
+  const dotNodes: ReactNode[] = dots.map(([t, rung], i) => (
+    <circle
+      key={`d${i}`}
+      cx={X(t)}
+      cy={rungY(rung)}
+      r={3.2}
+      fill={rung === 3 ? 'var(--bad)' : 'var(--ink-soft)'}
+    >
+      <title>{`${RUNGS[rung] ?? 'intervention'} @ ${Math.round(t)}s`}</title>
+    </circle>
+  ));
+
+  return (
+    <svg
+      className="fig"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label={`intervention ladder (time-aligned to the seismograph) — ${z.id}`}
+    >
+      {gridLines}
+      {rungs}
+      {connector}
+      {dotNodes}
+      {dots.length === 0 && (
+        <text
+          className="gm-faint"
+          x={padL + 10}
+          y={rungY(0) - 8}
+          fontStyle="italic"
+        >
+          no interventions — never left the ground
+        </text>
+      )}
+      {axisLabels}
+    </svg>
+  );
+}

--- a/frontend/src/components/zicato/MinimapZ.tsx
+++ b/frontend/src/components/zicato/MinimapZ.tsx
@@ -1,0 +1,212 @@
+// MinimapZ.tsx — the zicato-language port of Gantt/Minimap.tsx: a compact,
+// full-timeline overview of the session strip beneath the hero GanttZ. It draws
+// the WHOLE session range [0, T] (never the zoomed window) so the user always
+// sees where the current viewport sits within the run.
+//
+// Encoding (Tufte / line-art, token-only colour — matches the rest of the
+// zicato chrome):
+//   • one thin row per z.agent; every span a small rect coloured by statusFill
+//     (the SAME KIND-hue / gf / --bad encoding the hero gantt uses).
+//   • a translucent --accent VIEWPORT rectangle from mmX(view.t0)..mmX(view.t1)
+//     with crisp left/right edge strokes — the "you are here" indicator.
+//   • a faint baseline time axis.
+//
+// Interaction: click OR drag anywhere recenters the main window on the pointer
+// time, KEEPING the current width, via onViewChange(panView(...)). The pointer
+// time is mapped through an svg ref + getBoundingClientRect, mirroring GanttZ's
+// clientX→time math but over the full [0, T] domain.
+//
+// It is rendered inside <Fig> by GanttViewZ, so it accepts a MEASURED W (1:1,
+// no upscaling) exactly like GanttZ. Signatures are part of the frozen contract.
+
+import { useRef, type PointerEvent as ReactPointerEvent } from 'react';
+import type { ZSession } from './adapter';
+import { statusFill } from './svgUtils';
+import { panView, type GanttView } from './ganttViewport';
+
+export interface MinimapZProps {
+  z: ZSession;
+  /** the CURRENT visible window (= GanttViewZ's eff). The viewport rect tracks it. */
+  view: GanttView;
+  /** recenter the main window on a pointer time (keeps width) via panView. */
+  onViewChange: (v: GanttView) => void;
+  /** viewBox width in px (measured container width from <Fig>). */
+  W?: number;
+}
+
+// Plot frame — narrow gutter (the minimap carries no lane labels), matched to
+// the hero PAD_R so the right edges line up under the gantt above.
+const PAD_L = 8;
+const PAD_R = 14;
+const ROW_H = 6; // px per agent row
+const ROW_GAP = 2; // px between agent rows
+const TOP = 5; // px above the first row
+const AXIS_H = 12; // px reserved for the baseline time axis
+
+export function MinimapZ({ z, view, onViewChange, W = 940 }: MinimapZProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const draggingRef = useRef(false);
+
+  const T = z.T > 0 ? z.T : 30;
+  const agents = z.agents;
+  const plotW = W - PAD_L - PAD_R;
+
+  // Full-range time → x. The minimap ALWAYS spans [0, T] (it is the overview),
+  // independent of the zoomed `view`.
+  const mmX = (t: number): number => PAD_L + (plotW * t) / T;
+
+  // Row geometry. Keep a sane minimum height so an empty/agent-less session
+  // still draws a frame + axis instead of collapsing.
+  const rowsH = agents.length > 0 ? agents.length * (ROW_H + ROW_GAP) - ROW_GAP : ROW_H;
+  const H = TOP + rowsH + AXIS_H;
+  const rowTop = (i: number): number => TOP + i * (ROW_H + ROW_GAP);
+  const agentRow = new Map<string, number>();
+  agents.forEach((a, i) => agentRow.set(a.id, i));
+
+  // ── pointer → time, then recenter the window on it (keeping its width) ───────
+  // Map clientX → svg-x → time over the FULL [0, T] domain (mirrors GanttZ's
+  // mapping but with view fixed to fit). A click and a drag both seek: pan the
+  // current window so its CENTER lands on the pointer time.
+  const seekToClientX = (clientX: number): void => {
+    const rect = svgRef.current?.getBoundingClientRect();
+    if (!rect || rect.width <= 0) return;
+    const svgX = ((clientX - rect.left) / rect.width) * W;
+    const targetT = (plotW > 0 ? (svgX - PAD_L) / plotW : 0) * T;
+    const center = (view.t0 + view.t1) / 2;
+    onViewChange(panView(view, targetT - center, T));
+  };
+
+  const onPointerDown = (e: ReactPointerEvent<SVGSVGElement>): void => {
+    if (e.button !== 0) return;
+    draggingRef.current = true;
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      /* capture may be unavailable (jsdom) */
+    }
+    seekToClientX(e.clientX);
+  };
+
+  const onPointerMove = (e: ReactPointerEvent<SVGSVGElement>): void => {
+    if (!draggingRef.current) return;
+    seekToClientX(e.clientX);
+  };
+
+  const onPointerUp = (e: ReactPointerEvent<SVGSVGElement>): void => {
+    draggingRef.current = false;
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {
+      /* capture may already be released */
+    }
+  };
+
+  // ── viewport indicator geometry (clamped into the plot rect) ─────────────────
+  const vx0 = Math.max(PAD_L, mmX(Math.max(0, Math.min(T, view.t0))));
+  const vx1 = Math.min(W - PAD_R, mmX(Math.max(0, Math.min(T, view.t1))));
+  const vw = Math.max(1, vx1 - vx0);
+  const axisY = H - AXIS_H + 4;
+
+  return (
+    <svg
+      ref={svgRef}
+      className="fig zk-minimap"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label={`gantt minimap — ${z.id || 'session'}`}
+      style={{ touchAction: 'none', cursor: 'pointer' }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+    >
+      {/* per-agent rows: a faint row track + every span as a small rect coloured
+          by statusFill (the same KIND-hue / gf / --bad encoding as the hero). */}
+      {agents.map((a, i) => {
+        const y = rowTop(i);
+        return (
+          <g key={`mm-row-${a.id}`}>
+            <rect
+              className="zk-mm-track"
+              x={PAD_L}
+              y={y}
+              width={Math.max(0, plotW)}
+              height={ROW_H}
+              fill="var(--rule-soft)"
+              opacity={0.5}
+            />
+            {z.spans.map((sp) => {
+              if (sp.agent !== a.id) return null;
+              const t0 = Math.max(0, Math.min(T, sp.t0));
+              const t1 = Math.max(t0, Math.min(T, sp.t1));
+              const x = mmX(t0);
+              const w = Math.max(1, mmX(t1) - x);
+              return (
+                <rect
+                  key={`mm-${sp.id}`}
+                  className="zk-mm-span"
+                  x={x}
+                  y={y}
+                  width={w}
+                  height={ROW_H}
+                  fill={statusFill(sp)}
+                  opacity={sp.status === 'cancelled' ? 0.35 : 0.85}
+                />
+              );
+            })}
+          </g>
+        );
+      })}
+
+      {/* faint baseline time axis across the full range. */}
+      <line
+        className="hg-gantt-grid"
+        x1={PAD_L}
+        y1={axisY}
+        x2={W - PAD_R}
+        y2={axisY}
+        opacity={0.7}
+      />
+
+      {/* the --accent viewport rectangle: translucent fill + crisp edge strokes.
+          Drawn last so it sits above the span rects. */}
+      <rect
+        className="zk-mm-viewport"
+        x={vx0}
+        y={TOP - 2}
+        width={vw}
+        height={rowsH + 4}
+        fill="var(--accent)"
+        fillOpacity={0.14}
+        stroke="none"
+      >
+        <title>{`viewport · ${fmt(view.t0)}–${fmt(view.t1)}s of ${fmt(T)}s`}</title>
+      </rect>
+      <line
+        className="zk-mm-viewport-edge"
+        x1={vx0}
+        y1={TOP - 2}
+        x2={vx0}
+        y2={TOP + rowsH + 2}
+        stroke="var(--accent)"
+        strokeWidth={1}
+        vectorEffect="non-scaling-stroke"
+      />
+      <line
+        className="zk-mm-viewport-edge"
+        x1={vx1}
+        y1={TOP - 2}
+        x2={vx1}
+        y2={TOP + rowsH + 2}
+        stroke="var(--accent)"
+        strokeWidth={1}
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}
+
+/** Trim trailing `.0` so the tooltip reads like the rest of zicato (`16s`). */
+function fmt(t: number): string {
+  return Number.isInteger(t) ? String(t) : t.toFixed(1);
+}

--- a/frontend/src/components/zicato/PlanZ.tsx
+++ b/frontend/src/components/zicato/PlanZ.tsx
@@ -1,0 +1,413 @@
+// PlanZ.tsx — the plan block: ReelZ (version timeline) over DagZ (dependency
+// DAG). The version reel (v0…vN, replan-trigger seams) DRIVES the DAG —
+// selecting a revision redraws that version: tasks added at the revision show an
+// accent ○, tasks dropped since the prior revision show as dashed ghosts, and
+// the critical path is the accent spine.
+//
+// Ported from compose.html reelSVG (578-598) + wireReel (461-467) +
+// dagSVG (540-572). Two deltas from the study mock:
+//   • the adapter's ZPlanNode carries ABSOLUTE pixel x/y (already laid into the
+//     LX/LY grid), and ZPlanEdge references task ids — not array indices — so we
+//     look nodes up by tid rather than re-projecting columns/rows here;
+//   • the adapter already reframes node.st to 'added'/'ghost' for the selected
+//     revision (buildPlan), so DagZ renders straight off node.st rather than
+//     re-deriving the present/added/dropped role() the study computed in-renderer.
+//
+// selectedRevision ← useUiStore.selectedRevision; onSelect → setSelectedRevision
+// (SHARED with the MD3 trajectory view, so both consoles auto-sync). Task node
+// click → useUiStore.getState().selectTask(taskId).
+//
+// SIGNATURE IS FROZEN — do not change the props.
+
+import { useUiStore } from '../../state/uiStore';
+import type { ZPlan, ZPlanNode, ZSession, ZStratum } from './adapter';
+
+export interface PlanZProps {
+  z: ZSession;
+}
+
+// DAG node box geometry (compose.html dagSVG 540).
+const BW = 118;
+const BH = 24;
+
+export function PlanZ({ z }: PlanZProps) {
+  const selectedRevision = useUiStore((s) => s.selectedRevision);
+  const setSelectedRevision = useUiStore((s) => s.setSelectedRevision);
+  const plan = z.plan;
+
+  if (plan.planId == null || plan.nodes.length === 0) {
+    // Graceful fallback — never crash on an empty / loading session.
+    return (
+      <svg
+        className="fig plan-reel"
+        viewBox="0 0 940 60"
+        role="img"
+        aria-label={`plan ${z.id} — no plan yet`}
+      >
+        <text className="gm-faint" x={12} y={34}>
+          no plan yet
+        </text>
+      </svg>
+    );
+  }
+
+  return (
+    <div>
+      <ReelZ
+        plan={plan}
+        selectedRevision={selectedRevision}
+        onSelectRevision={setSelectedRevision}
+      />
+      <DagZ plan={plan} selectedRevision={selectedRevision} />
+    </div>
+  );
+}
+
+// ── ReelZ — the version timeline (drives the DAG) ────────────────────────────
+// compose.html reelSVG 578-598 + wireReel 461-467. Generalised from the study's
+// fixed 4 stops to the real revision count: stops read OLDEST→NEWEST left to
+// right, while plan.strata is stored NEWEST-FIRST, so we reverse for display.
+// `plan.rem` is OLDEST→NEWEST (aligns with the reversed strata order).
+
+interface ReelZProps {
+  plan: ZPlan;
+  selectedRevision: number | null;
+  onSelectRevision: (rev: number | null) => void;
+}
+
+function ReelZ({ plan, selectedRevision, onSelectRevision }: ReelZProps) {
+  const W = 940;
+  const H = 92;
+  // OLDEST→NEWEST for display (strata is stored newest-first).
+  const ordered: ZStratum[] = [...plan.strata].reverse();
+  const n = ordered.length;
+  if (n === 0) {
+    return (
+      <svg
+        className="fig plan-reel"
+        viewBox={`0 0 ${W} ${H}`}
+        role="img"
+        aria-label="plan reel — no revisions"
+      >
+        <text className="gm-faint" x={12} y={50}>
+          single plan · no revisions
+        </text>
+      </svg>
+    );
+  }
+
+  // Evenly spaced stops across the spine. With a single stop, centre it; with
+  // many, span 0.12 → 0.88 of the width (matches the study's spread).
+  const f0 = 0.12;
+  const f1 = 0.88;
+  const xAt = (i: number): number =>
+    n === 1 ? Math.round(W * 0.5) : Math.round(W * (f0 + ((f1 - f0) * i) / (n - 1)));
+  const xs = ordered.map((_, i) => xAt(i));
+
+  const pick = (s: ZStratum): void => {
+    // Toggle off when re-selecting the live revision (matches MD3 'latest' = null).
+    const next = s.live && selectedRevision === s.v ? null : s.v;
+    onSelectRevision(next);
+  };
+
+  return (
+    <svg
+      className="fig plan-reel"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label="plan reel — click a version to drive the DAG"
+    >
+      {/* the accent spine */}
+      {n > 1 && (
+        <line className="gm-spine" x1={xs[0]} y1={50} x2={xs[n - 1]} y2={50} />
+      )}
+      {ordered.map((s, i) => {
+        const x = xs[i];
+        // Active: explicit selection of this revision, OR the live revision when
+        // nothing is explicitly selected (selectedRevision === null → latest).
+        const active =
+          selectedRevision === s.v || (selectedRevision == null && s.live);
+        const latest = s.live;
+        const rem = plan.rem[i];
+        const prevRem = i > 0 ? plan.rem[i - 1] : null;
+        const delta = prevRem != null ? prevRem - rem : null;
+        const dotFill = active || latest ? 'var(--accent)' : 'var(--panel)';
+        const dotStroke = active || latest ? 'var(--accent)' : 'var(--ink-soft)';
+        return (
+          <g
+            key={s.v}
+            className="reel-stop"
+            data-ver={s.v}
+            tabIndex={0}
+            role="button"
+            aria-pressed={active}
+            aria-label={`show plan v${i}${s.seam ? ` (${s.seam})` : ''}`}
+            onClick={() => pick(s)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                pick(s);
+              }
+            }}
+          >
+            {/* replan-trigger seam label between this stop and the prior one */}
+            {i > 0 && s.seam && (
+              <text
+                className="gm-tick-label"
+                x={(xs[i - 1] + x) / 2 - 26}
+                y={30}
+              >
+                ↯ {s.seam}
+              </text>
+            )}
+            {/* per-stop task delta since the prior version */}
+            {delta != null && delta !== 0 && (
+              <text
+                x={(xs[i - 1] + x) / 2 - 10}
+                y={46}
+                fontSize={9}
+                fill={delta > 0 ? 'var(--good)' : 'var(--caution)'}
+              >
+                {delta > 0 ? `−${delta}` : `+${-delta}`}
+              </text>
+            )}
+            {/* active ring */}
+            {active && (
+              <circle
+                cx={x}
+                cy={50}
+                r={10}
+                fill="none"
+                stroke="var(--accent)"
+                strokeWidth={1.4}
+                opacity={0.9}
+              />
+            )}
+            {/* generous hit target */}
+            <circle className="reel-hit" cx={x} cy={50} r={14} fill="transparent" />
+            <circle
+              cx={x}
+              cy={50}
+              r={latest || active ? 5.5 : 4}
+              fill={dotFill}
+              stroke={dotStroke}
+              strokeWidth={1.5}
+            />
+            <text
+              className="gm-label"
+              x={x - 8}
+              y={71}
+              {...(active
+                ? { fill: 'var(--accent)', fontWeight: 600 }
+                : {})}
+            >
+              v{i}
+            </text>
+            {rem != null && (
+              <text className="gm-axis" x={x - 24} y={85}>
+                {rem} tasks left
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+// ── DagZ — the dependency DAG (driven by the reel selection) ─────────────────
+// compose.html dagSVG 540-572. Nodes carry absolute x/y from the adapter; node
+// .st already encodes the selected-revision reframing (added / ghost). Critical
+// path = accent spine (edge.crit); ghost endpoints → dashed faint edges.
+
+interface DagZProps {
+  plan: ZPlan;
+  selectedRevision: number | null;
+}
+
+interface NodeGlyph {
+  glyph: string;
+  glyphColor: string;
+  stroke: string;
+  strokeWidth: number;
+  dashed: boolean;
+  ghost: boolean;
+  tip: string;
+}
+
+function nodeGlyph(st: ZPlanNode['st']): NodeGlyph {
+  switch (st) {
+    case 'done':
+      return {
+        glyph: '✓',
+        glyphColor: 'var(--good)',
+        stroke: 'var(--good)',
+        strokeWidth: 1.2,
+        dashed: false,
+        ghost: false,
+        tip: 'done',
+      };
+    case 'running':
+      return {
+        glyph: '●',
+        glyphColor: 'var(--accent)',
+        stroke: 'var(--accent)',
+        strokeWidth: 2,
+        dashed: false,
+        ghost: false,
+        tip: 'running',
+      };
+    case 'added':
+      return {
+        glyph: '○',
+        glyphColor: 'var(--accent)',
+        stroke: 'var(--accent)',
+        strokeWidth: 2,
+        dashed: false,
+        ghost: false,
+        tip: 'added at this revision',
+      };
+    case 'ghost':
+      return {
+        glyph: '✕',
+        glyphColor: 'var(--bad)',
+        stroke: 'var(--rule)',
+        strokeWidth: 1.2,
+        dashed: true,
+        ghost: true,
+        tip: 'dropped since the prior revision',
+      };
+    default: // 'pending'
+      return {
+        glyph: '○',
+        glyphColor: 'var(--ink-faint)',
+        stroke: 'var(--ink-faint)',
+        strokeWidth: 1.2,
+        dashed: false,
+        ghost: false,
+        tip: 'pending',
+      };
+  }
+}
+
+function DagZ({ plan, selectedRevision }: DagZProps) {
+  const W = 940;
+  const H = 216;
+  const selectTask = useUiStore.getState().selectTask;
+
+  // Node lookup by task id (edges reference ids, not array indices).
+  const byId = new Map<string, ZPlanNode>();
+  for (const node of plan.nodes) byId.set(node.tid, node);
+
+  const selStratum =
+    selectedRevision != null
+      ? plan.strata.find((s) => s.v === selectedRevision)
+      : undefined;
+  const caption = selStratum
+    ? `v${selStratum.v} · ○ accent = added at this revision · dashed = dropped since the prior revision`
+    : 'the accent spine = the critical path · ghost = dropped at replan';
+
+  return (
+    <svg
+      className="fig"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label={`plan dependency DAG${selStratum ? ` · v${selStratum.v}` : ''}`}
+    >
+      {/* edges first, under the nodes */}
+      {plan.edges.map((e, i) => {
+        const A = byId.get(e.from);
+        const B = byId.get(e.to);
+        if (!A || !B) return null;
+        const x0 = A.x + BW / 2;
+        const y0 = A.y;
+        const x1 = B.x - BW / 2;
+        const y1 = B.y;
+        const c = (x0 + x1) / 2;
+        const eGhost = A.st === 'ghost' || B.st === 'ghost';
+        const stroke = eGhost
+          ? 'var(--ink-faint)'
+          : e.crit
+            ? 'var(--accent)'
+            : 'var(--ink-faint)';
+        const extra: React.SVGProps<SVGPathElement> = eGhost
+          ? { strokeDasharray: '3 4', opacity: 0.45 }
+          : e.crit
+            ? { strokeWidth: 2 }
+            : { strokeWidth: 1, opacity: 0.6 };
+        return (
+          <path
+            key={`e-${i}`}
+            d={`M${x0},${y0} C ${c},${y0} ${c},${y1} ${x1},${y1}`}
+            fill="none"
+            stroke={stroke}
+            vectorEffect="non-scaling-stroke"
+            {...extra}
+          >
+            <title>
+              {e.from} → {e.to}
+              {e.crit && !eGhost ? ' · critical path' : ''}
+            </title>
+          </path>
+        );
+      })}
+
+      {/* nodes */}
+      {plan.nodes.map((node) => {
+        const g = nodeGlyph(node.st);
+        const x = node.x;
+        const y = node.y;
+        return (
+          <g
+            key={node.tid}
+            style={{ cursor: 'pointer' }}
+            onClick={() => selectTask(node.tid)}
+          >
+            <rect
+              x={x - BW / 2}
+              y={y - BH / 2}
+              width={BW}
+              height={BH}
+              rx={4}
+              fill="var(--panel)"
+              stroke={g.stroke}
+              strokeWidth={g.strokeWidth}
+              vectorEffect="non-scaling-stroke"
+              {...(g.dashed ? { strokeDasharray: '4 3', opacity: 0.55 } : {})}
+            >
+              <title>
+                {node.tid} · {g.tip}
+              </title>
+            </rect>
+            <text
+              x={x - BW / 2 + 9}
+              y={y + 3.5}
+              fontSize={10}
+              fill={g.ghost ? 'var(--ink-faint)' : 'var(--ink-soft)'}
+            >
+              {truncate(node.title, 14)}
+            </text>
+            <text
+              x={x + BW / 2 - 15}
+              y={y + 4}
+              fontSize={9.5}
+              fill={g.glyphColor}
+            >
+              {g.glyph}
+            </text>
+          </g>
+        );
+      })}
+
+      <text className="gm-faint" x={10} y={H - 8}>
+        {caption}
+      </text>
+    </svg>
+  );
+}
+
+/** Clip a node label to fit the box (the study used short synthetic ids). */
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1)}…`;
+}

--- a/frontend/src/components/zicato/PlanZ.tsx
+++ b/frontend/src/components/zicato/PlanZ.tsx
@@ -24,13 +24,15 @@ import type { ZPlan, ZPlanNode, ZSession, ZStratum } from './adapter';
 
 export interface PlanZProps {
   z: ZSession;
+  /** viewBox width in px (measured container width from <Fig>). */
+  W?: number;
 }
 
 // DAG node box geometry (compose.html dagSVG 540).
 const BW = 118;
 const BH = 24;
 
-export function PlanZ({ z }: PlanZProps) {
+export function PlanZ({ z, W = 940 }: PlanZProps) {
   const selectedRevision = useUiStore((s) => s.selectedRevision);
   const setSelectedRevision = useUiStore((s) => s.setSelectedRevision);
   const plan = z.plan;
@@ -40,7 +42,7 @@ export function PlanZ({ z }: PlanZProps) {
     return (
       <svg
         className="fig plan-reel"
-        viewBox="0 0 940 60"
+        viewBox={`0 0 ${W} 60`}
         role="img"
         aria-label={`plan ${z.id} — no plan yet`}
       >
@@ -55,10 +57,11 @@ export function PlanZ({ z }: PlanZProps) {
     <div>
       <ReelZ
         plan={plan}
+        W={W}
         selectedRevision={selectedRevision}
         onSelectRevision={setSelectedRevision}
       />
-      <DagZ plan={plan} selectedRevision={selectedRevision} />
+      <DagZ plan={plan} W={W} selectedRevision={selectedRevision} />
     </div>
   );
 }
@@ -71,12 +74,12 @@ export function PlanZ({ z }: PlanZProps) {
 
 interface ReelZProps {
   plan: ZPlan;
+  W: number;
   selectedRevision: number | null;
   onSelectRevision: (rev: number | null) => void;
 }
 
-function ReelZ({ plan, selectedRevision, onSelectRevision }: ReelZProps) {
-  const W = 940;
+function ReelZ({ plan, W, selectedRevision, onSelectRevision }: ReelZProps) {
   const H = 92;
   // OLDEST→NEWEST for display (strata is stored newest-first).
   const ordered: ZStratum[] = [...plan.strata].reverse();
@@ -222,6 +225,7 @@ function ReelZ({ plan, selectedRevision, onSelectRevision }: ReelZProps) {
 
 interface DagZProps {
   plan: ZPlan;
+  W: number;
   selectedRevision: number | null;
 }
 
@@ -290,9 +294,12 @@ function nodeGlyph(st: ZPlanNode['st']): NodeGlyph {
   }
 }
 
-function DagZ({ plan, selectedRevision }: DagZProps) {
-  const W = 940;
+function DagZ({ plan, W, selectedRevision }: DagZProps) {
   const H = 216;
+  // The DAG has a fixed 4-column layout (node x from the adapter, 80..740 in a
+  // 940 design space); scale those x by W/940 so it fills the measured width
+  // while text/boxes stay 1:1 (no upscaling).
+  const sx = W / 940;
   const selectTask = useUiStore.getState().selectTask;
 
   // Node lookup by task id (edges reference ids, not array indices).
@@ -319,9 +326,9 @@ function DagZ({ plan, selectedRevision }: DagZProps) {
         const A = byId.get(e.from);
         const B = byId.get(e.to);
         if (!A || !B) return null;
-        const x0 = A.x + BW / 2;
+        const x0 = A.x * sx + BW / 2;
         const y0 = A.y;
-        const x1 = B.x - BW / 2;
+        const x1 = B.x * sx - BW / 2;
         const y1 = B.y;
         const c = (x0 + x1) / 2;
         const eGhost = A.st === 'ghost' || B.st === 'ghost';
@@ -355,7 +362,7 @@ function DagZ({ plan, selectedRevision }: DagZProps) {
       {/* nodes */}
       {plan.nodes.map((node) => {
         const g = nodeGlyph(node.st);
-        const x = node.x;
+        const x = node.x * sx;
         const y = node.y;
         return (
           <g

--- a/frontend/src/components/zicato/SeismographZ.tsx
+++ b/frontend/src/components/zicato/SeismographZ.tsx
@@ -1,0 +1,314 @@
+// SeismographZ.tsx — ONE combined drift trace + judge heartbeat on a SHARED
+// time axis, with the time-aligned intervention ladder folded in beneath via
+// the same trackGeom (timeScale) the LadderZ sibling reuses.
+//
+// Ported from compose.html seismoSVG (468-503) + judgeBeats (171-176, in
+// svgUtils) + trackGeom (timeScale in svgUtils) + heartSVG (506-515).
+//
+// Encoding (preserved verbatim from the study):
+//   • the judge HEARTBEAT strip (top) shares the EXACT same X as the lanes:
+//     ok → small goldfive-hue dot, warn → --caution ▲ tick, crit → --bad ✕ tick.
+//     The beats are DERIVED from the drift the judges watch (judgeBeats), so a
+//     firing mark always sits above the reading that earned it.
+//   • per lane: a --good tolerance band (.gm-tol), a dashed on-plan baseline
+//     (.gm-onplan), the drift TRACE (.gm-trace, --ink) jittered DETERMINISTICALLY
+//     via lcg (NEVER Math.random), --bad excursion polygons (.gm-excursion) where
+//     drift > TOL(8), and intervention ticks (.gm-tick) from z.ticks.
+//   • an --accent now-cursor line at min(now, T).
+//
+// Graceful fallback: with no drift (z.judges == {}) the figure still renders the
+// heartbeat baseline (all-ok beats) + a single empty-state line — never crashes.
+//
+// SIGNATURES ARE FROZEN — do not change the props.
+
+import { type ReactNode } from 'react';
+import { lcg, lerpKeys, timeScale, judgeBeats, SEISMO_LANES_DEFAULT } from './svgUtils';
+import type { ZSession } from './adapter';
+
+export interface SeismographZProps {
+  z: ZSession;
+  /** default: real busy (judged) lanes, fallback SEISMO_LANES_DEFAULT */
+  lanes?: string[];
+  W?: number;
+  axis?: boolean;
+  heart?: boolean;
+}
+
+const TOL = 8;
+
+/** Resolve the lanes to draw: real judged lanes, else the study default. */
+function resolveLanes(z: ZSession, lanes?: string[]): string[] {
+  if (lanes && lanes.length) return lanes;
+  const judged = Object.keys(z.judges);
+  return judged.length ? judged : [...SEISMO_LANES_DEFAULT];
+}
+
+/** agentId → display label (falls back to the raw lane key, e.g. the study default). */
+function laneLabel(z: ZSession, lane: string): string {
+  return z.agents.find((a) => a.id === lane)?.label ?? lane;
+}
+
+export function SeismographZ({
+  z,
+  lanes,
+  W = 940,
+  axis = true,
+  heart = true,
+}: SeismographZProps) {
+  const lanesToDraw = resolveLanes(z, lanes);
+  const { X } = timeScale(z.T, W);
+
+  const heartH = heart ? 30 : 0;
+  const rowH = 54;
+  const top = heartH;
+  const bottomPad = axis ? 24 : 6;
+  const H = top + lanesToDraw.length * rowH + bottomPad;
+  const gridBottom = H - (axis ? 18 : 6);
+
+  // Shared x-domain gridlines (and optional axis labels).
+  const gridLines: ReactNode[] = [];
+  for (let i = 0; i <= 4; i++) {
+    const gx = X((z.T * i) / 4);
+    gridLines.push(
+      <line key={`g${i}`} className="hg-gantt-grid" x1={gx} y1={4} x2={gx} y2={gridBottom} />,
+    );
+    if (axis) {
+      gridLines.push(
+        <text key={`gl${i}`} className="gm-axis" x={gx - 7} y={H - 5}>
+          {Math.round((z.T * i) / 4)}s
+        </text>,
+      );
+    }
+  }
+
+  // ── judge heartbeat strip — KIND hue baseline, STATUS treatment on warn/crit ──
+  const heartNodes: ReactNode[] = [];
+  if (heart) {
+    const hy = heartH - 10;
+    heartNodes.push(
+      <text key="hl" className="gm-label" x={6} y={hy + 4} fill="var(--hg-agent-goldfive)">
+        judges
+      </text>,
+      <line key="hb" className="gm-onplan" x1={X(0)} y1={hy} x2={X(z.T)} y2={hy} />,
+    );
+    judgeBeats(z.judges, lanesToDraw, z.T, z.now).forEach(([t, k], i) => {
+      if (t > z.T) return;
+      const x = X(t);
+      if (k === 'ok') {
+        heartNodes.push(
+          <circle key={`hk${i}`} cx={x} cy={hy} r={1.7} fill="var(--hg-agent-goldfive)" opacity={0.8}>
+            <title>{`judge fired · on-task @ ${t.toFixed(0)}s`}</title>
+          </circle>,
+        );
+      } else if (k === 'warn') {
+        heartNodes.push(
+          <line
+            key={`hkl${i}`}
+            x1={x}
+            y1={hy - 6}
+            x2={x}
+            y2={hy + 6}
+            stroke="var(--caution)"
+            strokeWidth={1.4}
+            vectorEffect="non-scaling-stroke"
+          />,
+          <text key={`hkt${i}`} x={x - 3.5} y={hy + 3} fontSize={8.5} fill="var(--caution)">
+            ▲
+          </text>,
+        );
+      } else {
+        heartNodes.push(
+          <line
+            key={`hkl${i}`}
+            x1={x}
+            y1={hy - 7}
+            x2={x}
+            y2={hy + 7}
+            stroke="var(--bad)"
+            strokeWidth={1.6}
+            vectorEffect="non-scaling-stroke"
+          />,
+          <text
+            key={`hkt${i}`}
+            x={x - 3.5}
+            y={hy + 3.5}
+            fontSize={9.5}
+            fill="var(--bad)"
+            fontWeight={700}
+          >
+            ✕
+          </text>,
+        );
+      }
+    });
+    heartNodes.push(
+      <line
+        key="hseam"
+        className="gm-seam"
+        x1={X(0)}
+        y1={heartH - 1}
+        x2={X(z.T)}
+        y2={heartH - 1}
+        opacity={0.5}
+      />,
+    );
+  }
+
+  // ── per-lane drift traces with tolerance band + excursion fills ──
+  let anyLaneData = false;
+  const laneNodes: ReactNode[] = [];
+  lanesToDraw.forEach((a, li) => {
+    const keys = z.judges[a];
+    if (!keys || !keys.length) return; // no drift for this lane → skip (study parity)
+    anyLaneData = true;
+
+    const base = top + 10 + li * rowH + rowH - 16;
+    const rnd = lcg(40 + li); // DETERMINISTIC jitter (stable across renders)
+    const yOf = (v: number): number => base - v * 1.9;
+
+    laneNodes.push(
+      <text key={`ll${li}`} className="gm-label" x={6} y={base - 12}>
+        {laneLabel(z, a)}
+      </text>,
+      <rect
+        key={`lt${li}`}
+        className="gm-tol"
+        x={X(0)}
+        y={yOf(TOL)}
+        width={X(z.T) - X(0)}
+        height={yOf(0) - yOf(TOL)}
+      />,
+      <line key={`lo${li}`} className="gm-onplan" x1={X(0)} y1={base} x2={X(z.T)} y2={base} />,
+    );
+
+    // Sample the drift trace deterministically (lcg + a fixed sine wobble).
+    const pts: [number, number, number][] = [];
+    for (let i = 0; i <= 260; i++) {
+      const t = (z.T * i) / 260;
+      const v = Math.max(0, lerpKeys(keys, t) + Math.sin(t * 2.3 + li) * 0.5 + (rnd() - 0.5) * 0.9);
+      pts.push([X(t), yOf(v), v]);
+    }
+
+    // Excursion polygons where drift > TOL.
+    let seg: [number, number, number][] | null = null;
+    const segs: [number, number, number][][] = [];
+    pts.forEach((p) => {
+      if (p[2] > TOL) {
+        if (!seg) seg = [];
+        seg.push(p);
+      } else if (seg) {
+        segs.push(seg);
+        seg = null;
+      }
+    });
+    if (seg) segs.push(seg);
+    segs.forEach((sg, si) => {
+      const tolY = yOf(TOL).toFixed(1);
+      const pointStr =
+        `${sg.map((p) => `${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(' ')} ` +
+        `${sg[sg.length - 1][0].toFixed(1)},${tolY} ${sg[0][0].toFixed(1)},${tolY}`;
+      laneNodes.push(<polygon key={`lx${li}-${si}`} className="gm-excursion" points={pointStr} />);
+    });
+
+    laneNodes.push(
+      <path
+        key={`lp${li}`}
+        className="gm-trace"
+        d={`M${pts.map((p) => `${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(' L')}`}
+      />,
+    );
+
+    // Intervention ticks for this lane.
+    (z.ticks[a] || []).forEach(([t, lbl], ti) => {
+      const tx = X(t);
+      laneNodes.push(
+        <line
+          key={`lk${li}-${ti}`}
+          className="gm-tick"
+          x1={tx}
+          y1={base - rowH + 22}
+          x2={tx}
+          y2={base + 3}
+        >
+          <title>{`intervention · ${lbl}`}</title>
+        </line>,
+        <text key={`lkt${li}-${ti}`} className="gm-tick-label" x={tx + 3} y={base - rowH + 27}>
+          {lbl.split(' ')[0]}
+        </text>,
+      );
+    });
+  });
+
+  const nx = X(Math.min(z.now, z.T));
+
+  return (
+    <svg
+      className="fig"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label={`drift seismograph + judge heartbeat — ${z.id}`}
+    >
+      {gridLines}
+      {heartNodes}
+      {laneNodes}
+      {!anyLaneData && (
+        <text className="gm-faint" x={timeScale(z.T, W).padL + 10} y={top + 24} fontStyle="italic">
+          no drift recorded — judges on-task
+        </text>
+      )}
+      <line className="hg-gantt-now" x1={nx} y1={4} x2={nx} y2={gridBottom} />
+    </svg>
+  );
+}
+
+export interface JudgeHeartbeatZProps {
+  z: ZSession;
+  W?: number;
+}
+
+// The judge heartbeat as its OWN small figure (inspector/drawer + ⌘K caption).
+// Same judgeBeats data, no lanes argument → all judged lanes contribute.
+// (compose.html heartSVG 506-515.)
+export function JudgeHeartbeatZ({ z, W = 940 }: JudgeHeartbeatZProps) {
+  const H = 40;
+  const { X } = timeScale(z.T, W);
+  const lanesToDraw = resolveLanes(z, undefined);
+
+  const beats: ReactNode[] = [];
+  judgeBeats(z.judges, lanesToDraw, z.T, z.now).forEach(([t, k], i) => {
+    if (t > z.T) return;
+    const x = X(t);
+    if (k === 'ok') {
+      beats.push(
+        <circle key={`b${i}`} cx={x} cy={18} r={1.5} fill="var(--hg-agent-goldfive)" opacity={0.8} />,
+      );
+    } else if (k === 'warn') {
+      beats.push(
+        <text key={`b${i}`} x={x - 3.5} y={22} fontSize={9} fill="var(--caution)">
+          ▲
+        </text>,
+      );
+    } else {
+      beats.push(
+        <text key={`b${i}`} x={x - 3.5} y={22} fontSize={10} fill="var(--bad)" fontWeight={700}>
+          ✕
+        </text>,
+      );
+    }
+  });
+
+  return (
+    <svg
+      className="fig"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label={`judge heartbeat — ${z.id}`}
+    >
+      <text className="gm-label" x={6} y={22} fill="var(--hg-agent-goldfive)">
+        judges
+      </text>
+      <line className="gm-onplan" x1={X(0)} y1={26} x2={X(z.T)} y2={26} />
+      {beats}
+    </svg>
+  );
+}

--- a/frontend/src/components/zicato/SequenceZ.tsx
+++ b/frontend/src/components/zicato/SequenceZ.tsx
@@ -1,0 +1,366 @@
+// SequenceZ.tsx — lifelines down, time down.
+//
+// Ported from compose.html seqDiagramSVG (326-363) + sessionMessages (314-323).
+// One dashed lifeline per agent (agent-color via colorVar), a chip + name at the
+// head; 6 horizontal gridlines with Ns axis labels; spans → narrow vertical
+// activation bars (KIND hue / --bad failed / wait-for-human awaiting, fill-opacity
+// by status); messages → horizontal connectors (solid call / dashed return) each
+// with a SMALL SOLID arrowhead at the receiver and a tiny label; an approval-gate
+// ring on an awaiting span; the accent now-line.
+//
+// Real-data deltas from the study:
+//   • columns come from z.agents (real lane order), not the fixed study name list.
+//     Lifeline colour is colorVar(agent); the activation/message x is keyed by the
+//     real agentId.
+//   • messages come from z.edges (the GraphView-derived transfer/delegation/return
+//     arrows) rather than the study mock's sessionMessages — enriched with the
+//     opening user-message span and the closing agent-message (approval-request)
+//     span so the conversation reads end-to-end.
+//   • graceful fallback: an empty session renders the staff + axis only (no crash).
+//
+// Span/activation click → useUiStore.getState().selectSpan(spanId) (opens the
+// existing inspector drawer). SIGNATURE IS FROZEN.
+
+import { useUiStore } from '../../state/uiStore';
+import type { ZSession, ZAgent, ZSpan } from './adapter';
+import { colorVar, KIND } from './svgUtils';
+
+export interface SequenceZProps {
+  z: ZSession;
+  W?: number;
+  H?: number;
+}
+
+/** A single horizontal message connector, time-ordered. */
+interface Msg {
+  t: number;
+  from: string; // agent id
+  to: string; // agent id
+  /** style family: solid call vs dashed return, hue per family. */
+  family: 'transfer' | 'delegation' | 'return' | 'user-message' | 'agent-message';
+  label: string;
+}
+
+/** The connector hue per message family (compose.html 350-351). */
+function msgColor(family: Msg['family']): string {
+  switch (family) {
+    case 'transfer':
+      return KIND('transfer');
+    case 'user-message':
+      return KIND('user-message');
+    case 'delegation':
+      return 'var(--ink-soft)';
+    case 'return':
+      return 'var(--ink-faint)';
+    case 'agent-message':
+    default:
+      return KIND('agent-message');
+  }
+}
+
+/** dash-array per family — solid call / dashed return (compose.html 352). */
+function msgDash(family: Msg['family']): string | undefined {
+  if (family === 'transfer') return '5 3';
+  if (family === 'return') return '4 3';
+  return undefined; // delegation / user-message / agent-message → solid call
+}
+
+/**
+ * Derive the time-ordered message list. The transfer / delegation / return arrows
+ * come from the GraphView-derived `z.edges`; the opening user-message and the
+ * closing agent-message (approval request) come from the matching spans so the
+ * sequence reads from the user's prompt to the agent's reply. (Replaces the study
+ * mock's sessionMessages, which scraped the same shapes from a flat object.)
+ */
+function buildMessages(z: ZSession, present: Set<string>): Msg[] {
+  const msgs: Msg[] = [];
+  const goalHead = z.goal ? z.goal.split(/\s+/).slice(0, 4).join(' ') + '…' : 'prompt';
+
+  // Opening user-message: user → its receiving agent.
+  const um = z.spans.find((s) => s.kind === 'user-message');
+  if (um && present.has(um.agent)) {
+    const fromUser = userAgentId(z);
+    if (fromUser && present.has(fromUser) && fromUser !== um.agent) {
+      msgs.push({
+        t: um.t0,
+        from: fromUser,
+        to: um.agent,
+        family: 'user-message',
+        label: 'user: ' + goalHead,
+      });
+    }
+  }
+
+  // Transfer / delegation / return arrows from the derived edge set.
+  for (const e of z.edges) {
+    if (!present.has(e.from) || !present.has(e.to) || e.from === e.to) continue;
+    if (e.t > z.T) continue;
+    msgs.push({
+      t: e.t,
+      from: e.from,
+      to: e.to,
+      family: e.kind,
+      label:
+        e.kind === 'transfer'
+          ? 'transfer'
+          : e.kind === 'return'
+            ? 'return'
+            : 'delegate',
+    });
+  }
+
+  // Closing agent-message: an approval request back to the user.
+  const am = z.spans.find((s) => s.kind === 'agent-message');
+  if (am) {
+    const toUser = userAgentId(z);
+    if (toUser && present.has(am.agent) && present.has(toUser) && am.agent !== toUser) {
+      msgs.push({
+        t: am.t1 || am.t0,
+        from: am.agent,
+        to: toUser,
+        family: 'agent-message',
+        label: 'approval requested',
+      });
+    }
+  }
+
+  msgs.sort((a, b) => a.t - b.t);
+  return msgs;
+}
+
+/** The synthetic user lane id (if present), used as the human endpoint. */
+function userAgentId(z: ZSession): string | null {
+  return z.agents.find((a) => a.synthetic === 'user')?.id ?? null;
+}
+
+/** Activation-bar fill (compose.html 342): failed→--bad, awaiting→wait hue, else KIND. */
+function actFill(sp: ZSpan): string {
+  if (sp.status === 'failed') return 'var(--bad)';
+  if (sp.status === 'awaiting') return KIND('wait-for-human');
+  return KIND(sp.kind);
+}
+
+/** Activation-bar fill-opacity by status (compose.html 343). */
+function actOpacity(sp: ZSpan): number {
+  if (sp.status === 'awaiting') return 0.4;
+  if (sp.status === 'failed') return 0.85;
+  return 0.55;
+}
+
+export function SequenceZ({ z, W = 520, H = 380 }: SequenceZProps) {
+  const padT = 52;
+  const padL = 58;
+
+  // Columns = the real lane order. Synthetic + working agents alike get a column.
+  const cols: ZAgent[] = z.agents;
+  const present = new Set(cols.map((a) => a.id));
+  const denom = z.T > 0 ? z.T : 1;
+
+  // Column x-positions (study geometry: padL+30 then evenly stepped).
+  const step = cols.length > 1 ? (W - padL - 44) / (cols.length - 1) : 0;
+  const X = new Map<string, number>();
+  cols.forEach((a, i) => X.set(a.id, padL + 30 + i * step));
+  const colorById = new Map<string, string>();
+  cols.forEach((a) => colorById.set(a.id, colorVar(a)));
+
+  const yT = (t: number): number => padT + (t / denom) * (H - padT - 26);
+
+  const select = (id: string): void => useUiStore.getState().selectSpan(id);
+
+  // Gridlines + axis labels (6 divisions).
+  const grid: React.ReactNode[] = [];
+  for (let i = 0; i <= 6; i++) {
+    const y = yT((z.T * i) / 6);
+    grid.push(
+      <line
+        key={`g${i}`}
+        className="hg-gantt-grid"
+        x1={padL - 4}
+        y1={y}
+        x2={W - 12}
+        y2={y}
+        opacity={0.5}
+      />,
+    );
+    grid.push(
+      <text key={`gl${i}`} className="gm-axis" x={26} y={y + 3}>
+        {Math.round((z.T * i) / 6)}s
+      </text>,
+    );
+  }
+
+  // Lifelines + chips + names.
+  const lifelines: React.ReactNode[] = [];
+  cols.forEach((a) => {
+    const x = X.get(a.id)!;
+    const col = colorById.get(a.id)!;
+    lifelines.push(
+      <line
+        key={`life-${a.id}`}
+        className="sq-life"
+        x1={x}
+        y1={30}
+        x2={x}
+        y2={H - 14}
+        stroke={col}
+        opacity={0.8}
+      />,
+    );
+    lifelines.push(
+      <rect
+        key={`chip-${a.id}`}
+        className="sq-chip"
+        x={x - 34}
+        y={10}
+        width={68}
+        height={19}
+        rx={4}
+        stroke={col}
+      />,
+    );
+    lifelines.push(
+      <text
+        key={`name-${a.id}`}
+        className="sq-name"
+        x={x}
+        y={23}
+        textAnchor="middle"
+      >
+        {a.label}
+      </text>,
+    );
+  });
+
+  // Activation bars — one per visible, non-planned, non-goldfive span.
+  const acts: React.ReactNode[] = [];
+  for (const sp of z.spans) {
+    if (!present.has(sp.agent) || sp.status === 'planned' || sp.gf) continue;
+    const x = X.get(sp.agent)!;
+    const y0 = yT(sp.t0);
+    const h = Math.max(6, yT(sp.t1) - y0);
+    acts.push(
+      <rect
+        key={`act-${sp.id}`}
+        className="sq-act"
+        data-span={sp.id}
+        x={x - 4}
+        y={y0}
+        width={8}
+        height={h}
+        rx={2.5}
+        fill={actFill(sp)}
+        fillOpacity={actOpacity(sp)}
+        tabIndex={0}
+        onClick={() => select(sp.id)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            select(sp.id);
+          }
+        }}
+      >
+        <title>{`${sp.label} · ${sp.status}`}</title>
+      </rect>,
+    );
+    if (sp.status === 'failed') {
+      acts.push(
+        <text
+          key={`fail-${sp.id}`}
+          x={x + 9}
+          y={y0 + h / 2 + 3}
+          fontSize={8.5}
+          fill="var(--bad)"
+        >
+          ✕
+        </text>,
+      );
+    }
+  }
+
+  // Messages — min-row-gap layout so each connector gets its own row.
+  const MINGAP = 24;
+  let prevY = -1e9;
+  const messages: React.ReactNode[] = [];
+  for (const m of buildMessages(z, present)) {
+    const x0 = X.get(m.from)!;
+    const x1 = X.get(m.to)!;
+    const y = Math.max(yT(m.t), prevY + MINGAP);
+    prevY = y;
+    const dir = x1 > x0 ? 1 : -1;
+    const color = msgColor(m.family);
+    const dash = msgDash(m.family);
+    messages.push(
+      <line
+        key={`msg-${m.t}-${m.from}-${m.to}`}
+        className="sq-msg"
+        x1={x0 + 4 * dir}
+        y1={y}
+        x2={x1 - 9 * dir}
+        y2={y}
+        stroke={color}
+        strokeDasharray={dash}
+      >
+        <title>{`${m.label} · ${Math.round(m.t)}s`}</title>
+      </line>,
+    );
+    // SMALL SOLID arrowhead at the receiver (compose.html 356).
+    messages.push(
+      <path
+        key={`ah-${m.t}-${m.from}-${m.to}`}
+        d={`M${x1 - 6 * dir},${y - 2.2} L${x1 - 1 * dir},${y} L${x1 - 6 * dir},${y + 2.2} Z`}
+        fill={color}
+        stroke="none"
+      />,
+    );
+    messages.push(
+      <text
+        key={`lbl-${m.t}-${m.from}-${m.to}`}
+        className="sq-lbl"
+        x={x0 + 16 * dir}
+        y={y - 5}
+        textAnchor={dir > 0 ? 'start' : 'end'}
+        fill={color}
+      >
+        {m.label}
+      </text>,
+    );
+  }
+
+  // Approval gate — a ring on the first awaiting span's lifeline.
+  const wait = z.spans.find((s) => s.status === 'awaiting' && present.has(s.agent));
+  const gate =
+    wait != null ? (
+      <circle
+        cx={X.get(wait.agent)!}
+        cy={yT(Math.min(wait.t1, z.T))}
+        r={5.5}
+        fill="none"
+        stroke="var(--ink-soft)"
+        strokeWidth={1.4}
+      >
+        <title>gate · deciding…</title>
+      </circle>
+    ) : null;
+
+  // Now-line.
+  const ny = yT(Math.min(z.now, z.T));
+
+  return (
+    <svg
+      className="fig"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label={`agent-interaction sequence diagram — ${z.id || 'session'}`}
+    >
+      {grid}
+      {lifelines}
+      {acts}
+      {messages}
+      {gate}
+      <line className="hg-gantt-now" x1={padL - 4} y1={ny} x2={W - 12} y2={ny} />
+      <text className="hg-gantt-now-label" x={padL} y={ny - 5}>
+        now {Math.round(z.now)}s
+      </text>
+    </svg>
+  );
+}

--- a/frontend/src/components/zicato/ZicatoConsole.tsx
+++ b/frontend/src/components/zicato/ZicatoConsole.tsx
@@ -1,0 +1,538 @@
+// ZicatoConsole.tsx — the parallel zicato-language console shell. Mirrors
+// compose.html appHybrid (742-745): topbar + strip + (rail · main · inspector)
+// + transport, with the ⌘K picker overlaid. Lives BESIDE the MD3 Shell; App.tsx
+// renders this when uiMode === 'zicato'.
+//
+// Because only ONE console mounts at a time, this console independently mounts
+// the headless pieces it needs (<SessionsSyncer/>, useGlobalShortcuts()) — they
+// are NOT inherited from Shell. It holds the single useSessionWatch for the
+// current session; sub-views read the store via getSessionStore.
+//
+// Theme: scoped to the zicato subtree via `data-zicato-theme` on .zk-root, so
+// the MD3 `<html data-theme>` is never touched (no MD3 regression).
+
+import { useEffect, useReducer, useState, type ReactElement } from 'react';
+import './zicato-tokens.css';
+import './zicato.css';
+import { useUiStore, type ZicatoTheme } from '../../state/uiStore';
+import {
+  useSessionWatch,
+  getSessionStore,
+  useSendControl,
+} from '../../rpc/hooks';
+import { SessionsSyncer } from '../../rpc/SessionsSyncer';
+import { SessionPicker } from '../SessionPicker/SessionPicker';
+import { useGlobalShortcuts } from '../../lib/shortcuts';
+import { formatDuration } from '../../lib/format';
+import { bareAgentName } from '../../gantt/index';
+import { actorDisplayLabel } from '../../theme/agentColors';
+import {
+  useZicatoSession,
+  toStatusToken,
+  gfClassForSpan,
+  type ZSession,
+} from './adapter';
+import { BrandMark, Wordmark } from './Brand';
+import { GanttViewZ } from './GanttViewZ';
+import { InstrumentsViewZ } from './InstrumentsViewZ';
+
+// ── Theme picker data tables (ported from compose.html 99-123) ───────────────
+
+const ZICATO_THEME_IDS: ZicatoTheme[] = [
+  'monokai',
+  'solarized-dark',
+  'solarized-light',
+  'google-light',
+  'google-dark',
+  'lunaria-light',
+  'lunaria-eclipse',
+  'belafonte-day',
+  'belafonte-night',
+  'paper',
+  'zenburn',
+  'selenized-black',
+  'relaxed',
+  'espresso',
+  'dracula',
+  'ubuntu',
+];
+
+const THEME_SWATCHES: Record<ZicatoTheme, string[]> = {
+  monokai: ['#1e1f1c', '#272822', '#f8f8f2', '#a6e22e', '#f92672', '#66d9ef'],
+  'solarized-dark': ['#04222B', '#0A2D38', '#93A1A1', '#8BB80E', '#E0483C', '#2AA198'],
+  'solarized-light': ['#FDF6E3', '#FBF1D6', '#586E75', '#6B9B0B', '#DC322F', '#268BD2'],
+  'google-light': ['#FFFFFF', '#F4F4F4', '#474A4E', '#34A853', '#EA4335', '#1B9CB8'],
+  'google-dark': ['#202124', '#2C2D30', '#FFFFFF', '#34A853', '#EA4335', '#24C1E0'],
+  'lunaria-light': ['#EBE4E1', '#E2DCD9', '#363434', '#497D46', '#783C1F', '#3778A9'],
+  'lunaria-eclipse': ['#323F46', '#3B484F', '#DFE2ED', '#BEDBC1', '#BA9088', '#C8429F'],
+  'belafonte-day': ['#D5CCBA', '#CCC3B2', '#34292D', '#6E6A4E', '#BE100E', '#426A79'],
+  'belafonte-night': ['#20111B', '#271821', '#D5CCBA', '#A6A07A', '#D6403E', '#6F8E97'],
+  paper: ['#F2EEDE', '#E6E2D3', '#1A1A1A', '#216609', '#CC3E28', '#1E6FCC'],
+  zenburn: ['#3A3A3A', '#424241', '#DCDCCC', '#8FB28F', '#CC9393', '#8CD0D3'],
+  'selenized-black': ['#181818', '#202020', '#DEDEDE', '#83C746', '#FF5E56', '#56D8C9'],
+  relaxed: ['#353A44', '#3D424B', '#F7F7F7', '#A0AC77', '#BC5653', '#7EAAC7'],
+  espresso: ['#323232', '#3A3A3A', '#FFFFFF', '#A5C261', '#D25252', '#6C99BB'],
+  dracula: ['#282A36', '#343746', '#F8F8F2', '#50FA7B', '#FF5555', '#BD93F9'],
+  ubuntu: ['#300A24', '#3D1530', '#EEEEEC', '#8AE234', '#CC0000', '#34E2E2'],
+};
+
+const THEME_LABELS: Record<ZicatoTheme, string> = {
+  monokai: 'Monokai',
+  'solarized-dark': 'Solarized Dark',
+  'solarized-light': 'Solarized Light',
+  'google-light': 'Google Light',
+  'google-dark': 'Google Dark',
+  'lunaria-light': 'Lunaria Light',
+  'lunaria-eclipse': 'Lunaria Eclipse',
+  'belafonte-day': 'Belafonte Day',
+  'belafonte-night': 'Belafonte Night',
+  paper: 'Paper',
+  zenburn: 'Zenburn',
+  'selenized-black': 'Selenized Black',
+  relaxed: 'Relaxed',
+  espresso: 'Espresso',
+  dracula: 'Dracula',
+  ubuntu: 'Ubuntu',
+};
+
+function SwatchStrip({ id }: { id: ZicatoTheme }) {
+  return (
+    <span className="dt-swatch-strip">
+      {THEME_SWATCHES[id].map((c, i) => (
+        <span key={i} className="dt-swatch" style={{ background: c }} />
+      ))}
+    </span>
+  );
+}
+
+// ── Theme picker (port of compose.html buildPicker/swatchStrip 98-140) ───────
+
+function ZicatoThemePicker() {
+  const theme = useUiStore((s) => s.zicatoTheme);
+  const setTheme = useUiStore((s) => s.setZicatoTheme);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = () => setOpen(false);
+    document.addEventListener('click', onDocClick);
+    return () => document.removeEventListener('click', onDocClick);
+  }, [open]);
+
+  return (
+    <div className={`dt-cd${open ? ' dt-cd-open' : ''}`}>
+      <button
+        className="dt-cd-trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+      >
+        <SwatchStrip id={theme} />
+        <span className="dt-cd-name">{THEME_LABELS[theme]}</span>
+        <span className="dt-cd-caret" aria-hidden="true">
+          ▾
+        </span>
+      </button>
+      <div className="dt-cd-list" role="listbox" aria-label="theme">
+        {ZICATO_THEME_IDS.map((id) => (
+          <button
+            key={id}
+            className="dt-cd-option"
+            role="option"
+            aria-selected={id === theme}
+            onClick={(e) => {
+              e.stopPropagation();
+              setTheme(id);
+              setOpen(false);
+            }}
+          >
+            <SwatchStrip id={id} />
+            <span className="dt-cd-name">{THEME_LABELS[id]}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Topbar (port of topbarHTML 623-633 + md3 toggle) ─────────────────────────
+
+function ZicatoTopbar({
+  z,
+  onToMd3,
+}: {
+  z: ZSession;
+  onToMd3: () => void;
+}) {
+  const openPicker = useUiStore((s) => s.openSessionPicker);
+  const inFlight = z.spans.filter(
+    (x) => x.status === 'running' || x.status === 'awaiting',
+  ).length;
+  const running = z.status === 'live';
+  return (
+    <div className="hg-topbar">
+      <span className="hg-brand">
+        <BrandMark height={20} />
+        <Wordmark />
+      </span>
+      <span className="hg-crumbs">
+        <span className="hg-crumb">~/ws</span>
+        <span className="hg-crumb-sep">▸</span>
+        <button className="hg-crumb hg-crumb-current" onClick={openPicker}>
+          {z.id || 'select session'} ▾
+        </button>
+        <span className="hg-picker-kbd">⌘K</span>
+      </span>
+      <span className="hg-topbar-spacer" />
+      <span className={`hg-status ${running ? 'is-running' : 'is-connected'}`}>
+        <span className="hg-status-dot" />
+        <span>{running ? 'streaming' : 'connected'}</span>
+        <span className="hg-run-badge">
+          <span className="hg-run-pulse" />
+          <span className="hg-run-label">{z.agents.length} agents</span>
+          <span>· {inFlight} in flight</span>
+        </span>
+      </span>
+      <ZicatoThemePicker />
+      <button
+        className="zk-iconbtn"
+        onClick={onToMd3}
+        aria-label="Switch to Material console"
+        title="md3 console"
+        data-testid="ui-mode-toggle-z"
+      >
+        ▤
+      </button>
+    </div>
+  );
+}
+
+// ── Strip (port of stripHTML 635-639) ────────────────────────────────────────
+
+function statusPill(z: ZSession) {
+  if (z.status === 'live') return <span className="dn-pill live">● live</span>;
+  if (z.status === 'done') return <span className="dn-pill good">✓ done</span>;
+  return <span className="dn-pill bad">✕ failed</span>;
+}
+
+function ZicatoStrip({ z }: { z: ZSession }) {
+  const run =
+    z.spans.find((x) => x.status === 'running') ??
+    z.spans.find((x) => x.status === 'awaiting');
+  return (
+    <div className="hg-strip">
+      <span className="hg-strip-label">goal</span>
+      <span className="hg-strip-title">{z.goal || '—'}</span>
+      {run && (
+        <>
+          <span className="hg-strip-agent">
+            {bareAgentName(run.agent) || run.agent}
+          </span>
+          <span className={`dn-pill ${run.status === 'awaiting' ? 'caution' : 'accent'}`}>
+            {run.status === 'awaiting' ? '◷ awaiting human' : `● ${run.label}`}
+          </span>
+        </>
+      )}
+      <span style={{ flex: 1 }} />
+      {statusPill(z)}
+    </div>
+  );
+}
+
+// ── Rail (port of railHTML 737-741) ──────────────────────────────────────────
+
+type ZicatoView = 'gantt' | 'instruments';
+
+function ZicatoRail({
+  view,
+  onView,
+}: {
+  view: ZicatoView;
+  onView: (v: ZicatoView) => void;
+}) {
+  const items: [ZicatoView, string][] = [
+    ['gantt', '▤'],
+    ['instruments', '⧉'],
+  ];
+  return (
+    <nav className="hg-rail">
+      {items.map(([v, ic]) => (
+        <button
+          key={v}
+          className="hg-rail-item"
+          aria-selected={view === v}
+          onClick={() => onView(v)}
+        >
+          <span className="hg-rail-icon">{ic}</span>
+          <span>{v}</span>
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+// ── Transport (reuse of TransportBar wiring 6-66, restyled in-language) ──────
+
+function ZicatoTransport() {
+  const liveFollow = useUiStore((s) => s.liveFollow);
+  const jumpToLive = useUiStore((s) => s.jumpToLive);
+  const agentsPaused = useUiStore((s) => s.agentsPaused);
+  const setAgentsPaused = useUiStore((s) => s.setAgentsPaused);
+  const sessionId = useUiStore((s) => s.currentSessionId);
+  const send = useSendControl();
+  const watch = useSessionWatch(sessionId);
+  const agents = watch.store.agents.list;
+
+  const [tick, setTick] = useState(0);
+  const [prevSessionId, setPrevSessionId] = useState(sessionId);
+  if (prevSessionId !== sessionId) {
+    setPrevSessionId(sessionId);
+    setTick(0);
+  }
+  useEffect(() => {
+    if (!sessionId) return;
+    const i = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(i);
+  }, [sessionId]);
+  const elapsedSeconds = sessionId ? tick : 0;
+
+  const handlePause = async () => {
+    if (!sessionId) return;
+    setAgentsPaused(true);
+    for (const a of agents) {
+      await send({ sessionId, agentId: a.id, kind: 'PAUSE' }).catch(() => {});
+    }
+  };
+  const handleResume = async () => {
+    if (!sessionId) return;
+    setAgentsPaused(false);
+    jumpToLive();
+    for (const a of agents) {
+      await send({ sessionId, agentId: a.id, kind: 'RESUME' }).catch(() => {});
+    }
+  };
+
+  return (
+    <footer
+      className="hg-transport"
+      role="toolbar"
+      aria-label="Transport controls"
+      data-testid="zicato-transport"
+    >
+      <span className="hg-transport-group">
+        <button
+          className="hg-transport-btn"
+          disabled={!sessionId}
+          title="jump to start"
+        >
+          ⏮
+        </button>
+        {agentsPaused ? (
+          <button
+            className="hg-transport-btn"
+            onClick={handleResume}
+            disabled={!sessionId}
+            title="resume agents"
+          >
+            ▶ resume
+          </button>
+        ) : (
+          <button
+            className="hg-transport-btn"
+            onClick={handlePause}
+            disabled={!sessionId}
+            title="pause agents"
+          >
+            ⏸ pause
+          </button>
+        )}
+        <button
+          className="hg-transport-btn"
+          onClick={jumpToLive}
+          disabled={!sessionId}
+          title="jump to now"
+        >
+          ⏭
+        </button>
+      </span>
+      <span className="hg-transport-divider" />
+      {agentsPaused ? (
+        <span className="dn-pill flat">paused</span>
+      ) : liveFollow && sessionId ? (
+        <span className="hg-live-badge">
+          <span className="hg-live-dot" aria-hidden="true" />
+          LIVE
+        </span>
+      ) : (
+        <span className="dn-pill flat">viewport locked</span>
+      )}
+      <span className="hg-clock tnum">
+        {sessionId ? formatDuration(elapsedSeconds) : '—'}
+      </span>
+      <span className="hg-transport-spacer" />
+      <span className="zk-prop-note">zoom: fit</span>
+    </footer>
+  );
+}
+
+// ── Inspector (mirror of drawerHTML 652-681, zicato-styled) ──────────────────
+
+function escapeJson(s: string): string {
+  return s.replace(/"/g, '\\"');
+}
+
+function ZicatoInspector() {
+  const drawerOpen = useUiStore((s) => s.drawerOpen);
+  const selectedSpanId = useUiStore((s) => s.selectedSpanId);
+  const closeDrawer = useUiStore((s) => s.closeDrawer);
+  const sessionId = useUiStore((s) => s.currentSessionId);
+  const store = getSessionStore(sessionId);
+  const [, bump] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => {
+    if (!store) return;
+    return store.spans.subscribe(() => bump());
+  }, [store]);
+
+  const span = selectedSpanId ? store?.spans.get(selectedSpanId) : undefined;
+
+  let body: ReactElement;
+  if (span) {
+    const status = toStatusToken(span.status);
+    const gf = gfClassForSpan(span);
+    const t0 = span.startMs / 1000;
+    const t1 = span.endMs != null ? span.endMs / 1000 : t0;
+    const statusClass =
+      status === 'failed'
+        ? 'bad'
+        : status === 'running'
+          ? 'accent'
+          : status === 'awaiting'
+            ? 'caution'
+            : 'good';
+    const agentLabel =
+      actorDisplayLabel(span.agentId) ?? bareAgentName(span.agentId) ?? span.agentId;
+    body = (
+      <>
+        <div
+          style={{
+            display: 'flex',
+            gap: 6,
+            flexWrap: 'wrap',
+            marginBottom: 10,
+          }}
+        >
+          <span className="dn-pill flat">{span.kind}</span>
+          <span className={`dn-pill ${statusClass}`}>{status}</span>
+        </div>
+        <dl className="hg-attrs">
+          <dt>agent</dt>
+          <dd>{agentLabel}</dd>
+          <dt>label</dt>
+          <dd>{span.name}</dd>
+          <dt>start</dt>
+          <dd className="tnum">{t0.toFixed(1)}s</dd>
+          <dt>end</dt>
+          <dd className="tnum">{span.endMs != null ? `${t1.toFixed(1)}s` : '—'}</dd>
+          <dt>duration</dt>
+          <dd className="tnum">{(t1 - t0).toFixed(1)}s</dd>
+          {gf && (
+            <>
+              <dt>gf category</dt>
+              <dd>{gf}</dd>
+            </>
+          )}
+        </dl>
+        <h3
+          style={{
+            fontSize: 10,
+            textTransform: 'uppercase',
+            letterSpacing: '.1em',
+            color: 'var(--ink-faint)',
+            margin: '14px 0 6px',
+          }}
+        >
+          payload
+        </h3>
+        <code className="hg-drawer-code">
+          <span className="hg-j-punct">{'{ '}</span>
+          <span className="hg-j-key">"span_id"</span>
+          <span className="hg-j-punct">: </span>
+          <span className="hg-j-str">"{escapeJson(span.id)}"</span>
+          <span className="hg-j-punct">,</span>
+          {'\n  '}
+          <span className="hg-j-key">"kind"</span>
+          <span className="hg-j-punct">: </span>
+          <span className="hg-j-str">"{span.kind}"</span>
+          <span className="hg-j-punct">,</span>
+          {'\n  '}
+          <span className="hg-j-key">"status"</span>
+          <span className="hg-j-punct">: </span>
+          <span className="hg-j-str">"{span.status}"</span>
+          <span className="hg-j-punct"> {'}'}</span>
+        </code>
+      </>
+    );
+  } else {
+    body = (
+      <p style={{ fontSize: 10, color: 'var(--ink-faint)' }}>
+        click any span for its detail · Esc closes
+      </p>
+    );
+  }
+
+  return (
+    <div className={`zk-drawer-host ${drawerOpen ? 'open' : ''}`}>
+      <div className="hg-drawer">
+        <div className="hg-drawer-header">
+          <span className="hg-drawer-title">{span ? span.name : 'session'}</span>
+          <button
+            className="hg-drawer-close"
+            onClick={closeDrawer}
+            title="close"
+            aria-label="Close inspector"
+          >
+            ×
+          </button>
+        </div>
+        <div className="hg-drawer-body">{body}</div>
+      </div>
+    </div>
+  );
+}
+
+// ── The console shell ────────────────────────────────────────────────────────
+
+export function ZicatoConsole() {
+  useGlobalShortcuts(); // ⌘K / Esc / j-k — owned here (not inherited from Shell)
+
+  const sessionId = useUiStore((s) => s.currentSessionId);
+  const setUiMode = useUiStore((s) => s.setUiMode);
+  const zicatoTheme = useUiStore((s) => s.zicatoTheme);
+
+  // Keep the stream alive for all sub-views + inspector (single watch).
+  useSessionWatch(sessionId);
+
+  const [view, setView] = useState<ZicatoView>('gantt'); // local; map-shell §6
+  const z = useZicatoSession(sessionId);
+
+  return (
+    <div className="zk-root" data-zicato-theme={zicatoTheme} data-testid="zicato-console">
+      <SessionsSyncer />
+      <ZicatoTopbar z={z} onToMd3={() => setUiMode('md3')} />
+      <ZicatoStrip z={z} />
+      <div className="zk-app-body">
+        <ZicatoRail view={view} onView={setView} />
+        <main className="zk-main" data-view={view}>
+          {view === 'gantt' && <GanttViewZ z={z} />}
+          {view === 'instruments' && <InstrumentsViewZ z={z} />}
+        </main>
+        <ZicatoInspector />
+      </div>
+      <ZicatoTransport />
+      <SessionPicker />
+    </div>
+  );
+}

--- a/frontend/src/components/zicato/ZicatoConsole.tsx
+++ b/frontend/src/components/zicato/ZicatoConsole.tsx
@@ -25,16 +25,25 @@ import { SessionPicker } from '../SessionPicker/SessionPicker';
 import { useGlobalShortcuts } from '../../lib/shortcuts';
 import { formatDuration } from '../../lib/format';
 import { bareAgentName } from '../../gantt/index';
+import { extractThinkingText, hasThinking } from '../../lib/thinking';
 import { actorDisplayLabel } from '../../theme/agentColors';
 import {
   useZicatoSession,
   toStatusToken,
   gfClassForSpan,
   type ZSession,
+  type ZSpan,
+  type ZSteer,
 } from './adapter';
 import { BrandMark, Wordmark } from './Brand';
 import { GanttViewZ } from './GanttViewZ';
 import { InstrumentsViewZ } from './InstrumentsViewZ';
+import {
+  FloatingDrawerZ,
+  ReasoningDetailBody,
+  SteeringDetailBodyZ,
+} from './FloatingDrawerZ';
+import { SteerSelectContext } from './steerContext';
 
 // ── Theme picker data tables (ported from compose.html 99-123) ───────────────
 
@@ -384,7 +393,12 @@ function escapeJson(s: string): string {
   return s.replace(/"/g, '\\"');
 }
 
-function ZicatoInspector() {
+function ZicatoInspector({
+  onOpenReasoning,
+}: {
+  /** Open the selected span's full reasoning in the floating drawer. */
+  onOpenReasoning?: (spanId: string) => void;
+}) {
   const drawerOpen = useUiStore((s) => s.drawerOpen);
   const selectedSpanId = useUiStore((s) => s.selectedSpanId);
   const closeDrawer = useUiStore((s) => s.closeDrawer);
@@ -402,6 +416,11 @@ function ZicatoInspector() {
   if (span) {
     const status = toStatusToken(span.status);
     const gf = gfClassForSpan(span);
+    // Reasoning detection mirrors the adapter (lib/thinking). The docked
+    // inspector shows a preview + a button to pop the full 🧠 chain-of-thought
+    // into the floating drawer.
+    const spanHasReasoning = hasThinking(span);
+    const reasoningText = extractThinkingText(span);
     const t0 = span.startMs / 1000;
     const t1 = span.endMs != null ? span.endMs / 1000 : t0;
     const statusClass =
@@ -473,6 +492,50 @@ function ZicatoInspector() {
           <span className="hg-j-str">"{span.status}"</span>
           <span className="hg-j-punct"> {'}'}</span>
         </code>
+        {spanHasReasoning && (
+          <section
+            className="zk-detail-section"
+            data-testid="zk-inspector-reasoning"
+            style={{ marginTop: 14 }}
+          >
+            <div className="zk-reasoning-head" style={{ marginBottom: 6 }}>
+              <span className="zk-reasoning-glyph" aria-hidden="true">
+                🧠
+              </span>
+              <h3
+                style={{
+                  fontSize: 10,
+                  textTransform: 'uppercase',
+                  letterSpacing: '.1em',
+                  color: 'var(--ink-faint)',
+                  margin: 0,
+                }}
+              >
+                reasoning
+              </h3>
+            </div>
+            {reasoningText ? (
+              <pre className="zk-reasoning" data-testid="zk-inspector-reasoning-text">
+                {reasoningText}
+              </pre>
+            ) : (
+              <div className="zk-reasoning-empty">
+                reasoning captured (full text in a payload reference)
+              </div>
+            )}
+            {onOpenReasoning && (
+              <button
+                type="button"
+                className="hg-transport-btn"
+                style={{ marginTop: 8 }}
+                onClick={() => onOpenReasoning(span.id)}
+                data-testid="zk-inspector-reasoning-expand"
+              >
+                🧠 open in drawer
+              </button>
+            )}
+          </section>
+        )}
       </>
     );
   } else {
@@ -505,6 +568,12 @@ function ZicatoInspector() {
 
 // ── The console shell ────────────────────────────────────────────────────────
 
+// Floating-drawer content union: a reasoning span detail or a steering detail.
+// Kept typed at the boundary so the drawer body never re-derives the selection.
+type ZDrawerContent =
+  | { type: 'reasoning'; span: ZSpan }
+  | { type: 'steering'; steer: ZSteer };
+
 export function ZicatoConsole() {
   useGlobalShortcuts(); // ⌘K / Esc / j-k — owned here (not inherited from Shell)
 
@@ -518,19 +587,53 @@ export function ZicatoConsole() {
   const [view, setView] = useState<ZicatoView>('gantt'); // local; map-shell §6
   const z = useZicatoSession(sessionId);
 
+  // Floating-drawer state: a steering-arrow click (via SteerSelectProvider) or
+  // an inspector "open reasoning" click lands a typed content union here. The
+  // drawer overlays the main area and unmounts when closed.
+  const [drawerContent, setDrawerContent] = useState<ZDrawerContent | null>(null);
+  const openSteerDrawer = (steer: ZSteer): void =>
+    setDrawerContent({ type: 'steering', steer });
+  const openReasoningDrawer = (spanId: string): void => {
+    const span = z.spans.find((s) => s.id === spanId);
+    if (span) setDrawerContent({ type: 'reasoning', span });
+  };
+  const closeFloatingDrawer = (): void => setDrawerContent(null);
+
+  const drawerTitle =
+    drawerContent?.type === 'steering'
+      ? 'steering detail'
+      : drawerContent?.type === 'reasoning'
+        ? 'reasoning detail'
+        : undefined;
+
   return (
     <div className="zk-root" data-zicato-theme={zicatoTheme} data-testid="zicato-console">
       <SessionsSyncer />
       <ZicatoTopbar z={z} onToMd3={() => setUiMode('md3')} />
       <ZicatoStrip z={z} />
-      <div className="zk-app-body">
-        <ZicatoRail view={view} onView={setView} />
-        <main className="zk-main" data-view={view}>
-          {view === 'gantt' && <GanttViewZ z={z} />}
-          {view === 'instruments' && <InstrumentsViewZ z={z} />}
-        </main>
-        <ZicatoInspector />
-      </div>
+      <SteerSelectContext.Provider value={openSteerDrawer}>
+        <div className="zk-app-body" style={{ position: 'relative' }}>
+          <ZicatoRail view={view} onView={setView} />
+          <main className="zk-main" data-view={view}>
+            {view === 'gantt' && <GanttViewZ z={z} />}
+            {view === 'instruments' && <InstrumentsViewZ z={z} />}
+          </main>
+          <ZicatoInspector onOpenReasoning={openReasoningDrawer} />
+          <FloatingDrawerZ
+            open={drawerContent !== null}
+            onClose={closeFloatingDrawer}
+            title={drawerTitle}
+            testId="zk-floating-drawer"
+          >
+            {drawerContent?.type === 'reasoning' && (
+              <ReasoningDetailBody span={drawerContent.span} z={z} />
+            )}
+            {drawerContent?.type === 'steering' && (
+              <SteeringDetailBodyZ steer={drawerContent.steer} z={z} />
+            )}
+          </FloatingDrawerZ>
+        </div>
+      </SteerSelectContext.Provider>
       <ZicatoTransport />
       <SessionPicker />
     </div>

--- a/frontend/src/components/zicato/adapter.ts
+++ b/frontend/src/components/zicato/adapter.ts
@@ -1,0 +1,1147 @@
+// adapter.ts — the REAL-data adapter for the zicato console.
+//
+// Maps the live `SessionStore` (gantt/index.ts) + the sessions list + plan
+// hooks + annotations into the per-figure input bundle (`ZSession`) the zicato
+// SVG renderers consume. NO study mock data.
+//
+// Time is converted ms → seconds here (the study renderers are in seconds).
+// Every mapper has a documented graceful fallback so a figure never throws on
+// absent data (see EMPTY_SESSION + the per-mapper notes).
+//
+// The single composing hook `useZicatoSession(sessionId)` is the only thing the
+// views call; the pure mappers are exported so figure agents / unit tests can
+// exercise them in isolation. The caller (ZicatoConsole) is responsible for
+// holding the `useSessionWatch` that keeps the stream alive — this hook reads
+// the store via `getSessionStore`.
+
+import { useEffect, useMemo, useReducer } from 'react';
+import { getSessionStore } from '../../rpc/hooks';
+import { useSessionsStore } from '../../state/sessionsStore';
+import { useUiStore } from '../../state/uiStore';
+import {
+  usePlanHistory,
+  useCumulativePlan,
+  useSupersedesMap,
+} from '../../state/planHistoryHooks';
+import type {
+  CumulativePlan,
+  PlanRevisionRecord,
+  SupersessionLink,
+} from '../../state/planHistoryStore';
+import { useAnnotationStore, type Annotation } from '../../state/annotationStore';
+import { deriveInterventionsFromStore } from '../../lib/interventions';
+import { bareAgentName, type SessionStore } from '../../gantt/index';
+import type {
+  Span,
+  SpanKind,
+  SpanStatus,
+  Task,
+} from '../../gantt/types';
+import {
+  isSyntheticActor,
+  actorDisplayLabel,
+  USER_ACTOR_ID,
+  GOLDFIVE_ACTOR_ID,
+} from '../../theme/agentColors';
+
+// ── 3.1 Output types — the figure-input contract (frozen) ────────────────────
+
+/** Lower-kebab span kind matching the `--hg-kind-*` token names. */
+export type ZKindToken =
+  | 'invocation'
+  | 'llm-call'
+  | 'tool-call'
+  | 'user-message'
+  | 'agent-message'
+  | 'transfer'
+  | 'wait-for-human'
+  | 'planned'
+  | 'custom';
+
+/** Lower treatment keys (status → treatment, not hue). */
+export type ZStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'awaiting'
+  | 'planned';
+
+/** `--hg-gf-*` category for goldfive spans, or null for non-goldfive spans. */
+export type ZGfClass =
+  | 'judge-on-task'
+  | 'judge-warning'
+  | 'judge-critical'
+  | 'judge-neutral'
+  | 'refine'
+  | 'plan'
+  | 'reflective'
+  | null;
+
+export type ZSessionStatus = 'live' | 'done' | 'failed';
+
+/** One agent lane. ordinal → `--hg-agent-N` (1..8); synthetics → -user/-goldfive. */
+export interface ZAgent {
+  /** real agentId ('<client>:<bare>' | '__user__' | '__goldfive__'). */
+  id: string;
+  /** bareAgentName / actorDisplayLabel. */
+  label: string;
+  /** 1..8 stable lane index; synthetic actors get 0 (resolved by colorVar). */
+  ordinal: number;
+  synthetic: 'user' | 'goldfive' | null;
+}
+
+/** One span bar (study `s.spans[]` shape, real-data-backed). */
+export interface ZSpan {
+  id: string;
+  /** agent = ZAgent.id */
+  agent: string;
+  kind: ZKindToken;
+  status: ZStatus;
+  gf: ZGfClass;
+  /** seconds, session-relative */
+  t0: number;
+  /** seconds, session-relative; equals `now` for running spans */
+  t1: number;
+  /** span.name */
+  label: string;
+}
+
+/** Hand-off chord. seconds, agent ids. */
+export interface ZTransfer {
+  t: number;
+  from: string;
+  to: string;
+}
+
+/** Optional single delegation block. */
+export interface ZDelegation {
+  from: string;
+  to: string;
+  t0: number;
+  t1: number;
+  tokens: number | null;
+  verdict: string | null;
+}
+
+export type ZArrowKind = 'transfer' | 'delegation' | 'return';
+
+/** Derived gantt/sequence edge. */
+export interface ZEdge {
+  t: number;
+  from: string;
+  to: string;
+  kind: ZArrowKind;
+}
+
+// Plan DAG + reel (study p.* shape).
+export interface ZPlanNode {
+  tid: string;
+  title: string;
+  x: number;
+  y: number;
+  st: 'done' | 'running' | 'pending' | 'added' | 'ghost';
+}
+export interface ZPlanEdge {
+  from: string;
+  to: string;
+  crit: boolean;
+}
+export interface ZStratum {
+  v: number;
+  has: Set<string>;
+  added: Set<string>;
+  /** revision trigger label ('' if none) */
+  seam: string;
+  live: boolean;
+}
+export interface ZPlan {
+  nodes: ZPlanNode[];
+  edges: ZPlanEdge[];
+  /** newest-first (study convention) */
+  strata: ZStratum[];
+  /** tasks-remaining per version, oldest→newest */
+  rem: number[];
+  planId: string | null;
+}
+
+// Seismograph / ladder.
+/** agentId → [[t_sec, driftValue], …] */
+export type ZJudges = Record<string, [number, number][]>;
+/** agentId → [[t_sec, label], …] */
+export type ZTicks = Record<string, [number, string][]>;
+/** [[t_sec, rungIdx 0..3], …] */
+export type ZLadder = [number, number][];
+/** [[t_sec, fraction 0..1], …] */
+export type ZCtx = [number, number][];
+
+/** Fingerprint Lissajous params (deterministic derivation). */
+export interface ZFingerprint {
+  fx: number;
+  fy: number;
+  px: number;
+  d: number;
+  corrAt: number | null;
+  grow: boolean;
+  T: number;
+}
+
+/** The full per-session bundle the views destructure. */
+export interface ZSession {
+  id: string;
+  /** goal = SessionSummary.title / Session.title (no separate goal field). */
+  goal: string;
+  status: ZSessionStatus;
+  /** seconds */
+  T: number;
+  /** seconds */
+  now: number;
+  /** lane order (join-time, synthetic actors included) */
+  agents: ZAgent[];
+  spans: ZSpan[];
+  transfers: ZTransfer[];
+  delegation: ZDelegation | null;
+  /** derived transfer/delegation/return edges (GraphView algo) */
+  edges: ZEdge[];
+  judges: ZJudges;
+  ticks: ZTicks;
+  ladder: ZLadder;
+  ctx: ZCtx;
+  plan: ZPlan;
+  fp: ZFingerprint;
+  /** true when no store/session → render placeholders */
+  empty: boolean;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const EMPTY_PLAN: ZPlan = {
+  nodes: [],
+  edges: [],
+  strata: [],
+  rem: [],
+  planId: null,
+};
+
+/** A tight default Lissajous knot (on-plan look) for sessions with no data. */
+const DEFAULT_FP: ZFingerprint = {
+  fx: 2,
+  fy: 3,
+  px: 0,
+  d: 0.05,
+  corrAt: null,
+  grow: false,
+  T: 30,
+};
+
+/** The placeholder bundle returned when no store/session is available. */
+export const EMPTY_SESSION: ZSession = {
+  id: '',
+  goal: '',
+  status: 'live',
+  T: 30,
+  now: 0,
+  agents: [],
+  spans: [],
+  transfers: [],
+  delegation: null,
+  edges: [],
+  judges: {},
+  ticks: {},
+  ladder: [],
+  ctx: [],
+  plan: EMPTY_PLAN,
+  fp: { ...DEFAULT_FP },
+  empty: true,
+};
+
+/** Stable empty annotation list — keeps the zustand selector reference cached. */
+const EMPTY_ANNOTATIONS: readonly Annotation[] = Object.freeze([]);
+
+// DAG layout constants (study dagSVG).
+const DAG_LX = [80, 300, 520, 740] as const;
+const DAG_LY = (v: number): number => 92 + v * 44;
+
+// ── 4-adjacent helper: severity → drift value (also re-exported from svgUtils) ─
+
+/** Map a goldfive drift severity string to a seismograph drift value. */
+export function severityToValue(sev: string): number {
+  switch (sev) {
+    case 'critical':
+      return 14;
+    case 'warning':
+      return 9;
+    case 'info':
+      return 4;
+    default:
+      return 2;
+  }
+}
+
+// ── 3.3 Pure mappers ─────────────────────────────────────────────────────────
+
+/** UPPER_SNAKE SpanKind → lower-kebab kind token. 'LLM_CALL' → 'llm-call'. */
+export function toKindToken(k: SpanKind): ZKindToken {
+  switch (k) {
+    case 'INVOCATION':
+      return 'invocation';
+    case 'LLM_CALL':
+      return 'llm-call';
+    case 'TOOL_CALL':
+      return 'tool-call';
+    case 'USER_MESSAGE':
+      return 'user-message';
+    case 'AGENT_MESSAGE':
+      return 'agent-message';
+    case 'TRANSFER':
+      return 'transfer';
+    case 'WAIT_FOR_HUMAN':
+      return 'wait-for-human';
+    case 'PLANNED':
+      return 'planned';
+    case 'CUSTOM':
+      return 'custom';
+    default:
+      return 'custom';
+  }
+}
+
+/** UPPER_SNAKE SpanStatus → lower treatment key. 'AWAITING_HUMAN' → 'awaiting'. */
+export function toStatusToken(s: SpanStatus): ZStatus {
+  switch (s) {
+    case 'PENDING':
+      return 'pending';
+    case 'RUNNING':
+      return 'running';
+    case 'COMPLETED':
+      return 'completed';
+    case 'FAILED':
+      return 'failed';
+    case 'CANCELLED':
+      return 'cancelled';
+    case 'AWAITING_HUMAN':
+      return 'awaiting';
+    default:
+      return 'completed';
+  }
+}
+
+/**
+ * Read a span's goldfive category from its attributes (if any). Looks for a
+ * string attribute under a goldfive-category key and maps it onto a `--hg-gf-*`
+ * class. Returns null for non-goldfive spans (the common case).
+ */
+export function gfClassForSpan(sp: Span): ZGfClass {
+  const candidates = [
+    'goldfive.category',
+    'goldfive_category',
+    'gf.category',
+    'gf_category',
+    'goldfive.class',
+  ];
+  let raw = '';
+  for (const key of candidates) {
+    const attr = sp.attributes[key];
+    if (attr && attr.kind === 'string' && attr.value) {
+      raw = attr.value;
+      break;
+    }
+  }
+  if (!raw) return null;
+  const v = raw.toLowerCase().replace(/_/g, '-');
+  switch (v) {
+    case 'judge-on-task':
+    case 'judge-warning':
+    case 'judge-critical':
+    case 'judge-neutral':
+    case 'refine':
+    case 'plan':
+    case 'reflective':
+      return v;
+    default:
+      return null;
+  }
+}
+
+/**
+ * agents → lanes. Join-time order (store.agents.list). Each non-synthetic agent
+ * gets a stable ordinal in 1..8 (`(index % 8) + 1`); the user/goldfive synthetic
+ * actors are flagged so colorVar can route them to the -user/-goldfive tokens.
+ * The goldfive row is canonicalized via store.resolveGoldfiveActorId().
+ */
+export function buildAgents(store: SessionStore): ZAgent[] {
+  const goldfiveId = store.resolveGoldfiveActorId();
+  const out: ZAgent[] = [];
+  let nonSyntheticIdx = 0;
+  for (const a of store.agents.list) {
+    const synthetic = syntheticKind(a.id, goldfiveId);
+    if (synthetic) {
+      out.push({
+        id: a.id,
+        label: actorDisplayLabel(a.id) ?? synthetic,
+        ordinal: 0,
+        synthetic,
+      });
+    } else {
+      const ordinal = (nonSyntheticIdx % 8) + 1;
+      nonSyntheticIdx += 1;
+      out.push({
+        id: a.id,
+        label: bareAgentName(a.id) || a.id,
+        ordinal,
+        synthetic: null,
+      });
+    }
+  }
+  return out;
+}
+
+function syntheticKind(
+  agentId: string,
+  goldfiveId: string,
+): 'user' | 'goldfive' | null {
+  if (agentId === USER_ACTOR_ID) return 'user';
+  if (agentId === GOLDFIVE_ACTOR_ID || agentId === goldfiveId) return 'goldfive';
+  if (agentId.endsWith(':goldfive')) return 'goldfive';
+  // Fall back to the synthetic-actor helper for any other synthetic ids.
+  const label = actorDisplayLabel(agentId);
+  if (label === 'user') return 'user';
+  if (label === 'goldfive') return 'goldfive';
+  return isSyntheticActor(agentId) ? 'goldfive' : null;
+}
+
+/**
+ * spans → bars. Queries the full session range. t0 = startMs/1000; running spans
+ * (endMs == null) extend to `nowSec`. Replaced spans are kept (the renderer dims
+ * them via status/opacity). Fallback: no spans → [].
+ */
+export function buildSpans(
+  store: SessionStore,
+  _agents: ZAgent[],
+  nowSec: number,
+): ZSpan[] {
+  void _agents;
+  const maxEnd = store.spans.maxEndMs();
+  const spans = store.spans.queryRange(0, maxEnd + 1);
+  const out: ZSpan[] = [];
+  for (const sp of spans) {
+    const t0 = sp.startMs / 1000;
+    const t1 = sp.endMs != null ? sp.endMs / 1000 : nowSec;
+    out.push({
+      id: sp.id,
+      agent: sp.agentId,
+      kind: toKindToken(sp.kind),
+      status: toStatusToken(sp.status),
+      gf: gfClassForSpan(sp),
+      t0,
+      t1: Math.max(t0, t1),
+      label: sp.name,
+    });
+  }
+  out.sort((a, b) => a.t0 - b.t0);
+  return out;
+}
+
+/**
+ * transfers → chords. Derived from the edge set (transfer-kind edges). Fallback:
+ * none derivable → [].
+ */
+export function buildTransfers(store: SessionStore): ZTransfer[] {
+  const out: ZTransfer[] = [];
+  for (const e of buildEdges(store)) {
+    if (e.kind === 'transfer') {
+      out.push({ t: e.t, from: e.from, to: e.to });
+    }
+  }
+  return out;
+}
+
+/**
+ * delegation → optional single block. Picks the first DelegationRecord and
+ * bounds it by the to-agent's first/last span when available. tokens/verdict are
+ * left null in cut 1 (deferred, no canonical attribute). Fallback: no record → null.
+ */
+export function buildDelegation(store: SessionStore): ZDelegation | null {
+  const recs = store.delegations.list();
+  if (recs.length === 0) return null;
+  const d = recs[0];
+  if (!d.fromAgentId || !d.toAgentId) return null;
+  const t0 = d.observedAtMs / 1000;
+  // Approximate the delegated span window from the to-agent's spans after t0.
+  const sub = store.spans
+    .queryAgent(d.toAgentId, d.observedAtMs, Number.POSITIVE_INFINITY)
+    .filter((s) => s.kind === 'INVOCATION');
+  let t1 = t0;
+  for (const s of sub) {
+    const end = s.endMs != null ? s.endMs / 1000 : t0;
+    if (end > t1) t1 = end;
+  }
+  return {
+    from: d.fromAgentId,
+    to: d.toAgentId,
+    t0,
+    t1: Math.max(t0, t1),
+    tokens: null,
+    verdict: null,
+  };
+}
+
+/**
+ * edges → transfer/delegation/return. Ported from GraphView.computeSequence
+ * (map-data §5.6): Method1 (INVOCATION + INVOKED link), 1b (TRANSFER span carries
+ * the link), 2 (cross-agent parent), 3 (store.delegations.list), + return edges.
+ * Deduped on `<from>→<to>@round(ms/500)`. Times in seconds. Fallback: none → [].
+ */
+export function buildEdges(store: SessionStore): ZEdge[] {
+  const allSpans = [...store.spans.all()];
+  const spanById = new Map<string, Span>();
+  for (const s of allSpans) spanById.set(s.id, s);
+
+  interface Raw {
+    fromId: string;
+    toId: string;
+    kind: 'transfer' | 'delegation';
+    yMs: number;
+  }
+  const forward: Raw[] = [];
+  const covered = new Set<string>();
+  const keyFor = (from: string, to: string, ms: number): string =>
+    `${from}→${to}@${Math.round(ms / 500)}`;
+
+  // Method 1 — INVOCATION span with INVOKED link to a different agent.
+  for (const s of allSpans) {
+    if (s.kind !== 'INVOCATION') continue;
+    for (const link of s.links) {
+      if (link.relation !== 'INVOKED') continue;
+      if (!link.targetAgentId || link.targetAgentId === s.agentId) continue;
+      const anchorMs = s.startMs;
+      covered.add(keyFor(link.targetAgentId, s.agentId, anchorMs));
+      forward.push({
+        fromId: link.targetAgentId,
+        toId: s.agentId,
+        kind: 'transfer',
+        yMs: anchorMs,
+      });
+    }
+  }
+  // Method 1b — a TRANSFER span itself carries the INVOKED link.
+  for (const s of allSpans) {
+    if (s.kind !== 'TRANSFER') continue;
+    for (const link of s.links) {
+      if (link.relation !== 'INVOKED') continue;
+      if (!link.targetAgentId || link.targetAgentId === s.agentId) continue;
+      const targetSpan = link.targetSpanId
+        ? spanById.get(link.targetSpanId)
+        : undefined;
+      const anchorMs = targetSpan ? targetSpan.startMs : s.startMs;
+      const k = keyFor(s.agentId, link.targetAgentId, anchorMs);
+      if (covered.has(k)) continue;
+      covered.add(k);
+      forward.push({
+        fromId: s.agentId,
+        toId: link.targetAgentId,
+        kind: 'transfer',
+        yMs: anchorMs,
+      });
+    }
+  }
+  // Method 2 — cross-agent INVOCATION parents (delegation).
+  for (const s of allSpans) {
+    if (s.kind !== 'INVOCATION') continue;
+    if (!s.parentSpanId) continue;
+    const parent = spanById.get(s.parentSpanId);
+    if (!parent || parent.agentId === s.agentId) continue;
+    const k = keyFor(parent.agentId, s.agentId, s.startMs);
+    if (covered.has(k)) continue;
+    covered.add(k);
+    forward.push({
+      fromId: parent.agentId,
+      toId: s.agentId,
+      kind: 'delegation',
+      yMs: s.startMs,
+    });
+  }
+  // Method 3 — goldfive DelegationObserved events.
+  for (const d of store.delegations.list()) {
+    if (!d.fromAgentId || !d.toAgentId) continue;
+    if (d.fromAgentId === d.toAgentId) continue;
+    const k = keyFor(d.fromAgentId, d.toAgentId, d.observedAtMs);
+    if (covered.has(k)) continue;
+    covered.add(k);
+    forward.push({
+      fromId: d.fromAgentId,
+      toId: d.toAgentId,
+      kind: 'delegation',
+      yMs: d.observedAtMs,
+    });
+  }
+
+  // Return edges — for each finished INVOCATION, find the most recent forward
+  // arrow that targeted its agent before it started; emit a return at endMs.
+  const forwardByDest = new Map<string, Raw[]>();
+  for (const e of forward) {
+    const arr = forwardByDest.get(e.toId) ?? [];
+    arr.push(e);
+    forwardByDest.set(e.toId, arr);
+  }
+  const returns: Raw[] = [];
+  for (const s of allSpans) {
+    if (s.kind !== 'INVOCATION') continue;
+    if (s.endMs === null) continue;
+    const incoming = forwardByDest.get(s.agentId) ?? [];
+    const caller = incoming
+      .filter((e) => e.yMs <= s.startMs)
+      .sort((a, b) => b.yMs - a.yMs)[0];
+    if (!caller) continue;
+    if (caller.fromId === s.agentId) continue;
+    returns.push({
+      fromId: s.agentId,
+      toId: caller.fromId,
+      kind: 'delegation',
+      yMs: s.endMs,
+    });
+  }
+
+  const out: ZEdge[] = [];
+  for (const e of forward) {
+    out.push({ t: e.yMs / 1000, from: e.fromId, to: e.toId, kind: e.kind });
+  }
+  for (const e of returns) {
+    out.push({ t: e.yMs / 1000, from: e.fromId, to: e.toId, kind: 'return' });
+  }
+  out.sort((a, b) => a.t - b.t);
+  return out;
+}
+
+/**
+ * judges → per-agent drift trace keyframes. From store.drifts.list(): push
+ * [recordedAtMs/1000, severityToValue(severity)] per drift, grouped by agentId
+ * (falling back to the goldfive lane when a drift has no agent). Fallback: no
+ * drift → {} (seismograph baseline only).
+ */
+export function buildJudges(store: SessionStore, agents: ZAgent[]): ZJudges {
+  void agents;
+  const goldfiveId = store.resolveGoldfiveActorId();
+  const out: ZJudges = {};
+  for (const d of store.drifts.list()) {
+    const agent = d.agentId || goldfiveId;
+    if (!agent) continue;
+    const arr = out[agent] ?? (out[agent] = []);
+    arr.push([d.recordedAtMs / 1000, severityToValue(d.severity)]);
+  }
+  for (const k of Object.keys(out)) out[k].sort((a, b) => a[0] - b[0]);
+  return out;
+}
+
+/**
+ * ticks → intervention markers per agent. deriveInterventionsFromStore grouped
+ * by targetAgentId (fallback the goldfive lane), [atMs/1000, kind]. Fallback: no
+ * interventions → {}.
+ */
+export function buildTicks(
+  store: SessionStore,
+  annotations: readonly Annotation[],
+): ZTicks {
+  const goldfiveId = store.resolveGoldfiveActorId() || GOLDFIVE_ACTOR_ID;
+  const rows = deriveInterventionsFromStore(store, annotations);
+  const out: ZTicks = {};
+  for (const r of rows) {
+    const agent = r.targetAgentId || goldfiveId;
+    const arr = out[agent] ?? (out[agent] = []);
+    arr.push([r.atMs / 1000, r.kind || r.source]);
+  }
+  for (const k of Object.keys(out)) out[k].sort((a, b) => a[0] - b[0]);
+  return out;
+}
+
+/**
+ * ladder → intervention-ladder dots. Maps each intervention row's kind/severity
+ * to a rung: nudge(0) / refine(1) / replan(2) / escalate(3). escalate when the
+ * severity is critical or the row came from a goldfive escalation. Fallback: no
+ * interventions → [] ("never left the ground").
+ */
+export function buildLadder(
+  store: SessionStore,
+  annotations: readonly Annotation[],
+): ZLadder {
+  const rows = deriveInterventionsFromStore(store, annotations);
+  const out: ZLadder = [];
+  for (const r of rows) {
+    out.push([r.atMs / 1000, rungForRow(r.source, r.kind, r.severity, r.outcome)]);
+  }
+  out.sort((a, b) => a[0] - b[0]);
+  return out;
+}
+
+function rungForRow(
+  source: string,
+  kind: string,
+  severity: string,
+  outcome: string,
+): number {
+  if (severity === 'critical') return 3; // escalate
+  const k = (kind || '').toLowerCase();
+  if (k.includes('escalat')) return 3;
+  if (source === 'refine' || k.includes('refine')) return 1;
+  if (
+    source === 'transition' ||
+    k.includes('replan') ||
+    k.includes('revis') ||
+    outcome.startsWith('plan_revised')
+  ) {
+    return 2;
+  }
+  return 0; // nudge / steer / comment
+}
+
+/**
+ * ctx → context-window utilisation curve for the busiest non-synthetic agent.
+ * store.contextSeries.forAgent(id) → [tMs/1000, tokens/limitTokens]. Fallback: no
+ * samples → [].
+ */
+export function buildCtx(store: SessionStore, agents: ZAgent[]): ZCtx {
+  // Pick the busiest non-synthetic agent (most spans).
+  let bestId: string | null = null;
+  let bestCount = -1;
+  for (const a of agents) {
+    if (a.synthetic) continue;
+    const count = store.spans.queryAgent(
+      a.id,
+      0,
+      Number.POSITIVE_INFINITY,
+    ).length;
+    if (count > bestCount) {
+      bestCount = count;
+      bestId = a.id;
+    }
+  }
+  if (!bestId) return [];
+  const samples = store.contextSeries.forAgent(bestId);
+  const out: ZCtx = [];
+  for (const s of samples) {
+    if (s.limitTokens <= 0) continue;
+    out.push([s.tMs / 1000, Math.min(1, s.tokens / s.limitTokens)]);
+  }
+  return out;
+}
+
+/**
+ * plan → DAG + reel. Lays cumulative.tasks into 4 cols by topo-depth (LX/LY),
+ * derives node state from task.status + revision meta, edges from cumulative.edges
+ * with a longest-path "critical" heuristic, and strata (newest-first) + rem from
+ * the revision history. Fallback: no planId → empty ZPlan.
+ */
+export function buildPlan(
+  history: readonly PlanRevisionRecord[],
+  cumulative: CumulativePlan | null,
+  supersedes: Map<string, SupersessionLink>,
+  selectedRevision: number | null,
+): ZPlan {
+  if (!cumulative || !cumulative.id) return { ...EMPTY_PLAN };
+  const planId = cumulative.id;
+  const tasks = cumulative.tasks;
+  const meta = cumulative.taskRevisionMeta;
+  // The newest revision index — from the history (CumulativePlan extends
+  // TaskPlan and has no explicit latestRevisionIndex field).
+  const latestRev = history.reduce((m, r) => Math.max(m, r.revision), 0);
+  const selRev = selectedRevision;
+
+  // ── topological depth for column placement ───────────────────────────────
+  const depth = topoDepths(
+    tasks.map((t) => t.id),
+    cumulative.edges,
+  );
+  const perCol: Record<number, number> = {};
+  const nodes: ZPlanNode[] = tasks.map((t) => {
+    const d = Math.min(DAG_LX.length - 1, depth.get(t.id) ?? 0);
+    const rowInCol = perCol[d] ?? 0;
+    perCol[d] = rowInCol + 1;
+    return {
+      tid: t.id,
+      title: t.title || t.id,
+      x: DAG_LX[d],
+      y: DAG_LY(rowInCol),
+      st: nodeState(t, meta.get(t.id)?.isSuperseded ?? false, supersedes),
+    };
+  });
+
+  // ── critical-path heuristic: longest dependency chain ────────────────────
+  const critEdges = criticalEdgeSet(
+    tasks.map((t) => t.id),
+    cumulative.edges,
+  );
+  const edges: ZPlanEdge[] = cumulative.edges.map((e) => ({
+    from: e.fromTaskId,
+    to: e.toTaskId,
+    crit: critEdges.has(`${e.fromTaskId}→${e.toTaskId}`),
+  }));
+
+  // ── strata (newest-first) + rem (oldest→newest) ──────────────────────────
+  const strata: ZStratum[] = [];
+  const rem: number[] = [];
+  const ordered = [...history].sort((a, b) => a.revision - b.revision);
+  let prevIds = new Set<string>();
+  for (const rec of ordered) {
+    const ids = new Set(rec.plan.tasks.map((t) => t.id));
+    const added = new Set<string>();
+    for (const id of ids) if (!prevIds.has(id)) added.add(id);
+    strata.push({
+      v: rec.revision,
+      has: ids,
+      added,
+      seam: seamLabel(rec.kind),
+      live: rec.revision === latestRev,
+    });
+    rem.push(
+      rec.plan.tasks.filter((t) => !isTerminalTaskStatus(t.status)).length,
+    );
+    prevIds = ids;
+  }
+  strata.reverse(); // newest-first (study convention)
+
+  // Tag added nodes for the selected revision so DagZ can render added/ghost.
+  if (selRev != null) {
+    const stratum = strata.find((s) => s.v === selRev);
+    if (stratum) {
+      for (const n of nodes) {
+        if (stratum.added.has(n.tid) && n.st !== 'done') n.st = 'added';
+        else if (!stratum.has.has(n.tid)) n.st = 'ghost';
+      }
+    }
+  }
+
+  return { nodes, edges, strata, rem, planId };
+}
+
+function nodeState(
+  task: Task,
+  isSuperseded: boolean,
+  supersedes: Map<string, SupersessionLink>,
+): ZPlanNode['st'] {
+  if (isSuperseded || supersedes.has(task.id)) return 'ghost';
+  switch (task.status) {
+    case 'COMPLETED':
+      return 'done';
+    case 'RUNNING':
+      return 'running';
+    case 'FAILED':
+    case 'CANCELLED':
+      return 'ghost';
+    default:
+      return 'pending';
+  }
+}
+
+function isTerminalTaskStatus(status: string): boolean {
+  return (
+    status === 'COMPLETED' || status === 'FAILED' || status === 'CANCELLED'
+  );
+}
+
+function seamLabel(kind: string): string {
+  const k = (kind || '').toLowerCase();
+  if (!k) return '';
+  if (k.includes('off_topic') || k.includes('off-topic')) return 'goal-drift';
+  if (k.includes('scope')) return 'scope-creep';
+  if (k.includes('tool')) return 'tool-misuse';
+  if (k.includes('user_steer') || k.includes('user-steer')) return 'user-steer';
+  return k.replace(/_/g, '-');
+}
+
+/** Topological depth (0-based) for each node id over the given edges. */
+function topoDepths(
+  ids: string[],
+  edges: readonly { fromTaskId: string; toTaskId: string }[],
+): Map<string, number> {
+  const adj = new Map<string, string[]>();
+  const indeg = new Map<string, number>();
+  for (const id of ids) {
+    adj.set(id, []);
+    indeg.set(id, 0);
+  }
+  for (const e of edges) {
+    if (!adj.has(e.fromTaskId) || !indeg.has(e.toTaskId)) continue;
+    adj.get(e.fromTaskId)!.push(e.toTaskId);
+    indeg.set(e.toTaskId, (indeg.get(e.toTaskId) ?? 0) + 1);
+  }
+  const depth = new Map<string, number>();
+  const queue: string[] = [];
+  for (const id of ids) {
+    if ((indeg.get(id) ?? 0) === 0) {
+      depth.set(id, 0);
+      queue.push(id);
+    }
+  }
+  while (queue.length) {
+    const cur = queue.shift()!;
+    const cd = depth.get(cur) ?? 0;
+    for (const next of adj.get(cur) ?? []) {
+      const nd = cd + 1;
+      const indegNext = (indeg.get(next) ?? 0) - 1;
+      indeg.set(next, indegNext);
+      if ((depth.get(next) ?? -1) < nd) depth.set(next, nd);
+      if (indegNext === 0) queue.push(next);
+    }
+  }
+  for (const id of ids) if (!depth.has(id)) depth.set(id, 0);
+  return depth;
+}
+
+/**
+ * The set of edges on the longest path through the DAG (the "critical path").
+ * Returns a set of `<from>→<to>` keys. A pragmatic heuristic matching the study
+ * dagSVG spine.
+ */
+function criticalEdgeSet(
+  ids: string[],
+  edges: readonly { fromTaskId: string; toTaskId: string }[],
+): Set<string> {
+  const adj = new Map<string, string[]>();
+  for (const id of ids) adj.set(id, []);
+  for (const e of edges) {
+    if (adj.has(e.fromTaskId)) adj.get(e.fromTaskId)!.push(e.toTaskId);
+  }
+  const depth = topoDepths(ids, edges);
+  // best[id] = [length, predecessor] of the longest path ending at id.
+  const best = new Map<string, { len: number; prev: string | null }>();
+  const order = [...ids].sort(
+    (a, b) => (depth.get(a) ?? 0) - (depth.get(b) ?? 0),
+  );
+  for (const id of order) best.set(id, { len: 0, prev: null });
+  let endId: string | null = null;
+  let endLen = -1;
+  for (const id of order) {
+    const cur = best.get(id)!;
+    for (const next of adj.get(id) ?? []) {
+      const cand = cur.len + 1;
+      const nb = best.get(next);
+      if (nb && cand > nb.len) {
+        best.set(next, { len: cand, prev: id });
+      }
+    }
+    if (cur.len > endLen) {
+      endLen = cur.len;
+      endId = id;
+    }
+  }
+  const out = new Set<string>();
+  let walk = endId;
+  while (walk) {
+    const node = best.get(walk);
+    if (!node || node.prev == null) break;
+    out.add(`${node.prev}→${walk}`);
+    walk = node.prev;
+  }
+  return out;
+}
+
+/**
+ * fingerprint → deterministic Lissajous params (no Math.random). Base fx=2,
+ * fy=3, px=0. Damping `d` rises with on-plan-ness (fewer revisions + more
+ * completed tasks → tighter knot). grow=true when revisions keep adding scope.
+ * corrAt is the first revision time (a correction kink) when there is exactly one
+ * steer. Fallback: no revisions → tight default Lissajous. (Documented first
+ * pass — the ONE figure with no direct real source.)
+ */
+export function deriveFingerprint(
+  history: readonly PlanRevisionRecord[],
+  cumulative: CumulativePlan | null,
+  status: ZSessionStatus,
+  T: number,
+): ZFingerprint {
+  void status;
+  const revisions = Math.max(0, history.length - 1); // beyond the initial plan
+  const tasks = cumulative?.tasks ?? [];
+  const total = tasks.length;
+  const completed = tasks.filter((t) => t.status === 'COMPLETED').length;
+  const completion = total > 0 ? completed / total : 0;
+
+  // More revisions / lower completion → looser knot (smaller damping).
+  // Few revisions + high completion → tighter (higher damping).
+  const base = 0.02;
+  const d = Math.max(
+    0.01,
+    base + 0.06 * completion - 0.018 * Math.min(revisions, 4),
+  );
+
+  // Diverging: scope grows monotonically across revisions.
+  let grow = false;
+  if (history.length >= 2) {
+    const sizes = [...history]
+      .sort((a, b) => a.revision - b.revision)
+      .map((r) => r.plan.tasks.length);
+    grow = sizes.every((s, i) => i === 0 || s >= sizes[i - 1]) &&
+      sizes[sizes.length - 1] > sizes[0];
+  }
+
+  // Exactly one steer → a single correction kink at its revision time.
+  let corrAt: number | null = null;
+  if (revisions === 1) {
+    const steer = [...history]
+      .sort((a, b) => a.revision - b.revision)
+      .find((r) => r.revision > 0);
+    if (steer) {
+      const tSec = steer.plan.createdAtMs / 1000;
+      corrAt = T > 0 ? Math.max(0, Math.min(T, tSec)) : tSec;
+    }
+  }
+
+  return { fx: 2, fy: 3, px: 0, d, corrAt, grow, T: T > 0 ? T : 30 };
+}
+
+/** synthetic → `--hg-agent-user`/`-goldfive`; else `--hg-agent-<ordinal>`. */
+export function colorVar(a: ZAgent): string {
+  if (a.synthetic === 'user') return 'var(--hg-agent-user)';
+  if (a.synthetic === 'goldfive') return 'var(--hg-agent-goldfive)';
+  const ord = a.ordinal >= 1 && a.ordinal <= 8 ? a.ordinal : 1;
+  return `var(--hg-agent-${ord})`;
+}
+
+// ── 3.2 / 3.4 The composing hook ─────────────────────────────────────────────
+
+/**
+ * The per-session bundle for the zicato views. Reads the live SessionStore via
+ * getSessionStore (the caller holds the watch), subscribes to the registry
+ * channels for reactivity, and composes the figure inputs inside a useMemo.
+ *
+ * Time derivation (map-data §1.4 gotcha — do NOT trust store.nowMs):
+ *   T   = store.spans.maxEndMs() / 1000
+ *   now = max(T, (Date.now() - wallClockStartMs) / 1000), clamped ≥ 0.
+ */
+export function useZicatoSession(sessionId: string | null): ZSession {
+  const store = getSessionStore(sessionId);
+
+  // Reactivity + a captured wall-clock timestamp. We snapshot `Date.now()` in
+  // the reducer / lazy initializer (NOT in render), so the memo derives `now`
+  // purely from `tick.nowMs`. Every `bump()` (registry change OR the 1s timer)
+  // writes a fresh nowMs, which drives both reactivity and the advancing
+  // play-head for running spans.
+  const [tick, bump] = useReducer(
+    (s: { n: number; nowMs: number }) => ({ n: s.n + 1, nowMs: Date.now() }),
+    0,
+    (): { n: number; nowMs: number } => ({ n: 0, nowMs: Date.now() }),
+  );
+  useEffect(() => {
+    if (!store) return;
+    const uns = [
+      store.spans.subscribe(() => bump()),
+      store.agents.subscribe(() => bump()),
+      store.tasks.subscribe(() => bump()),
+      store.drifts.subscribe(() => bump()),
+      store.delegations.subscribe(() => bump()),
+      store.contextSeries.subscribe(() => bump()),
+    ];
+    const timer = setInterval(() => bump(), 1000);
+    return () => {
+      clearInterval(timer);
+      for (const un of uns) un();
+    };
+  }, [store]);
+
+  // Read the per-session annotation list. Falls back to a STABLE empty array
+  // (EMPTY_ANNOTATIONS) so the zustand selector returns a cached reference when
+  // there are none — a fresh `[]` each render would trip useSyncExternalStore's
+  // infinite-loop guard.
+  const annotations = useAnnotationStore((s) =>
+    sessionId ? s.bySession.get(sessionId) ?? EMPTY_ANNOTATIONS : EMPTY_ANNOTATIONS,
+  );
+
+  // Session goal (title) from the sessions list, AppBar-style fallback.
+  const sessions = useSessionsStore((s) => s.sessions);
+  const goal = useMemo(() => {
+    if (!sessionId) return '';
+    return sessions.find((s) => s.id === sessionId)?.title ?? '';
+  }, [sessions, sessionId]);
+
+  // Plan inputs are hook-fed (frozen plan hooks; safe with null planId).
+  const trajectoryPlanId = useUiStore((s) => s.trajectorySelectedPlanId);
+  const planId =
+    trajectoryPlanId ?? store?.tasks.listPlans()[0]?.id ?? null;
+  const history = usePlanHistory(sessionId, planId);
+  const cumulative = useCumulativePlan(sessionId, planId);
+  const supersedes = useSupersedesMap(sessionId, planId);
+  const selectedRevision = useUiStore((s) => s.selectedRevision);
+
+  return useMemo(() => {
+    if (!store) return EMPTY_SESSION;
+    const maxEndMs = store.spans.maxEndMs();
+    const spanCount = [...store.spans.all()].length;
+    if (spanCount === 0 && store.agents.list.length === 0) {
+      // Graceful empty: no observable data yet.
+      const fp = deriveFingerprint(history, cumulative, 'live', 30);
+      return { ...EMPTY_SESSION, id: sessionId ?? '', goal, fp };
+    }
+
+    const T = maxEndMs / 1000;
+    const wallNowSec = (tick.nowMs - store.wallClockStartMs) / 1000;
+    const now = Math.max(0, Math.max(T, wallNowSec));
+
+    const status = deriveStatus(store);
+    const agents = buildAgents(store);
+    const spans = buildSpans(store, agents, now);
+    const edges = buildEdges(store);
+    const transfers: ZTransfer[] = edges
+      .filter((e) => e.kind === 'transfer')
+      .map((e) => ({ t: e.t, from: e.from, to: e.to }));
+    const delegation = buildDelegation(store);
+    const judges = buildJudges(store, agents);
+    const ticks = buildTicks(store, annotations);
+    const ladder = buildLadder(store, annotations);
+    const ctx = buildCtx(store, agents);
+    const plan = buildPlan(history, cumulative, supersedes, selectedRevision);
+    const fp = deriveFingerprint(history, cumulative, status, T || 30);
+
+    return {
+      id: sessionId ?? '',
+      goal,
+      status,
+      T: T > 0 ? T : 30,
+      now,
+      agents,
+      spans,
+      transfers,
+      delegation,
+      edges,
+      judges,
+      ticks,
+      ladder,
+      ctx,
+      plan,
+      fp,
+      empty: false,
+    };
+    // tick.nowMs is included so each registry subscribe() bump + the 1s timer
+    // (both write a fresh nowMs) recompute the bundle and advance `now`.
+  }, [
+    store,
+    sessionId,
+    tick.nowMs,
+    annotations,
+    goal,
+    history,
+    cumulative,
+    supersedes,
+    selectedRevision,
+  ]);
+}
+
+/**
+ * Map the live session into the study's `'live' | 'done' | 'failed'` status.
+ * A session with any failed (non-replaced) span and no running spans reads as
+ * failed; once everything is terminal it reads done; otherwise live.
+ */
+function deriveStatus(store: SessionStore): ZSessionStatus {
+  let anyRunning = false;
+  let anyFailed = false;
+  let anyOpen = false;
+  for (const s of store.spans.all()) {
+    if (s.status === 'RUNNING') anyRunning = true;
+    if (s.status === 'FAILED' && !s.replaced) anyFailed = true;
+    if (s.status === 'PENDING' || s.status === 'AWAITING_HUMAN') anyOpen = true;
+    if (s.endMs === null) anyOpen = true;
+  }
+  if (anyRunning || anyOpen) return 'live';
+  if (anyFailed) return 'failed';
+  return 'done';
+}

--- a/frontend/src/components/zicato/adapter.ts
+++ b/frontend/src/components/zicato/adapter.ts
@@ -348,7 +348,20 @@ export function gfClassForSpan(sp: Span): ZGfClass {
       break;
     }
   }
-  if (!raw) return null;
+  if (!raw) {
+    // Goldfive's OWN llm spans (goal_derive / refine / judge_* / plan) carry no
+    // category attribute, so they would all fall through to one llm-call hue.
+    // Infer the sub-type from the span name — but ONLY for the goldfive actor,
+    // so a work span that merely mentions "plan" is never miscoloured.
+    const isGf =
+      sp.agentId === GOLDFIVE_ACTOR_ID || sp.agentId.endsWith(':goldfive');
+    if (!isGf) return null;
+    const n = (sp.name ?? '').toLowerCase();
+    if (n.includes('judge')) return 'judge-neutral';
+    if (n.includes('refine') || n.includes('steer')) return 'refine';
+    if (n.includes('plan')) return 'plan';
+    return 'reflective'; // goal_derive and other goldfive own-ops
+  }
   const v = raw.toLowerCase().replace(/_/g, '-');
   switch (v) {
     case 'judge-on-task':

--- a/frontend/src/components/zicato/adapter.ts
+++ b/frontend/src/components/zicato/adapter.ts
@@ -31,6 +31,7 @@ import type {
 import { useAnnotationStore, type Annotation } from '../../state/annotationStore';
 import { deriveInterventionsFromStore } from '../../lib/interventions';
 import { bareAgentName, type SessionStore } from '../../gantt/index';
+import { extractThinkingText, hasThinking } from '../../lib/thinking';
 import type {
   Span,
   SpanKind,
@@ -106,6 +107,18 @@ export interface ZSpan {
   t1: number;
   /** span.name */
   label: string;
+  /**
+   * True when the span carries model reasoning / chain-of-thought (detected
+   * via lib/thinking.hasThinking — the `has_reasoning` flag or any
+   * `llm.reasoning` / `llm.reasoning_trail` attribute). Drives the 🧠 glyph.
+   */
+  hasReasoning: boolean;
+  /**
+   * The reasoning text for this span (extractThinkingText), or null. The
+   * INVOCATION-level `llm.reasoning_trail` aggregate is preferred over a
+   * single LLM_CALL's `llm.reasoning`. Surfaced in the inspector + drawer.
+   */
+  reasoning: string | null;
 }
 
 /** Hand-off chord. seconds, agent ids. */
@@ -133,6 +146,32 @@ export interface ZEdge {
   from: string;
   to: string;
   kind: ZArrowKind;
+}
+
+/**
+ * A goldfive steering / correction event: a refine (or plan revision) the
+ * orchestrator emitted in response to a drift, pointing at the agent/task it
+ * steered. The gantt renders an arrow from the correction's moment on the
+ * goldfive lane → the target agent's span at the steer time. Severity drives
+ * the arrow hue (warning → --caution, critical → --bad).
+ */
+export interface ZSteer {
+  /** seconds — when goldfive emitted the correction (refine recordedAt). */
+  t: number;
+  /** the goldfive lane id the arrow originates from. */
+  from: string;
+  /** the target agent id the correction steered (arrow lands here). */
+  to: string;
+  /** target task id, if the correction scoped one ('' otherwise). */
+  taskId: string;
+  /** lowercase drift kind that triggered the refine (e.g. 'off_topic'). */
+  kind: string;
+  /** lowercase severity of the trigger ('info'|'warning'|'critical'|''). */
+  severity: string;
+  /** short reason / detail text for the tooltip + drawer. */
+  reason: string;
+  /** revision number this correction produced, when resolvable (0 if not). */
+  revision: number;
 }
 
 // Plan DAG + reel (study p.* shape).
@@ -204,6 +243,8 @@ export interface ZSession {
   delegation: ZDelegation | null;
   /** derived transfer/delegation/return edges (GraphView algo) */
   edges: ZEdge[];
+  /** goldfive steering corrections → their target agent/task (drift-driven). */
+  steers: ZSteer[];
   judges: ZJudges;
   ticks: ZTicks;
   ladder: ZLadder;
@@ -247,6 +288,7 @@ export const EMPTY_SESSION: ZSession = {
   transfers: [],
   delegation: null,
   edges: [],
+  steers: [],
   judges: {},
   ticks: {},
   ladder: [],
@@ -441,6 +483,9 @@ export function buildSpans(
   for (const sp of spans) {
     const t0 = sp.startMs / 1000;
     const t1 = sp.endMs != null ? sp.endMs / 1000 : nowSec;
+    // Reasoning detection: reuse lib/thinking heuristics (has_reasoning flag
+    // or any llm.reasoning / llm.reasoning_trail attribute). The 🧠 glyph and
+    // the inspector/drawer reasoning block key off these two fields.
     out.push({
       id: sp.id,
       agent: sp.agentId,
@@ -450,6 +495,8 @@ export function buildSpans(
       t0,
       t1: Math.max(t0, t1),
       label: sp.name,
+      hasReasoning: hasThinking(sp),
+      reasoning: extractThinkingText(sp),
     });
   }
   out.sort((a, b) => a.t0 - b.t0);
@@ -625,6 +672,132 @@ export function buildEdges(store: SessionStore): ZEdge[] {
   }
   out.sort((a, b) => a.t - b.t);
   return out;
+}
+
+/**
+ * steers → goldfive correction arrows. A "steer" is a refine the orchestrator
+ * emitted in response to a drift, pointing at the agent/task it corrected. We
+ * model the arrow from the goldfive lane (at the refine moment) → the steered
+ * agent. (Mirrors TrajectoryView.buildSteeringEvents but anchored in time so it
+ * can ride the Gantt's lanes/zoom window instead of the plan DAG.)
+ *
+ * Target resolution, in priority order:
+ *   1. the synthesized `refine:` span's `refine.target_agent_id` (matched by
+ *      `refine.index == revision`) — the authoritative post-merge wire field.
+ *   2. the RefineAttemptRecord's own `agentId` (the steered agent).
+ *   3. the triggering DriftRecord's `agentId`.
+ * The origin is always the goldfive lane. A steer with no resolvable, non-self
+ * target agent is dropped (no arrow to draw).
+ *
+ * Primary source is `store.refineAttempts.list()`; when that registry is empty
+ * (older sessions that never emitted RefineAttempted) we fall back to drifts
+ * that triggered a plan revision (history.triggerEventId == driftId).
+ */
+export function buildSteers(
+  store: SessionStore,
+  history: readonly PlanRevisionRecord[],
+): ZSteer[] {
+  const goldfiveId = store.resolveGoldfiveActorId() || GOLDFIVE_ACTOR_ID;
+  // Index refine spans on the goldfive row by refine.index so we can read the
+  // target_agent_id the orchestrator stamped.
+  const refineSpans: Span[] = [];
+  store.spans.queryAgent(goldfiveId, 0, Number.POSITIVE_INFINITY, refineSpans);
+  const targetByIndex = new Map<string, string>();
+  for (const s of refineSpans) {
+    if (!s.name.startsWith('refine:')) continue;
+    const idx = readStringAttr(s, 'refine.index');
+    const tgt = readStringAttr(s, 'refine.target_agent_id');
+    if (idx && tgt) targetByIndex.set(idx, tgt);
+  }
+  // driftId → revision number, from the plan history (a plan revision triggered
+  // by a drift carries triggerEventId == driftId).
+  const revisionByDrift = new Map<string, number>();
+  const reasonByDrift = new Map<string, string>();
+  for (const rec of history) {
+    if (rec.revision <= 0) continue;
+    if (rec.triggerEventId) {
+      if (!revisionByDrift.has(rec.triggerEventId)) {
+        revisionByDrift.set(rec.triggerEventId, rec.revision);
+      }
+      if (rec.reason) reasonByDrift.set(rec.triggerEventId, rec.reason);
+    }
+  }
+  const driftById = new Map<string, ReturnType<typeof driftToTuple>>();
+  for (const d of store.drifts.list()) {
+    if (d.driftId) driftById.set(d.driftId, driftToTuple(d));
+  }
+
+  const out: ZSteer[] = [];
+  const attempts = store.refineAttempts.list();
+  if (attempts.length > 0) {
+    for (const a of attempts) {
+      const revision =
+        revisionByDrift.get(a.driftId) ?? 0;
+      const target =
+        (revision ? targetByIndex.get(String(revision)) : undefined) ||
+        a.agentId ||
+        driftById.get(a.driftId)?.agentId ||
+        '';
+      if (!target || target === goldfiveId) continue;
+      out.push({
+        t: a.recordedAtMs / 1000,
+        from: goldfiveId,
+        to: target,
+        taskId: a.taskId || driftById.get(a.driftId)?.taskId || '',
+        kind: a.triggerKind || driftById.get(a.driftId)?.kind || '',
+        severity: a.triggerSeverity || driftById.get(a.driftId)?.severity || '',
+        reason:
+          reasonByDrift.get(a.driftId) || driftById.get(a.driftId)?.detail || '',
+        revision,
+      });
+    }
+  } else {
+    // Fallback: drifts that produced a plan revision (no RefineAttempted rows).
+    for (const d of store.drifts.list()) {
+      const revision = d.driftId ? revisionByDrift.get(d.driftId) ?? 0 : 0;
+      if (revision <= 0) continue;
+      const target =
+        targetByIndex.get(String(revision)) || d.agentId || '';
+      if (!target || target === goldfiveId) continue;
+      out.push({
+        t: d.recordedAtMs / 1000,
+        from: goldfiveId,
+        to: target,
+        taskId: d.taskId || '',
+        kind: d.kind || '',
+        severity: d.severity || '',
+        reason: reasonByDrift.get(d.driftId) || d.detail || '',
+        revision,
+      });
+    }
+  }
+  out.sort((a, b) => a.t - b.t);
+  return out;
+}
+
+/** Pull a string attribute off a span (helper for the steer/target lookups). */
+function readStringAttr(span: Span | null, key: string): string {
+  if (!span) return '';
+  const attr = span.attributes[key];
+  if (!attr || attr.kind !== 'string') return '';
+  return attr.value;
+}
+
+/** Narrow a DriftRecord to the fields buildSteers reads (keeps the Map typed). */
+function driftToTuple(d: {
+  agentId: string;
+  taskId: string;
+  kind: string;
+  severity: string;
+  detail: string;
+}): { agentId: string; taskId: string; kind: string; severity: string; detail: string } {
+  return {
+    agentId: d.agentId,
+    taskId: d.taskId,
+    kind: d.kind,
+    severity: d.severity,
+    detail: d.detail,
+  };
 }
 
 /**
@@ -1098,6 +1271,7 @@ export function useZicatoSession(sessionId: string | null): ZSession {
       .filter((e) => e.kind === 'transfer')
       .map((e) => ({ t: e.t, from: e.from, to: e.to }));
     const delegation = buildDelegation(store);
+    const steers = buildSteers(store, history);
     const judges = buildJudges(store, agents);
     const ticks = buildTicks(store, annotations);
     const ladder = buildLadder(store, annotations);
@@ -1116,6 +1290,7 @@ export function useZicatoSession(sessionId: string | null): ZSession {
       transfers,
       delegation,
       edges,
+      steers,
       judges,
       ticks,
       ladder,

--- a/frontend/src/components/zicato/ganttViewport.ts
+++ b/frontend/src/components/zicato/ganttViewport.ts
@@ -1,0 +1,80 @@
+// ganttViewport.ts — the FROZEN viewport math shared by GanttZ + MinimapZ +
+// GanttViewZ for the zoom/minimap feature. A GanttView is the visible time
+// window in seconds; all four helpers keep it inside [0, T] with a sane minimum
+// width, so a zoomed/panned gantt never escapes the session range.
+//
+// Pure, no React, no DOM. The renderers map this window onto plot pixels.
+
+/** Visible window in seconds, 0 <= t0 < t1 <= T. */
+export type GanttView = { t0: number; t1: number };
+
+/** The minimum visible window (seconds): never zoom past T/200 (floor 1s). */
+function minWindow(T: number): number {
+  return Math.max(1, T / 200);
+}
+
+/** The full session range as a view. */
+export function fitView(T: number): GanttView {
+  return { t0: 0, t1: T };
+}
+
+/**
+ * Zoom by `factor` (factor < 1 = zoom IN, > 1 = zoom OUT) keeping `focusT` at the
+ * same SCREEN FRACTION it currently occupies, then clamp the window into [0, T]
+ * with a minimum width of max(1, T/200).
+ */
+export function zoomView(
+  v: GanttView,
+  factor: number,
+  focusT: number,
+  T: number,
+): GanttView {
+  const oldW = v.t1 - v.t0;
+  if (oldW <= 0) return fitView(T);
+  // The screen fraction of focusT within the current window (clamped 0..1 so a
+  // focus outside the window still produces a sane anchor).
+  const frac = Math.min(1, Math.max(0, (focusT - v.t0) / oldW));
+  const minW = minWindow(T);
+  // New width: clamp to [minW, T].
+  const newW = Math.min(T, Math.max(minW, oldW * factor));
+  // Keep focusT at the same fraction: focusT = t0 + frac*newW.
+  let t0 = focusT - frac * newW;
+  let t1 = t0 + newW;
+  // Slide the window back inside [0, T] without changing its width.
+  if (t0 < 0) {
+    t0 = 0;
+    t1 = newW;
+  }
+  if (t1 > T) {
+    t1 = T;
+    t0 = T - newW;
+  }
+  if (t0 < 0) t0 = 0;
+  return { t0, t1 };
+}
+
+/**
+ * Pan by `dt` seconds (positive → window moves later), keeping the window WIDTH
+ * fixed and clamping into [0, T].
+ */
+export function panView(v: GanttView, dt: number, T: number): GanttView {
+  const w = Math.min(T, v.t1 - v.t0);
+  let t0 = v.t0 + dt;
+  let t1 = t0 + w;
+  if (t0 < 0) {
+    t0 = 0;
+    t1 = w;
+  }
+  if (t1 > T) {
+    t1 = T;
+    t0 = T - w;
+  }
+  if (t0 < 0) t0 = 0;
+  return { t0, t1 };
+}
+
+/** True when the view is (within epsilon) the full [0, T] range. */
+export function isFit(v: GanttView, T: number): boolean {
+  const eps = Math.max(1e-6, T * 1e-4);
+  return Math.abs(v.t0) <= eps && Math.abs(v.t1 - T) <= eps;
+}

--- a/frontend/src/components/zicato/steerContext.ts
+++ b/frontend/src/components/zicato/steerContext.ts
@@ -1,0 +1,22 @@
+// steerContext.ts — routes a Gantt steering-arrow click up to the console's
+// floating drawer WITHOUT threading a prop through the do-not-edit
+// GanttViewZ/Fig layers. ZicatoConsole provides the handler via
+// <SteerSelectContext.Provider>; GanttZ consumes it with useSteerSelect() as
+// the default `onSteerSelect`. A no-op default keeps GanttZ safe when rendered
+// standalone (tests, the minimap, future call sites outside the console).
+//
+// Lives in its own non-component module so FloatingDrawerZ.tsx /
+// ZicatoConsole.tsx stay Fast-Refresh-clean (a file that exports a React
+// component may not also export a hook).
+
+import { createContext, useContext } from 'react';
+import type { ZSteer } from './adapter';
+
+export type SteerSelectHandler = (steer: ZSteer) => void;
+
+export const SteerSelectContext = createContext<SteerSelectHandler>(() => {});
+
+/** GanttZ's default steering-click handler — the console's drawer opener. */
+export function useSteerSelect(): SteerSelectHandler {
+  return useContext(SteerSelectContext);
+}

--- a/frontend/src/components/zicato/svgUtils.ts
+++ b/frontend/src/components/zicato/svgUtils.ts
@@ -4,10 +4,23 @@
 // the figure components import. `colorVar`/`severityToValue` are owned by
 // adapter.ts and re-exported here so there is exactly one definition of each.
 
-import type { ZKindToken, ZGfClass, ZSpan, ZJudges } from './adapter';
+import type { ZKindToken, ZGfClass, ZSpan, ZJudges, ZSteer } from './adapter';
 import { colorVar, severityToValue } from './adapter';
 
 export { colorVar, severityToValue };
+
+/**
+ * The hue a goldfive steering arrow takes, keyed off the trigger severity:
+ * critical → --bad, warning → --caution, anything else (info / unspecified) →
+ * the goldfive-refine token. Keeps steering distinct from transfer/delegation
+ * edges while still reading as "a correction".
+ */
+export function steerColor(s: Pick<ZSteer, 'severity'>): string {
+  const sev = (s.severity || '').toLowerCase();
+  if (sev === 'critical') return 'var(--bad)';
+  if (sev === 'warning' || sev === 'warn') return 'var(--caution)';
+  return 'var(--hg-gf-refine)';
+}
 
 /** KIND = hue. `'llm-call'` → `var(--hg-kind-llm-call)`. (compose.html:161) */
 export const KIND = (k: ZKindToken): string => `var(--hg-kind-${k})`;

--- a/frontend/src/components/zicato/svgUtils.ts
+++ b/frontend/src/components/zicato/svgUtils.ts
@@ -1,0 +1,140 @@
+// svgUtils.ts — shared pure helpers for the zicato SVG renderers. Ported from
+// compose.html (KIND/lerpKeys/lcg 161-176, brand 149-157, trackGeom 448-449,
+// judgeBeats 171-176). No React, no data fetching — just geometry + color math
+// the figure components import. `colorVar`/`severityToValue` are owned by
+// adapter.ts and re-exported here so there is exactly one definition of each.
+
+import type { ZKindToken, ZGfClass, ZSpan, ZJudges } from './adapter';
+import { colorVar, severityToValue } from './adapter';
+
+export { colorVar, severityToValue };
+
+/** KIND = hue. `'llm-call'` → `var(--hg-kind-llm-call)`. (compose.html:161) */
+export const KIND = (k: ZKindToken): string => `var(--hg-kind-${k})`;
+
+/** `--hg-gf-*` for a goldfive category. */
+export function gfVar(gf: Exclude<ZGfClass, null>): string {
+  return `var(--hg-gf-${gf})`;
+}
+
+/**
+ * The fill a span bar takes (KIND-first encoding):
+ *   failed → --bad, goldfive → gfVar, planned → CSS-driven (KIND fallback),
+ *   else the kind hue.
+ * (compose.html ganttSVG fill decision, 85.)
+ */
+export function statusFill(sp: ZSpan): string {
+  if (sp.status === 'failed') return 'var(--bad)';
+  if (sp.gf) return gfVar(sp.gf);
+  return KIND(sp.kind);
+}
+
+/**
+ * Piecewise-linear interpolation over `[[t, v], …]` keyframes. (compose.html
+ * 162-164.) Clamps to the endpoints outside the keyframe range.
+ */
+export function lerpKeys(keys: [number, number][], t: number): number {
+  if (keys.length === 0) return 0;
+  if (t <= keys[0][0]) return keys[0][1];
+  for (let i = 1; i < keys.length; i++) {
+    if (t <= keys[i][0]) {
+      const [t0, v0] = keys[i - 1];
+      const [t1, v1] = keys[i];
+      if (t1 === t0) return v1;
+      return v0 + ((v1 - v0) * (t - t0)) / (t1 - t0);
+    }
+  }
+  return keys[keys.length - 1][1];
+}
+
+/**
+ * Deterministic LCG PRNG seeded by `seed`. Returns a `() => number` in [0,1).
+ * Used for the seismograph's drift jitter so the trace is stable across renders
+ * (NEVER Math.random in render). (compose.html:165.)
+ */
+export function lcg(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => ((s = (s * 1664525 + 1013904223) >>> 0) / 4294967296);
+}
+
+/**
+ * Time→x scale shared by the seismograph + ladder so a reading at t lines up
+ * vertically. (compose.html trackGeom 448-449.) `padL` defaults narrow for tiny
+ * widths. Callers may override padL/padR.
+ */
+export function timeScale(
+  T: number,
+  W: number,
+  padL = W < 400 ? 40 : 76,
+  padR = 14,
+): { padL: number; padR: number; X: (t: number) => number } {
+  const denom = T > 0 ? T : 1;
+  return {
+    padL,
+    padR,
+    X: (t: number) => padL + ((W - padL - padR) * t) / denom,
+  };
+}
+
+/**
+ * A stable, DOM-safe id derived from a seed string. Used for per-instance
+ * `<defs>` gradient ids (ChordZ) so multiple chords on one page don't collide.
+ */
+export function uniqueId(seed: string): string {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return `zk-${h.toString(36)}`;
+}
+
+/**
+ * The harmonograf α-mark path 'd': ONE period of a 2:3 Lissajous mirrored about
+ * the vertical axis (reads as a lowercase α). (compose.html hgAlphaPath 149-152.)
+ * Geometry only — BrandMark renders the JSX around it.
+ */
+export function hgAlphaPath(cx: number, cy: number, A: number, B: number): string {
+  const pts: string[] = [];
+  for (let i = 0; i <= 240; i++) {
+    const t = (2 * Math.PI * i) / 240;
+    pts.push(
+      `${(cx - A * Math.cos(2 * t)).toFixed(2)},${(
+        cy +
+        B * Math.sin(3 * t)
+      ).toFixed(2)}`,
+    );
+  }
+  return `M${pts.join(' L')} Z`;
+}
+
+/**
+ * The study's default seismograph lanes. The adapter overrides this with the
+ * real busy lanes when available; this is the empty-data fallback.
+ */
+export const SEISMO_LANES_DEFAULT = ['coder', 'reviewer', 'planner'] as const;
+
+/**
+ * The judge heartbeat beats DERIVED from the drift the judges watch, so every
+ * firing mark sits above the drift reading that earned it. (compose.html
+ * judgeBeats 171-176.) TOL=8, step 2.6s; ok / warn(▲) / crit(✕).
+ */
+export function judgeBeats(
+  judges: ZJudges,
+  lanes: string[],
+  T: number,
+  now: number,
+): [number, 'ok' | 'warn' | 'crit'][] {
+  const TOL = 8;
+  const beats: [number, 'ok' | 'warn' | 'crit'][] = [];
+  const end = Math.min(now, T);
+  for (let t = 2; t <= end + 0.001; t += 2.6) {
+    let d = 0;
+    for (const a of lanes) {
+      const keys = judges[a];
+      if (keys && keys.length) d = Math.max(d, lerpKeys(keys, t));
+    }
+    beats.push([t, d >= TOL * 1.5 ? 'crit' : d >= TOL ? 'warn' : 'ok']);
+  }
+  return beats;
+}

--- a/frontend/src/components/zicato/zicato-tokens.css
+++ b/frontend/src/components/zicato/zicato-tokens.css
@@ -1,0 +1,715 @@
+/* =====================================================================
+   zicato-tokens.css — the 16-theme colour contract for the in-app
+   zicato-language console. Ported from
+   docs/design/zicato-ui-study/_tokens.css, with EVERY selector re-scoped
+   from `html[data-theme="<id>"]` to `.zk-root[data-zicato-theme="<id>"]`
+   so the tokens cascade ONLY inside the zicato subtree and never disturb
+   the MD3 console (which keeps `:root` / `<html data-theme>` to itself).
+
+   Layers per theme: zicato --v2-N role contract + study short aliases
+   (--paper/--panel/--ink/--accent/--flat), the ANSI palette (--ansi-N),
+   and the harmonograf categorical encoding (--hg-kind-N / --hg-gf-N /
+   --hg-agent-N). NOTE: the zicato renderers read --hg-gf-N (NOT the MD3
+   --hg-goldfive-N). Default theme: monokai.
+
+   GENERATED from the study tokens — do not hand-edit; re-derive from the
+   study source if the palette changes. The brand accent (--hgraf-brand)
+   is appended at the end (ported from _study.css 371-374).
+   ===================================================================== */
+
+/* =====================================================================
+   _tokens.css — the 16-theme colour contract for the harmonograf
+   zicato-language UI study. GENERATED — see /tmp/gen_tokens.py in the
+   build notes (STYLE-GUIDE.md). The ONLY place raw hex appears.
+
+   Each html[data-theme="<id>"] block carries three layers:
+
+   1. zicato --v2-N ROLE CONTRACT (paper/panel/ink/.../accent/flat),
+      ported 1:1 from console4.css via single-matchup.html, plus the
+      study-local short aliases (--paper/--panel/--ink/...) the pages read.
+      Meaning is FIXED across all 16 themes (DESIGN-LANGUAGE.md §2.1):
+      good/bad earned by direction; --accent is the ONE structural emphasis.
+
+   2. the terminal ANSI palette (--ansi-N), wired from _refs/gogh-palettes.json
+      — the Gogh scheme each zicato theme derives from. 16 slots:
+      normal black/red/green/yellow/blue/magenta/cyan/white + bright variants.
+
+   3. the harmonograf CATEGORICAL encoding, ALL derived from (1)+(2):
+      · span KIND hue  → --hg-kind-N   (KIND = hue axis, BRIEF §2.1)
+      · goldfive class → --hg-gf-N
+      · agent identity → --hg-agent-1..8 (+ user / goldfive synthetic actors):
+        an ORDINAL ramp, each lane an ANSI slot color-mixed toward --ink-faint
+        so lanes stay distinguishable without competing with kind hues or accent.
+
+   STATUS (running/failed/pending/...) is NOT here — it is a treatment applied
+   over the kind hue (accent+breathe / bad+glyph / dashed / hatch), so good/bad/
+   accent appear ONLY for status, never for identity. See STYLE-GUIDE.md.
+
+   Default theme: monokai (set on <html data-theme> by each page).
+   ===================================================================== */
+
+.zk-root[data-zicato-theme="monokai"] {
+  --v2-paper:#1e1f1c; --v2-panel:#272822; --v2-panel-2:#23241f;
+  --v2-ink:#f8f8f2; --v2-ink-soft:#c9cabf; --v2-ink-faint:#8f908a;
+  --v2-rule:#3a3b34; --v2-rule-soft:#2f302a;
+  --v2-good:#a6e22e; --v2-good-soft:#2c361a; --v2-bad:#f92672; --v2-caution:#e6db74;
+  --v2-accent:#66d9ef; --v2-flat:#75715e;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#272822; --ansi-red:#f92672; --ansi-green:#a6e22e; --ansi-yellow:#e6db74;
+  --ansi-blue:#66d9ef; --ansi-magenta:#ae81ff; --ansi-cyan:#a1efe4; --ansi-white:#f8f8f2;
+  --ansi-bright-black:#75715e; --ansi-bright-red:#f92672; --ansi-bright-green:#a6e22e; --ansi-bright-yellow:#e6db74;
+  --ansi-bright-blue:#66d9ef; --ansi-bright-magenta:#ae81ff; --ansi-bright-cyan:#a1efe4; --ansi-bright-white:#f9f8f5;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="solarized-dark"] {
+  --v2-paper:#04222B; --v2-panel:#0A2D38; --v2-panel-2:#0A2730;
+  --v2-ink:#93A1A1; --v2-ink-soft:#839496; --v2-ink-faint:#5E7079;
+  --v2-rule:#0E3540; --v2-rule-soft:#0B2E39;
+  --v2-good:#8BB80E; --v2-good-soft:#1C3320; --v2-bad:#E0483C; --v2-caution:#C4920A;
+  --v2-accent:#2AA198; --v2-flat:#46606B;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#073642; --ansi-red:#DC322F; --ansi-green:#859900; --ansi-yellow:#B58900;
+  --ansi-blue:#268BD2; --ansi-magenta:#D33682; --ansi-cyan:#2AA198; --ansi-white:#EEE8D5;
+  --ansi-bright-black:#657B83; --ansi-bright-red:#CB4B16; --ansi-bright-green:#586E75; --ansi-bright-yellow:#657B83;
+  --ansi-bright-blue:#6c71c4; --ansi-bright-magenta:#D33682; --ansi-bright-cyan:#2AA198; --ansi-bright-white:#FDF6E3;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="solarized-light"] {
+  --v2-paper:#FDF6E3; --v2-panel:#FBF1D6; --v2-panel-2:#F2E9CE;
+  --v2-ink:#586E75; --v2-ink-soft:#657B83; --v2-ink-faint:#93A1A1;
+  --v2-rule:#E7DCBE; --v2-rule-soft:#F0E7CC;
+  --v2-good:#6B9B0B; --v2-good-soft:#E3ECCB; --v2-bad:#DC322F; --v2-caution:#B58900;
+  --v2-accent:#268BD2; --v2-flat:#93A1A1;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#EEE8D5; --ansi-red:#DC322F; --ansi-green:#859900; --ansi-yellow:#B58900;
+  --ansi-blue:#268BD2; --ansi-magenta:#D33682; --ansi-cyan:#2AA198; --ansi-white:#073642;
+  --ansi-bright-black:#93A1A1; --ansi-bright-red:#CB4B16; --ansi-bright-green:#586E75; --ansi-bright-yellow:#839496;
+  --ansi-bright-blue:#6C71C4; --ansi-bright-magenta:#D33682; --ansi-bright-cyan:#2AA198; --ansi-bright-white:#002B36;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="google-light"] {
+  --v2-paper:#FFFFFF; --v2-panel:#F4F4F4; --v2-panel-2:#F8F8F8;
+  --v2-ink:#474A4E; --v2-ink-soft:#5F6368; --v2-ink-faint:#9FA1A4;
+  --v2-rule:#E2E3E4; --v2-rule-soft:#F1F1F1;
+  --v2-good:#34A853; --v2-good-soft:#D2ECD9; --v2-bad:#EA4335; --v2-caution:#C99700;
+  --v2-accent:#1B9CB8; --v2-flat:#9AA0A6;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#1D1F21; --ansi-red:#CC342B; --ansi-green:#198844; --ansi-yellow:#FBA922;
+  --ansi-blue:#3971ED; --ansi-magenta:#A36AC7; --ansi-cyan:#3971ED; --ansi-white:#C5C8C6;
+  --ansi-bright-black:#969896; --ansi-bright-red:#CC342B; --ansi-bright-green:#198844; --ansi-bright-yellow:#FBA922;
+  --ansi-bright-blue:#3971ED; --ansi-bright-magenta:#A36AC7; --ansi-bright-cyan:#3971ED; --ansi-bright-white:#FFFFFF;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="google-dark"] {
+  --v2-paper:#202124; --v2-panel:#2C2D30; --v2-panel-2:#28292C;
+  --v2-ink:#FFFFFF; --v2-ink-soft:#E8EAED; --v2-ink-faint:#989A9D;
+  --v2-rule:#444548; --v2-rule-soft:#323336;
+  --v2-good:#34A853; --v2-good-soft:#243F2E; --v2-bad:#EA4335; --v2-caution:#FBBC05;
+  --v2-accent:#24C1E0; --v2-flat:#5F6368;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#202124; --ansi-red:#EA4335; --ansi-green:#34A853; --ansi-yellow:#FBBC04;
+  --ansi-blue:#4285F4; --ansi-magenta:#A142F4; --ansi-cyan:#24C1E0; --ansi-white:#E8EAED;
+  --ansi-bright-black:#5F6368; --ansi-bright-red:#EA4335; --ansi-bright-green:#34A853; --ansi-bright-yellow:#FBBC05;
+  --ansi-bright-blue:#4285F4; --ansi-bright-magenta:#A142F4; --ansi-bright-cyan:#24C1E0; --ansi-bright-white:#FFFFFF;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="lunaria-light"] {
+  --v2-paper:#EBE4E1; --v2-panel:#E2DCD9; --v2-panel-2:#E6DFDC;
+  --v2-ink:#363434; --v2-ink-soft:#484646; --v2-ink-faint:#898584;
+  --v2-rule:#CEC8C5; --v2-rule-soft:#DCD6D3;
+  --v2-good:#497D46; --v2-good-soft:#C7CDBF; --v2-bad:#783C1F; --v2-caution:#8F750B;
+  --v2-accent:#3778A9; --v2-flat:#898584;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#3E3C3D; --ansi-red:#783C1F; --ansi-green:#497D46; --ansi-yellow:#8F750B;
+  --ansi-blue:#3F3566; --ansi-magenta:#793F62; --ansi-cyan:#3778A9; --ansi-white:#D5CFCC;
+  --ansi-bright-black:#484646; --ansi-bright-red:#B06240; --ansi-bright-green:#7BC175; --ansi-bright-yellow:#DCB735;
+  --ansi-bright-blue:#5C4F89; --ansi-bright-magenta:#B56895; --ansi-bright-cyan:#64BAFF; --ansi-bright-white:#EBE4E1;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="lunaria-eclipse"] {
+  --v2-paper:#323F46; --v2-panel:#3B484F; --v2-panel-2:#38454C;
+  --v2-ink:#DFE2ED; --v2-ink-soft:#C9CDD7; --v2-ink-faint:#8D949D;
+  --v2-rule:#4D5960; --v2-rule-soft:#404C53;
+  --v2-good:#BEDBC1; --v2-good-soft:#516161; --v2-bad:#BA9088; --v2-caution:#F1DFB4;
+  --v2-accent:#C8429F; --v2-flat:#6B767D;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#323F46; --ansi-red:#83615B; --ansi-green:#7F9781; --ansi-yellow:#A69875;
+  --ansi-blue:#53516F; --ansi-magenta:#856880; --ansi-cyan:#7D96B2; --ansi-white:#C9CDD7;
+  --ansi-bright-black:#3D4950; --ansi-bright-red:#BA9088; --ansi-bright-green:#BEDBC1; --ansi-bright-yellow:#F1DFB4;
+  --ansi-bright-blue:#767495; --ansi-bright-magenta:#BE9CB8; --ansi-bright-cyan:#BCDBFF; --ansi-bright-white:#DFE2ED;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="belafonte-day"] {
+  --v2-paper:#D5CCBA; --v2-panel:#CCC3B2; --v2-panel-2:#D0C6B5;
+  --v2-ink:#34292D; --v2-ink-soft:#45373C; --v2-ink-faint:#7F736E;
+  --v2-rule:#BBB1A3; --v2-rule-soft:#C8BFAF;
+  --v2-good:#6E6A4E; --v2-good-soft:#C3BCA7; --v2-bad:#BE100E; --v2-caution:#B57A1E;
+  --v2-accent:#426A79; --v2-flat:#5E5252;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#20111B; --ansi-red:#BE100E; --ansi-green:#858162; --ansi-yellow:#EAA549;
+  --ansi-blue:#426A79; --ansi-magenta:#97522C; --ansi-cyan:#989A9C; --ansi-white:#968C83;
+  --ansi-bright-black:#5E5252; --ansi-bright-red:#BE100E; --ansi-bright-green:#858162; --ansi-bright-yellow:#EAA549;
+  --ansi-bright-blue:#426A79; --ansi-bright-magenta:#97522C; --ansi-bright-cyan:#989A9C; --ansi-bright-white:#D5CCBA;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="belafonte-night"] {
+  --v2-paper:#20111B; --v2-panel:#271821; --v2-panel-2:#25161F;
+  --v2-ink:#D5CCBA; --v2-ink-soft:#968C83; --v2-ink-faint:#675B59;
+  --v2-rule:#35272E; --v2-rule-soft:#2B1C24;
+  --v2-good:#A6A07A; --v2-good-soft:#362A2B; --v2-bad:#D6403E; --v2-caution:#EAA549;
+  --v2-accent:#6F8E97; --v2-flat:#5E5252;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#20111B; --ansi-red:#BE100E; --ansi-green:#858162; --ansi-yellow:#EAA549;
+  --ansi-blue:#426A79; --ansi-magenta:#97522C; --ansi-cyan:#989A9C; --ansi-white:#968C83;
+  --ansi-bright-black:#5E5252; --ansi-bright-red:#BE100E; --ansi-bright-green:#858162; --ansi-bright-yellow:#EAA549;
+  --ansi-bright-blue:#426A79; --ansi-bright-magenta:#97522C; --ansi-bright-cyan:#989A9C; --ansi-bright-white:#D5CCBA;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="paper"] {
+  --v2-paper:#F2EEDE; --v2-panel:#E6E2D3; --v2-panel-2:#E8E4D5;
+  --v2-ink:#1A1A1A; --v2-ink-soft:#33312B; --v2-ink-faint:#85837A;
+  --v2-rule:#C6C3B6; --v2-rule-soft:#DCD9CA;
+  --v2-good:#216609; --v2-good-soft:#CCD6B8; --v2-bad:#CC3E28; --v2-caution:#B58900;
+  --v2-accent:#1E6FCC; --v2-flat:#6E6A5E;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#000000; --ansi-red:#cc3e28; --ansi-green:#216609; --ansi-yellow:#b58900;
+  --ansi-blue:#1e6fcc; --ansi-magenta:#5c21a5; --ansi-cyan:#158c86; --ansi-white:#aaaaaa;
+  --ansi-bright-black:#555555; --ansi-bright-red:#cc3e28; --ansi-bright-green:#216609; --ansi-bright-yellow:#b58900;
+  --ansi-bright-blue:#1e6fcc; --ansi-bright-magenta:#5c21a5; --ansi-bright-cyan:#158c86; --ansi-bright-white:#aaaaaa;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="zenburn"] {
+  --v2-paper:#3A3A3A; --v2-panel:#424241; --v2-panel-2:#404040;
+  --v2-ink:#DCDCCC; --v2-ink-soft:#C5C5B8; --v2-ink-faint:#83837C;
+  --v2-rule:#575754; --v2-rule-soft:#494947;
+  --v2-good:#8FB28F; --v2-good-soft:#2E3A2E; --v2-bad:#CC9393; --v2-caution:#FFD7A7;
+  --v2-accent:#8CD0D3; --v2-flat:#757575;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#333333; --ansi-red:#cc9393; --ansi-green:#7f9f7f; --ansi-yellow:#efef87;
+  --ansi-blue:#c3bf97; --ansi-magenta:#bca3a3; --ansi-cyan:#93b3a3; --ansi-white:#f0efd0;
+  --ansi-bright-black:#757575; --ansi-bright-red:#dfaf87; --ansi-bright-green:#9fc59f; --ansi-bright-yellow:#ffff87;
+  --ansi-bright-blue:#d7d7af; --ansi-bright-magenta:#d7afaf; --ansi-bright-cyan:#93bea3; --ansi-bright-white:#dcdccc;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="selenized-black"] {
+  --v2-paper:#181818; --v2-panel:#202020; --v2-panel-2:#1E1E1E;
+  --v2-ink:#DEDEDE; --v2-ink-soft:#B9B9B9; --v2-ink-faint:#606060;
+  --v2-rule:#353535; --v2-rule-soft:#262626;
+  --v2-good:#83C746; --v2-good-soft:#243218; --v2-bad:#FF5E56; --v2-caution:#EFC541;
+  --v2-accent:#56D8C9; --v2-flat:#3B3B3B;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#252525; --ansi-red:#ed4a46; --ansi-green:#70b433; --ansi-yellow:#dbb32d;
+  --ansi-blue:#368aeb; --ansi-magenta:#eb6eb7; --ansi-cyan:#3fc5b7; --ansi-white:#777777;
+  --ansi-bright-black:#3b3b3b; --ansi-bright-red:#ff5e56; --ansi-bright-green:#83c746; --ansi-bright-yellow:#efc541;
+  --ansi-bright-blue:#4f9cfe; --ansi-bright-magenta:#ff81ca; --ansi-bright-cyan:#56d8c9; --ansi-bright-white:#dedede;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="relaxed"] {
+  --v2-paper:#353A44; --v2-panel:#3D424B; --v2-panel-2:#3C404A;
+  --v2-ink:#F7F7F7; --v2-ink-soft:#D9D9D9; --v2-ink-faint:#7F8287;
+  --v2-rule:#53575F; --v2-rule-soft:#444851;
+  --v2-good:#A0AC77; --v2-good-soft:#353D2E; --v2-bad:#BC5653; --v2-caution:#EBC17A;
+  --v2-accent:#7EAAC7; --v2-flat:#636363;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#151515; --ansi-red:#BC5653; --ansi-green:#909D63; --ansi-yellow:#EBC17A;
+  --ansi-blue:#6A8799; --ansi-magenta:#B06698; --ansi-cyan:#7EAAC7; --ansi-white:#D9D9D9;
+  --ansi-bright-black:#636363; --ansi-bright-red:#BC5653; --ansi-bright-green:#A0AC77; --ansi-bright-yellow:#EBC17A;
+  --ansi-bright-blue:#7EAAC7; --ansi-bright-magenta:#B06698; --ansi-bright-cyan:#ACBBD0; --ansi-bright-white:#F7F7F7;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="espresso"] {
+  --v2-paper:#323232; --v2-panel:#3A3A3A; --v2-panel-2:#383838;
+  --v2-ink:#FFFFFF; --v2-ink-soft:#D9D9D9; --v2-ink-faint:#8A8A8A;
+  --v2-rule:#4C4C4C; --v2-rule-soft:#3E3E3E;
+  --v2-good:#A5C261; --v2-good-soft:#353D24; --v2-bad:#D25252; --v2-caution:#FFC66D;
+  --v2-accent:#6C99BB; --v2-flat:#6E6E6E;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#353535; --ansi-red:#D25252; --ansi-green:#A5C261; --ansi-yellow:#FFC66D;
+  --ansi-blue:#6C99BB; --ansi-magenta:#D197D9; --ansi-cyan:#BED6FF; --ansi-white:#EEEEEC;
+  --ansi-bright-black:#535353; --ansi-bright-red:#F00C0C; --ansi-bright-green:#C2E075; --ansi-bright-yellow:#E1E48B;
+  --ansi-bright-blue:#8AB7D9; --ansi-bright-magenta:#EFB5F7; --ansi-bright-cyan:#DCF4FF; --ansi-bright-white:#FFFFFF;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="dracula"] {
+  --v2-paper:#282A36; --v2-panel:#343746; --v2-panel-2:#2E303D;
+  --v2-ink:#F8F8F2; --v2-ink-soft:#D4D4CF; --v2-ink-faint:#6272A4;
+  --v2-rule:#44475A; --v2-rule-soft:#353848;
+  --v2-good:#50FA7B; --v2-good-soft:#213A2A; --v2-bad:#FF5555; --v2-caution:#F1FA8C;
+  --v2-accent:#BD93F9; --v2-flat:#6272A4;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#262626; --ansi-red:#E64747; --ansi-green:#42E66C; --ansi-yellow:#E4F34A;
+  --ansi-blue:#9B6BDF; --ansi-magenta:#E356A7; --ansi-cyan:#75D7EC; --ansi-white:#F8F8F2;
+  --ansi-bright-black:#7A7A7A; --ansi-bright-red:#FF5555; --ansi-bright-green:#50FA7B; --ansi-bright-yellow:#F1FA8C;
+  --ansi-bright-blue:#BD93F9; --ansi-bright-magenta:#FF79C6; --ansi-bright-cyan:#8BE9FD; --ansi-bright-white:#F9F9FB;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+.zk-root[data-zicato-theme="ubuntu"] {
+  --v2-paper:#300A24; --v2-panel:#3D1530; --v2-panel-2:#371129;
+  --v2-ink:#EEEEEC; --v2-ink-soft:#CBC3C9; --v2-ink-faint:#8A7383;
+  --v2-rule:#4B2640; --v2-rule-soft:#3E1A32;
+  --v2-good:#8AE234; --v2-good-soft:#2E3320; --v2-bad:#CC0000; --v2-caution:#FCE94F;
+  --v2-accent:#34E2E2; --v2-flat:#847683;
+  --paper:var(--v2-paper); --panel:var(--v2-panel); --panel-2:var(--v2-panel-2);
+  --ink:var(--v2-ink); --ink-soft:var(--v2-ink-soft); --ink-faint:var(--v2-ink-faint);
+  --rule:var(--v2-rule); --rule-soft:var(--v2-rule-soft);
+  --good:var(--v2-good); --good-soft:var(--v2-good-soft); --bad:var(--v2-bad); --caution:var(--v2-caution);
+  --accent:var(--v2-accent); --flat:var(--v2-flat); --zicato-accent:var(--v2-accent);
+  --bad-soft:color-mix(in srgb, var(--v2-bad) 22%, var(--v2-panel));
+  --ansi-black:#2E3436; --ansi-red:#CC0000; --ansi-green:#4E9A06; --ansi-yellow:#C4A000;
+  --ansi-blue:#3465A4; --ansi-magenta:#75507B; --ansi-cyan:#06989A; --ansi-white:#D3D7CF;
+  --ansi-bright-black:#555753; --ansi-bright-red:#EF2929; --ansi-bright-green:#8AE234; --ansi-bright-yellow:#FCE94F;
+  --ansi-bright-blue:#729FCF; --ansi-bright-magenta:#AD7FA8; --ansi-bright-cyan:#34E2E2; --ansi-bright-white:#EEEEEC;
+  --hg-kind-invocation:var(--ansi-bright-black);
+  --hg-kind-llm-call:var(--ansi-blue);
+  --hg-kind-tool-call:var(--ansi-cyan);
+  --hg-kind-user-message:var(--ansi-green);
+  --hg-kind-agent-message:var(--ansi-bright-green);
+  --hg-kind-transfer:var(--ansi-yellow);
+  --hg-kind-wait-for-human:var(--ansi-magenta);
+  --hg-kind-planned:var(--ansi-bright-black);
+  --hg-kind-custom:var(--ansi-white);
+  --hg-gf-judge-on-task:var(--v2-good); --hg-gf-judge-warning:var(--v2-caution); --hg-gf-judge-critical:var(--v2-bad); --hg-gf-judge-neutral:var(--v2-flat);
+  --hg-gf-refine:var(--ansi-magenta);
+  --hg-gf-plan:var(--ansi-cyan);
+  --hg-gf-reflective:var(--ansi-bright-black);
+  --hg-agent-1:color-mix(in oklab, var(--ansi-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-2:color-mix(in oklab, var(--ansi-cyan) 62%, var(--v2-ink-faint));
+  --hg-agent-3:color-mix(in oklab, var(--ansi-green) 62%, var(--v2-ink-faint));
+  --hg-agent-4:color-mix(in oklab, var(--ansi-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-5:color-mix(in oklab, var(--ansi-magenta) 62%, var(--v2-ink-faint));
+  --hg-agent-6:color-mix(in oklab, var(--ansi-bright-blue) 62%, var(--v2-ink-faint));
+  --hg-agent-7:color-mix(in oklab, var(--ansi-bright-green) 62%, var(--v2-ink-faint));
+  --hg-agent-8:color-mix(in oklab, var(--ansi-bright-yellow) 62%, var(--v2-ink-faint));
+  --hg-agent-user:color-mix(in oklab, var(--v2-caution) 55%, var(--v2-ink-faint));
+  --hg-agent-goldfive:color-mix(in oklab, var(--v2-accent) 55%, var(--v2-ink-faint));
+}
+
+/* ---- harmonograf brand accent (the "now blue" dot) — ported from
+   _study.css 371-374, re-scoped onto .zk-root. A FIXED pair pinned per
+   ground, independent of the active theme's --accent. */
+.zk-root { --hgraf-brand: #5EA3EC; }
+.zk-root[data-zicato-theme="solarized-light"],
+.zk-root[data-zicato-theme="google-light"],
+.zk-root[data-zicato-theme="lunaria-light"],
+.zk-root[data-zicato-theme="belafonte-day"],
+.zk-root[data-zicato-theme="paper"] { --hgraf-brand: #2F7FD0; }

--- a/frontend/src/components/zicato/zicato.css
+++ b/frontend/src/components/zicato/zicato.css
@@ -852,6 +852,80 @@
   outline: 2px solid var(--accent);
 }
 
+/* ---- 6b. gantt zoom toolbar + minimap (zoom/pan/overview) ---------- */
+/* the gantt header row: the §6.5 <h3> on the left, the zoom controls right.
+   align-items:baseline so the small monospace buttons sit on the h3's
+   text baseline, matching the calm zicato chrome. */
+.zk-root .zk-gantt-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.zk-root .zk-gantt-head h3 {
+  margin: 16px 0 8px;
+}
+.zk-root .zk-gantt-head h3:first-child {
+  margin-top: 0;
+}
+/* − / + / fit cluster — modeled on .zk-iconbtn / .hg-transport-btn */
+.zk-root .zk-zoom {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.zk-root .zk-zoom button {
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-radius: var(--r-panel);
+  padding: 2px 8px;
+  min-width: 22px;
+  cursor: pointer;
+  color: var(--ink-soft);
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.3;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+}
+.zk-root .zk-zoom button:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--ink);
+}
+.zk-root .zk-zoom button:active:not(:disabled),
+.zk-root .zk-zoom button[aria-pressed='true'] {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.zk-root .zk-zoom button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* the full-range overview strip beneath the gantt */
+.zk-root .zk-minimap {
+  display: block;
+  margin-top: 8px;
+}
+/* one thin per-agent row track; every span coloured by statusFill (inline). The
+   load-bearing fills are set inline on the rects (so it renders pre-CSS); these
+   just keep the non-scaling stroke crisp. */
+.zk-root .zk-minimap .zk-mm-track {
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .zk-minimap .zk-mm-span {
+  vector-effect: non-scaling-stroke;
+}
+/* the translucent draggable viewport window over the overview */
+.zk-root .zk-minimap .zk-mm-viewport {
+  fill: var(--accent);
+  fill-opacity: 0.14;
+}
+.zk-root .zk-minimap .zk-mm-viewport-edge {
+  stroke: var(--accent);
+  stroke-width: 1.2;
+  vector-effect: non-scaling-stroke;
+}
+
 /* ---- 7. figure-local classes (compose.html <style> 30-82) ---------- */
 /* chord interactivity */
 .zk-root .topo-chord g[data-agent] {

--- a/frontend/src/components/zicato/zicato.css
+++ b/frontend/src/components/zicato/zicato.css
@@ -236,6 +236,11 @@
 
 /* ---- 2. rail / strip / transport ----------------------------------- */
 .zk-root .hg-rail {
+  /* reset the leaked MD3 global `.hg-rail { grid-area: rail }`: the zicato
+     grid (.zk-app-body) has no named `rail` area, so the inherited grid-area
+     pulled the rail out of placement and collapsed .zk-main into the 84px
+     first column. Auto-placement puts it back as the left column. */
+  grid-area: auto;
   display: flex;
   flex-direction: column;
   gap: 4px;

--- a/frontend/src/components/zicato/zicato.css
+++ b/frontend/src/components/zicato/zicato.css
@@ -1,0 +1,1041 @@
+/* =====================================================================
+   zicato.css — chrome + line-art component vocabulary for the in-app
+   zicato-language console. Ported from
+   docs/design/zicato-ui-study/_study.css (sections 0-7) + the figure-local
+   classes in compose.html's <style> block (lines 30-82). EVERY selector is
+   scoped under `.zk-root` so nothing leaks into the MD3 tree.
+
+   The token vars (--paper/--ink/--accent/--hg-kind-N/--hg-gf-N/--hg-agent-N)
+   come from zicato-tokens.css, scoped to `.zk-root[data-zicato-theme]`.
+
+   Sections:
+     0  root vars (mono/radii) + the zk-N grid layout
+     1  topbar / brand / crumbs / status / run badge
+     2  rail / strip / transport
+     3  drawer + json tint
+     4  pills / cards / hovercard / ⌘K picker
+     5  theme picker (the .dt-N swatch dropdown)
+     6  the GANTT line-art classes (.hg-gantt-N)
+     7  figure-local classes (.sq-N / .gm-N / .topo-chord / .plan-reel / …)
+     8  motion (now/breathe pulse) + reduced-motion
+   ===================================================================== */
+
+/* ---- 0. root vars + the zk-N grid layout --------------------------- */
+.zk-root {
+  --mono: ui-monospace, 'JetBrains Mono', 'SF Mono', 'Cascadia Mono', Menlo, Consolas, monospace;
+  --brand-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --r-panel: 4px; /* panels */
+  --r-pill: 10px; /* pills */
+  --r-card: 5px; /* cards / buttons */
+
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  min-height: 0;
+  position: relative;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+}
+.zk-root *,
+.zk-root *::before,
+.zk-root *::after {
+  box-sizing: border-box;
+}
+.zk-root .tnum {
+  font-variant-numeric: tabular-nums;
+}
+
+/* rail (observatory) · main · inspector — sessions live ONLY in the ⌘K picker */
+.zk-app-body {
+  flex: 1;
+  display: grid;
+  min-height: 0;
+  grid-template-columns: 84px minmax(0, 1fr) auto;
+}
+.zk-main {
+  overflow: auto;
+  padding: 14px 18px;
+  min-width: 0;
+}
+.zk-main h3 {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+  margin: 16px 0 8px;
+  font-weight: 600;
+}
+.zk-main h3:first-child {
+  margin-top: 0;
+}
+.zk-panes-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+@media (max-width: 1100px) {
+  .zk-panes-2 {
+    grid-template-columns: 1fr;
+  }
+}
+.zk-prop-note {
+  font-size: 10.5px;
+  color: var(--ink-faint);
+}
+.zk-sess-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 6px;
+}
+.zk-sess-title {
+  font-size: 15px;
+  font-weight: 700;
+}
+.zk-sess-stats {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+/* ---- 1. topbar / brand / crumbs / status --------------------------- */
+.zk-root .hg-topbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 18px;
+  background: color-mix(in srgb, var(--paper) 92%, transparent);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--rule);
+}
+.zk-root .hg-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ink);
+}
+.zk-root .hg-brand-mark {
+  height: 24px;
+  width: auto;
+  display: block;
+  flex: none;
+  overflow: visible;
+}
+.zk-root .hg-brand-name {
+  height: 15px;
+  width: auto;
+  display: block;
+  flex: none;
+  color: var(--ink);
+  overflow: visible;
+}
+.zk-root .hg-crumbs {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--ink-faint);
+}
+.zk-root .hg-crumb {
+  color: var(--ink-soft);
+}
+.zk-root .hg-crumb:hover {
+  color: var(--accent);
+  text-decoration: none;
+}
+.zk-root .hg-crumb-current {
+  color: var(--ink);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+}
+.zk-root .hg-crumb-sep {
+  opacity: 0.5;
+}
+.zk-root .hg-topbar-spacer {
+  flex: 1;
+}
+.zk-root .hg-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  color: var(--ink-faint);
+}
+.zk-root .hg-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--flat);
+  transition: background 0.2s;
+}
+.zk-root .hg-status.is-connected .hg-status-dot {
+  background: var(--good);
+}
+.zk-root .hg-status.is-running .hg-status-dot {
+  background: var(--accent);
+}
+.zk-root .hg-run-badge {
+  display: none;
+  align-items: center;
+  gap: 5px;
+  margin-left: 6px;
+  padding: 1px 7px;
+  border-radius: 9px;
+  border: 1px solid var(--rule);
+  background: var(--panel);
+  color: var(--ink-soft);
+  font-size: 10px;
+  white-space: nowrap;
+}
+.zk-root .hg-status.is-running .hg-run-badge {
+  display: inline-flex;
+}
+.zk-root .hg-run-pulse {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex: none;
+  box-shadow: 0 0 0 0 var(--accent);
+  animation: hg-now-pulse 1.6s ease-out infinite;
+}
+.zk-root .hg-run-label {
+  color: var(--accent);
+}
+.zk-root .hg-picker-kbd {
+  font-size: 10px;
+  color: var(--ink-faint);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+/* the md3 toggle + theme picker host live in the topbar; plain mono button */
+.zk-root .zk-iconbtn {
+  background: transparent;
+  border: 1px solid var(--rule);
+  border-radius: var(--r-panel);
+  padding: 4px 9px;
+  cursor: pointer;
+  color: var(--ink-soft);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1;
+  transition: border-color 0.12s, color 0.12s;
+}
+.zk-root .zk-iconbtn:hover {
+  border-color: var(--accent);
+  color: var(--ink);
+}
+
+/* ---- 2. rail / strip / transport ----------------------------------- */
+.zk-root .hg-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 8px;
+  background: var(--panel);
+  border-right: 1px solid var(--rule);
+}
+.zk-root .hg-rail-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  padding: 8px 4px;
+  background: transparent;
+  border: none;
+  border-radius: var(--r-panel);
+  color: var(--ink-soft);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  transition: background 0.12s, color 0.12s;
+}
+.zk-root .hg-rail-item:hover {
+  background: var(--rule-soft);
+  color: var(--ink);
+}
+.zk-root .hg-rail-item[aria-selected='true'] {
+  background: color-mix(in srgb, var(--accent) 14%, var(--panel));
+  color: var(--accent);
+}
+.zk-root .hg-rail-icon {
+  font-size: 17px;
+  line-height: 1;
+}
+
+.zk-root .hg-strip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 16px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--rule);
+  font-size: 11.5px;
+  min-height: 26px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.zk-root .hg-strip-label {
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+}
+.zk-root .hg-strip-title {
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--ink);
+}
+.zk-root .hg-strip-agent {
+  color: var(--ink-soft);
+  border: 1px solid var(--rule);
+  padding: 1px 8px;
+  border-radius: var(--r-pill);
+  font-size: 10.5px;
+}
+
+.zk-root .hg-transport {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 14px;
+  background: var(--panel);
+  border-top: 1px solid var(--rule);
+  height: 42px;
+}
+.zk-root .hg-transport-btn {
+  background: transparent;
+  border: 1px solid var(--rule);
+  border-radius: var(--r-panel);
+  padding: 4px 9px;
+  cursor: pointer;
+  color: var(--ink-soft);
+  font: inherit;
+  font-size: 11px;
+  transition: border-color 0.12s, color 0.12s;
+}
+.zk-root .hg-transport-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--ink);
+}
+.zk-root .hg-transport-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.zk-root .hg-transport-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.zk-root .hg-transport-divider {
+  width: 1px;
+  height: 18px;
+  background: var(--rule);
+}
+.zk-root .hg-transport-spacer {
+  flex: 1;
+}
+.zk-root .hg-live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+}
+.zk-root .hg-live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: hg-now-pulse 1.6s ease-out infinite;
+  flex: none;
+}
+.zk-root .hg-clock {
+  font-size: 12px;
+  color: var(--ink-soft);
+}
+
+/* ---- 3. drawer + json tint ----------------------------------------- */
+.zk-drawer-host {
+  width: 0;
+  overflow: hidden;
+  transition: width 0.16s ease;
+}
+.zk-drawer-host.open {
+  width: 320px;
+}
+.zk-drawer-host .hg-drawer {
+  width: 320px;
+}
+.zk-root .hg-drawer {
+  display: flex;
+  flex-direction: column;
+  background: var(--panel);
+  border-left: 1px solid var(--rule);
+  height: 100%;
+  min-height: 0;
+}
+.zk-root .hg-drawer-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--rule);
+}
+.zk-root .hg-drawer-title {
+  font-weight: 600;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+.zk-root .hg-drawer-close {
+  background: transparent;
+  border: none;
+  color: var(--ink-faint);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.zk-root .hg-drawer-close:hover {
+  color: var(--ink);
+  background: var(--rule-soft);
+}
+.zk-root .hg-drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 14px;
+  font-size: 12.5px;
+}
+.zk-root .hg-attrs {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 5px 14px;
+  font-size: 12px;
+}
+.zk-root .hg-attrs dt {
+  color: var(--ink-faint);
+}
+.zk-root .hg-attrs dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+.zk-root .hg-drawer-code {
+  display: block;
+  background: var(--panel-2);
+  padding: 9px 11px;
+  border-radius: var(--r-panel);
+  border: 1px solid var(--rule);
+  font-family: var(--mono);
+  font-size: 11px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+  max-height: 320px;
+}
+.zk-root .hg-j-key {
+  color: var(--accent);
+}
+.zk-root .hg-j-str {
+  color: var(--good);
+}
+.zk-root .hg-j-num {
+  color: var(--caution);
+}
+.zk-root .hg-j-bool {
+  color: var(--bad);
+}
+.zk-root .hg-j-null {
+  color: var(--ink-faint);
+  font-style: italic;
+}
+.zk-root .hg-j-punct {
+  color: var(--ink-soft);
+}
+
+/* ---- 4. pills / cards / hovercard / ⌘K picker ---------------------- */
+.zk-root .dn-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  padding: 2px 8px;
+  border-radius: var(--r-pill);
+  border: 1px solid var(--rule);
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+.zk-root .dn-pill.good {
+  border-color: var(--good);
+  color: var(--good);
+}
+.zk-root .dn-pill.bad {
+  border-color: var(--bad);
+  color: var(--bad);
+}
+.zk-root .dn-pill.caution {
+  border-color: var(--caution);
+  color: var(--caution);
+}
+.zk-root .dn-pill.accent {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.zk-root .dn-pill.live {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.zk-root .dn-pill.flat {
+  border-color: var(--rule);
+  color: var(--ink-soft);
+}
+.zk-root .dn-card {
+  border: 1px solid var(--rule);
+  border-radius: var(--r-card);
+  background: var(--panel);
+  padding: 12px 14px;
+  transition: border-color 0.12s, transform 0.12s;
+}
+.zk-root .dn-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+.zk-root .dn-card.is-current {
+  border-color: var(--good);
+}
+.zk-root .hg-hovercard {
+  position: fixed;
+  z-index: 200;
+  pointer-events: none;
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  padding: 7px 10px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  max-width: 320px;
+  opacity: 0;
+  transform: translateY(2px);
+  transition: opacity 0.12s, transform 0.12s;
+}
+.zk-root .hg-hovercard.on {
+  opacity: 1;
+  transform: translateY(0);
+}
+.zk-root .hg-hc-title {
+  color: var(--ink);
+  font-weight: 700;
+  margin-bottom: 3px;
+}
+.zk-root .hg-hc-row {
+  color: var(--ink-soft);
+  font-size: 10.5px;
+}
+.zk-root .hg-hc-row b {
+  color: var(--ink);
+}
+
+/* ⌘K session picker — note: cut 1 reuses the global <SessionPicker/>, so
+   these zicato-styled picker classes are ported for the deferred zicato
+   picker (§7 of PLAN.md). Scoped + harmless when unused. */
+.zk-root .hg-picker-backdrop {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--paper) 30%, rgba(0, 0, 0, 0.55));
+  backdrop-filter: blur(4px);
+  z-index: 900;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+}
+.zk-root .hg-picker {
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  width: min(640px, 92vw);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: 66vh;
+}
+.zk-root .hg-picker-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--rule);
+}
+.zk-root .hg-picker-search input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--ink);
+  font: inherit;
+  font-size: 14px;
+  outline: none;
+}
+.zk-root .hg-picker-list {
+  overflow-y: auto;
+}
+.zk-root .hg-picker-section {
+  padding: 8px 16px 4px;
+  font-size: 10px;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.zk-root .hg-picker-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 16px;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  color: var(--ink);
+  width: 100%;
+  text-align: left;
+  font: inherit;
+}
+.zk-root .hg-picker-row:hover,
+.zk-root .hg-picker-row[aria-selected='true'] {
+  background: var(--rule-soft);
+}
+.zk-root .hg-picker-row-title {
+  font-size: 13px;
+}
+.zk-root .hg-picker-row-sub {
+  font-size: 10.5px;
+  color: var(--ink-faint);
+}
+.zk-root .hg-picker-row-meta {
+  margin-left: auto;
+  font-size: 10.5px;
+  color: var(--ink-faint);
+}
+
+/* ---- 5. theme picker (the .dt-N swatch dropdown) ------------------- */
+.zk-root .dt-cd {
+  position: relative;
+  display: inline-block;
+}
+.zk-root .dt-cd-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: transparent;
+  border: 1px solid var(--rule);
+  border-radius: 5px;
+  padding: 3px 8px;
+  cursor: pointer;
+  color: var(--ink-soft);
+  font: inherit;
+  font-size: 10.5px;
+}
+.zk-root .dt-cd-trigger:hover {
+  border-color: var(--accent);
+}
+.zk-root .dt-cd-name {
+  color: var(--ink);
+}
+.zk-root .dt-cd-caret {
+  color: var(--ink-faint);
+  font-size: 8px;
+  transition: transform 0.15s;
+}
+.zk-root .dt-cd.dt-cd-open .dt-cd-caret {
+  transform: rotate(180deg);
+}
+.zk-root .dt-swatch-strip {
+  display: inline-flex;
+  border-radius: 3px;
+  overflow: hidden;
+  border: 1px solid var(--rule);
+}
+.zk-root .dt-swatch {
+  display: inline-block;
+  width: 11px;
+  height: 13px;
+}
+.zk-root .dt-cd-list {
+  display: none;
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
+  z-index: 60;
+  min-width: 210px;
+  max-height: 70vh;
+  overflow-y: auto;
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  padding: 4px;
+}
+.zk-root .dt-cd.dt-cd-open .dt-cd-list {
+  display: block;
+}
+.zk-root .dt-cd-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 7px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--ink-soft);
+  border: none;
+  background: transparent;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  transition: background 0.12s, color 0.12s;
+}
+.zk-root .dt-cd-option .dt-cd-name {
+  font-size: 10.5px;
+}
+.zk-root .dt-cd-option:hover,
+.zk-root .dt-cd-option.dt-cd-active {
+  background: var(--rule-soft);
+  color: var(--ink);
+}
+.zk-root .dt-cd-option[aria-selected='true'] .dt-cd-name {
+  color: var(--accent);
+}
+
+/* ---- 6. GANTT line-art classes (.hg-gantt-N) ----------------------- */
+.zk-root svg.fig {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+.zk-root svg.fig text {
+  font-family: var(--mono);
+}
+.zk-root .hg-gantt-grid {
+  stroke: var(--rule-soft);
+  stroke-width: 0.6;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .hg-gantt-axis {
+  fill: var(--ink-faint);
+  font-size: 9.5px;
+}
+.zk-root .hg-gantt-axis-major {
+  fill: var(--ink-soft);
+  font-size: 9.5px;
+}
+.zk-root .hg-gantt-lane-label {
+  fill: var(--ink-soft);
+  font-size: 10px;
+}
+.zk-root .hg-gantt-lane-sep {
+  stroke: var(--rule-soft);
+  stroke-width: 0.6;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .hg-gantt-gutter {
+  fill: var(--panel-2);
+}
+.zk-root .hg-gantt-bar {
+  rx: 3;
+  stroke: none;
+  fill-opacity: 0.55;
+  transition: fill-opacity 0.1s;
+}
+.zk-root .hg-gantt-bar:hover {
+  fill-opacity: 1;
+}
+.zk-root .hg-gantt-bar.is-pending {
+  fill-opacity: 0.32;
+}
+.zk-root .hg-gantt-bar.is-invocation {
+  fill-opacity: 0.3;
+}
+.zk-root .hg-gantt-bar.is-planned {
+  fill: var(--rule-soft);
+  stroke: var(--ink-faint);
+  stroke-dasharray: 4 3;
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+  fill-opacity: 0.5;
+}
+.zk-root .hg-gantt-bar.is-running {
+  stroke: var(--accent);
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .hg-gantt-bar.is-failed {
+  fill: var(--bad);
+  fill-opacity: 0.8;
+}
+.zk-root .hg-gantt-bar.is-cancelled {
+  fill-opacity: 0.28;
+}
+.zk-root .hg-gantt-bar.is-selected {
+  stroke: var(--accent);
+  stroke-width: 2.2;
+  vector-effect: non-scaling-stroke;
+  fill-opacity: 1;
+}
+.zk-root .hg-gantt-now {
+  stroke: var(--accent);
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .hg-gantt-now-cap {
+  fill: var(--accent);
+}
+.zk-root .hg-gantt-now-label {
+  fill: var(--accent);
+  font-size: 9.5px;
+  font-variant-numeric: tabular-nums;
+}
+.zk-root .hg-gantt-glyph-fail {
+  fill: var(--bad);
+  font-size: 10px;
+}
+.zk-root .hg-gantt-glyph-wait {
+  fill: var(--caution);
+  font-size: 10px;
+}
+.zk-root .hg-gantt-edge {
+  stroke: var(--ink-faint);
+  stroke-width: 1;
+  fill: none;
+  vector-effect: non-scaling-stroke;
+  opacity: 0.62;
+}
+.zk-root .hg-gantt-edge.is-transfer {
+  stroke: var(--hg-kind-transfer);
+  stroke-dasharray: 3 2;
+}
+.zk-root .hg-gantt-ctxband {
+  fill: var(--caution);
+  fill-opacity: 0.14;
+}
+.zk-root .hg-gantt-ctxband-line {
+  stroke: var(--caution);
+  stroke-width: 0.8;
+  fill: none;
+  vector-effect: non-scaling-stroke;
+  opacity: 0.6;
+}
+.zk-root .hg-gantt-row:focus-visible,
+.zk-root .hg-gantt-bar:focus-visible {
+  outline: 2px solid var(--accent);
+}
+
+/* ---- 7. figure-local classes (compose.html <style> 30-82) ---------- */
+/* chord interactivity */
+.zk-root .topo-chord g[data-agent] {
+  cursor: pointer;
+}
+.zk-root .topo-chord [data-ribbon],
+.zk-root .topo-chord [data-ahead],
+.zk-root .topo-chord [data-agent] {
+  transition: opacity 0.15s ease;
+}
+.zk-root .tch-count {
+  fill: var(--ink);
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+  paint-order: stroke;
+  stroke: var(--paper);
+  stroke-width: 3px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+/* sequence */
+.zk-root .sq-act {
+  fill-opacity: 0.55;
+}
+.zk-root .sq-act:hover {
+  fill-opacity: 1;
+}
+.zk-root .sq-staff {
+  stroke: var(--rule);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .sq-life {
+  stroke: var(--rule);
+  stroke-width: 1.1;
+  stroke-dasharray: 1 4;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .sq-chip {
+  fill: var(--panel);
+  stroke: var(--rule);
+}
+.zk-root .sq-msg {
+  fill: none;
+  stroke-width: 1.4;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .sq-head {
+  stroke-width: 1.2;
+  fill: none;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .sq-name {
+  fill: var(--ink);
+  font-size: 10px;
+  font-weight: 500;
+}
+.zk-root .sq-lbl {
+  fill: var(--ink-soft);
+  font-size: 8.5px;
+}
+/* seismograph / ladder / reel */
+.zk-root .gm-onplan {
+  stroke: var(--ink-faint);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .gm-tol {
+  fill: var(--good);
+  fill-opacity: 0.07;
+}
+.zk-root .gm-trace {
+  stroke: var(--ink);
+  stroke-width: 1.3;
+  fill: none;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .gm-excursion {
+  fill: var(--bad);
+  fill-opacity: 0.14;
+}
+.zk-root .gm-tick {
+  stroke: var(--caution);
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .gm-tick-label {
+  fill: var(--caution);
+  font-size: 8.5px;
+}
+.zk-root .gm-label {
+  fill: var(--ink-soft);
+  font-size: 10px;
+}
+.zk-root .gm-faint {
+  fill: var(--ink-faint);
+  font-size: 9px;
+}
+.zk-root .gm-axis {
+  fill: var(--ink-faint);
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+}
+.zk-root .gm-seam {
+  stroke: var(--rule);
+  stroke-width: 1;
+  stroke-dasharray: 5 4;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .gm-spine {
+  stroke: var(--accent);
+  stroke-width: 2.2;
+  vector-effect: non-scaling-stroke;
+}
+.zk-root .gantt-click .hg-gantt-bar,
+.zk-root .gantt-click .sq-act {
+  cursor: pointer;
+}
+/* the plan reel drives the DAG: each version stop is a button */
+.zk-root .plan-reel .reel-stop[data-ver] {
+  cursor: pointer;
+}
+.zk-root .plan-reel .reel-stop[data-ver]:hover .reel-hit,
+.zk-root .plan-reel .reel-stop[data-ver]:focus-visible .reel-hit {
+  fill: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+.zk-root .plan-reel .reel-stop[data-ver]:focus {
+  outline: none;
+}
+.zk-root .plan-reel .reel-stop[data-ver]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 50%;
+}
+.zk-root .reel-host,
+.zk-root .dag-host {
+  display: block;
+}
+/* the coordinated time-track stack: seismograph over the time-aligned ladder */
+.zk-root .track-stack {
+  display: block;
+}
+.zk-root .track-stack .track-sub {
+  font-size: 9.5px;
+  color: var(--ink-faint);
+  margin: 2px 0 0;
+  padding-left: 76px;
+}
+
+/* ---- 8. motion + a11y ---------------------------------------------- */
+@keyframes hg-now-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 70%, transparent);
+    opacity: 1;
+  }
+  70% {
+    box-shadow: 0 0 0 5px transparent;
+    opacity: 0.65;
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+    opacity: 1;
+  }
+}
+@keyframes hg-breathe {
+  0%,
+  100% {
+    opacity: 0.85;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+.zk-root .hg-breathe {
+  animation: hg-breathe 2s ease-in-out infinite;
+}
+.zk-root :focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zk-root *,
+  .zk-root *::before,
+  .zk-root *::after {
+    animation-duration: 0ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0ms !important;
+  }
+}

--- a/frontend/src/components/zicato/zicato.css
+++ b/frontend/src/components/zicato/zicato.css
@@ -825,6 +825,13 @@
   fill: var(--caution);
   font-size: 10px;
 }
+/* 🧠 reasoning glyph — rendered LITERAL (emoji). Sized prominently so the
+   reasoning marker reads at a glance; the emoji carries its own colour. */
+.zk-root .hg-gantt-glyph-reason {
+  font-size: 11px;
+  /* keep the bar drawing crisp under zoom; the emoji ignores fill anyway */
+  pointer-events: none;
+}
 .zk-root .hg-gantt-edge {
   stroke: var(--ink-faint);
   stroke-width: 1;
@@ -835,6 +842,13 @@
 .zk-root .hg-gantt-edge.is-transfer {
   stroke: var(--hg-kind-transfer);
   stroke-dasharray: 3 2;
+}
+/* goldfive steering / correction edge — the curve hue is set inline from the
+   trigger severity (steerColor); here we only nudge weight/opacity so it reads
+   as a deliberate correction rather than an ambient transfer. */
+.zk-root .hg-gantt-edge.is-steer {
+  stroke-width: 1.3;
+  opacity: 0.92;
 }
 .zk-root .hg-gantt-ctxband {
   fill: var(--caution);
@@ -1117,4 +1131,131 @@
     animation-iteration-count: 1 !important;
     transition-duration: 0ms !important;
   }
+}
+
+/* ---- 12. floating detail drawer (reasoning / steering) ------------- */
+/* A floating panel (port of TrajectoryFloatingDrawer) that slides in over the
+   main area to surface reasoning / steering detail. Distinct from the docked
+   ZicatoInspector — it overlays rather than reserving a right column. Scoped to
+   .zk-root so it never leaks into the MD3 console. */
+.zk-root .zk-fdrawer-backdrop {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, var(--bg) 55%, transparent);
+  z-index: 40;
+}
+.zk-root .zk-fdrawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--panel);
+  border-left: 1px solid var(--rule);
+  box-shadow: -6px 0 18px -8px rgba(0, 0, 0, 0.5);
+  z-index: 41;
+  animation: zk-fdrawer-in 0.18s ease;
+}
+@keyframes zk-fdrawer-in {
+  from {
+    transform: translateX(12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+.zk-root .zk-fdrawer-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--rule);
+}
+.zk-root .zk-fdrawer-title {
+  flex: 1;
+  margin: 0;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-soft);
+}
+.zk-root .zk-fdrawer-close {
+  background: transparent;
+  border: none;
+  color: var(--ink-faint);
+  cursor: pointer;
+  font: inherit;
+  font-size: 15px;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.zk-root .zk-fdrawer-close:hover {
+  color: var(--ink);
+  background: var(--rule-soft);
+}
+.zk-root .zk-fdrawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 14px;
+  font-size: 12px;
+}
+.zk-root .zk-detail-section {
+  margin-bottom: 14px;
+}
+.zk-root .zk-detail-section h4 {
+  margin: 0 0 5px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-faint);
+}
+.zk-root .zk-detail-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--ink-soft);
+  margin-bottom: 10px;
+}
+.zk-root .zk-detail-target {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--ink);
+}
+.zk-root .zk-detail-target .zk-detail-target-label {
+  color: var(--ink-faint);
+  margin-right: 6px;
+}
+/* The reasoning block: the 🧠 chain-of-thought rendered verbatim in a calm
+   monospace pre-block, so the operator can read what the agent was thinking. */
+.zk-root .zk-reasoning {
+  display: block;
+  background: var(--panel-2);
+  border: 1px solid var(--rule);
+  border-radius: var(--r-panel);
+  padding: 9px 11px;
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  overflow-y: auto;
+  max-height: 340px;
+  color: var(--ink);
+}
+.zk-root .zk-reasoning-empty {
+  font-size: 11px;
+  color: var(--ink-faint);
+}
+.zk-root .zk-reasoning-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.zk-root .zk-reasoning-glyph {
+  font-size: 14px;
 }

--- a/frontend/src/lib/sessionRoute.ts
+++ b/frontend/src/lib/sessionRoute.ts
@@ -1,0 +1,17 @@
+// Hash-route parsing for the `#/session/<id>` deep link consumed by App.tsx.
+// Kept in its own module so App.tsx only exports its component (react-refresh).
+
+// Parse a `#/session/<id>` deep link, returning the (decoded) session id or
+// null. Tolerates a trailing slash and an empty id. Accepts both
+// `#/session/<id>` and a bare `/session/<id>` defensively.
+export function sessionIdFromHash(hash: string): string | null {
+  const m = /^#?\/session\/([^/]+)\/?$/.exec(hash);
+  if (!m) return null;
+  const raw = m[1];
+  if (!raw) return null;
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/frontend/src/rpc/transport.ts
+++ b/frontend/src/rpc/transport.ts
@@ -1,10 +1,17 @@
 // Connect-Web transport. We speak gRPC-Web so Connect-Web's createGrpcWebTransport
 // is the right wire format for the Python harmonograf_server (sonora grpcASGI,
-// served by hypercorn — no Envoy/grpcwebproxy needed). The base URL is taken
-// from the Vite env var VITE_HARMONOGRAF_API, falling back to the server's
-// default --web-port (7532) on loopback. To point at a non-default server,
-// set the env var before running `pnpm dev`, e.g.:
-//     VITE_HARMONOGRAF_API=http://127.0.0.1:17532 pnpm dev
+// served by hypercorn — no Envoy/grpcwebproxy needed). The base URL is resolved
+// in three steps, most-specific first:
+//
+//   1. window.__HARMONOGRAF_API__ — a runtime global the server injects into
+//      the index.html it serves itself (see server/harmonograf_server/
+//      static_site.py). This lets a single built bundle work behind any
+//      host/port without a rebuild, because the server fills in the URL the
+//      browser actually used to reach it.
+//   2. VITE_HARMONOGRAF_API — a build-time env var, useful for `pnpm dev`
+//      against a non-default server:
+//          VITE_HARMONOGRAF_API=http://127.0.0.1:17532 pnpm dev
+//   3. the compiled-in default --web-port (7532) on loopback.
 
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import type { Transport } from '@connectrpc/connect';
@@ -12,11 +19,26 @@ import type { Transport } from '@connectrpc/connect';
 // Must track server/harmonograf_server/cli.py --web-port default.
 const DEFAULT_BASE_URL = 'http://127.0.0.1:7532';
 
+// The runtime global the server injects when it serves the bundle itself.
+declare global {
+  interface Window {
+    __HARMONOGRAF_API__?: string;
+  }
+}
+
 export function apiBaseUrl(): string {
-  // Vite injects env vars prefixed with VITE_.
+  // 1. Runtime global injected by the serving harmonograf_server.
+  if (typeof window !== 'undefined') {
+    const fromRuntime = window.__HARMONOGRAF_API__;
+    if (typeof fromRuntime === 'string' && fromRuntime.length > 0) {
+      return fromRuntime;
+    }
+  }
+  // 2. Build-time env var (Vite injects env vars prefixed with VITE_).
   const fromEnv =
     typeof import.meta !== 'undefined' &&
     (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_HARMONOGRAF_API;
+  // 3. Compiled-in default.
   return fromEnv || DEFAULT_BASE_URL;
 }
 

--- a/frontend/src/state/uiStore.ts
+++ b/frontend/src/state/uiStore.ts
@@ -13,6 +13,51 @@ export type NavSection =
 
 export type TaskPlanMode = 'pre-strip' | 'ghost' | 'hybrid';
 
+// Console UI mode. 'md3' (default) = the existing Material console; 'zicato' =
+// the parallel zicato-language console (a separate render tree under
+// src/components/zicato). Persisted to localStorage so a toggle survives reload.
+export type UiMode = 'md3' | 'zicato';
+
+// The 16 zicato palette ids (ported from the study's THEME_IDS). The zicato
+// console scopes these under `data-zicato-theme` on its own root element, so
+// they never collide with the MD3 `<html data-theme>` (dark/light/…).
+export type ZicatoTheme =
+  | 'monokai'
+  | 'solarized-dark'
+  | 'solarized-light'
+  | 'google-light'
+  | 'google-dark'
+  | 'lunaria-light'
+  | 'lunaria-eclipse'
+  | 'belafonte-day'
+  | 'belafonte-night'
+  | 'paper'
+  | 'zenburn'
+  | 'selenized-black'
+  | 'relaxed'
+  | 'espresso'
+  | 'dracula'
+  | 'ubuntu';
+
+const ZICATO_THEME_IDS: readonly ZicatoTheme[] = [
+  'monokai',
+  'solarized-dark',
+  'solarized-light',
+  'google-light',
+  'google-dark',
+  'lunaria-light',
+  'lunaria-eclipse',
+  'belafonte-day',
+  'belafonte-night',
+  'paper',
+  'zenburn',
+  'selenized-black',
+  'relaxed',
+  'espresso',
+  'dracula',
+  'ubuntu',
+];
+
 // Task/Plan panel view mode. 'cumulative' renders the union-DAG across
 // revisions (default, with generation badges + supersedes edges).
 // 'latest' renders only the latest revision of each plan (legacy view).
@@ -31,6 +76,12 @@ const INTERVENTION_BANDS_VISIBLE_KEY = 'harmonograf.interventionBandsVisible';
 // (new compact layout); persisted so a user who expands it doesn't lose the
 // state on reload.
 const TRAJECTORY_LEGACY_EXPANDED_KEY = 'harmonograf.trajectoryLegacyExpanded';
+// Parallel zicato console: the active console mode + its scoped palette.
+// Deliberately NOT reusing the study's `hgraf-study-theme` key — keeps the
+// in-app zicato theme independent of any standalone study page in the same
+// origin.
+const UI_MODE_KEY = 'harmonograf.uiMode';
+const ZICATO_THEME_KEY = 'harmonograf.zicatoTheme';
 
 function readGraphViewport(): GraphViewport | null {
   try {
@@ -176,6 +227,44 @@ function writeTrajectoryLegacyExpanded(v: boolean): void {
   }
 }
 
+function readUiMode(): UiMode {
+  try {
+    const v = localStorage.getItem(UI_MODE_KEY);
+    if (v === 'md3' || v === 'zicato') return v;
+  } catch {
+    /* ignore (SSR / privacy mode) */
+  }
+  return 'md3'; // DEFAULT: production unchanged until toggled
+}
+
+function writeUiMode(m: UiMode): void {
+  try {
+    localStorage.setItem(UI_MODE_KEY, m);
+  } catch {
+    /* ignore */
+  }
+}
+
+function readZicatoTheme(): ZicatoTheme {
+  try {
+    const v = localStorage.getItem(ZICATO_THEME_KEY);
+    if (v && (ZICATO_THEME_IDS as readonly string[]).includes(v)) {
+      return v as ZicatoTheme;
+    }
+  } catch {
+    /* ignore */
+  }
+  return 'monokai';
+}
+
+function writeZicatoTheme(t: ZicatoTheme): void {
+  try {
+    localStorage.setItem(ZICATO_THEME_KEY, t);
+  } catch {
+    /* ignore */
+  }
+}
+
 // harmonograf: TrajectoryView plan picker selection. Persisted across
 // reloads so the operator's choice survives a refresh. ``null`` ⇒
 // default to latest plan by created_at.
@@ -272,6 +361,16 @@ interface UiState {
   jumpToLive: () => void;
   toggleLiveFollow: () => void;
   setActiveRenderer: (r: GanttRenderer | null) => void;
+
+  // Console UI mode. 'md3' (default) = existing Material console; 'zicato' =
+  // the parallel zicato-language console. Persisted to localStorage.
+  uiMode: UiMode;
+  setUiMode: (m: UiMode) => void;
+  toggleUiMode: () => void;
+  // Active zicato palette (16 study themes). Persisted; scoped to the zicato
+  // subtree via `data-zicato-theme` (never touches the MD3 :root data-theme).
+  zicatoTheme: ZicatoTheme;
+  setZicatoTheme: (t: ZicatoTheme) => void;
 
   // Task-plan rendering preferences (persisted to localStorage).
   taskPlanMode: TaskPlanMode;
@@ -433,6 +532,25 @@ export const useUiStore = create<UiState>((set) => ({
       return { liveFollow: next };
     }),
   setActiveRenderer: (r) => set({ activeRenderer: r }),
+
+  uiMode: readUiMode(),
+  setUiMode: (m) =>
+    set(() => {
+      writeUiMode(m);
+      return { uiMode: m };
+    }),
+  toggleUiMode: () =>
+    set((s) => {
+      const next: UiMode = s.uiMode === 'md3' ? 'zicato' : 'md3';
+      writeUiMode(next);
+      return { uiMode: next };
+    }),
+  zicatoTheme: readZicatoTheme(),
+  setZicatoTheme: (t) =>
+    set(() => {
+      writeZicatoTheme(t);
+      return { zicatoTheme: t };
+    }),
 
   taskPlanMode: readTaskPlanMode(),
   taskPlanVisible: readTaskPlanVisible(),

--- a/server/README.md
+++ b/server/README.md
@@ -17,8 +17,12 @@ browser the whole console — no separate static host or frontend dev server.
 
 - `GET /` and `GET /index.html` → the SPA's `index.html`.
 - `GET /assets/*` and any other real file in the web root → served directly.
-- Any other non-API path that isn't a real file → falls back to `index.html`,
-  so client-side hash routes such as `#/session/<id>` load when deep-linked.
+  Content-hashed `/assets/*` are sent `Cache-Control: immutable`; `index.html`
+  is sent `no-cache` so a redeploy is picked up.
+- Any other **extension-less** non-API path → falls back to `index.html`, so
+  client-side hash routes such as `#/session/<id>` load when deep-linked. A
+  missing *file-like* path (`*.js`, `*.svg`, …) returns `404` rather than HTML,
+  to avoid handing the browser a MIME-mismatched `index.html`.
 - gRPC-Web requests (`application/grpc-web*`), gRPC service-method paths
   (`/<pkg>.<Service>/<Method>`), and the health routes are never intercepted —
   they always reach the gRPC-Web / health app.

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,72 @@
+# harmonograf-server
+
+gRPC fan-in for multi-agent telemetry and control, plus the self-served
+console UI.
+
+## Ports
+
+- `--port` (default `7531`) — native gRPC, for agents/SDKs.
+- `--web-port` (default `7532`) — gRPC-Web (for browsers) **and** the console
+  SPA + health endpoints, all on one ASGI app.
+
+## Self-served console UI
+
+The web port serves the built console single-page app alongside gRPC-Web and
+the `/healthz` / `/readyz` probes. One `harmonograf-server` process hands a
+browser the whole console — no separate static host or frontend dev server.
+
+- `GET /` and `GET /index.html` → the SPA's `index.html`.
+- `GET /assets/*` and any other real file in the web root → served directly.
+- Any other non-API path that isn't a real file → falls back to `index.html`,
+  so client-side hash routes such as `#/session/<id>` load when deep-linked.
+- gRPC-Web requests (`application/grpc-web*`), gRPC service-method paths
+  (`/<pkg>.<Service>/<Method>`), and the health routes are never intercepted —
+  they always reach the gRPC-Web / health app.
+
+### Runtime endpoint config (one bundle, any host/port)
+
+When serving `index.html`, the server injects a `window.__HARMONOGRAF_API__`
+global with the gRPC-Web base URL the browser should use to reach this server.
+The frontend's `transport.ts` reads the endpoint in this precedence:
+
+1. `window.__HARMONOGRAF_API__` (runtime — injected by this server),
+2. `VITE_HARMONOGRAF_API` (build-time env var, for `pnpm dev`),
+3. the compiled-in default (`http://127.0.0.1:7532`).
+
+So a single built bundle works behind any host/port with no rebuild. The
+injected URL is derived per-request from the `Host` / `X-Forwarded-*` headers,
+or set explicitly with `--public-base-url` when behind a reverse proxy.
+
+### Locating the bundle
+
+In precedence order:
+
+1. `--web-root <dir>` (explicit override),
+2. the packaged console shipped in the wheel
+   (`harmonograf_server/_console/`, located via `importlib.resources`),
+3. a dev fallback to `../frontend/dist` in a repo checkout.
+
+If no bundle is found the server logs a warning and keeps serving gRPC-Web +
+health (graceful degradation).
+
+## Packaging: shipping the console in the wheel
+
+`pip/uv install harmonograf-server` carries the console so consumers don't need
+to build the frontend. The build flow:
+
+1. `make console` builds the frontend (`pnpm build`) and stages the output
+   into `server/harmonograf_server/_console/`.
+2. `uv build` (hatchling) collects that directory into the wheel via the
+   `tool.hatch.build.targets.wheel.artifacts` glob in `pyproject.toml`
+   (`artifacts` overrides the repo `.gitignore`, which ignores build output).
+3. At runtime `static_site.py` locates the packaged `_console/` directory via
+   `importlib.resources`.
+
+`make console` is only required when producing a distributable wheel —
+`make server-run` in a repo checkout works without it (it falls back to
+`../frontend/dist`). The `_console/` directory is build output and is
+git-ignored.
+
+**Release note:** a release/publish workflow must run `make console` before
+`uv build` so the wheel includes the UI. CI currently runs tests only (no
+wheel build); the server test suite is independent of a built bundle.

--- a/server/harmonograf_server/cli.py
+++ b/server/harmonograf_server/cli.py
@@ -90,6 +90,29 @@ def build_parser() -> argparse.ArgumentParser:
             "disables auth. /healthz and /readyz are always unauthenticated."
         ),
     )
+    # ---- console UI serving (static_site.py) ------------------------
+    p.add_argument(
+        "--web-root",
+        default="",
+        help=(
+            "directory to serve the built console SPA from on the web port "
+            "(alongside gRPC-Web + health); empty auto-locates the packaged "
+            "console, then ../frontend/dist. If no bundle is found the server "
+            "logs a warning and serves gRPC-Web + health only."
+        ),
+    )
+    p.add_argument(
+        "--public-base-url",
+        default="",
+        help=(
+            "public gRPC-Web base URL the browser should use to reach this "
+            "server; injected into the served index.html as "
+            "window.__HARMONOGRAF_API__. Empty derives it per-request from the "
+            "Host / X-Forwarded-* headers, so one bundle works behind any "
+            "host/port (set this only behind a reverse proxy that rewrites the "
+            "path or terminates on a different public URL)."
+        ),
+    )
     p.add_argument(
         "--legacy-plan-attribution-window-ms",
         type=float,
@@ -159,6 +182,8 @@ def config_from_args(argv: list[str] | None = None) -> ServerConfig:
         log_format=args.log_format,
         metrics_interval_seconds=args.metrics_interval_seconds,
         auth_token=args.auth_token,
+        web_root=args.web_root,
+        public_base_url=args.public_base_url,
         legacy_plan_attribution_window_ms=args.legacy_plan_attribution_window_ms,
         heartbeat_timeout_seconds=args.heartbeat_timeout_seconds,
         payload_max_bytes=args.payload_max_bytes,

--- a/server/harmonograf_server/config.py
+++ b/server/harmonograf_server/config.py
@@ -24,6 +24,18 @@ class ServerConfig:
     metrics_interval_seconds: float = 30.0  # 0 disables periodic metrics
     auth_token: str = ""  # empty string disables shared-secret auth
 
+    # ---- console UI serving (static_site.py) -------------------------
+    # The web port serves the built console SPA alongside gRPC-Web +
+    # health. ``web_root`` overrides where the bundle is read from; empty
+    # auto-locates (packaged _console dir, then ../frontend/dist). When no
+    # bundle is found the server logs a warning and serves gRPC-Web +
+    # health only. ``public_base_url`` (if set) is injected verbatim into
+    # the served index.html as the SPA's gRPC-Web endpoint
+    # (window.__HARMONOGRAF_API__); empty derives it per-request from the
+    # Host / X-Forwarded-* headers so one bundle works behind any host/port.
+    web_root: str = ""
+    public_base_url: str = ""
+
     # Opt-in legacy time-window fallback for plan-revision attribution
     # (pre-strict-id-dedup behaviour from before harmonograf#99). Default
     # 0 disables the fallback — plan revisions without a trigger_event_id

--- a/server/harmonograf_server/main.py
+++ b/server/harmonograf_server/main.py
@@ -39,6 +39,7 @@ from harmonograf_server.pb import service_pb2_grpc
 from harmonograf_server.metrics import metrics_loop
 from harmonograf_server.retention import retention_loop
 from harmonograf_server.rpc.telemetry import TelemetryServicer, heartbeat_sweeper
+from harmonograf_server.static_site import build_static_router
 from harmonograf_server.storage import make_store
 
 
@@ -177,7 +178,17 @@ class Harmonograf:
         # CORS middleware sits outside auth so preflights succeed even
         # before the browser attaches the bearer token.
         grpc_web_app = asgi_cors(grpc_web_app)
-        self._web_app = build_health_router(self.store, grpc_web_app)
+        # Health router answers /healthz + /readyz and forwards everything
+        # else to gRPC-Web. The static layer wraps that: it serves the
+        # built console SPA (with runtime endpoint injection + SPA fallback)
+        # for browser GET/HEAD paths and forwards gRPC-Web + health through.
+        health_app = build_health_router(self.store, grpc_web_app)
+        self._web_app = build_static_router(
+            health_app,
+            web_root=self.cfg.web_root,
+            web_port=self.cfg.web_port,
+            public_base_url=self.cfg.public_base_url,
+        )
         self._web_shutdown = asyncio.Event()
         hc = HypercornConfig()
         hc.bind = [f"{self.cfg.host}:{self.cfg.web_port}"]

--- a/server/harmonograf_server/static_site.py
+++ b/server/harmonograf_server/static_site.py
@@ -8,9 +8,10 @@ layer that:
   * serves ``index.html`` at ``/`` (and as the SPA fallback),
   * serves hashed asset files under ``/assets/*`` and any other real file
     in the web root (favicon, etc.),
-  * falls back to ``index.html`` for any *other* GET/HEAD path that is not
-    a real file — so client-side hash routes like ``/#/session/<id>`` load
-    the SPA when deep-linked, and
+  * falls back to ``index.html`` for any *other* extension-less GET/HEAD
+    path that is not a real file — so client-side hash routes like
+    ``/#/session/<id>`` load the SPA when deep-linked, while a missing
+    file-like path (``*.js``/``*.svg`` …) returns 404 rather than HTML, and
   * never touches gRPC-Web requests (content-type ``application/grpc-web*``)
     or the health routes — those flow straight through to ``inner``.
 
@@ -33,6 +34,8 @@ gRPC-Web + health, just without the bundled UI.
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 import os
 import re
@@ -121,6 +124,17 @@ def _content_type(path: str) -> str:
     return _CONTENT_TYPES.get(ext.lower(), "application/octet-stream")
 
 
+def _looks_like_file(path: str) -> bool:
+    """True when the last path segment has a file extension (e.g. ``.js``,
+    ``.svg``). Such a request is for a concrete asset, so when it isn't found
+    we return 404 rather than the SPA fallback — handing back ``index.html``
+    (text/html) for a missing ``.js``/``.css`` only yields confusing MIME
+    errors in the browser. Navigation/hash routes have no extension and still
+    fall through to the SPA."""
+
+    return "." in os.path.basename(path)
+
+
 def _is_grpc_web(scope: dict) -> bool:
     for k, v in scope.get("headers") or ():
         if k.lower() == b"content-type" and v.lower().startswith(b"application/grpc-web"):
@@ -147,14 +161,13 @@ def _inject_runtime_config(html: str, api_base_url: str) -> str:
     gRPC-Web endpoint at runtime. Injected just before the first module
     script so it runs before the app boots."""
 
-    # JS string-literal escaping for the URL (it is operator-controlled but
-    # be defensive about quotes / closing tags anyway).
-    safe = (
-        api_base_url.replace("\\", "\\\\")
-        .replace('"', '\\"')
-        .replace("</", "<\\/")
-    )
-    snippet = f'<script>window.__HARMONOGRAF_API__ = "{safe}";</script>'
+    # Emit a valid JS string literal. ``json.dumps`` handles all string
+    # escaping (quotes, backslashes, control chars, U+2028/U+2029); the URL is
+    # largely operator-controlled but can be host/X-Forwarded-Host-derived, so
+    # we additionally neutralise ``</`` (which JSON leaves intact) to keep a
+    # crafted value from closing the <script> element early.
+    literal = json.dumps(api_base_url).replace("</", "<\\/")
+    snippet = f"<script>window.__HARMONOGRAF_API__ = {literal};</script>"
     needle = "<script type=\"module\""
     idx = html.find(needle)
     if idx != -1:
@@ -207,13 +220,31 @@ def build_static_router(
 ) -> ASGIApp:
     """Wrap ``inner`` (gRPC-Web + health) with static SPA serving.
 
-    ``web_root`` is an explicit override; when ``None`` the bundle is
-    auto-located. ``public_base_url`` (if non-empty) is injected verbatim as
-    the SPA's gRPC-Web endpoint; otherwise it is derived per-request from the
-    Host / forwarding headers.
+    ``web_root`` is an explicit override; when falsy (``None``/``""``) the
+    bundle is auto-located. ``public_base_url`` (if non-empty) is injected
+    verbatim as the SPA's gRPC-Web endpoint; otherwise it is derived
+    per-request from the Host / forwarding headers.
     """
 
     root = locate_web_root(web_root)
+    # Read index.html once at startup: it is an immutable build artifact, so
+    # re-reading it per request would only add blocking disk I/O to the shared
+    # event loop (which also serves gRPC-Web streaming). Only the per-request
+    # endpoint injection varies, and that is done in memory below. A read
+    # failure here degrades to "no bundle" (gRPC-Web + health only).
+    index_template: Optional[str] = None
+    if root is not None:
+        index_path = os.path.join(root, "index.html")
+        try:
+            with open(index_path, "r", encoding="utf-8") as f:
+                index_template = f.read()
+        except OSError:
+            logger.exception(
+                "failed to read index.html at %s; serving gRPC-Web + health only",
+                index_path,
+            )
+            root = None
+
     if root is None:
         logger.warning(
             "console UI bundle not found (looked for index.html via "
@@ -224,9 +255,17 @@ def build_static_router(
     else:
         logger.info("serving console UI from %s", root)
 
-    index_path = os.path.join(root, "index.html") if root else None
-
-    async def _send_bytes(send, status: int, body: bytes, content_type: str, *, extra_headers=None) -> None:
+    async def _send_bytes(
+        send,
+        status: int,
+        body: bytes,
+        content_type: str,
+        *,
+        extra_headers=None,
+        head: bool = False,
+    ) -> None:
+        # Content-Length always reflects the GET body; a HEAD response carries
+        # the headers but no body (RFC 9110 §9.3.2).
         headers = [
             (b"content-type", content_type.encode("latin-1")),
             (b"content-length", str(len(body)).encode("latin-1")),
@@ -234,24 +273,18 @@ def build_static_router(
         if extra_headers:
             headers.extend(extra_headers)
         await send({"type": "http.response.start", "status": status, "headers": headers})
-        await send({"type": "http.response.body", "body": body})
+        await send({"type": "http.response.body", "body": b"" if head else body})
 
-    async def _serve_index(scope, send, *, status: int = 200) -> None:
-        try:
-            with open(index_path, "r", encoding="utf-8") as f:
-                html = f.read()
-        except OSError:
-            logger.exception("failed to read index.html at %s", index_path)
-            await _send_bytes(send, 500, b"internal error\n", "text/plain; charset=utf-8")
-            return
+    async def _serve_index(scope, send, *, status: int = 200, head: bool = False) -> None:
         api_base = _resolve_api_base_url(scope, public_base_url, web_port)
-        html = _inject_runtime_config(html, api_base)
+        html = _inject_runtime_config(index_template, api_base)
         await _send_bytes(
             send,
             status,
             html.encode("utf-8"),
             "text/html; charset=utf-8",
             extra_headers=[(b"cache-control", b"no-cache")],
+            head=head,
         )
 
     async def app(scope, receive, send):
@@ -276,26 +309,52 @@ def build_static_router(
             await inner(scope, receive, send)
             return
 
+        head = method == "HEAD"
+
         # Root + explicit index → serve the (config-injected) index.html.
         if path in ("/", "/index.html"):
-            await _serve_index(scope, send)
+            await _serve_index(scope, send, head=head)
             return
 
         # Try to serve a real file from the web root.
         fs_path = _safe_join(root, path)
         if fs_path and os.path.isfile(fs_path):
             try:
-                with open(fs_path, "rb") as f:
-                    body = f.read()
+                # Off-load the (potentially large) read so a big bundle can't
+                # block the event loop shared with gRPC-Web streaming.
+                body = await asyncio.to_thread(_read_file, fs_path)
             except OSError:
                 logger.exception("failed to read static file %s", fs_path)
-                await _send_bytes(send, 500, b"internal error\n", "text/plain; charset=utf-8")
+                await _send_bytes(
+                    send, 500, b"internal error\n", "text/plain; charset=utf-8", head=head
+                )
                 return
-            await _send_bytes(send, 200, body, _content_type(fs_path))
+            # Vite content-hashes everything under /assets/, so it is safe to
+            # cache immutably; other real files (favicon, etc.) stay uncached.
+            extra = None
+            if path.startswith("/assets/"):
+                extra = [(b"cache-control", b"public, max-age=31536000, immutable")]
+            await _send_bytes(
+                send, 200, body, _content_type(fs_path), extra_headers=extra, head=head
+            )
             return
 
-        # SPA fallback: any unknown non-API path serves index.html so the
-        # client-side hash router can take over (e.g. /#/session/<id>).
-        await _serve_index(scope, send)
+        # A request for a concrete asset that doesn't exist → 404, not the SPA
+        # fallback (returning index.html for a missing .js/.svg only produces
+        # MIME errors). Extension-less paths are navigation/hash routes.
+        if _looks_like_file(path):
+            await _send_bytes(
+                send, 404, b"not found\n", "text/plain; charset=utf-8", head=head
+            )
+            return
+
+        # SPA fallback: any unknown non-API, non-file path serves index.html so
+        # the client-side hash router can take over (e.g. /#/session/<id>).
+        await _serve_index(scope, send, head=head)
 
     return app
+
+
+def _read_file(path: str) -> bytes:
+    with open(path, "rb") as f:
+        return f.read()

--- a/server/harmonograf_server/static_site.py
+++ b/server/harmonograf_server/static_site.py
@@ -1,0 +1,301 @@
+"""Serve the built console SPA on the web port, beside gRPC-Web + health.
+
+A single ``harmonograf-server`` process should be able to hand a browser
+the whole console without a separate static host or a frontend dev
+server. This module wraps the gRPC-Web/health ASGI app with a thin static
+layer that:
+
+  * serves ``index.html`` at ``/`` (and as the SPA fallback),
+  * serves hashed asset files under ``/assets/*`` and any other real file
+    in the web root (favicon, etc.),
+  * falls back to ``index.html`` for any *other* GET/HEAD path that is not
+    a real file — so client-side hash routes like ``/#/session/<id>`` load
+    the SPA when deep-linked, and
+  * never touches gRPC-Web requests (content-type ``application/grpc-web*``)
+    or the health routes — those flow straight through to ``inner``.
+
+The served ``index.html`` is rewritten on the fly to inject the server's
+own gRPC-Web base URL as ``window.__HARMONOGRAF_API__`` so one built
+bundle works behind any host/port without a rebuild (see ``transport.ts``).
+
+Locating the bundle (in precedence order):
+
+  1. an explicit ``web_root`` (the ``--web-root`` CLI flag),
+  2. the packaged console shipped inside the wheel
+     (``harmonograf_server/_console``), located via ``importlib.resources``,
+  3. a dev fallback to ``../../frontend/dist`` relative to this file
+     (the repo checkout).
+
+If none of those contains an ``index.html`` the layer logs a warning once
+and forwards every request to ``inner`` — the server keeps serving
+gRPC-Web + health, just without the bundled UI.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from importlib import resources
+from typing import Awaitable, Callable, Optional
+
+logger = logging.getLogger("harmonograf_server.static_site")
+
+
+ASGIApp = Callable[..., Awaitable[None]]
+
+# Minimal extension → content-type map. Covers everything Vite emits plus
+# the static assets we ship; anything unknown falls back to
+# application/octet-stream.
+_CONTENT_TYPES = {
+    ".html": "text/html; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".mjs": "text/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".map": "application/json; charset=utf-8",
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".ico": "image/x-icon",
+    ".webp": "image/webp",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".txt": "text/plain; charset=utf-8",
+    ".wasm": "application/wasm",
+}
+
+# Paths that must always reach the inner gRPC-Web/health app, never the
+# static layer. gRPC-Web is additionally identified by content-type below.
+_HEALTH_PATHS = frozenset({"/healthz", "/readyz"})
+
+# gRPC service-method routes look like ``/<pkg>.<Service>/<Method>`` (e.g.
+# ``/harmonograf.v1.Harmonograf/GetStats``). Real gRPC-Web traffic is POST
+# with an ``application/grpc-web*`` content-type and is already excluded, but
+# we additionally never hijack a gRPC-shaped path as an SPA route regardless
+# of method — so the inner auth/gRPC-Web app always owns it (no SPA fallback
+# masking a 401, no surprises for non-binary gRPC-Web). A leading segment
+# containing a dot is the tell; the SPA never serves such paths.
+_GRPC_PATH_RE = re.compile(r"^/[A-Za-z_][\w.]*\.[A-Za-z_]\w*/[A-Za-z_]\w*/?$")
+
+
+def locate_web_root(web_root: Optional[str] = None) -> Optional[str]:
+    """Return an absolute path to a directory containing ``index.html``,
+    or ``None`` if no console bundle can be found.
+
+    Precedence: explicit ``web_root`` → packaged ``_console`` → repo
+    ``frontend/dist`` dev fallback.
+    """
+
+    candidates: list[str] = []
+    if web_root:
+        candidates.append(os.path.abspath(os.path.expanduser(web_root)))
+
+    # Packaged console inside the installed wheel.
+    try:
+        pkg_console = resources.files("harmonograf_server") / "_console"
+        # ``files()`` returns a Traversable; for a normal filesystem install
+        # str() yields a usable path. Guard against zipped installs by
+        # checking existence below.
+        candidates.append(str(pkg_console))
+    except (ModuleNotFoundError, AttributeError):  # pragma: no cover - defensive
+        pass
+
+    # Dev fallback: repo checkout's frontend/dist (../../frontend/dist).
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates.append(
+        os.path.abspath(os.path.join(here, "..", "..", "frontend", "dist"))
+    )
+
+    for cand in candidates:
+        if cand and os.path.isfile(os.path.join(cand, "index.html")):
+            return cand
+    return None
+
+
+def _content_type(path: str) -> str:
+    _, ext = os.path.splitext(path)
+    return _CONTENT_TYPES.get(ext.lower(), "application/octet-stream")
+
+
+def _is_grpc_web(scope: dict) -> bool:
+    for k, v in scope.get("headers") or ():
+        if k.lower() == b"content-type" and v.lower().startswith(b"application/grpc-web"):
+            return True
+    return False
+
+
+def _safe_join(root: str, url_path: str) -> Optional[str]:
+    """Resolve ``url_path`` against ``root``, refusing any traversal that
+    escapes ``root``. Returns the absolute filesystem path or ``None``."""
+
+    rel = url_path.lstrip("/")
+    # Normalize and reject anything that climbs out of root.
+    candidate = os.path.normpath(os.path.join(root, rel))
+    root_abs = os.path.abspath(root)
+    candidate_abs = os.path.abspath(candidate)
+    if candidate_abs != root_abs and not candidate_abs.startswith(root_abs + os.sep):
+        return None
+    return candidate_abs
+
+
+def _inject_runtime_config(html: str, api_base_url: str) -> str:
+    """Insert ``window.__HARMONOGRAF_API__`` so the bundle learns its
+    gRPC-Web endpoint at runtime. Injected just before the first module
+    script so it runs before the app boots."""
+
+    # JS string-literal escaping for the URL (it is operator-controlled but
+    # be defensive about quotes / closing tags anyway).
+    safe = (
+        api_base_url.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("</", "<\\/")
+    )
+    snippet = f'<script>window.__HARMONOGRAF_API__ = "{safe}";</script>'
+    needle = "<script type=\"module\""
+    idx = html.find(needle)
+    if idx != -1:
+        return html[:idx] + snippet + "\n    " + html[idx:]
+    # Fall back to injecting at end of <head>, then start of <body>.
+    for anchor in ("</head>", "<body>"):
+        idx = html.find(anchor)
+        if idx != -1:
+            if anchor == "</head>":
+                return html[:idx] + snippet + "\n  " + html[idx:]
+            return html[: idx + len(anchor)] + "\n    " + snippet + html[idx + len(anchor):]
+    # Last resort: prepend.
+    return snippet + html
+
+
+def _resolve_api_base_url(scope: dict, configured_public_base: str, web_port: int) -> str:
+    """Derive the gRPC-Web base URL the *browser* should use to reach this
+    server. Prefers an operator-configured public base; otherwise derives
+    scheme+host from the request (so it follows whatever host:port the user
+    actually typed, including reverse proxies that set forwarded headers)."""
+
+    if configured_public_base:
+        return configured_public_base.rstrip("/")
+
+    headers = {k.lower(): v for k, v in (scope.get("headers") or ())}
+
+    # Honor common reverse-proxy forwarding headers when present.
+    fwd_proto = headers.get(b"x-forwarded-proto")
+    fwd_host = headers.get(b"x-forwarded-host")
+    if fwd_host:
+        scheme = (fwd_proto or b"http").split(b",")[0].strip().decode("latin-1")
+        host = fwd_host.split(b",")[0].strip().decode("latin-1")
+        return f"{scheme}://{host}"
+
+    host = headers.get(b"host")
+    if host:
+        scheme = scope.get("scheme") or "http"
+        return f"{scheme}://{host.decode('latin-1')}"
+
+    # No Host header (rare): fall back to the bind port on loopback.
+    return f"http://127.0.0.1:{web_port}"
+
+
+def build_static_router(
+    inner: ASGIApp,
+    *,
+    web_root: Optional[str],
+    web_port: int,
+    public_base_url: str = "",
+) -> ASGIApp:
+    """Wrap ``inner`` (gRPC-Web + health) with static SPA serving.
+
+    ``web_root`` is an explicit override; when ``None`` the bundle is
+    auto-located. ``public_base_url`` (if non-empty) is injected verbatim as
+    the SPA's gRPC-Web endpoint; otherwise it is derived per-request from the
+    Host / forwarding headers.
+    """
+
+    root = locate_web_root(web_root)
+    if root is None:
+        logger.warning(
+            "console UI bundle not found (looked for index.html via "
+            "--web-root, the packaged _console dir, and ../frontend/dist); "
+            "serving gRPC-Web + health only. Build the frontend "
+            "(cd frontend && pnpm build) or pass --web-root to enable the UI."
+        )
+    else:
+        logger.info("serving console UI from %s", root)
+
+    index_path = os.path.join(root, "index.html") if root else None
+
+    async def _send_bytes(send, status: int, body: bytes, content_type: str, *, extra_headers=None) -> None:
+        headers = [
+            (b"content-type", content_type.encode("latin-1")),
+            (b"content-length", str(len(body)).encode("latin-1")),
+        ]
+        if extra_headers:
+            headers.extend(extra_headers)
+        await send({"type": "http.response.start", "status": status, "headers": headers})
+        await send({"type": "http.response.body", "body": body})
+
+    async def _serve_index(scope, send, *, status: int = 200) -> None:
+        try:
+            with open(index_path, "r", encoding="utf-8") as f:
+                html = f.read()
+        except OSError:
+            logger.exception("failed to read index.html at %s", index_path)
+            await _send_bytes(send, 500, b"internal error\n", "text/plain; charset=utf-8")
+            return
+        api_base = _resolve_api_base_url(scope, public_base_url, web_port)
+        html = _inject_runtime_config(html, api_base)
+        await _send_bytes(
+            send,
+            status,
+            html.encode("utf-8"),
+            "text/html; charset=utf-8",
+            extra_headers=[(b"cache-control", b"no-cache")],
+        )
+
+    async def app(scope, receive, send):
+        # Non-HTTP (lifespan/websocket) and the "no bundle" case go straight
+        # through to the inner app.
+        if scope.get("type") != "http" or root is None:
+            await inner(scope, receive, send)
+            return
+
+        path = scope.get("path", "") or "/"
+        method = (scope.get("method") or "GET").upper()
+
+        # Health + gRPC-Web (by content-type) + gRPC-shaped service paths
+        # always belong to the inner app — never the SPA layer.
+        if path in _HEALTH_PATHS or _is_grpc_web(scope) or _GRPC_PATH_RE.match(path):
+            await inner(scope, receive, send)
+            return
+
+        # Anything that isn't a static-servable verb (POST gRPC-Web, etc.)
+        # also belongs to the inner app — the SPA only needs GET/HEAD.
+        if method not in ("GET", "HEAD"):
+            await inner(scope, receive, send)
+            return
+
+        # Root + explicit index → serve the (config-injected) index.html.
+        if path in ("/", "/index.html"):
+            await _serve_index(scope, send)
+            return
+
+        # Try to serve a real file from the web root.
+        fs_path = _safe_join(root, path)
+        if fs_path and os.path.isfile(fs_path):
+            try:
+                with open(fs_path, "rb") as f:
+                    body = f.read()
+            except OSError:
+                logger.exception("failed to read static file %s", fs_path)
+                await _send_bytes(send, 500, b"internal error\n", "text/plain; charset=utf-8")
+                return
+            await _send_bytes(send, 200, body, _content_type(fs_path))
+            return
+
+        # SPA fallback: any unknown non-API path serves index.html so the
+        # client-side hash router can take over (e.g. /#/session/<id>).
+        await _serve_index(scope, send)
+
+    return app

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -30,6 +30,16 @@ harmonograf-server = "harmonograf_server.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["harmonograf_server"]
+# Ship the built console SPA inside the wheel so `pip/uv install
+# harmonograf-server` carries the UI with no separate frontend build on the
+# consumer's side. The bundle is staged into harmonograf_server/_console/ by
+# `make console` (frontend pnpm build → copy into the package) before
+# packaging; static_site.py locates it at runtime via importlib.resources.
+# `artifacts` overrides the repo .gitignore so the staged, uncommitted bundle
+# is collected. It is permissive: when _console/ is absent (a plain dev
+# checkout / editable install) the wheel simply omits it and the server falls
+# back to ../frontend/dist or serves gRPC-Web + health only.
+artifacts = ["harmonograf_server/_console/**"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/server/tests/test_static_site.py
+++ b/server/tests/test_static_site.py
@@ -1,0 +1,317 @@
+"""Tests for serving the built console SPA on the web port.
+
+Covers both the pure ASGI wrapper (``build_static_router``) with a temporary
+web root and an end-to-end run through ``Harmonograf`` confirming:
+
+  * ``GET /`` serves index.html with the injected ``window.__HARMONOGRAF_API__``,
+  * a real static asset under ``/assets/`` is served with the right type,
+  * an unknown non-API path falls back to index.html (SPA hash routing),
+  * ``/healthz`` + ``/readyz`` still work, and
+  * gRPC-shaped service paths are never hijacked by the SPA layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+
+import pytest
+
+from harmonograf_server.config import ServerConfig
+from harmonograf_server.main import Harmonograf
+from harmonograf_server.static_site import (
+    build_static_router,
+    locate_web_root,
+)
+
+
+INDEX_HTML = (
+    "<!doctype html>\n<html><head><title>Harmonograf</title>\n"
+    '<script type="module" crossorigin src="/assets/index.js"></script>\n'
+    "</head><body><div id=\"root\"></div></body></html>\n"
+)
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _make_web_root(tmp_path) -> str:
+    root = tmp_path / "dist"
+    (root / "assets").mkdir(parents=True)
+    (root / "index.html").write_text(INDEX_HTML, encoding="utf-8")
+    (root / "assets" / "index.js").write_text("console.log('hi');\n", encoding="utf-8")
+    (root / "favicon.svg").write_text("<svg/>", encoding="utf-8")
+    return str(root)
+
+
+# ---- pure ASGI wrapper ---------------------------------------------------
+
+
+async def _collect(app, scope):
+    """Drive an ASGI app once and return (status, headers, body)."""
+    sent: list[dict] = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    await app(scope, receive, send)
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+    headers = {k.lower(): v for k, v in start["headers"]}
+    return start["status"], headers, body
+
+
+def _http_scope(path: str, *, method: str = "GET", host: str = "console.test:9000", headers=None):
+    hdrs = [(b"host", host.encode())]
+    if headers:
+        hdrs.extend(headers)
+    return {"type": "http", "method": method, "path": path, "headers": hdrs, "scheme": "http"}
+
+
+@pytest.mark.asyncio
+async def test_serves_index_with_injected_runtime_config(tmp_path):
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover - must not be hit
+        raise AssertionError("inner should not be called for GET /")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    status, headers, body = await _collect(app, _http_scope("/"))
+    assert status == 200
+    assert headers[b"content-type"].startswith(b"text/html")
+    text = body.decode()
+    # Runtime endpoint global injected, derived from the request Host.
+    assert 'window.__HARMONOGRAF_API__ = "http://console.test:9000"' in text
+    # The original module script is still present.
+    assert "/assets/index.js" in text
+
+
+@pytest.mark.asyncio
+async def test_public_base_url_overrides_host_derivation(tmp_path):
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called")
+
+    app = build_static_router(
+        inner, web_root=root, web_port=7532, public_base_url="https://obs.example/"
+    )
+    _, _, body = await _collect(app, _http_scope("/"))
+    assert 'window.__HARMONOGRAF_API__ = "https://obs.example"' in body.decode()
+
+
+@pytest.mark.asyncio
+async def test_serves_static_asset(tmp_path):
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    status, headers, body = await _collect(app, _http_scope("/assets/index.js"))
+    assert status == 200
+    assert headers[b"content-type"].startswith(b"text/javascript")
+    assert b"console.log" in body
+
+
+@pytest.mark.asyncio
+async def test_spa_fallback_for_unknown_path(tmp_path):
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called for SPA fallback")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    status, headers, body = await _collect(app, _http_scope("/some/deep/route"))
+    assert status == 200
+    assert headers[b"content-type"].startswith(b"text/html")
+    assert "window.__HARMONOGRAF_API__" in body.decode()
+
+
+@pytest.mark.asyncio
+async def test_health_and_grpc_paths_pass_through(tmp_path):
+    root = _make_web_root(tmp_path)
+    forwarded: list[str] = []
+
+    async def inner(scope, receive, send):
+        forwarded.append(scope["path"])
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    # Health endpoints belong to the inner app.
+    await _collect_passthrough(app, _http_scope("/healthz"))
+    await _collect_passthrough(app, _http_scope("/readyz"))
+    # gRPC-shaped service path is never hijacked, even on GET.
+    await _collect_passthrough(app, _http_scope("/harmonograf.v1.Harmonograf/GetStats"))
+    # A gRPC-Web POST (by content-type) also passes through.
+    await _collect_passthrough(
+        app,
+        _http_scope(
+            "/harmonograf.v1.Harmonograf/GetStats",
+            method="POST",
+            headers=[(b"content-type", b"application/grpc-web+proto")],
+        ),
+    )
+
+    # Re-run against a forwarding inner to assert paths actually reached it.
+    app2 = build_static_router(inner, web_root=root, web_port=7532)
+
+    async def noop_send(_msg):
+        pass
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    for scope in (
+        _http_scope("/healthz"),
+        _http_scope("/harmonograf.v1.Harmonograf/GetStats"),
+    ):
+        await app2(scope, receive, noop_send)
+    assert "/healthz" in forwarded
+    assert forwarded.count("/harmonograf.v1.Harmonograf/GetStats") >= 1
+
+
+async def _collect_passthrough(app, scope):
+    """Assert the request reaches inner (which here records nothing/sends nothing)."""
+    sent: list[dict] = []
+
+    async def send(msg):  # pragma: no cover - inner may not send
+        sent.append(msg)
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    await app(scope, receive, send)
+
+
+@pytest.mark.asyncio
+async def test_no_bundle_forwards_everything(monkeypatch):
+    """With no locatable bundle, every request flows to inner unchanged.
+
+    We force ``locate_web_root`` to ``None`` because a repo checkout normally
+    has a built ``frontend/dist`` the locator would fall back to.
+    """
+    import harmonograf_server.static_site as ss
+
+    monkeypatch.setattr(ss, "locate_web_root", lambda *_a, **_k: None)
+
+    forwarded: list[str] = []
+
+    async def inner(scope, receive, send):
+        forwarded.append(scope["path"])
+
+    app = build_static_router(inner, web_root="", web_port=7532)
+
+    async def send(_msg):  # pragma: no cover
+        pass
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    await app(_http_scope("/"), receive, send)
+    await app(_http_scope("/anything"), receive, send)
+    assert forwarded == ["/", "/anything"]
+
+
+def test_locate_web_root_prefers_explicit(tmp_path):
+    root = _make_web_root(tmp_path)
+    assert locate_web_root(root) == os.path.abspath(root)
+    # A bogus explicit root falls through (here to the repo dev fallback or
+    # None); the function must not return the bogus path.
+    assert locate_web_root(str(tmp_path / "nope")) != str(tmp_path / "nope")
+
+
+# ---- end-to-end through Harmonograf -------------------------------------
+
+
+async def _wait_for_port(port: int, timeout: float = 3.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    last_err: Exception | None = None
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+            return
+        except OSError as e:
+            last_err = e
+            await asyncio.sleep(0.05)
+    raise TimeoutError(f"port {port} not ready after {timeout}s: {last_err}")
+
+
+async def _http_get(port: int, path: str) -> tuple[int, bytes, bytes]:
+    await _wait_for_port(port)
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    req = (
+        f"GET {path} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n"
+    )
+    writer.write(req.encode())
+    await writer.drain()
+    resp = b""
+    while True:
+        chunk = await reader.read(4096)
+        if not chunk:
+            break
+        resp += chunk
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except Exception:
+        pass
+    head, _, body = resp.partition(b"\r\n\r\n")
+    status = int(head.split(b"\r\n", 1)[0].split()[1])
+    return status, head, body
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_serves_spa_and_keeps_health(tmp_path):
+    root = _make_web_root(tmp_path)
+    cfg = ServerConfig(
+        host="127.0.0.1",
+        grpc_port=_free_port(),
+        web_port=_free_port(),
+        store_backend="memory",
+        data_dir="",
+        grace_seconds=0.5,
+        metrics_interval_seconds=0.0,
+        web_root=root,
+    )
+    app = await Harmonograf.from_config(cfg)
+    await app.start()
+    try:
+        # GET / → SPA with injected config.
+        status, head, body = await _http_get(cfg.web_port, "/")
+        assert status == 200
+        assert b"text/html" in head.lower()
+        text = body.decode()
+        assert "window.__HARMONOGRAF_API__" in text
+        assert f"127.0.0.1:{cfg.web_port}" in text
+
+        # Static asset.
+        status, head, body = await _http_get(cfg.web_port, "/assets/index.js")
+        assert status == 200
+        assert b"javascript" in head.lower()
+
+        # SPA fallback for an unknown deep path.
+        status, _, body = await _http_get(cfg.web_port, "/deeplink/here")
+        assert status == 200
+        assert b"window.__HARMONOGRAF_API__" in body
+
+        # Health still works alongside the SPA.
+        status, _, body = await _http_get(cfg.web_port, "/healthz")
+        assert status == 200
+        assert b"ok" in body
+        status, _, body = await _http_get(cfg.web_port, "/readyz")
+        assert status == 200
+        assert b"ready" in body
+    finally:
+        await app.stop()

--- a/server/tests/test_static_site.py
+++ b/server/tests/test_static_site.py
@@ -21,6 +21,8 @@ import pytest
 from harmonograf_server.config import ServerConfig
 from harmonograf_server.main import Harmonograf
 from harmonograf_server.static_site import (
+    _inject_runtime_config,
+    _safe_join,
     build_static_router,
     locate_web_root,
 )
@@ -225,6 +227,73 @@ def test_locate_web_root_prefers_explicit(tmp_path):
     # A bogus explicit root falls through (here to the repo dev fallback or
     # None); the function must not return the bogus path.
     assert locate_web_root(str(tmp_path / "nope")) != str(tmp_path / "nope")
+
+
+@pytest.mark.asyncio
+async def test_missing_file_like_path_returns_404(tmp_path):
+    """A request for a concrete asset that doesn't exist must 404, not serve
+    the SPA fallback (returning index.html for a missing .js/.svg only yields
+    MIME errors in the browser)."""
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    status, headers, body = await _collect(app, _http_scope("/does-not-exist.js"))
+    assert status == 404
+    assert headers[b"content-type"].startswith(b"text/plain")
+    assert b"window.__HARMONOGRAF_API__" not in body
+
+
+@pytest.mark.asyncio
+async def test_assets_get_immutable_cache_header(tmp_path):
+    """Vite content-hashes /assets/*, so they are served cache-immutable."""
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    _, headers, _ = await _collect(app, _http_scope("/assets/index.js"))
+    assert b"immutable" in headers.get(b"cache-control", b"")
+
+
+@pytest.mark.asyncio
+async def test_head_request_sends_no_body_but_keeps_content_length(tmp_path):
+    """HEAD carries the headers (incl. the GET Content-Length) but no body."""
+    root = _make_web_root(tmp_path)
+
+    async def inner(scope, receive, send):  # pragma: no cover
+        raise AssertionError("inner should not be called")
+
+    app = build_static_router(inner, web_root=root, web_port=7532)
+    status, headers, body = await _collect(app, _http_scope("/", method="HEAD"))
+    assert status == 200
+    assert body == b""
+    # Content-Length reflects what a GET would have returned (non-zero).
+    assert int(headers[b"content-length"]) > 0
+
+
+def test_safe_join_rejects_traversal(tmp_path):
+    """Path traversal must not escape the web root."""
+    root = _make_web_root(tmp_path)
+    # A benign nested path resolves inside root.
+    inside = _safe_join(root, "/assets/index.js")
+    assert inside is not None and inside.startswith(os.path.abspath(root))
+    # Climbing out of root is refused.
+    assert _safe_join(root, "/../../etc/passwd") is None
+    assert _safe_join(root, "/../" + os.path.basename(root) + "_sibling/x") is None
+
+
+def test_inject_runtime_config_escapes_hostile_url():
+    """A crafted endpoint can't break out of the JS string or the <script>."""
+    html = '<html><head><script type="module" src="/a.js"></script></head></html>'
+    out = _inject_runtime_config(html, '"></script><script>alert(1)//')
+    # No raw closing tag survives to terminate our injected <script> early.
+    assert "</script><script>alert(1)" not in out
+    # The original module script is preserved exactly once.
+    assert out.count('<script type="module"') == 1
 
 
 # ---- end-to-end through Harmonograf -------------------------------------


### PR DESCRIPTION
Redraws the harmonograf console's sequence story in the zicato design language with the corrected framing: the **sequence view shows how the agents interact** — who said what to whom, when.

## Task 1 — vertical sequence diagram is now the recommended view
`sequence.html` is restructured so **Option B (the vertical staff)** is the RECOMMENDED, primary view, redrawn to read unambiguously as an agent-interaction sequence diagram: one vertical lifeline per agent (neutral, with a name chip), time flowing down, each message a horizontal connector from sender to receiver with an explicit arrowhead — **solid for a call, dashed for a return** — and the label above in the KIND hue. Activations hug the lifelines; the delegation opens a child band on the tester lifeline and returns; the approval is a gate; the failed check is the only red. Messages use a minimum-row-gap layout so a near-coincident call+return never overprint. The horizontal **score** becomes the explicit Gantt-companion *alternative*; the UML frame stays as the *before*.

## Task 2 — directional transfer chord
Figure 11 in `grammar.html` (`mountChord`) is rebuilt so direction is obvious **three redundant ways at once**:
1. each agent's arc sector splits into a **solid outbound half** and a **dashed inbound half**;
2. each ribbon is an **asymmetric teardrop** — pinched at the source, broad at the target;
3. a **source→target hue gradient** plus a small **arrowhead landing on the receiver's arc**.

"Who talks to whom AND in which direction" is legible at a glance, and it stays legible even on `belafonte-night` where the ANSI kind hues collapse (direction carried by treatment, not hue). The same chord is incorporated into the sequence view as the communication-topology summary beside the time-ordered diagram.

## Task 3 — information parity across the three compose proposals
Audited what each proposal surfaced from the session model and closed every gap so no proposal is missing what the others expose:
- **A · observatory** — sequence view now renders the corrected vertical diagram + topology chord (was the flat score).
- **B · score** — main is the corrected sequence diagram; the margin gains the **topology chord, intervention ladder, plan reel** (already had drift, interventions, heartbeat, fingerprint, DAG, strata in main).
- **C · mission control** — gains the **sequence diagram, topology chord, plan DAG, plan strata, and judge heartbeat** (already had gantt, drift, ladder, reel, fingerprints).
- The **span inspector** is now reachable in every proposal (A docks it in the rail drawer; B & C float it as an overlay), plus a `?span=` deep-link.

## Constraints / verification
Preserves the zicato design language, the 16-theme ANSI-sourced categorical system, and the KIND=hue / STATUS=treatment grammar. Standalone HTML/CSS/vanilla-JS, no build, no network. Theme switch re-skins without a re-render; `_embed.js` `?only/?bare/?theme` still works (smoke-tested on the 3 restructured sequence sections). Verified headless across monokai, paper, dracula, belafonte-night, and solarized-dark.